### PR TITLE
fix:internal subtitle load error

### DIFF
--- a/lib/player_abstraction/mdk_player_adapter_io.dart
+++ b/lib/player_abstraction/mdk_player_adapter_io.dart
@@ -344,39 +344,11 @@ class MdkPlayerAdapter implements AbstractPlayer {
   @override
   PlayerMediaInfo get mediaInfo => _toPlayerMediaInfo(_mdkPlayer.mediaInfo);
 
-  List<int> _mapSubtitleTrackIndicesFromMdk(List<int> value) {
-    final subtitleTracks = _mdkPlayer.mediaInfo.subtitle;
-    if (subtitleTracks == null || subtitleTracks.isEmpty) {
-      return List<int>.from(value);
-    }
-
-    return value.map((trackIndex) {
-      final uiIndex =
-          subtitleTracks.indexWhere((track) => track.index == trackIndex);
-      return uiIndex >= 0 ? uiIndex : trackIndex;
-    }).toList();
-  }
-
-  List<int> _mapSubtitleTrackIndicesToMdk(List<int> value) {
-    final subtitleTracks = _mdkPlayer.mediaInfo.subtitle;
-    if (subtitleTracks == null || subtitleTracks.isEmpty) {
-      return List<int>.from(value);
-    }
-
-    return value.map((uiIndex) {
-      if (uiIndex >= 0 && uiIndex < subtitleTracks.length) {
-        return subtitleTracks[uiIndex].index;
-      }
-      return uiIndex;
-    }).toList();
-  }
-
   @override
-  List<int> get activeSubtitleTracks =>
-      _mapSubtitleTrackIndicesFromMdk(_mdkPlayer.activeSubtitleTracks);
+  List<int> get activeSubtitleTracks => _mdkPlayer.activeSubtitleTracks;
   @override
   set activeSubtitleTracks(List<int> value) =>
-      _mdkPlayer.activeSubtitleTracks = _mapSubtitleTrackIndicesToMdk(value);
+      _mdkPlayer.activeSubtitleTracks = value;
 
   @override
   List<int> get activeAudioTracks => _mdkPlayer.activeAudioTracks;


### PR DESCRIPTION
## Summary

- 修复了新版本（v1.9.19之后）中内嵌字幕无法加载的问题

## Related Issue

- Closes #371 

## What Changed

  -删除了`lib\player_abstraction\mdk_player_adapter_io.dart`中的`_mapSubtitleTrackIndicesFromMdk`和`_mapSubtitleTrackIndicesToMdk`方法以及相应调用（Commit b2082f1引入）

## Bug Analysis

- 属性访问错误 ：尝试访问 PlayerSubtitleStreamInfo 类中不存在的 index 属性

- 映射逻辑失败 ：由于 track.index 属性不存在，导致映射逻辑无法正确工作

- 类型安全问题 ：映射方法的返回类型可能与预期不匹配