### PR TITLE
linux kwin x11 csd 窗口阴影

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -32,8 +32,9 @@ static void my_application_activate(GApplication* application) {
   GdkScreen* screen = gtk_window_get_screen(window);
   if (GDK_IS_X11_SCREEN(screen)) {
     const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
+    if (g_strcmp0(wm_name, "GNOME Shell") != 0 &&
+        g_strcmp0(wm_name, "KWin") != 0) {
+        use_header_bar = FALSE;
     }
   }
 #endif


### PR DESCRIPTION
linux 上，kde x11没有窗口阴影，这样能解决