### PR TITLE
fix:danmaku-switch-tooltip&tooltip-display

### DIFF
--- a/lib/themes/nipaplay/widgets/modern_video_controls.dart
+++ b/lib/themes/nipaplay/widgets/modern_video_controls.dart
@@ -609,9 +609,12 @@ class _ModernVideoControlsState extends State<ModernVideoControls> {
                                           () => _isDanmakuHovered = value),
                                       onPressed: (value) => setState(
                                           () => _isDanmakuPressed = value),
-                                      tooltip: videoState.danmakuVisible
-                                          ? '关闭弹幕(D)'
-                                          : '开启弹幕(D)',
+                                      tooltip: _tooltipManager
+                                          .formatActionWithShortcut(
+                                              'toggle_danmaku',
+                                              videoState.danmakuVisible
+                                                  ? '关闭弹幕'
+                                                  : '开启弹幕'),
                                       useAnimatedSwitcher: true,
                                     ),
 

--- a/lib/themes/nipaplay/widgets/modern_video_controls.dart
+++ b/lib/themes/nipaplay/widgets/modern_video_controls.dart
@@ -613,8 +613,8 @@ class _ModernVideoControlsState extends State<ModernVideoControls> {
                                           .formatActionWithShortcut(
                                               'toggle_danmaku',
                                               videoState.danmakuVisible
-                                                  ? '关闭弹幕'
-                                                  : '开启弹幕'),
+                                                  ? '隐藏弹幕'
+                                                  : '显示弹幕'),
                                       useAnimatedSwitcher: true,
                                     ),
 

--- a/lib/themes/nipaplay/widgets/tooltip_bubble.dart
+++ b/lib/themes/nipaplay/widgets/tooltip_bubble.dart
@@ -128,7 +128,10 @@ class _TooltipBubbleState extends State<TooltipBubble> {
 
     // 增加额外的宽度，确保组合键能够完整显示
     final String lowerText = widget.text.toLowerCase();
-    if (lowerText.contains('shift') ||
+    if (lowerText.contains('(') && lowerText.contains(')')) {
+      // 如果文本包含括号（通常是快捷键），增加额外宽度
+      return textPainter.width + widget.padding * 2 + 20;
+    } else if (lowerText.contains('shift') ||
         lowerText.contains('ctrl') ||
         lowerText.contains('command') ||
         lowerText.contains('tab') ||

--- a/lib/themes/nipaplay/widgets/tooltip_bubble.dart
+++ b/lib/themes/nipaplay/widgets/tooltip_bubble.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'dart:io';
 import 'dart:ui';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'package:provider/provider.dart';
@@ -128,8 +129,10 @@ class _TooltipBubbleState extends State<TooltipBubble> {
 
     // 增加额外的宽度，确保组合键能够完整显示
     final String lowerText = widget.text.toLowerCase();
-    if (lowerText.contains('(') && lowerText.contains(')')) {
-      // 如果文本包含括号（通常是快捷键），增加额外宽度
+    if (Platform.isWindows &&
+        lowerText.contains('(') &&
+        lowerText.contains(')')) {
+      // 只在 Windows 端，如果文本包含括号（通常是快捷键），增加额外宽度
       return textPainter.width + widget.padding * 2 + 20;
     } else if (lowerText.contains('shift') ||
         lowerText.contains('ctrl') ||


### PR DESCRIPTION
## Summary

- 优化了弹幕开关按钮的tooltip，使用已有的`_tooltipManager`获取快捷键配置
- 修复了部分按钮快捷键部分无法正常显示的问题

## Related Issue

无

## What Changed

- 在`lib\themes\nipaplay\widgets\tooltip_bubble.dart`中引入判断：当平台为Windows且tooltip中含一对括号时加宽，防止截断
