### PR TITLE
feat:add regex support for danmaku filter

### DIFF
--- a/lib/themes/cupertino/widgets/player_menu/cupertino_danmaku_settings_pane.dart
+++ b/lib/themes/cupertino/widgets/player_menu/cupertino_danmaku_settings_pane.dart
@@ -442,7 +442,7 @@ class _CupertinoDanmakuSettingsPaneState
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text(word),
+              Text(_getDisplayText(word)),
               const SizedBox(width: 6),
               GestureDetector(
                 onTap: () => widget.videoState.removeDanmakuBlockWord(word),
@@ -456,5 +456,20 @@ class _CupertinoDanmakuSettingsPaneState
         );
       }).toList(),
     );
+  }
+
+  bool _isRegexRule(String word) {
+    if (!word.contains('/')) return false;
+    final parts = word.split('/');
+    return parts.length >= 3 && parts.first.isNotEmpty && parts.last.isEmpty;
+  }
+
+  String _getDisplayText(String word) {
+    if (_isRegexRule(word)) {
+      final firstSlash = word.indexOf('/');
+      final name = word.substring(0, firstSlash);
+      return '规则：$name';
+    }
+    return word;
   }
 }

--- a/lib/themes/nipaplay/widgets/danmaku_settings_menu.dart
+++ b/lib/themes/nipaplay/widgets/danmaku_settings_menu.dart
@@ -236,6 +236,23 @@ class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
         '${twoDigits(time.second)}';
   }
 
+  // 检查是否是正则表达式规则格式: 规则名称/表达式/
+  bool _isRegexRule(String word) {
+    if (!word.contains('/')) return false;
+    final parts = word.split('/');
+    return parts.length >= 3 && parts.first.isNotEmpty && parts.last.isEmpty;
+  }
+
+  // 获取屏蔽词的显示文本
+  String _getDisplayText(String word) {
+    if (_isRegexRule(word)) {
+      final firstSlash = word.indexOf('/');
+      final name = word.substring(0, firstSlash);
+      return '规则：$name';
+    }
+    return word;
+  }
+
   // 构建屏蔽词展示UI
   Widget _buildBlockWordsList() {
     return Consumer<VideoPlayerState>(
@@ -276,7 +293,7 @@ class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         Text(
-                          word,
+                          _getDisplayText(word),
                           style: const TextStyle(
                               color: Colors.white, fontSize: 12),
                         ),
@@ -743,7 +760,7 @@ class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
                         child: BackdropFilter(
                           filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
                           child: Container(
-                            height: 40, // 设置固定高度
+                            height: 80, // 设置固定高度
                             decoration: BoxDecoration(
                               color: Colors.white.withOpacity(0.1),
                               borderRadius: BorderRadius.circular(8),
@@ -761,8 +778,10 @@ class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
                                 style: const TextStyle(
                                     color: Colors.white, fontSize: 13),
                                 textAlignVertical: TextAlignVertical.center,
+                                maxLines: 3,
                                 decoration: InputDecoration(
-                                  hintText: '输入要屏蔽的关键词',
+                                  hintText:
+                                      '输入要屏蔽的关键词\n（支持正则，以"规则名称/表达式/"形式输入）',
                                   hintStyle: TextStyle(
                                       color: Colors.white.withOpacity(0.5),
                                       fontSize: 13),
@@ -800,7 +819,7 @@ class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
                         ),
                       const SizedBox(height: 8),
                       _buildBlockWordsList(),
-                      const SettingsHintText('包含屏蔽词的弹幕将被过滤不显示'),
+                      const SettingsHintText('包含屏蔽词或被正则表达式命中的弹幕将被过滤'),
                     ],
                   );
                 }),

--- a/lib/utils/video_player_state/video_player_state_subtitles.dart
+++ b/lib/utils/video_player_state/video_player_state_subtitles.dart
@@ -470,6 +470,22 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
     await prefs.setString(_danmakuBlockWordsKey, blockWordsJson);
   }
 
+  // 检查是否是正则表达式规则格式: 规则名称/表达式/
+  bool _isRegexRule(String word) {
+    if (!word.contains('/')) return false;
+    final parts = word.split('/');
+    return parts.length >= 3 && parts.first.isNotEmpty && parts.last.isEmpty;
+  }
+
+  // 解析正则表达式规则，返回 (规则名称, 正则表达式)
+  (String, String)? _parseRegexRule(String word) {
+    if (!_isRegexRule(word)) return null;
+    final firstSlash = word.indexOf('/');
+    final name = word.substring(0, firstSlash);
+    final pattern = word.substring(firstSlash + 1, word.length - 1);
+    return (name, pattern);
+  }
+
   // 检查弹幕是否应该被屏蔽
   bool shouldBlockDanmaku(Map<String, dynamic> danmaku) {
     final String type = danmaku['type']?.toString() ?? '';
@@ -488,8 +504,23 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
     }
 
     for (final word in _danmakuBlockWords) {
-      if (content.contains(word)) {
-        return true;
+      if (_isRegexRule(word)) {
+        final parsed = _parseRegexRule(word);
+        if (parsed != null) {
+          final (_, pattern) = parsed;
+          try {
+            final regex = RegExp(pattern);
+            if (regex.hasMatch(content)) {
+              return true;
+            }
+          } catch (e) {
+            debugPrint('正则表达式规则无效: $pattern, 错误: $e');
+          }
+        }
+      } else {
+        if (content.contains(word)) {
+          return true;
+        }
       }
     }
     return false;


### PR DESCRIPTION
## Summary

- 为“弹幕屏蔽词”处添加了对正则表达式的支持，以“规则名称/表达式/”形式输入，以“规则：规则名称”的标签形式显示。

## Related Issue

- Closes #418 

## What Changed
### 1. 正则表达式规则支持
修改文件：

- lib/utils/video_player_state/video_player_state_subtitles.dart
- packages/danmaku_canvas/lib/canvas_danmaku_renderer.dart
新增功能：

- 屏蔽词现在支持正则表达式格式： 规则名称/正则表达式/，例如： `刷屏/(?:刷屏重复){0}[3啦嚯哦啊哈呵嘿嘻红惚火恍吼桀hw]{7,}/`
### 2. 屏蔽词显示优化
修改文件：

- lib/themes/nipaplay/widgets/danmaku_settings_menu.dart
- lib/themes/cupertino/widgets/player_menu/cupertino_danmaku_settings_pane.dart
变更：

- 正则表达式规则在标签中显示为 "规则：规则名称"

## Screen Shot
### 屏蔽前
<img width="1584" height="891" alt="Snipaste_2026-04-18_10-17-54" src="https://github.com/user-attachments/assets/e7cb1d83-837b-4536-9750-5818f17d56df" />

### 屏蔽后
<img width="1584" height="891" alt="Snipaste_2026-04-18_10-37-33" src="https://github.com/user-attachments/assets/dc7b805d-95bd-4d4e-9230-6fc8edb735c0" />

