### PR TITLE
Feat/anime info zh cn to zh tw support

### DIFF
--- a/lib/models/bangumi_model.dart
+++ b/lib/models/bangumi_model.dart
@@ -23,6 +23,9 @@ class BangumiAnime {
   final String? searchKeyword;
 
   final List<EpisodeData>? episodeList; // Changed from 'episodes' to 'episodeList' to avoid conflict if 'episodes' is a field name in JSON for BangumiDetails itself.
+  
+  // 新增字段：存储番剧信息的语言类型
+  final String? language; // 'zh' for简体中文, 'zh_Hant' for繁体中文
 
   bool get hasDetails => summary != null && (rating != null || ratingDetails != null) && (tags != null || metadata != null);
 
@@ -48,6 +51,7 @@ class BangumiAnime {
     this.titles,
     this.searchKeyword,
     this.episodeList,
+    this.language,
   });
 
   BangumiAnime copyWith({
@@ -72,6 +76,7 @@ class BangumiAnime {
     List<Map<String, String>>? titles,
     String? searchKeyword,
     List<EpisodeData>? episodeList,
+    String? language,
   }) {
     return BangumiAnime(
       id: id ?? this.id,
@@ -95,6 +100,7 @@ class BangumiAnime {
       titles: titles ?? this.titles,
       searchKeyword: searchKeyword ?? this.searchKeyword,
       episodeList: episodeList ?? this.episodeList,
+      language: language ?? this.language,
     );
   }
 
@@ -127,6 +133,7 @@ class BangumiAnime {
       typeDescription: null,
       titles: null,
       episodeList: null, // Episodes are not in BangumiIntro
+      language: 'zh', // 默认语言为简体中文
     );
   }
 
@@ -246,6 +253,7 @@ class BangumiAnime {
       titles: parsedTitles,
       searchKeyword: json['searchKeyword'] as String?,
       episodeList: parsedEpisodeList,
+      language: 'zh', // 默认语言为简体中文
     );
   }
 
@@ -281,6 +289,7 @@ class BangumiAnime {
         'episodeTitle': e.title,
         'airDate': e.airDate
       }).toList(), // 额外保存一份原始格式的数据，确保fromDandanplayDetail能正确解析
+      'language': language, // 保存番剧信息的语言类型
     };
   }
 
@@ -377,6 +386,7 @@ class BangumiAnime {
       titles: titles,
       searchKeyword: json['searchKeyword']?.toString(),
       episodeList: parsedEpisodeList,
+      language: json['language']?.toString() ?? 'zh', // 从JSON读取language字段，默认为简体中文
     );
   }
 }

--- a/lib/pages/media_library_page.dart
+++ b/lib/pages/media_library_page.dart
@@ -29,6 +29,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/webdav_connection_dialog.dart';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'dart:ui' as ui;
 import 'package:nipaplay/services/web_remote_access_service.dart';
+import 'package:nipaplay/utils/chinese_converter.dart';
 
 // Define a callback type for when an episode is selected for playing
 typedef OnPlayEpisodeCallback = void Function(WatchHistoryItem item);
