### PR TITLE
fix:language change anime card title outdate

### DIFF
--- a/lib/pages/media_library_page.dart
+++ b/lib/pages/media_library_page.dart
@@ -1029,9 +1029,17 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
                           displayImage = detailData.imageUrl;
                         }
 
+                        // 标题：优先使用详情数据中的名称（支持多语言）
+                        String displayTitle = nameToDisplay;
+                        if (detailData.name.isNotEmpty) {
+                          displayTitle = detailData.name;
+                        } else if (detailData.nameCn.isNotEmpty) {
+                          displayTitle = detailData.nameCn;
+                        }
+
                         final card = HorizontalAnimeCard(
                           imageUrl: displayImage,
-                          title: nameToDisplay,
+                          title: displayTitle,
                           rating: detailData.rating,
                           source: AnimeCard.getSourceFromFilePath(
                               historyItem.filePath),
@@ -1066,12 +1074,22 @@ class _MediaLibraryPageState extends State<MediaLibraryPage> {
                               displayImage = detail.imageUrl;
                             }
 
+                            // 标题：优先使用详情数据中的名称（支持多语言）
+                            String displayTitle = nameToDisplay;
+                            if (detail != null) {
+                              if (detail.name.isNotEmpty) {
+                                displayTitle = detail.name;
+                              } else if (detail.nameCn.isNotEmpty) {
+                                displayTitle = detail.nameCn;
+                              }
+                            }
+
                             // 评分
                             double? displayRating = detail?.rating;
 
                             return HorizontalAnimeCard(
                               imageUrl: displayImage,
-                              title: nameToDisplay,
+                              title: displayTitle,
                               rating: displayRating,
                               source: AnimeCard.getSourceFromFilePath(
                                   historyItem.filePath),


### PR DESCRIPTION
## Summary

- 修复了切换语言后媒体库番剧卡片标题不会跟着切换语言的问题

## Related Issue

无

## What Changed

在两处卡片构建逻辑中，添加了对 `detailData` 中标题字段的使用：

1. 有同步数据时（第1030行后新增） ：
   
   - 优先使用 `detailData.name`
   - 其次使用 `detailData.nameCn`
   - 最后才使用本地存储的 `nameToDisplay`
2. 使用 FutureBuilder 时（第1075行后新增） ：
   
   - 同样优先使用 `detailData.name`
   - 其次使用 `detailData.nameCn`
