### PR TITLE
fix:language-key check logic optimize

### DIFF
--- a/lib/pages/media_library_page.dart
+++ b/lib/pages/media_library_page.dart
@@ -30,6 +30,7 @@ import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'dart:ui' as ui;
 import 'package:nipaplay/services/web_remote_access_service.dart';
 import 'package:nipaplay/utils/chinese_converter.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
 
 // Define a callback type for when an episode is selected for playing
 typedef OnPlayEpisodeCallback = void Function(WatchHistoryItem item);
@@ -85,6 +86,12 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
 
   bool _isJellyfinConnected = false;
   bool _isSyncing = false;
+
+  // 新增状态变量
+  String? _lastLanguageSetting; // 上次检查的语言设置
+  bool _isManualRefresh = false; // 是否是手动刷新
+  Set<int> _existingAnimeIds = {}; // 已存在的番剧ID
+  bool _languageUpdated = false; // 语言是否已更新
 
   // 🔥 临时禁用页面保活
   // @override
@@ -246,6 +253,12 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
     final uniqueAnimeItemsFromHistory = latestHistoryItemMap.values.toList();
     uniqueAnimeItemsFromHistory
         .sort((a, b) => b.lastWatchTime.compareTo(a.lastWatchTime));
+
+    // 记录已存在的番剧ID
+    _existingAnimeIds = latestHistoryItemMap.keys.toSet();
+
+    // 检查语言设置是否变化
+    _checkLanguageChange();
 
     Map<int, String> loadedPersistedUrls = {};
     final prefs = await SharedPreferences.getInstance();
@@ -464,6 +477,12 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
     });
 
     try {
+      // 检查语言设置是否变化
+      await _checkLanguageChange();
+
+      // 设置为手动刷新模式
+      _isManualRefresh = true;
+
       final historyProvider =
           Provider.of<WatchHistoryProvider>(context, listen: false);
       historyProvider.clearInvalidPathCache();
@@ -623,8 +642,12 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
 
     for (var historyItem in _uniqueLibraryItems) {
       if (historyItem.animeId != null) {
-        // 🔥 修改条件：只要动画ID不为空，就尝试获取详情
-        // 不再跳过已有图片或已缓存的项目
+        // 检查是否是手动刷新，如果是，只处理新增的条目，除非语言已更新
+        if (_isManualRefresh &&
+            !_languageUpdated &&
+            _existingAnimeIds.contains(historyItem.animeId!)) {
+          continue; // 跳过已存在的条目
+        }
 
         Future<void> fetchDetailForItem() async {
           try {
@@ -680,6 +703,10 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
 
     await Future.wait(pendingRequests);
 
+    // 重置标志
+    _isManualRefresh = false;
+    _languageUpdated = false; // 重置语言更新标志
+
     // 🔥 CPU优化：最后一次性刷新UI，而不是每个项目都setState
     if (mounted) {
       setState(() {
@@ -715,6 +742,27 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
     } catch (e) {
       // Silent fail
     }
+  }
+
+  Future<void> _checkLanguageChange() async {
+    // 获取当前语言设置
+    final prefs = await SharedPreferences.getInstance();
+    final currentLanguage =
+        prefs.getString(SettingsKeys.appLanguageMode) ?? 'auto';
+
+    // 检查语言设置是否变化
+    if (_lastLanguageSetting != null &&
+        _lastLanguageSetting != currentLanguage) {
+      // 语言设置变化，标记所有缓存为需要更新
+      _fetchedFullAnimeData.clear();
+      // 标记语言已更新
+      _languageUpdated = true;
+      // 重新获取所有番剧详情
+      await _fetchAndPersistFullDetailsInBackground();
+    }
+
+    // 更新上次语言设置
+    _lastLanguageSetting = currentLanguage;
   }
 
   void _navigateToAnimeDetail(int animeId) {

--- a/lib/utils/chinese_converter.dart
+++ b/lib/utils/chinese_converter.dart
@@ -17,7 +17,6 @@ class ChineseConverter {
     try {
       _ensureDictLoaded();
       final result = ChineseHelper.convertToTraditionalChinese(text);
-      print('简转繁转换: $text -> $result');
       return result;
     } catch (e) {
       print('简转繁失败: $e');
@@ -32,7 +31,6 @@ class ChineseConverter {
     try {
       _ensureDictLoaded();
       final result = ChineseHelper.convertToTraditionalChinese(text);
-      print('简转繁转换 (async): $text -> $result');
       return result;
     } catch (e) {
       print('简转繁失败 (async): $e');


### PR DESCRIPTION
## Summary

- 优化了媒体库中检查language键并重新刮削的逻辑：
    **1. 正常启动（初始化媒体库） ：**
    - 直接跳过语言检查和重新刮削
    - 只在首次启动时记录已存在的番剧ID

    **2. 切换了语言设置 ：**

    - 检测到语言设置变化时，清空缓存并重新获取所有番剧详情
    - 确保所有番剧信息显示为当前语言
    - 标记语言已更新，下次初始化不再遍历
 
    **3. 手动点击刷新按钮 ：**

    - 首先检查语言设置是否变化
    - 如果语言设置变化，遍历所有条目重新获取
    - 如果语言设置未变化，只检查新增的条目，跳过已存在的条目
  
- 删除了部分无用日志


## Related Issue

无

## What Changed

### 添加状态变量 ：

- _lastLanguageSetting ：记录上次检查的语言设置
- _isManualRefresh ：标记是否是手动刷新
- _existingAnimeIds ：记录已存在的番剧ID
- _languageUpdated ：标记语言是否已更新
### 优化方法 ：

- _checkLanguageChange ：检查语言设置是否变化，标记语言已更新
- _fetchAndPersistFullDetailsInBackground ：根据刷新类型和语言更新状态处理不同的条目
- _syncLibrary ：在手动刷新时检查语言设置是否变化
