### PR TITLE
feat:add custom media entrance for phone UI

### DIFF
--- a/lib/themes/cupertino/pages/cupertino_media_library_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_media_library_page.dart
@@ -44,6 +44,7 @@ import 'package:nipaplay/services/playback_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/batch_danmaku_dialog.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/custom_media_info_dialog.dart';
 import 'package:nipaplay/providers/jellyfin_provider.dart';
 import 'package:nipaplay/providers/emby_provider.dart';
 import 'package:nipaplay/themes/cupertino/pages/cupertino_media_server_detail_page.dart';
@@ -3262,10 +3263,6 @@ class _CupertinoLibraryManagementSheetState
         .where(_isBatchMatchVideoFilePath)
         .toList(growable: false);
 
-    if (candidateFiles.length < 2) {
-      return const SizedBox.shrink();
-    }
-
     final labelColor =
         CupertinoDynamicColor.resolve(CupertinoColors.label, context);
     final subtitleColor =
@@ -3273,45 +3270,104 @@ class _CupertinoLibraryManagementSheetState
     final accentColor = CupertinoDynamicColor.resolve(
         CupertinoTheme.of(context).primaryColor, context);
 
-    return Padding(
-      padding: EdgeInsets.fromLTRB(indentation, 6, 12, 6),
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: () => _showBatchDanmakuMatchDialog(folderPath, candidateFiles),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Icon(
-              CupertinoIcons.collections,
-              size: 16,
-              color: accentColor,
+    final List<Widget> children = [];
+
+    if (candidateFiles.length >= 2) {
+      children.add(
+        Padding(
+          padding: EdgeInsets.fromLTRB(indentation, 6, 12, 6),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () => _showBatchDanmakuMatchDialog(folderPath, candidateFiles),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Icon(
+                  CupertinoIcons.collections,
+                  size: 16,
+                  color: accentColor,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '批量匹配弹幕（本文件夹）',
+                        style: TextStyle(fontSize: 13, color: labelColor),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        '对齐顺序后批量匹配 ${candidateFiles.length} 个文件',
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(fontSize: 11, color: subtitleColor),
+                      ),
+                    ],
+                  ),
+                ),
+                Text(
+                  '开始',
+                  style: TextStyle(fontSize: 12, color: accentColor),
+                ),
+              ],
             ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    '批量匹配弹幕（本文件夹）',
-                    style: TextStyle(fontSize: 13, color: labelColor),
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    '对齐顺序后批量匹配 ${candidateFiles.length} 个文件',
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(fontSize: 11, color: subtitleColor),
-                  ),
-                ],
+          ),
+        ),
+      );
+    }
+
+    children.add(
+      Padding(
+        padding: EdgeInsets.fromLTRB(indentation, 6, 12, 6),
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () async {
+            final result = await CustomMediaInfoDialog.show(context, folderPath);
+            if (result != null) {
+              _refreshExpandedFolderContents(folderPath);
+            }
+          },
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Icon(
+                CupertinoIcons.info,
+                size: 16,
+                color: accentColor,
               ),
-            ),
-            Text(
-              '开始',
-              style: TextStyle(fontSize: 12, color: accentColor),
-            ),
-          ],
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '自定义媒体信息（实验性）',
+                      style: TextStyle(fontSize: 13, color: labelColor),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      '自定义媒体信息，并将当前文件夹添加到媒体库中',
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(fontSize: 11, color: subtitleColor),
+                    ),
+                  ],
+                ),
+              ),
+              Text(
+                '开始',
+                style: TextStyle(fontSize: 12, color: accentColor),
+              ),
+            ],
+          ),
         ),
       ),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: children,
     );
   }
 
@@ -3440,6 +3496,24 @@ class _CupertinoLibraryManagementSheetState
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  CupertinoButton(
+                    padding: EdgeInsets.zero,
+                    minSize: 28,
+                    onPressed: () async {
+                      final result = await CustomMediaInfoDialog.show(
+                        context,
+                        p.dirname(file.path),
+                        initialVideoPath: file.path,
+                      );
+                      if (result != null) {
+                        _refreshExpandedFolderContents(p.dirname(file.path));
+                      }
+                    },
+                    child: Text(
+                      '自定义',
+                      style: TextStyle(fontSize: 12, color: accentColor),
+                    ),
+                  ),
                   CupertinoButton(
                     padding: EdgeInsets.zero,
                     minSize: 28,

--- a/lib/themes/cupertino/pages/cupertino_media_library_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_media_library_page.dart
@@ -3278,7 +3278,8 @@ class _CupertinoLibraryManagementSheetState
           padding: EdgeInsets.fromLTRB(indentation, 6, 12, 6),
           child: GestureDetector(
             behavior: HitTestBehavior.opaque,
-            onTap: () => _showBatchDanmakuMatchDialog(folderPath, candidateFiles),
+            onTap: () =>
+                _showBatchDanmakuMatchDialog(folderPath, candidateFiles),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
@@ -3323,7 +3324,8 @@ class _CupertinoLibraryManagementSheetState
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: () async {
-            final result = await CustomMediaInfoDialog.show(context, folderPath);
+            final result =
+                await CustomMediaInfoDialog.show(context, folderPath);
             if (result != null) {
               _refreshExpandedFolderContents(folderPath);
             }
@@ -3510,7 +3512,7 @@ class _CupertinoLibraryManagementSheetState
                       }
                     },
                     child: Text(
-                      '自定义',
+                      '自定义媒体信息',
                       style: TextStyle(fontSize: 12, color: accentColor),
                     ),
                   ),

