### PR TITLE
feat:add WebDAV&SMB library refresh button

### DIFF
--- a/lib/pages/media_library_page.dart
+++ b/lib/pages/media_library_page.dart
@@ -13,7 +13,8 @@ import 'package:nipaplay/themes/nipaplay/widgets/network_media_server_dialog.dar
 import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:flutter/foundation.dart' show kIsWeb, defaultTargetPlatform, TargetPlatform;
+import 'package:flutter/foundation.dart'
+    show kIsWeb, defaultTargetPlatform, TargetPlatform;
 import 'package:nipaplay/utils/media_source_utils.dart';
 import 'package:nipaplay/providers/jellyfin_provider.dart';
 import 'package:nipaplay/providers/dandanplay_remote_provider.dart';
@@ -45,7 +46,7 @@ class MediaLibraryPage extends StatefulWidget {
   final MediaLibrarySourceType sourceType;
 
   const MediaLibraryPage({
-    super.key, 
+    super.key,
     this.onPlayEpisode,
     this.jellyfinMode = false,
     this.onSourcesUpdated,
@@ -60,28 +61,29 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
   static const Color _accentColor = Color(0xFFFF2E55);
   // 🔥 临时禁用页面保活，测试是否解决CPU泄漏问题
   // with AutomaticKeepAliveClientMixin {
-  List<WatchHistoryItem> _uniqueLibraryItems = []; 
-  Map<int, String> _persistedImageUrls = {}; 
-  final Map<int, BangumiAnime> _fetchedFullAnimeData = {}; 
-  bool _isLoadingInitial = true; 
+  List<WatchHistoryItem> _uniqueLibraryItems = [];
+  Map<int, String> _persistedImageUrls = {};
+  final Map<int, BangumiAnime> _fetchedFullAnimeData = {};
+  bool _isLoadingInitial = true;
   String? _error;
-  
+
   // 🔥 CPU优化：防止重复处理相同的历史数据
   int _lastProcessedHistoryHashCode = 0;
   bool _isBackgroundFetching = false;
   bool _hasWebDataLoaded = false; // 添加Web数据加载标记
-  
+
   // 🔥 CPU优化：缓存已构建的卡片Widget
   final Map<String, Widget> _cardWidgetCache = {};
-  
+
   final ScrollController _gridScrollController = ScrollController();
   final TextEditingController _searchController = TextEditingController();
   LocalLibrarySortType _currentSort = LocalLibrarySortType.dateAdded;
   List<WatchHistoryItem> _filteredItems = [];
 
   static const String _prefsKeyPrefix = 'media_library_image_url_';
-  
+
   bool _isJellyfinConnected = false;
+  bool _isSyncing = false;
 
   // 🔥 临时禁用页面保活
   // @override
@@ -95,7 +97,8 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
       if (mounted) {
         //debugPrint('[媒体库CPU] 开始加载初始数据');
         _loadInitialMediaLibraryData();
-        final jellyfinProvider = Provider.of<JellyfinProvider>(context, listen: false);
+        final jellyfinProvider =
+            Provider.of<JellyfinProvider>(context, listen: false);
         _isJellyfinConnected = jellyfinProvider.isConnected; // Initialize
         jellyfinProvider.addListener(_onJellyfinProviderChanged);
       }
@@ -107,8 +110,9 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
     //debugPrint('[CPU-泄漏排查] MediaLibraryPage dispose 被调用！！！');
     _searchController.dispose();
     try {
-      if (mounted) { 
-        final jellyfinProvider = Provider.of<JellyfinProvider>(context, listen: false);
+      if (mounted) {
+        final jellyfinProvider =
+            Provider.of<JellyfinProvider>(context, listen: false);
         jellyfinProvider.removeListener(_onJellyfinProviderChanged);
       }
     } catch (e) {
@@ -122,7 +126,8 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
 
   void _onJellyfinProviderChanged() {
     if (mounted) {
-      final jellyfinProvider = Provider.of<JellyfinProvider>(context, listen: false);
+      final jellyfinProvider =
+          Provider.of<JellyfinProvider>(context, listen: false);
       if (_isJellyfinConnected != jellyfinProvider.isConnected) {
         setState(() {
           _isJellyfinConnected = jellyfinProvider.isConnected;
@@ -145,7 +150,8 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
           _filteredItems.sort((a, b) => a.animeName.compareTo(b.animeName));
           break;
         case LocalLibrarySortType.dateAdded:
-          _filteredItems.sort((a, b) => b.lastWatchTime.compareTo(a.lastWatchTime));
+          _filteredItems
+              .sort((a, b) => b.lastWatchTime.compareTo(a.lastWatchTime));
           break;
         case LocalLibrarySortType.rating:
           break;
@@ -200,9 +206,10 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
     }
   }
 
-  Future<void> _processAndSortHistory(List<WatchHistoryItem> watchHistory) async {
+  Future<void> _processAndSortHistory(
+      List<WatchHistoryItem> watchHistory) async {
     if (!mounted) return;
-    
+
     // 🔥 CPU优化：检查数据是否已经处理过，避免重复处理
     final currentHashCode = watchHistory.hashCode;
     if (currentHashCode == _lastProcessedHistoryHashCode) {
@@ -215,7 +222,7 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
     if (watchHistory.isEmpty) {
       setState(() {
         _uniqueLibraryItems = [];
-        _isLoadingInitial = false; 
+        _isLoadingInitial = false;
       });
       return;
     }
@@ -226,7 +233,8 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
     for (var item in filteredHistory) {
       if (item.animeId != null) {
         if (latestHistoryItemMap.containsKey(item.animeId!)) {
-          if (item.lastWatchTime.isAfter(latestHistoryItemMap[item.animeId!]!.lastWatchTime)) {
+          if (item.lastWatchTime
+              .isAfter(latestHistoryItemMap[item.animeId!]!.lastWatchTime)) {
             latestHistoryItemMap[item.animeId!] = item;
           }
         } else {
@@ -235,19 +243,22 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
       }
     }
     final uniqueAnimeItemsFromHistory = latestHistoryItemMap.values.toList();
-    uniqueAnimeItemsFromHistory.sort((a, b) => b.lastWatchTime.compareTo(a.lastWatchTime));
+    uniqueAnimeItemsFromHistory
+        .sort((a, b) => b.lastWatchTime.compareTo(a.lastWatchTime));
 
     Map<int, String> loadedPersistedUrls = {};
     final prefs = await SharedPreferences.getInstance();
     for (var item in uniqueAnimeItemsFromHistory) {
       if (item.animeId != null) {
-        String? persistedUrl = prefs.getString('$_prefsKeyPrefix${item.animeId}');
+        String? persistedUrl =
+            prefs.getString('$_prefsKeyPrefix${item.animeId}');
         if (persistedUrl != null && persistedUrl.isNotEmpty) {
           loadedPersistedUrls[item.animeId!] = persistedUrl;
         }
-        
+
         // 尝试从BangumiService内存缓存中恢复详情数据
-        final cachedDetail = BangumiService.instance.getAnimeDetailsFromMemory(item.animeId!);
+        final cachedDetail =
+            BangumiService.instance.getAnimeDetailsFromMemory(item.animeId!);
         if (cachedDetail != null) {
           _fetchedFullAnimeData[item.animeId!] = cachedDetail;
         }
@@ -257,12 +268,12 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
     setState(() {
       _uniqueLibraryItems = uniqueAnimeItemsFromHistory;
       _persistedImageUrls = loadedPersistedUrls;
-      _isLoadingInitial = false; 
+      _isLoadingInitial = false;
       // 🔥 CPU优化：清空卡片缓存，因为数据已更新
       _cardWidgetCache.clear();
       _applyFilter();
     });
-    _fetchAndPersistFullDetailsInBackground(); 
+    _fetchAndPersistFullDetailsInBackground();
   }
 
   Future<void> _loadInitialMediaLibraryData() async {
@@ -286,7 +297,7 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
         }
         // Web environment: 完全模仿新番更新页面的逻辑
         List<BangumiAnime> animes;
-        
+
         try {
           final apiUri =
               WebRemoteAccessService.apiUri('/api/media/local/items');
@@ -295,15 +306,18 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
           }
           final response = await http.get(apiUri);
           if (response.statusCode == 200) {
-            final List<dynamic> data = json.decode(utf8.decode(response.bodyBytes));
-            animes = data.map((d) => BangumiAnime.fromJson(d as Map<String, dynamic>)).toList();
+            final List<dynamic> data =
+                json.decode(utf8.decode(response.bodyBytes));
+            animes = data
+                .map((d) => BangumiAnime.fromJson(d as Map<String, dynamic>))
+                .toList();
           } else {
             throw Exception('Failed to load from API: ${response.statusCode}');
           }
         } catch (e) {
           throw Exception('Failed to connect to the local API: $e');
         }
-        
+
         // 转换为WatchHistoryItem（保持兼容性）
         final webHistoryItems = animes.map((anime) {
           final animeJson = anime.toJson();
@@ -312,8 +326,8 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
             animeName: anime.nameCn.isNotEmpty ? anime.nameCn : anime.name,
             episodeTitle: '',
             filePath: 'web_${anime.id}',
-            lastWatchTime: animeJson['_localLastWatchTime'] != null 
-                ? DateTime.parse(animeJson['_localLastWatchTime']) 
+            lastWatchTime: animeJson['_localLastWatchTime'] != null
+                ? DateTime.parse(animeJson['_localLastWatchTime'])
                 : DateTime.now(),
             watchProgress: 0.0,
             lastPosition: 0,
@@ -321,12 +335,12 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
             thumbnailPath: anime.imageUrl,
           );
         }).toList();
-        
+
         // 缓存BangumiAnime数据
         for (var anime in animes) {
           _fetchedFullAnimeData[anime.id] = anime;
         }
-        
+
         if (mounted) {
           setState(() {
             _uniqueLibraryItems = webHistoryItems;
@@ -337,13 +351,14 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
         }
       } else {
         // Mobile/Desktop environment: use local providers
-        final historyProvider = Provider.of<WatchHistoryProvider>(context, listen: false);
+        final historyProvider =
+            Provider.of<WatchHistoryProvider>(context, listen: false);
         if (!historyProvider.isLoaded && !historyProvider.isLoading) {
-          await historyProvider.loadHistory(); 
+          await historyProvider.loadHistory();
         }
-        
+
         if (historyProvider.isLoaded) {
-            await _processAndSortHistory(historyProvider.history);
+          await _processAndSortHistory(historyProvider.history);
         }
       }
     } catch (e) {
@@ -359,18 +374,21 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
   Future<void> _fetchAndPersistFullDetailsInBackgroundForWeb() async {
     if (_isBackgroundFetching) return;
     _isBackgroundFetching = true;
-    
+
     final prefs = await SharedPreferences.getInstance();
     const int maxConcurrentRequests = 8; // 增加并发数
     int processed = 0;
-    final total = _uniqueLibraryItems.where((item) => item.animeId != null).length;
-    
+    final total =
+        _uniqueLibraryItems.where((item) => item.animeId != null).length;
+
     // 批量处理请求
     final futures = <Future<void>>[];
-    
+
     for (var historyItem in _uniqueLibraryItems) {
-      if (historyItem.animeId != null && !_fetchedFullAnimeData.containsKey(historyItem.animeId!)) {
-        final future = _fetchSingleAnimeDetail(historyItem.animeId!, prefs).then((_) {
+      if (historyItem.animeId != null &&
+          !_fetchedFullAnimeData.containsKey(historyItem.animeId!)) {
+        final future =
+            _fetchSingleAnimeDetail(historyItem.animeId!, prefs).then((_) {
           processed++;
           // 每处理5个项目批量更新一次UI，避免频繁更新
           if (processed % 5 == 0 && mounted) {
@@ -378,7 +396,7 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
           }
         });
         futures.add(future);
-        
+
         // 控制并发数量
         if (futures.length >= maxConcurrentRequests) {
           await Future.any(futures);
@@ -387,35 +405,39 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
         }
       }
     }
-    
+
     // 等待所有剩余请求完成
     if (futures.isNotEmpty) {
       await Future.wait(futures);
     }
-    
+
     // 最后一次UI更新
     if (mounted) {
       setState(() {});
     }
-    
+
     _isBackgroundFetching = false;
   }
-  
-  Future<void> _fetchSingleAnimeDetail(int animeId, SharedPreferences prefs) async {
+
+  Future<void> _fetchSingleAnimeDetail(
+      int animeId, SharedPreferences prefs) async {
     try {
-      final apiUri = WebRemoteAccessService.apiUri('/api/bangumi/detail/$animeId');
+      final apiUri =
+          WebRemoteAccessService.apiUri('/api/bangumi/detail/$animeId');
       if (apiUri == null) {
         throw Exception('未配置远程访问地址');
       }
       final response = await http.get(apiUri);
       if (response.statusCode == 200) {
-        final Map<String, dynamic> animeDetailData = json.decode(utf8.decode(response.bodyBytes));
+        final Map<String, dynamic> animeDetailData =
+            json.decode(utf8.decode(response.bodyBytes));
         final animeDetail = BangumiAnime.fromJson(animeDetailData);
-        
+
         if (mounted) {
           _fetchedFullAnimeData[animeId] = animeDetail;
           if (animeDetail.imageUrl.isNotEmpty) {
-            await prefs.setString('$_prefsKeyPrefix$animeId', animeDetail.imageUrl);
+            await prefs.setString(
+                '$_prefsKeyPrefix$animeId', animeDetail.imageUrl);
             if (mounted) {
               _persistedImageUrls[animeId] = animeDetail.imageUrl;
             }
@@ -433,18 +455,60 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
     }
   }
 
-  Future<void> _syncLocalLibrary() async {
-    if (!mounted || kIsWeb) return;
-    final historyProvider =
-        Provider.of<WatchHistoryProvider>(context, listen: false);
-    historyProvider.clearInvalidPathCache();
-    await historyProvider.refresh();
-    _lastProcessedHistoryHashCode = 0;
-    await _processAndSortHistory(historyProvider.history);
-    if (!mounted) return;
-    BlurSnackBar.show(context, '已同步本地媒体库');
+  Future<void> _syncLibrary(MediaLibrarySourceType type) async {
+    if (!mounted || kIsWeb || _isSyncing) return;
+
+    setState(() {
+      _isSyncing = true;
+    });
+
+    try {
+      final historyProvider =
+          Provider.of<WatchHistoryProvider>(context, listen: false);
+      historyProvider.clearInvalidPathCache();
+      await historyProvider.refresh();
+      _lastProcessedHistoryHashCode = 0;
+      await _processAndSortHistory(historyProvider.history);
+      if (!mounted) return;
+
+      String message;
+      switch (type) {
+        case MediaLibrarySourceType.local:
+          message = '已同步本地媒体库';
+          break;
+        case MediaLibrarySourceType.webdav:
+          message = '已同步WebDAV媒体库';
+          break;
+        case MediaLibrarySourceType.smb:
+          message = '已同步SMB媒体库';
+          break;
+      }
+      BlurSnackBar.show(context, message);
+    } catch (e) {
+      if (mounted) {
+        BlurSnackBar.show(context, '同步失败: ${e.toString()}');
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSyncing = false;
+        });
+      }
+    }
   }
-  
+
+  Future<void> _syncLocalLibrary() async {
+    await _syncLibrary(MediaLibrarySourceType.local);
+  }
+
+  Future<void> _syncWebDavLibrary() async {
+    await _syncLibrary(MediaLibrarySourceType.webdav);
+  }
+
+  Future<void> _syncSmbLibrary() async {
+    await _syncLibrary(MediaLibrarySourceType.smb);
+  }
+
   Future<void> _showJellyfinServerDialog() async {
     await NetworkMediaServerDialog.show(context, MediaServerType.jellyfin);
   }
@@ -489,7 +553,8 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
   }
 
   Future<void> _showDandanplayServerDialog() async {
-    final provider = Provider.of<DandanplayRemoteProvider>(context, listen: false);
+    final provider =
+        Provider.of<DandanplayRemoteProvider>(context, listen: false);
     if (!provider.isInitialized) {
       await provider.initialize();
     }
@@ -509,9 +574,7 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
         LoginField(
           key: 'token',
           label: 'API密钥 (可选)',
-          hint: provider.tokenRequired
-              ? '服务器已启用 API 验证'
-              : '若服务器开启验证请填写',
+          hint: provider.tokenRequired ? '服务器已启用 API 验证' : '若服务器开启验证请填写',
           isPassword: true,
           required: false,
         ),
@@ -550,39 +613,43 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
       return;
     }
     _isBackgroundFetching = true;
-    
+
     //debugPrint('[媒体库CPU] 开始后台获取详细信息 - 项目数量: ${_uniqueLibraryItems.length}');
     final stopwatch = Stopwatch()..start();
     final prefs = await SharedPreferences.getInstance();
     List<Future> pendingRequests = [];
     const int maxConcurrentRequests = 2; // 🔥 CPU优化：减少并发请求数量
-    
+
     for (var historyItem in _uniqueLibraryItems) {
-      if (historyItem.animeId != null) { 
+      if (historyItem.animeId != null) {
         // 🔥 修改条件：只要动画ID不为空，就尝试获取详情
         // 不再跳过已有图片或已缓存的项目
-        
+
         Future<void> fetchDetailForItem() async {
           try {
             // 如果已经有详细数据，则跳过获取
             if (_fetchedFullAnimeData.containsKey(historyItem.animeId!)) {
               return;
             }
-            
-            final animeDetail = await BangumiService.instance.getAnimeDetails(historyItem.animeId!);
+
+            final animeDetail = await BangumiService.instance
+                .getAnimeDetails(historyItem.animeId!);
             //debugPrint('[媒体库CPU] 获取到动画详情: ${historyItem.animeId} - ${animeDetail.name}');
             if (mounted) {
               _fetchedFullAnimeData[historyItem.animeId!] = animeDetail;
               setState(() {});
               if (animeDetail.imageUrl.isNotEmpty) {
-                await prefs.setString('$_prefsKeyPrefix${historyItem.animeId!}', animeDetail.imageUrl);
+                await prefs.setString('$_prefsKeyPrefix${historyItem.animeId!}',
+                    animeDetail.imageUrl);
                 if (mounted) {
-                  _persistedImageUrls[historyItem.animeId!] = animeDetail.imageUrl;
+                  _persistedImageUrls[historyItem.animeId!] =
+                      animeDetail.imageUrl;
                   setState(() {});
                 }
               } else {
                 await prefs.remove('$_prefsKeyPrefix${historyItem.animeId!}');
-                if(mounted && _persistedImageUrls.containsKey(historyItem.animeId!)){
+                if (mounted &&
+                    _persistedImageUrls.containsKey(historyItem.animeId!)) {
                   _persistedImageUrls.remove(historyItem.animeId!);
                   setState(() {});
                 }
@@ -592,25 +659,26 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
             //debugPrint('[媒体库CPU] 获取动画详情失败: ${historyItem.animeId} - $e');
           }
         }
-        
+
         if (pendingRequests.length >= maxConcurrentRequests) {
           await Future.any(pendingRequests);
-          pendingRequests.removeWhere((f) => f.toString().contains('Completed'));
+          pendingRequests
+              .removeWhere((f) => f.toString().contains('Completed'));
         }
-        
+
         pendingRequests.add(fetchDetailForItem());
       }
     }
-    
+
     await Future.wait(pendingRequests);
-    
+
     // 🔥 CPU优化：最后一次性刷新UI，而不是每个项目都setState
     if (mounted) {
       setState(() {
         // 触发UI重建，显示所有更新的数据
       });
     }
-    
+
     //debugPrint('[媒体库CPU] 后台获取完成 - 耗时: ${stopwatch.elapsedMilliseconds}ms');
     _isBackgroundFetching = false;
   }
@@ -619,9 +687,10 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
     if (_fetchedFullAnimeData.containsKey(animeId)) {
       return;
     }
-    
+
     try {
-      final animeDetail = await BangumiService.instance.getAnimeDetails(animeId);
+      final animeDetail =
+          await BangumiService.instance.getAnimeDetails(animeId);
       if (mounted) {
         setState(() {
           _fetchedFullAnimeData[animeId] = animeDetail;
@@ -638,12 +707,12 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
         widget.onPlayEpisode?.call(result);
       }
     });
-    
+
     if (!_fetchedFullAnimeData.containsKey(animeId)) {
       _preloadAnimeDetail(animeId);
     }
   }
-  
+
   @override
   Widget build(BuildContext context) {
     // 🔥 移除super.build(context)调用，因为已禁用AutomaticKeepAliveClientMixin
@@ -665,18 +734,19 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
       },
     );
   }
-  
+
   String? _getWatchProgress(int? animeId) {
     if (animeId == null) return null;
-    
+
     final detail = _fetchedFullAnimeData[animeId];
-    final watchHistoryProvider = Provider.of<WatchHistoryProvider>(context, listen: false);
-    
+    final watchHistoryProvider =
+        Provider.of<WatchHistoryProvider>(context, listen: false);
+
     // 获取该动画的所有历史记录并去重（按episodeId或标题，如果有的话）
     final allHistory = watchHistoryProvider.history
         .where((h) => h.animeId == animeId && _matchesSource(h))
         .toList();
-    
+
     // 如果没有历史记录（理论上不应该，因为这里是媒体库），显示未观看
     if (allHistory.isEmpty) return '未观看';
 
@@ -690,20 +760,22 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
         watchedIds.add(h.episodeId!);
       }
     }
-    
+
     int watchedCount = watchedIds.length;
     if (watchedCount == 0) {
       // 如果没有episodeId信息，按条目数估算（但不准确）
       watchedCount = watchedHistory.length;
     }
 
-    if (detail != null && detail.totalEpisodes != null && detail.totalEpisodes! > 0) {
+    if (detail != null &&
+        detail.totalEpisodes != null &&
+        detail.totalEpisodes! > 0) {
       if (watchedCount >= detail.totalEpisodes!) {
         return '已看完';
       }
       return '已看 $watchedCount / ${detail.totalEpisodes} 集';
     }
-    
+
     return '已看 $watchedCount 集';
   }
 
@@ -717,7 +789,7 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
   Widget _buildLocalMediaLibrary() {
     if (_isLoadingInitial) {
       return const SizedBox(
-        height: 200, 
+        height: 200,
         child: Center(child: CircularProgressIndicator(color: _accentColor)),
       );
     }
@@ -729,7 +801,8 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Text('加载媒体库失败: $_error', style: const TextStyle(color: Colors.white70)),
+              Text('加载媒体库失败: $_error',
+                  style: const TextStyle(color: Colors.white70)),
               const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: _loadInitialMediaLibraryData,
@@ -751,7 +824,7 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
               Text(
                 _emptyMessage,
                 textAlign: TextAlign.center,
-                locale: const Locale("zh-Hans","zh"),
+                locale: const Locale("zh-Hans", "zh"),
                 style: const TextStyle(color: Colors.grey, fontSize: 16),
               ),
               const SizedBox(height: 16),
@@ -778,14 +851,69 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
               ? [
                   IconButton(
                     tooltip: '同步本地媒体库',
-                    onPressed: _syncLocalLibrary,
-                    icon: Icon(
-                      Icons.sync,
-                      color: Theme.of(context).colorScheme.onSurface,
-                    ),
+                    onPressed: _isSyncing ? null : _syncLocalLibrary,
+                    icon: _isSyncing
+                        ? SizedBox(
+                            width: 24,
+                            height: 24,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                  Theme.of(context).colorScheme.onSurface),
+                            ),
+                          )
+                        : Icon(
+                            Icons.sync,
+                            color: Theme.of(context).colorScheme.onSurface,
+                          ),
                   ),
                 ]
-              : null,
+              : widget.sourceType == MediaLibrarySourceType.webdav
+                  ? [
+                      IconButton(
+                        tooltip: '同步WebDAV媒体库',
+                        onPressed: _isSyncing ? null : _syncWebDavLibrary,
+                        icon: _isSyncing
+                            ? SizedBox(
+                                width: 24,
+                                height: 24,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  valueColor: AlwaysStoppedAnimation<Color>(
+                                      Theme.of(context).colorScheme.onSurface),
+                                ),
+                              )
+                            : Icon(
+                                Icons.sync,
+                                color: Theme.of(context).colorScheme.onSurface,
+                              ),
+                      ),
+                    ]
+                  : widget.sourceType == MediaLibrarySourceType.smb
+                      ? [
+                          IconButton(
+                            tooltip: '同步SMB媒体库',
+                            onPressed: _isSyncing ? null : _syncSmbLibrary,
+                            icon: _isSyncing
+                                ? SizedBox(
+                                    width: 24,
+                                    height: 24,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      valueColor: AlwaysStoppedAnimation<Color>(
+                                          Theme.of(context)
+                                              .colorScheme
+                                              .onSurface),
+                                    ),
+                                  )
+                                : Icon(
+                                    Icons.sync,
+                                    color:
+                                        Theme.of(context).colorScheme.onSurface,
+                                  ),
+                          ),
+                        ]
+                      : null,
         ),
         Expanded(
           child: Stack(
@@ -793,7 +921,12 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
               RepaintBoundary(
                 child: Scrollbar(
                   controller: _gridScrollController,
-                  thickness: kIsWeb ? 4 : (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS) ? 0 : 4,
+                  thickness: kIsWeb
+                      ? 4
+                      : (defaultTargetPlatform == TargetPlatform.android ||
+                              defaultTargetPlatform == TargetPlatform.iOS)
+                          ? 0
+                          : 4,
                   radius: const Radius.circular(2),
                   child: GridView.builder(
                     controller: _gridScrollController,
@@ -814,7 +947,8 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
                     padding: const EdgeInsets.fromLTRB(16, 0, 16, 80),
                     cacheExtent: 800,
                     clipBehavior: Clip.hardEdge,
-                    physics: const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics()),
+                    physics: const AlwaysScrollableScrollPhysics(
+                        parent: BouncingScrollPhysics()),
                     addAutomaticKeepAlives: false,
                     addRepaintBoundaries: true,
                     itemCount: _filteredItems.length,
@@ -824,106 +958,113 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
                         //debugPrint('[媒体库CPU] GridView itemBuilder - 索引: $index/${_filteredItems.length}');
                       }
                       final historyItem = _filteredItems[index];
-                final animeId = historyItem.animeId;
-                
-                // 🔥 CPU优化：使用文件路径作为缓存键，检查是否已缓存
-                final cacheKey = historyItem.filePath;
-                if (_cardWidgetCache.containsKey(cacheKey)) {
-                  return _cardWidgetCache[cacheKey]!;
-                }
+                      final animeId = historyItem.animeId;
 
-                String imageUrlToDisplay = historyItem.thumbnailPath ?? '';
-                String nameToDisplay = historyItem.animeName.isNotEmpty 
-                    ? historyItem.animeName 
-                    : (historyItem.episodeTitle ?? '未知动画');
+                      // 🔥 CPU优化：使用文件路径作为缓存键，检查是否已缓存
+                      final cacheKey = historyItem.filePath;
+                      if (_cardWidgetCache.containsKey(cacheKey)) {
+                        return _cardWidgetCache[cacheKey]!;
+                      }
 
-                // 尝试从持久化缓存中获取图片（作为初始值）
-                if (animeId != null && _persistedImageUrls.containsKey(animeId)) {
-                    imageUrlToDisplay = _persistedImageUrls[animeId]!;
-                }
+                      String imageUrlToDisplay =
+                          historyItem.thumbnailPath ?? '';
+                      String nameToDisplay = historyItem.animeName.isNotEmpty
+                          ? historyItem.animeName
+                          : (historyItem.episodeTitle ?? '未知动画');
 
-                // 优先使用已获取的详情数据
-                BangumiAnime? detailData;
-                if (animeId != null && _fetchedFullAnimeData.containsKey(animeId)) {
-                  detailData = _fetchedFullAnimeData[animeId];
-                }
+                      // 尝试从持久化缓存中获取图片（作为初始值）
+                      if (animeId != null &&
+                          _persistedImageUrls.containsKey(animeId)) {
+                        imageUrlToDisplay = _persistedImageUrls[animeId]!;
+                      }
 
-                if (detailData != null) {
-                   // 有同步数据，直接构建
-                   String displayImage = imageUrlToDisplay;
-                   if (detailData.imageUrl.isNotEmpty) {
-                      displayImage = detailData.imageUrl;
-                   }
-                   
-                   final card = HorizontalAnimeCard(
-                     imageUrl: displayImage,
-                     title: nameToDisplay,
-                     rating: detailData.rating,
-                     source: AnimeCard.getSourceFromFilePath(historyItem.filePath),
-                     summary: detailData.summary,
-                     progress: _getWatchProgress(animeId),
-                     onTap: () {
-                       if (animeId != null) {
-                         _navigateToAnimeDetail(animeId);
-                       } else {
-                         BlurSnackBar.show(context, '无法打开详情，动画ID未知');
-                       }
-                     },
-                   );
-                   
-                   if (_cardWidgetCache.length < 100) {
-                     _cardWidgetCache[cacheKey] = card;
-                   }
-                   return card;
-                }
+                      // 优先使用已获取的详情数据
+                      BangumiAnime? detailData;
+                      if (animeId != null &&
+                          _fetchedFullAnimeData.containsKey(animeId)) {
+                        detailData = _fetchedFullAnimeData[animeId];
+                      }
 
-                // 没有同步数据，使用FutureBuilder来构建卡片
-                final card = FutureBuilder<BangumiAnime>(
-                  future: animeId != null ? BangumiService.instance.getAnimeDetails(animeId) : null,
-                  builder: (context, snapshot) {
-                    final detail = snapshot.data;
-                    
-                    // 图片：优先用 detail.imageUrl (高清)，其次用 persisted/thumbnail
-                    String displayImage = imageUrlToDisplay;
-                    if (detail != null && detail.imageUrl.isNotEmpty) {
-                       displayImage = detail.imageUrl;
-                    }
-                    
-                    // 评分
-                    double? displayRating = detail?.rating;
-                    
-                    return HorizontalAnimeCard(
-                      imageUrl: displayImage,
-                      title: nameToDisplay,
-                      rating: displayRating,
-                      source: AnimeCard.getSourceFromFilePath(historyItem.filePath),
-                      summary: detail?.summary,
-                      progress: _getWatchProgress(animeId),
-                      onTap: () {
-                        if (animeId != null) {
-                          _navigateToAnimeDetail(animeId);
-                        } else {
-                          BlurSnackBar.show(context, '无法打开详情，动画ID未知');
+                      if (detailData != null) {
+                        // 有同步数据，直接构建
+                        String displayImage = imageUrlToDisplay;
+                        if (detailData.imageUrl.isNotEmpty) {
+                          displayImage = detailData.imageUrl;
                         }
-                      },
-                    );
-                  }
-                );
-                
-                // 🔥 CPU优化：缓存卡片Widget，限制缓存大小避免内存泄漏
-                if (_cardWidgetCache.length < 100) { // 限制最多缓存100个卡片
-                  _cardWidgetCache[cacheKey] = card;
-                }
-                
-                return card;
-              },
-            ),
+
+                        final card = HorizontalAnimeCard(
+                          imageUrl: displayImage,
+                          title: nameToDisplay,
+                          rating: detailData.rating,
+                          source: AnimeCard.getSourceFromFilePath(
+                              historyItem.filePath),
+                          summary: detailData.summary,
+                          progress: _getWatchProgress(animeId),
+                          onTap: () {
+                            if (animeId != null) {
+                              _navigateToAnimeDetail(animeId);
+                            } else {
+                              BlurSnackBar.show(context, '无法打开详情，动画ID未知');
+                            }
+                          },
+                        );
+
+                        if (_cardWidgetCache.length < 100) {
+                          _cardWidgetCache[cacheKey] = card;
+                        }
+                        return card;
+                      }
+
+                      // 没有同步数据，使用FutureBuilder来构建卡片
+                      final card = FutureBuilder<BangumiAnime>(
+                          future: animeId != null
+                              ? BangumiService.instance.getAnimeDetails(animeId)
+                              : null,
+                          builder: (context, snapshot) {
+                            final detail = snapshot.data;
+
+                            // 图片：优先用 detail.imageUrl (高清)，其次用 persisted/thumbnail
+                            String displayImage = imageUrlToDisplay;
+                            if (detail != null && detail.imageUrl.isNotEmpty) {
+                              displayImage = detail.imageUrl;
+                            }
+
+                            // 评分
+                            double? displayRating = detail?.rating;
+
+                            return HorizontalAnimeCard(
+                              imageUrl: displayImage,
+                              title: nameToDisplay,
+                              rating: displayRating,
+                              source: AnimeCard.getSourceFromFilePath(
+                                  historyItem.filePath),
+                              summary: detail?.summary,
+                              progress: _getWatchProgress(animeId),
+                              onTap: () {
+                                if (animeId != null) {
+                                  _navigateToAnimeDetail(animeId);
+                                } else {
+                                  BlurSnackBar.show(context, '无法打开详情，动画ID未知');
+                                }
+                              },
+                            );
+                          });
+
+                      // 🔥 CPU优化：缓存卡片Widget，限制缓存大小避免内存泄漏
+                      if (_cardWidgetCache.length < 100) {
+                        // 限制最多缓存100个卡片
+                        _cardWidgetCache[cacheKey] = card;
+                      }
+
+                      return card;
+                    },
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ],
-    ),
-    ),
-    ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- 为WebDAV和SMB媒体库加了本地媒体库同款的同步按钮，省去重启应用初始化媒体库的麻烦
<img width="1584" height="421" alt="image" src="https://github.com/user-attachments/assets/e03f8cc0-dbeb-463c-a8d0-9ad5af3e2231" />

## Related Issue

- #318 

## What Changed

- 逻辑部分：复用并整合了本地媒体库的同步逻辑，将其封装为`_syncLibrary`方法，通过参数区分媒体库类型 line458~499
- UI部分：禁用重复点击：防止按钮重复触发 line 854~916