### PR TITLE
feat:add remote control trust devices support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+import 'package:nipaplay/services/remote_control_access_guard_service.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -164,6 +165,9 @@ void main(List<String> args) async {
   }
 
   WatchHistoryDatabase.ensureInitialized();
+
+  // 初始化远程控制访问保护服务
+  await RemoteControlAccessGuardService.instance.loadTrustedDevices();
 
   // 安装 HTTP 客户端覆盖（自签名证书信任规则），尽早生效
   await HttpClientInitializer.install();

--- a/lib/services/remote_control_access_guard_service.dart
+++ b/lib/services/remote_control_access_guard_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:nipaplay/services/remote_control_settings.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:shelf/shelf.dart';
 
@@ -67,6 +68,7 @@ class RemoteControlAccessGuardService {
   final Map<String, DateTime> _approvedClients = {};
   final Map<String, DateTime> _deniedClients = {};
   final Map<String, Future<bool>> _pendingPrompts = {};
+  final Map<String, Map<String, dynamic>> _trustedDevices = {};
 
   Future<RemoteControlAccessResult> evaluate(
     Request request, {
@@ -74,6 +76,16 @@ class RemoteControlAccessGuardService {
   }) async {
     final identity = _resolveIdentity(request);
     final now = DateTime.now();
+
+    // 优先检查受信任设备
+    if (_trustedDevices.containsKey(identity.clientKey)) {
+      _approvedClients[identity.clientKey] = now;
+
+      return RemoteControlAccessResult(
+        status: RemoteControlAccessStatus.authorized,
+        identity: identity,
+      );
+    }
 
     final approved = _approvedClients[identity.clientKey];
     if (approved != null) {
@@ -122,12 +134,22 @@ class RemoteControlAccessGuardService {
       '[RemoteControlAuth] 请求授权: ${identity.displayName}, '
       'id=${identity.clientId ?? '-'}, platform=${identity.platform ?? '-'}',
     );
-    final promptFuture = _showApprovalDialog(identity).then((approved) {
+    final promptFuture = _showApprovalDialog(identity).then((result) async {
+      final approved = result['approved'] == true;
+      final trusted = result['trusted'] == true;
+
       if (approved) {
         final now = DateTime.now();
         _approvedClients[identity.clientKey] = now;
         _deniedClients.remove(identity.clientKey);
+
+        if (trusted) {
+          await _addTrustedDevice(identity);
+          debugPrint('[RemoteControlAuth] 用户已信任: ${identity.displayName}');
+        }
+
         debugPrint('[RemoteControlAuth] 用户已允许: ${identity.displayName}');
+
         return true;
       }
 
@@ -145,41 +167,100 @@ class RemoteControlAccessGuardService {
     );
   }
 
-  Future<bool> _showApprovalDialog(RemoteControlClientIdentity identity) async {
+  Future<void> _addTrustedDevice(RemoteControlClientIdentity identity) async {
+    final device = {
+      'clientKey': identity.clientKey,
+      'clientId': identity.clientId,
+      'clientName': identity.clientName,
+      'platform': identity.platform,
+      'remoteIp': identity.remoteIp,
+      'trustedAt': DateTime.now().toIso8601String(),
+    };
+
+    _trustedDevices[identity.clientKey] = device;
+    await RemoteControlSettings.addTrustedDevice(device);
+  }
+
+  Future<void> loadTrustedDevices() async {
+    final devices = await RemoteControlSettings.getTrustedDevices();
+    _trustedDevices.clear();
+    for (final device in devices) {
+      _trustedDevices[device['clientKey'] as String] = device;
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> getTrustedDevices() async {
+    return _trustedDevices.values.toList();
+  }
+
+  Future<void> removeTrustedDevice(String clientKey) async {
+    _trustedDevices.remove(clientKey);
+    await RemoteControlSettings.removeTrustedDevice(clientKey);
+  }
+
+  Future<Map<String, dynamic>> _showApprovalDialog(
+      RemoteControlClientIdentity identity) async {
     final navigator = globals.navigatorKey.currentState;
     final context = navigator?.overlay?.context ?? navigator?.context;
     if (context == null) {
       debugPrint('[RemoteControlAuth] 无法弹窗：navigator context 为空');
-      return false;
+      return {'approved': false, 'trusted': false};
     }
 
     try {
-      final result = await showDialog<bool>(
+      final result = await showDialog<Map<String, dynamic>>(
         context: context,
         barrierDismissible: false,
         builder: (dialogContext) {
-          return AlertDialog.adaptive(
-            title: const Text('遥控连接请求'),
-            content: Text(
-              '${identity.displayName} 正在请求连接并遥控此设备，是否允许？',
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(dialogContext).pop(false),
-                child: const Text('拒绝'),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(dialogContext).pop(true),
-                child: const Text('允许'),
-              ),
-            ],
+          bool trustDevice = false;
+          return StatefulBuilder(
+            builder: (context, setState) {
+              return AlertDialog.adaptive(
+                title: const Text('遥控连接请求'),
+                content: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '${identity.displayName} 正在请求连接并遥控此设备，是否允许？',
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      children: [
+                        Checkbox(
+                          value: trustDevice,
+                          onChanged: (value) {
+                            setState(() {
+                              trustDevice = value ?? false;
+                            });
+                          },
+                        ),
+                        const Text('信任此设备'),
+                      ],
+                    ),
+                  ],
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(dialogContext)
+                        .pop({'approved': false, 'trusted': false}),
+                    child: const Text('拒绝'),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.of(dialogContext)
+                        .pop({'approved': true, 'trusted': trustDevice}),
+                    child: const Text('允许'),
+                  ),
+                ],
+              );
+            },
           );
         },
       );
-      return result == true;
+      return result ?? {'approved': false, 'trusted': false};
     } catch (e) {
       debugPrint('[RemoteControlAuth] 弹窗失败: $e');
-      return false;
+      return {'approved': false, 'trusted': false};
     }
   }
 

--- a/lib/services/remote_control_auth_manager.dart
+++ b/lib/services/remote_control_auth_manager.dart
@@ -1,0 +1,202 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class RemoteControlAuthManager {
+  RemoteControlAuthManager._();
+
+  static final RemoteControlAuthManager instance = RemoteControlAuthManager._();
+
+  static const String trustedDevicesKey = 'remote_control_trusted_devices';
+  static const String pendingRequestsKey = 'remote_control_pending_requests';
+
+  final List<RemoteControlDevice> _trustedDevices = [];
+  final List<ConnectionRequest> _pendingRequests = [];
+
+  ValueNotifier<List<ConnectionRequest>> pendingRequestsNotifier = ValueNotifier([]);
+  ValueNotifier<List<RemoteControlDevice>> trustedDevicesNotifier = ValueNotifier([]);
+
+  Future<void> initialize() async {
+    await _loadTrustedDevices();
+    await _loadPendingRequests();
+  }
+
+  Future<void> _loadTrustedDevices() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(trustedDevicesKey);
+    if (data != null) {
+      try {
+        final List<dynamic> list = json.decode(data);
+        _trustedDevices.clear();
+        for (final item in list) {
+          _trustedDevices.add(RemoteControlDevice.fromJson(item));
+        }
+        trustedDevicesNotifier.value = List.from(_trustedDevices);
+      } catch (e) {
+        debugPrint('Failed to load trusted devices: $e');
+      }
+    }
+  }
+
+  Future<void> _saveTrustedDevices() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = json.encode(_trustedDevices.map((device) => device.toJson()).toList());
+    await prefs.setString(trustedDevicesKey, data);
+    trustedDevicesNotifier.value = List.from(_trustedDevices);
+  }
+
+  Future<void> _loadPendingRequests() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(pendingRequestsKey);
+    if (data != null) {
+      try {
+        final List<dynamic> list = json.decode(data);
+        _pendingRequests.clear();
+        for (final item in list) {
+          _pendingRequests.add(ConnectionRequest.fromJson(item));
+        }
+        pendingRequestsNotifier.value = List.from(_pendingRequests);
+      } catch (e) {
+        debugPrint('Failed to load pending requests: $e');
+      }
+    }
+  }
+
+  Future<void> _savePendingRequests() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = json.encode(_pendingRequests.map((request) => request.toJson()).toList());
+    await prefs.setString(pendingRequestsKey, data);
+    pendingRequestsNotifier.value = List.from(_pendingRequests);
+  }
+
+  Future<ConnectionRequest> createConnectionRequest({
+    required String deviceName,
+    required String deviceType,
+    required String ipAddress,
+  }) async {
+    final request = ConnectionRequest(
+      id: '${DateTime.now().millisecondsSinceEpoch}',
+      deviceName: deviceName,
+      deviceType: deviceType,
+      ipAddress: ipAddress,
+      timestamp: DateTime.now(),
+    );
+
+    _pendingRequests.add(request);
+    await _savePendingRequests();
+    return request;
+  }
+
+  Future<void> authorizeRequest(String requestId, bool allow, bool trustDevice) async {
+    final requestIndex = _pendingRequests.indexWhere((r) => r.id == requestId);
+    if (requestIndex == -1) return;
+
+    final request = _pendingRequests[requestIndex];
+    _pendingRequests.removeAt(requestIndex);
+    await _savePendingRequests();
+
+    if (allow && trustDevice) {
+      final device = RemoteControlDevice(
+        id: '${request.deviceName}_${request.ipAddress}',
+        deviceName: request.deviceName,
+        deviceType: request.deviceType,
+        ipAddress: request.ipAddress,
+        trustedAt: DateTime.now(),
+      );
+
+      if (!_trustedDevices.any((d) => d.id == device.id)) {
+        _trustedDevices.add(device);
+        await _saveTrustedDevices();
+      }
+    }
+  }
+
+  bool isTrustedDevice(String ipAddress) {
+    return _trustedDevices.any((device) => device.ipAddress == ipAddress);
+  }
+
+  Future<void> removeTrustedDevice(String deviceId) async {
+    _trustedDevices.removeWhere((device) => device.id == deviceId);
+    await _saveTrustedDevices();
+  }
+
+  List<RemoteControlDevice> getTrustedDevices() {
+    return List.from(_trustedDevices);
+  }
+
+  List<ConnectionRequest> getPendingRequests() {
+    return List.from(_pendingRequests);
+  }
+}
+
+class RemoteControlDevice {
+  final String id;
+  final String deviceName;
+  final String deviceType;
+  final String ipAddress;
+  final DateTime trustedAt;
+
+  RemoteControlDevice({
+    required this.id,
+    required this.deviceName,
+    required this.deviceType,
+    required this.ipAddress,
+    required this.trustedAt,
+  });
+
+  factory RemoteControlDevice.fromJson(Map<String, dynamic> json) {
+    return RemoteControlDevice(
+      id: json['id'] ?? '',
+      deviceName: json['deviceName'] ?? '',
+      deviceType: json['deviceType'] ?? '',
+      ipAddress: json['ipAddress'] ?? '',
+      trustedAt: DateTime.parse(json['trustedAt'] ?? DateTime.now().toIso8601String()),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'deviceName': deviceName,
+      'deviceType': deviceType,
+      'ipAddress': ipAddress,
+      'trustedAt': trustedAt.toIso8601String(),
+    };
+  }
+}
+
+class ConnectionRequest {
+  final String id;
+  final String deviceName;
+  final String deviceType;
+  final String ipAddress;
+  final DateTime timestamp;
+
+  ConnectionRequest({
+    required this.id,
+    required this.deviceName,
+    required this.deviceType,
+    required this.ipAddress,
+    required this.timestamp,
+  });
+
+  factory ConnectionRequest.fromJson(Map<String, dynamic> json) {
+    return ConnectionRequest(
+      id: json['id'] ?? '',
+      deviceName: json['deviceName'] ?? '',
+      deviceType: json['deviceType'] ?? '',
+      ipAddress: json['ipAddress'] ?? '',
+      timestamp: DateTime.parse(json['timestamp'] ?? DateTime.now().toIso8601String()),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'deviceName': deviceName,
+      'deviceType': deviceType,
+      'ipAddress': ipAddress,
+      'timestamp': timestamp.toIso8601String(),
+    };
+  }
+}

--- a/lib/services/remote_control_client_service.dart
+++ b/lib/services/remote_control_client_service.dart
@@ -276,9 +276,8 @@ class RemoteControlClientService {
         return false;
       }
 
-      final state = await fetchState(normalized);
-      if (state == null) return false;
-      final receiverEnabled = state['receiverEnabled'] == true;
+      // 检查info端点中的remoteControlReceiverEnabled字段
+      final receiverEnabled = infoJson['remoteControlReceiverEnabled'] == true;
       return receiverEnabled;
     } catch (_) {
       return false;

--- a/lib/services/remote_control_settings.dart
+++ b/lib/services/remote_control_settings.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
+import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:shared_preferences/shared_preferences.dart';
 
 class RemoteControlSettings {
@@ -9,13 +12,24 @@ class RemoteControlSettings {
   static const String matchedBaseUrlKey = 'remote_control_matched_base_url';
   static const String matchedHostnameKey = 'remote_control_matched_hostname';
   static const String clientIdKey = 'remote_control_client_id';
+  static const String trustedDevicesKey = 'remote_control_trusted_devices';
 
   static Future<bool> isReceiverEnabled() async {
+    // 在移动端（phone）禁用被控监听
+    if (globals.isPhone) {
+      return false;
+    }
+    
     final prefs = await SharedPreferences.getInstance();
     return prefs.getBool(receiverEnabledKey) ?? true;
   }
 
   static Future<void> setReceiverEnabled(bool enabled) async {
+    // 在移动端（phone）不允许设置为启用状态
+    if (globals.isPhone) {
+      return;
+    }
+    
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(receiverEnabledKey, enabled);
   }
@@ -69,5 +83,47 @@ class RemoteControlSettings {
     final clientId = 'rc-$timestamp-$random';
     await prefs.setString(clientIdKey, clientId);
     return clientId;
+  }
+
+  static Future<List<Map<String, dynamic>>> getTrustedDevices() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(trustedDevicesKey);
+    if (raw == null || raw.isEmpty) {
+      return [];
+    }
+    try {
+      final List<dynamic> list = jsonDecode(raw);
+      return list.cast<Map<String, dynamic>>();
+    } catch (e) {
+      return [];
+    }
+  }
+
+  static Future<void> addTrustedDevice(Map<String, dynamic> device) async {
+    final devices = await getTrustedDevices();
+    final clientKey = device['clientKey'] as String;
+    final existingIndex = devices.indexWhere((d) => d['clientKey'] == clientKey);
+    
+    if (existingIndex >= 0) {
+      devices[existingIndex] = device;
+    } else {
+      devices.add(device);
+    }
+    
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(trustedDevicesKey, jsonEncode(devices));
+  }
+
+  static Future<void> removeTrustedDevice(String clientKey) async {
+    final devices = await getTrustedDevices();
+    devices.removeWhere((d) => d['clientKey'] == clientKey);
+    
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(trustedDevicesKey, jsonEncode(devices));
+  }
+
+  static Future<void> clearTrustedDevices() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(trustedDevicesKey);
   }
 }

--- a/lib/themes/nipaplay/pages/settings/remote_access_page.dart
+++ b/lib/themes/nipaplay/pages/settings/remote_access_page.dart
@@ -1,7 +1,9 @@
 // remote_access_page.dart
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/providers/service_provider.dart';
+import 'package:nipaplay/services/remote_control_access_guard_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/fluent_settings_switch.dart';
@@ -28,6 +30,10 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
   bool _isLoadingPublicIp = false;
   int _currentPort = 1180;
 
+  // Trusted devices
+  List<Map<String, dynamic>> _trustedDevices = [];
+  bool _isLoadingTrustedDevices = false;
+
   @override
   void initState() {
     super.initState();
@@ -38,6 +44,10 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
     final server = ServiceProvider.webServer;
     await server.loadSettings();
     final receiverEnabled = await RemoteControlSettings.isReceiverEnabled();
+
+    // 加载受信任设备
+    await _loadTrustedDevices();
+
     if (mounted) {
       setState(() {
         _webServerEnabled = server.isRunning;
@@ -48,6 +58,51 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
           _updateAccessUrls();
         }
       });
+    }
+  }
+
+  Future<void> _loadTrustedDevices() async {
+    setState(() {
+      _isLoadingTrustedDevices = true;
+    });
+
+    try {
+      final guardService = RemoteControlAccessGuardService.instance;
+      // 确保受信任设备已加载
+      await guardService.loadTrustedDevices();
+      final devices = await guardService.getTrustedDevices();
+      if (mounted) {
+        setState(() {
+          _trustedDevices = devices;
+        });
+      }
+    } catch (e) {
+      debugPrint('加载受信任设备失败: $e');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoadingTrustedDevices = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _removeTrustedDevice(String clientKey) async {
+    try {
+      final guardService = RemoteControlAccessGuardService.instance;
+      await guardService.removeTrustedDevice(clientKey);
+      if (mounted) {
+        setState(() {
+          _trustedDevices
+              .removeWhere((device) => device['clientKey'] == clientKey);
+        });
+        BlurSnackBar.show(context, '已移除受信任设备');
+      }
+    } catch (e) {
+      debugPrint('移除受信任设备失败: $e');
+      if (mounted) {
+        BlurSnackBar.show(context, '移除受信任设备失败');
+      }
     }
   }
 
@@ -309,6 +364,7 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
       padding: const EdgeInsets.all(24.0),
       children: [
         _buildWebServerSection(),
+        if (_receiverEnabled) _buildTrustedDevicesSection(),
       ],
     );
   }
@@ -599,6 +655,152 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
             ),
           ),
           if (trailing != null) trailing,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTrustedDevicesSection() {
+    final colorScheme = Theme.of(context).colorScheme;
+    return DefaultTextStyle.merge(
+      style: _pageTextStyle(context),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 32),
+          Row(
+            children: [
+              Icon(
+                Ionicons.shield_checkmark_outline,
+                color: colorScheme.onSurface,
+                size: 24,
+              ),
+              const SizedBox(width: 12),
+              Text(
+                '受信任设备',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            '受信任的设备可以直接连接并控制播放器，无需再次确认。',
+            style: TextStyle(
+              color: colorScheme.onSurface.withValues(alpha: 0.7),
+              fontSize: 14,
+            ),
+          ),
+          const SizedBox(height: 16),
+          if (_isLoadingTrustedDevices)
+            const Center(
+              child: Padding(
+                padding: EdgeInsets.all(16.0),
+                child: CircularProgressIndicator(),
+              ),
+            )
+          else if (_trustedDevices.isEmpty)
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text(
+                '暂无受信任设备',
+                style: TextStyle(
+                  color: colorScheme.onSurface.withValues(alpha: 0.5),
+                  fontSize: 14,
+                ),
+              ),
+            )
+          else
+            Column(
+              children: _trustedDevices.map((device) {
+                final clientName = device['clientName'] as String? ?? '未知设备';
+                final platform = device['platform'] as String? ?? '未知平台';
+                final remoteIp = device['remoteIp'] as String? ?? '未知IP';
+                final trustedAt = device['trustedAt'] as String? ?? '';
+                final clientKey = device['clientKey'] as String;
+
+                String trustedTime = '未知时间';
+                if (trustedAt.isNotEmpty) {
+                  try {
+                    final date = DateTime.parse(trustedAt);
+                    trustedTime =
+                        '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')} ${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
+                  } catch (e) {
+                    // 解析失败，使用原始值
+                  }
+                }
+
+                return Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8.0),
+                  child: Container(
+                    padding: const EdgeInsets.all(16.0),
+                    decoration: BoxDecoration(
+                      color: colorScheme.surface.withValues(alpha: 0.5),
+                      borderRadius: BorderRadius.circular(8.0),
+                      border: Border.all(
+                        color: colorScheme.onSurface.withValues(alpha: 0.1),
+                      ),
+                    ),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Icon(
+                          Ionicons.phone_portrait_outline,
+                          color: colorScheme.primary,
+                          size: 24,
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                clientName,
+                                style: TextStyle(
+                                  color: colorScheme.onSurface,
+                                  fontWeight: FontWeight.w500,
+                                  fontSize: 15,
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                '$platform · $remoteIp',
+                                style: TextStyle(
+                                  color: colorScheme.onSurface
+                                      .withValues(alpha: 0.7),
+                                  fontSize: 14,
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                '信任时间: $trustedTime',
+                                style: TextStyle(
+                                  color: colorScheme.onSurface
+                                      .withValues(alpha: 0.5),
+                                  fontSize: 12,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        IconButton(
+                          icon: Icon(
+                            Icons.delete,
+                            color: colorScheme.onSurface.withValues(alpha: 0.5),
+                          ),
+                          onPressed: () {
+                            _removeTrustedDevice(clientKey);
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
         ],
       ),
     );

--- a/lib/widgets/remote_control_auth_dialog.dart
+++ b/lib/widgets/remote_control_auth_dialog.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:nipaplay/services/remote_control_auth_manager.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
+
+class RemoteControlAuthDialog {
+  static Future<void> show(
+    BuildContext context,
+    ConnectionRequest request,
+    Function(String, bool, bool) onAuthorize,
+  ) {
+    final colorScheme = Theme.of(context).colorScheme;
+    bool trustDevice = false;
+
+    return BlurDialog.show(
+      context: context,
+      title: '远程控制连接请求',
+      contentWidget: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '设备尝试连接并控制您的播放器',
+            style: TextStyle(
+              color: colorScheme.onSurface,
+              fontSize: 14,
+            ),
+          ),
+          const SizedBox(height: 16),
+          _buildInfoRow('设备名称', request.deviceName, colorScheme),
+          _buildInfoRow('设备类型', request.deviceType, colorScheme),
+          _buildInfoRow('IP地址', request.ipAddress, colorScheme),
+          _buildInfoRow('请求时间', _formatTime(request.timestamp), colorScheme),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Checkbox(
+                value: trustDevice,
+                onChanged: (value) {
+                  trustDevice = value ?? false;
+                },
+                checkColor: colorScheme.surface,
+                fillColor: MaterialStateProperty.resolveWith(
+                  (states) => states.contains(MaterialState.selected)
+                      ? colorScheme.primary
+                      : null,
+                ),
+              ),
+              Text(
+                '信任此设备，下次自动授权',
+                style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontSize: 14,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+      actions: [
+        HoverScaleTextButton(
+          text: '拒绝',
+          idleColor: colorScheme.onSurface.withAlpha(180),
+          onPressed: () {
+            Navigator.of(context).pop();
+            onAuthorize(request.id, false, false);
+          },
+        ),
+        HoverScaleTextButton(
+          text: '允许',
+          idleColor: colorScheme.primary,
+          onPressed: () {
+            Navigator.of(context).pop();
+            onAuthorize(request.id, true, trustDevice);
+          },
+        ),
+      ],
+    );
+  }
+
+  static Widget _buildInfoRow(String label, String value, ColorScheme colorScheme) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '$label: ',
+            style: TextStyle(
+              color: colorScheme.onSurface.withAlpha(180),
+              fontSize: 14,
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: TextStyle(
+                color: colorScheme.onSurface,
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _formatTime(DateTime time) {
+    final now = DateTime.now();
+    final diff = now.difference(time);
+    
+    if (diff.inSeconds < 60) {
+      return '刚刚';
+    } else if (diff.inMinutes < 60) {
+      return '${diff.inMinutes}分钟前';
+    } else if (diff.inHours < 24) {
+      return '${diff.inHours}小时前';
+    } else {
+      return '${time.month}月${time.day}日 ${time.hour}:${time.minute.toString().padLeft(2, '0')}';
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- 为遥控器功能添加了“受信任的设备相关功能”，包括免授权以及设置界面中的管理列表
- 关闭了手机端（`Phone`）的被控监听以防自己发起控制自己的请求

## Related Issue

无

## What Changed
### 1. remote_control_access_guard_service.dart
- 添加了受信任设备功能 ：
  - 实现了受信任设备的检查和自动授权
  - 添加了受信任设备的添加和管理方法
  - 实现了受信任设备列表的持久化存储
- 修改了连接授权逻辑 ：
  - 优先检查受信任设备，自动授权
  - 保留了用户手动授权的流程
### 2. remote_control_settings.dart
- 添加了受信任设备存储 ：
  - 实现了受信任设备的添加、获取和删除方法
  - 使用SharedPreferences持久化存储受信任设备信息
- 修改了被控监听逻辑 ：
  - 在移动端（phone）时禁用被控监听
  - 确保移动端不会被自己扫描到
### 3. remote_control_client_service.dart
- 修改了扫描逻辑 ：
  - 从 /api/info 端点获取 remoteControlReceiverEnabled 字段
  - 确保即使设备没有授权，也能正确检查服务端是否启用了被控功能
### 4. remote_access_page.dart
- 添加了受信任设备管理界面 ：
  - 显示所有已信任设备的详细信息
  - 支持移除受信任设备
  - 添加了相关的提示信息
### 5. main.dart
- 添加了受信任设备初始化 ：
  - 在应用启动时加载受信任设备列表
  - 确保应用重启后受信任设备仍然生效

## Screen Shot
<img width="1288" height="759" alt="cc46fc7a-55ce-4bf7-845f-6b3278ca8891" src="https://github.com/user-attachments/assets/87f3377e-534e-4ae1-8ed4-8d0ce2929eca" />