--- a/lib/themes/nipaplay/widgets/custom_media_info_dialog.dart
+++ b/lib/themes/nipaplay/widgets/custom_media_info_dialog.dart
@@ -26,7 +26,9 @@ class CustomMediaInfoDialog {
 
   static Future<Map<String, dynamic>?> _showStep1(
       BuildContext context, String folderPath,
-      {String? initialVideoPath, Map<String, dynamic>? step1Data}) async {
+      {String? initialVideoPath,
+      Map<String, dynamic>? step1Data,
+      VoidCallback? onBack}) async {
     final enableAnimation = Provider.of<AppearanceSettingsProvider>(
       context,
       listen: false,
@@ -63,6 +65,7 @@ class CustomMediaInfoDialog {
     final TextEditingController coverUrlController =
         TextEditingController(text: step1Data?['coverUrl'] ?? '');
 
+    final callerContext = context;
     return NipaplayWindow.show<Map<String, dynamic>>(
       context: context,
       enableAnimation: enableAnimation,
@@ -891,8 +894,14 @@ class CustomMediaInfoDialog {
 
                           // 关闭当前对话框并打开第二步
                           Navigator.of(context).pop();
-                          _Step2Dialog.show(context, step1Data,
-                              initialVideoPath: initialVideoPath);
+                          _Step2Dialog.show(callerContext, step1Data,
+                              initialVideoPath: initialVideoPath,
+                              onBack: onBack ??
+                                  () {
+                                    _showStep1(callerContext, folderPath,
+                                        initialVideoPath: initialVideoPath,
+                                        step1Data: step1Data);
+                                  });
                         },
                         style: ButtonStyle(
                           backgroundColor:
@@ -1106,7 +1115,7 @@ class _Step2Dialog extends StatefulWidget {
 
   static Future<Map<String, dynamic>?> show(
       BuildContext context, Map<String, dynamic> step1Data,
-      {String? initialVideoPath}) async {
+      {String? initialVideoPath, VoidCallback? onBack}) async {
     final _Step2Dialog dialog =
         _Step2Dialog(step1Data: step1Data, initialVideoPath: initialVideoPath);
     final enableAnimation = Provider.of<AppearanceSettingsProvider>(
@@ -1200,7 +1209,10 @@ class _Step2Dialog extends StatefulWidget {
                       ),
                     ),
                     ElevatedButton(
-                      onPressed: () => Navigator.of(context).pop('back'),
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                        onBack?.call();
+                      },
                       style: ButtonStyle(
                         backgroundColor:
                             MaterialStateProperty.all(Colors.transparent),
@@ -1299,14 +1311,6 @@ class _Step2Dialog extends StatefulWidget {
         );
       }),
     );
-
-    // 处理上一步逻辑
-    if (result == 'back') {
-      // 关闭当前对话框并重新打开第一步，传递回 step1Data
-      return CustomMediaInfoDialog._showStep1(
-          context, step1Data['folderPath'] as String,
-          initialVideoPath: initialVideoPath, step1Data: step1Data);
-    }
 
     return result as Map<String, dynamic>?;
   }


### PR DESCRIPTION
## Summary

- 为手机端cupertinoUI添加了媒体库中自定义媒体信息的入口
- 修复了自定义媒体信息窗口中点击“上一步”会直接关闭窗口的问题

## Related Issue

无

## What Changed

- In `lib/themes/nipaplay/widgets/custom_media_info_dialog.dart`
    1. _showStep1 — Added VoidCallback? onBack parameter. Captured callerContext = context before the Builder (which
  shadows context).
    2. "下一步" button — Uses callerContext (the original caller's valid context) when calling _Step2Dialog.show, and
  passes an onBack callback that calls _showStep1 with the same valid context and the user's entered step1Data.
    3. _Step2Dialog.show — Added VoidCallback? onBack parameter. The "上一步" button now calls Navigator.of(context).pop()
   then onBack?.call() directly, instead of popping with a 'back' sentinel.
    4. Removed the old if (result == 'back') handling block, since the callback pattern replaces it.
  The onBack callback chains through iterations: if _showStep1 was itself called from a back action, the original onBack
   is propagated, ensuring the valid caller context is always used for opening new dialog routes.