@@ -627,9 +628,16 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
 
         Future<void> fetchDetailForItem() async {
           try {
-            // 如果已经有详细数据，则跳过获取
+            // 检查已缓存的详细数据是否语言匹配
             if (_fetchedFullAnimeData.containsKey(historyItem.animeId!)) {
-              return;
+              final cachedAnime = _fetchedFullAnimeData[historyItem.animeId!];
+              // 检查语言是否匹配
+              final isTraditional =
+                  await ChineseConverter.isTraditionalChineseEnvironment(null);
+              final expectedLanguage = isTraditional ? 'zh_Hant' : 'zh';
+              if (cachedAnime?.language == expectedLanguage) {
+                return; // 语言匹配，跳过获取
+              }
             }
 
             final animeDetail = await BangumiService.instance
@@ -684,8 +692,16 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
   }
 
   Future<void> _preloadAnimeDetail(int animeId) async {
+    // 检查已缓存的详细数据是否语言匹配
     if (_fetchedFullAnimeData.containsKey(animeId)) {
-      return;
+      final cachedAnime = _fetchedFullAnimeData[animeId];
+      // 检查语言是否匹配
+      final isTraditional =
+          await ChineseConverter.isTraditionalChineseEnvironment(null);
+      final expectedLanguage = isTraditional ? 'zh_Hant' : 'zh';
+      if (cachedAnime?.language == expectedLanguage) {
+        return; // 语言匹配，跳过获取
+      }
     }
 
     try {

--- a/lib/services/bangumi_service.dart
+++ b/lib/services/bangumi_service.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nipaplay/models/bangumi_model.dart';
 import './dandanplay_service.dart';
 import 'package:nipaplay/services/web_remote_access_service.dart';
+import 'package:nipaplay/utils/chinese_converter.dart';
 
 class BangumiService {
   static final BangumiService instance = BangumiService._();
@@ -258,8 +259,10 @@ class BangumiService {
               .clear(); // Clear old memory list cache before populating with new data
           for (var animeData in data) {
             try {
-              final anime = BangumiAnime.fromDandanplayIntro(
+              var anime = BangumiAnime.fromDandanplayIntro(
                   animeData as Map<String, dynamic>);
+              // 转换为繁体中文（如果需要）
+              anime = await ChineseConverter.convertAnime(anime);
               _listCache[anime.id.toString()] = anime; // Update memory cache
               animes.add(anime);
             } catch (e) {
@@ -364,6 +367,10 @@ class BangumiService {
   }
 
   Future<BangumiAnime> getAnimeDetails(int animeId) async {
+    // 检查是否需要繁体中文
+    final isTraditional = await ChineseConverter.isTraditionalChineseEnvironment(null);
+    final expectedLanguage = isTraditional ? 'zh_Hant' : 'zh';
+
     // 检查内存缓存
     if (_detailsCache.containsKey(animeId)) {
       final cacheTime = _detailsCacheTime[animeId];
@@ -371,8 +378,16 @@ class BangumiService {
         final cachedAnime = _detailsCache[animeId]!;
         // 检查缓存数据是否包含标签信息
         if (cachedAnime.tags != null && cachedAnime.tags!.isNotEmpty) {
-          //debugPrint('[番剧服务] 从内存缓存获取番剧 $animeId 的详情 (缓存时间: ${_getCacheDurationForAnime(animeId).inHours}小时)');
-          return cachedAnime;
+          // 检查语言是否匹配
+          if (cachedAnime.language == expectedLanguage) {
+            //debugPrint('[番剧服务] 从内存缓存获取番剧 $animeId 的详情 (缓存时间: ${_getCacheDurationForAnime(animeId).inHours}小时)');
+            return cachedAnime;
+          } else {
+            //debugPrint('[番剧服务] 番剧 $animeId 的内存缓存语言不匹配，将重新获取');
+            // 移除缓存，强制重新获取
+            _detailsCache.remove(animeId);
+            _detailsCacheTime.remove(animeId);
+          }
         } else {
           //debugPrint('[番剧服务] 番剧 $animeId 的内存缓存缺少标签信息，将重新获取');
           // 移除缓存，强制重新获取
@@ -389,8 +404,17 @@ class BangumiService {
     if (diskCachedDetail != null) {
       // 检查磁盘缓存是否包含标签信息
       if (diskCachedDetail.tags != null && diskCachedDetail.tags!.isNotEmpty) {
-        //debugPrint('[番剧服务] 从磁盘缓存获取番剧 $animeId 的详情成功');
-        return diskCachedDetail;
+        // 检查语言是否匹配
+        if (diskCachedDetail.language == expectedLanguage) {
+          //debugPrint('[番剧服务] 从磁盘缓存获取番剧 $animeId 的详情成功');
+          return diskCachedDetail;
+        } else {
+          //debugPrint('[番剧服务] 番剧 $animeId 的磁盘缓存语言不匹配，将重新获取');
+          // 删除有问题的磁盘缓存
+          final prefs = await SharedPreferences.getInstance();
+          final cacheKey = '$_detailsCacheKeyPrefix$animeId';
+          await prefs.remove(cacheKey);
+        }
       } else {
         //debugPrint('[番剧服务] 番剧 $animeId 的磁盘缓存缺少标签信息，将重新获取');
         // 删除有问题的磁盘缓存
@@ -412,7 +436,7 @@ class BangumiService {
             json.decode(utf8.decode(response.bodyBytes));
         if (decodedResponse['success'] == true &&
             decodedResponse['bangumi'] != null) {
-          final anime = BangumiAnime.fromDandanplayDetail(
+          var anime = BangumiAnime.fromDandanplayDetail(
               decodedResponse['bangumi'] as Map<String, dynamic>);
 
           // 验证获取的数据是否包含标签
@@ -421,6 +445,9 @@ class BangumiService {
           } else {
             //debugPrint('[番剧服务] 警告：API获取的番剧 $animeId 没有标签信息');
           }
+
+          // 转换为繁体中文（如果需要）
+          anime = await ChineseConverter.convertAnime(anime);
 
           // 更新内存缓存
           _detailsCache[animeId] = anime;

--- a/lib/themes/nipaplay/widgets/batch_danmaku_dialog.dart
+++ b/lib/themes/nipaplay/widgets/batch_danmaku_dialog.dart
@@ -10,6 +10,7 @@ import 'package:nipaplay/services/web_remote_access_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
 import 'package:nipaplay/utils/global_hotkey_manager.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
+import 'package:nipaplay/utils/chinese_converter.dart';
 import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 
@@ -231,6 +232,19 @@ class _BatchDanmakuMatchDialogState extends State<BatchDanmakuMatchDialog>
           ? List<Map<String, dynamic>>.from(data['animes'] as List)
           : <Map<String, dynamic>>[];
 
+      // 对搜索结果进行简繁转换
+      final isTraditional =
+          await ChineseConverter.isTraditionalChineseEnvironment(context);
+      if (isTraditional) {
+        // 对每个搜索结果进行转换
+        for (var anime in results) {
+          if (anime['animeTitle'] != null) {
+            anime['animeTitle'] =
+                ChineseConverter.convert(anime['animeTitle'].toString());
+          }
+        }
+      }
+
       setState(() {
         _isSearching = false;
         _searchResults = results;
@@ -311,16 +325,24 @@ class _BatchDanmakuMatchDialogState extends State<BatchDanmakuMatchDialog>
           : (data is Map<String, dynamic> ? data['episodes'] : null);
 
       final parsedEpisodes = <_EpisodeItem>[];
+      // 检查是否需要繁体中文
+      final isTraditional =
+          await ChineseConverter.isTraditionalChineseEnvironment(context);
       if (rawEpisodes is List) {
         for (final entry in rawEpisodes) {
           if (entry is! Map) continue;
           final map = Map<String, dynamic>.from(entry);
           final episodeId = _tryParsePositiveInt(map['episodeId']);
           if (episodeId == null) continue;
+          var episodeTitle = map['episodeTitle']?.toString().trim() ?? '未命名剧集';
+          // 对剧集标题进行简繁转换
+          if (isTraditional) {
+            episodeTitle = ChineseConverter.convert(episodeTitle);
+          }
           parsedEpisodes.add(
             _EpisodeItem(
               episodeId: episodeId,
-              episodeTitle: map['episodeTitle']?.toString().trim() ?? '未命名剧集',
+              episodeTitle: episodeTitle,
               episodeNumber: _tryParsePositiveInt(map['episodeNumber']),
             ),
           );

--- a/lib/themes/nipaplay/widgets/manual_danmaku_dialog.dart
+++ b/lib/themes/nipaplay/widgets/manual_danmaku_dialog.dart
@@ -7,6 +7,7 @@ import 'package:nipaplay/services/web_remote_access_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
 import 'package:nipaplay/utils/global_hotkey_manager.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
+import 'package:nipaplay/utils/chinese_converter.dart';
 
 /// 手动弹幕匹配对话框
 ///
@@ -144,6 +145,21 @@ class _ManualDanmakuMatchDialogState extends State<ManualDanmakuMatchDialog>
 
     try {
       final results = await _searchAnime(keyword);
+      
+      // 检查是否需要转换为繁体中文（不使用context，避免异步间隙问题）
+      final isTraditional = await ChineseConverter.isTraditionalChineseEnvironment(null);
+      if (isTraditional) {
+        // 转换搜索结果
+        for (var result in results) {
+          if (result.containsKey('animeTitle')) {
+            result['animeTitle'] = ChineseConverter.convert(result['animeTitle']);
+          }
+          if (result.containsKey('typeDescription')) {
+            result['typeDescription'] = ChineseConverter.convert(result['typeDescription']);
+          }
+        }
+      }
+      
       setState(() {
         _isSearching = false;
         _currentMatches = results;
@@ -276,8 +292,19 @@ class _ManualDanmakuMatchDialogState extends State<ManualDanmakuMatchDialog>
           final bangumi = data['bangumi'];
 
           if (bangumi['episodes'] != null && bangumi['episodes'] is List) {
-            final episodes =
-                List<Map<String, dynamic>>.from(bangumi['episodes']);
+            final episodes = List<Map<String, dynamic>>.from(bangumi['episodes']);
+            
+            // 检查是否需要转换为繁体中文（不使用context，避免异步间隙问题）
+            final isTraditional = await ChineseConverter.isTraditionalChineseEnvironment(null);
+            if (isTraditional) {
+              // 转换剧集标题
+              for (var episode in episodes) {
+                if (episode.containsKey('episodeTitle')) {
+                  episode['episodeTitle'] = ChineseConverter.convert(episode['episodeTitle']);
+                }
+              }
+            }
+            
             setState(() {
               _currentEpisodes = episodes;
               _episodesMessage = episodes.isEmpty ? '该动画暂无剧集信息' : '';

--- a/lib/utils/chinese_converter.dart
+++ b/lib/utils/chinese_converter.dart
@@ -1,0 +1,267 @@
+import 'package:flutter/material.dart';
+import 'package:nipaplay/l10n/app_locale_utils.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:nipaplay/models/bangumi_model.dart';
+import 'package:pinyin/pinyin.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
+
+class ChineseConverter {
+  // pinyin库v3.3.0中，ChineseHelper已经内置了简繁转换功能，不需要手动加载字典
+  static void _ensureDictLoaded() {
+    // 不需要任何操作，ChineseHelper已经内置了简繁转换功能
+  }
+
+  static String convert(String? text, {String config = 's2t'}) {
+    if (text == null || text.isEmpty) return text ?? '';
+
+    try {
+      _ensureDictLoaded();
+      final result = ChineseHelper.convertToTraditionalChinese(text);
+      print('简转繁转换: $text -> $result');
+      return result;
+    } catch (e) {
+      print('简转繁失败: $e');
+      return text; // 转换失败时返回原文本
+    }
+  }
+
+  static Future<String> convertAsync(String? text,
+      {String config = 's2t'}) async {
+    if (text == null || text.isEmpty) return text ?? '';
+
+    try {
+      _ensureDictLoaded();
+      final result = ChineseHelper.convertToTraditionalChinese(text);
+      print('简转繁转换 (async): $text -> $result');
+      return result;
+    } catch (e) {
+      print('简转繁失败 (async): $e');
+      return text; // 转换失败时返回原文本
+    }
+  }
+
+  static Future<Map<String, dynamic>> convertAnimeData(
+      Map<String, dynamic> data, BuildContext? context) async {
+    bool isTraditional = await isTraditionalChineseEnvironment(context);
+
+    if (!isTraditional) {
+      return data; // 非繁体中文环境，不转换
+    }
+
+    // 转换番剧基本信息
+    if (data.containsKey('animeTitle')) {
+      data['animeTitle'] = convert(data['animeTitle']);
+    }
+    if (data.containsKey('animeTitleTranslate')) {
+      data['animeTitleTranslate'] = convert(data['animeTitleTranslate']);
+    }
+    if (data.containsKey('summary')) {
+      data['summary'] = convert(data['summary']);
+    }
+    if (data.containsKey('name_cn')) {
+      data['name_cn'] = convert(data['name_cn']);
+    }
+
+    // 转换剧集信息
+    if (data.containsKey('episodes') && data['episodes'] is List) {
+      final episodes = data['episodes'] as List;
+      for (int i = 0; i < episodes.length; i++) {
+        if (episodes[i] is Map<String, dynamic>) {
+          final episode = episodes[i] as Map<String, dynamic>;
+          if (episode.containsKey('episodeTitle')) {
+            episode['episodeTitle'] = convert(episode['episodeTitle']);
+          }
+        }
+      }
+    }
+
+    return data;
+  }
+
+  // 转换BangumiAnime对象
+  static Future<BangumiAnime> convertAnime(BangumiAnime anime) async {
+    try {
+      // 从shared preferences获取语言设置
+      bool isTraditional = await isTraditionalChineseEnvironment(null);
+
+      if (!isTraditional) {
+        return anime; // 非繁体中文环境，不转换
+      }
+
+      // 创建新的BangumiAnime对象进行转换
+      final convertedAnime = BangumiAnime(
+        id: anime.id,
+        name: convert(anime.name),
+        nameCn: convert(anime.nameCn),
+        imageUrl: anime.imageUrl,
+        summary: anime.summary != null ? convert(anime.summary) : null,
+        airDate: anime.airDate,
+        airWeekday: anime.airWeekday,
+        rating: anime.rating,
+        ratingDetails: anime.ratingDetails,
+        tags: anime.tags,
+        metadata: anime.metadata,
+        isNSFW: anime.isNSFW,
+        platform: anime.platform,
+        totalEpisodes: anime.totalEpisodes,
+        typeDescription: anime.typeDescription != null
+            ? convert(anime.typeDescription)
+            : null,
+        bangumiUrl: anime.bangumiUrl,
+        isOnAir: anime.isOnAir,
+        isFavorited: anime.isFavorited,
+        titles: anime.titles,
+        searchKeyword: anime.searchKeyword,
+        episodeList: anime.episodeList != null
+            ? anime.episodeList!.map((ep) {
+                return EpisodeData(
+                  id: ep.id,
+                  title: convert(ep.title),
+                  airDate: ep.airDate,
+                );
+              }).toList()
+            : null,
+        language: 'zh_Hant', // 设置语言为繁体中文
+      );
+
+      return convertedAnime;
+    } catch (e) {
+      print('转换BangumiAnime失败: $e');
+      return anime; // 转换失败时返回原对象
+    }
+  }
+
+  // 检查是否为繁体中文环境
+  static Future<bool> isTraditionalChineseEnvironment(
+      BuildContext? context) async {
+    if (context != null) {
+      final locale = Localizations.localeOf(context);
+      final isTraditional = AppLocaleUtils.isTraditionalChineseLocale(locale);
+      print('简转繁环境检查 (context): locale=$locale, isTraditional=$isTraditional');
+      return isTraditional;
+    } else {
+      // 如果没有context，从shared preferences获取语言设置
+      try {
+        final prefs = await SharedPreferences.getInstance();
+        final languageMode = prefs.getString(SettingsKeys.appLanguageMode);
+        bool isTraditional = false;
+
+        if (languageMode == 'traditional') {
+          isTraditional = true;
+        } else if (languageMode == 'auto') {
+          // 如果是自动模式，根据系统语言判断
+          final systemLocale =
+              WidgetsBinding.instance.platformDispatcher.locale;
+          isTraditional =
+              AppLocaleUtils.isTraditionalChineseLocale(systemLocale);
+        }
+
+        print(
+            '简转繁环境检查 (prefs): languageMode=$languageMode, isTraditional=$isTraditional');
+        return isTraditional;
+      } catch (e) {
+        print('获取语言设置失败: $e');
+        return false;
+      }
+    }
+  }
+
+  // 示例：在fromJson中使用转换
+  static Map<String, dynamic> convertFromJson(Map<String, dynamic> json) {
+    final Map<String, dynamic> convertedJson = Map.from(json);
+
+    // 检查是否需要转换
+    SharedPreferences.getInstance().then((prefs) {
+      final languageCode = prefs.getString('language_code');
+      if (languageCode == 'zh_Hant') {
+        // 转换name_cn字段
+        if (convertedJson.containsKey('name_cn')) {
+          convertedJson['name_cn'] = convert(convertedJson['name_cn']);
+        }
+        // 转换summary字段
+        if (convertedJson.containsKey('summary')) {
+          convertedJson['summary'] = convert(convertedJson['summary']);
+        }
+        // 转换其他文本字段
+        if (convertedJson.containsKey('animeTitle')) {
+          convertedJson['animeTitle'] = convert(convertedJson['animeTitle']);
+        }
+      }
+    });
+
+    return convertedJson;
+  }
+
+  // 示例：fromJson方法中使用转换
+  static Future<BangumiAnime> fromJson(Map<String, dynamic> json) async {
+    // 先创建基本对象
+    var anime = BangumiAnime(
+      id: json['id'],
+      name: json['name'],
+      nameCn: json['name_cn'],
+      imageUrl: json['imageUrl'],
+      summary: json['summary'],
+      airDate: json['airDate'],
+      airWeekday: json['airWeekday'],
+      rating: json['rating'],
+      ratingDetails: json['ratingDetails'],
+      tags: json['tags'],
+      metadata: json['metadata'],
+      isNSFW: json['isNSFW'],
+      platform: json['platform'],
+      totalEpisodes: json['totalEpisodes'],
+      typeDescription: json['typeDescription'],
+      bangumiUrl: json['bangumiUrl'],
+      isOnAir: json['isOnAir'],
+      isFavorited: json['isFavorited'],
+      titles: json['titles'],
+      searchKeyword: json['searchKeyword'],
+      episodeList: json['episodeList'] != null
+          ? (json['episodeList'] as List)
+              .map((ep) => EpisodeData.fromJson(ep))
+              .toList()
+          : null,
+    );
+
+    // 检查是否需要转换
+    bool isTraditional = await isTraditionalChineseEnvironment(null);
+    if (isTraditional) {
+      // 转换字段
+      anime = BangumiAnime(
+        id: anime.id,
+        name: convert(anime.name),
+        nameCn: convert(anime.nameCn),
+        imageUrl: anime.imageUrl,
+        summary: anime.summary != null ? convert(anime.summary) : null,
+        airDate: anime.airDate,
+        airWeekday: anime.airWeekday,
+        rating: anime.rating,
+        ratingDetails: anime.ratingDetails,
+        tags: anime.tags,
+        metadata: anime.metadata,
+        isNSFW: anime.isNSFW,
+        platform: anime.platform,
+        totalEpisodes: anime.totalEpisodes,
+        typeDescription: anime.typeDescription != null
+            ? convert(anime.typeDescription)
+            : null,
+        bangumiUrl: anime.bangumiUrl,
+        isOnAir: anime.isOnAir,
+        isFavorited: anime.isFavorited,
+        titles: anime.titles,
+        searchKeyword: anime.searchKeyword,
+        episodeList: anime.episodeList != null
+            ? anime.episodeList!
+                .map((ep) => EpisodeData(
+                      id: ep.id,
+                      title: convert(ep.title),
+                      airDate: ep.airDate,
+                    ))
+                .toList()
+            : null,
+      );
+    }
+
+    return anime;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -92,10 +92,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -743,18 +743,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   math_expressions:
     dependency: transitive
     description:
@@ -1054,6 +1054,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
+  pinyin:
+    dependency: "direct main"
+    description:
+      name: pinyin
+      sha256: "240f271a3c71af20c8d2757756b5ee8e9d79a955d37abad4b3568fd406b22411"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0"
   platform:
     dependency: transitive
     description:
@@ -1470,10 +1478,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   transparent_image:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,6 +103,7 @@ dependencies:
   nipaplay_smb2:
     path: packages/nipaplay_smb2
   battery_plus: ^7.0.0
+  pinyin: ^3.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- 为除弹幕以外的几乎所有外部数据添加了繁简转换，包括：
    - 媒体库番剧信息
    - 手动匹配弹幕时搜索列出的信息

## Related Issue

无

## What Changed

- 引入pinyin库
- 新增了`lib/utils/chinese_converter.dart`用于繁简转换
- 在`lib/models/bangumi_model.dart`增加了**language键**用于检查当前数据库中的番剧信息语言是否和设置相符
- 在`lib/pages/media_library_page.dart`中新增当初始化媒体库或点击刷新按钮时检查**language键**的逻辑
- 在`lib/services/bangumi_service.dart`中增加了调用`lib/utils/chinese_converter.dart`来对api请求到的数据进行繁简转换
- 在`lib/themes/nipaplay/widgets/manual_danmaku_dialog.dart`和`lib/themes/nipaplay/widgets/batch_danmaku_dialog.dart`中调用`lib/utils/chinese_converter.dart`来对搜索得到的数据进行繁简转换

## Screen Shot
### Windows 端测试
<img width="2560" height="1528" alt="cd30757ab7af3eb518289bf4f8583e6f" src="https://github.com/user-attachments/assets/87d2f7d2-aaea-4ef0-bff3-0242cacffb76" />

### Andorid 端测试
<img width="2213" height="1245" alt="image" src="https://github.com/user-attachments/assets/634b911c-5415-49c8-a99f-5f9a5032a598" />
