### PR TITLE
feat:add custom subtitles font floder support

### DIFF
--- a/lib/themes/cupertino/widgets/player_menu/cupertino_subtitle_settings_pane.dart
+++ b/lib/themes/cupertino/widgets/player_menu/cupertino_subtitle_settings_pane.dart
@@ -106,13 +106,15 @@ class _CupertinoSubtitleSettingsPaneState
   }
 
   String _getFontDirDisplayText(VideoPlayerState videoState) {
-    final source = videoState.subtitleFontDirSource;
-    if (source == SubtitleFontDirSource.localFonts) {
-      return '${videoState.subtitleFontDir} [本地fonts]';
-    } else if (source == SubtitleFontDirSource.customLibrary) {
-      return '${videoState.subtitleFontDir} [字体库]';
+    final fontDir = videoState.subtitleFontDir;
+    if (fontDir.isEmpty) return '无';
+
+    // 根据路径特征动态推断来源
+    if (fontDir.contains('subtitle_fonts')) {
+      return '$fontDir [字体库]';
+    } else {
+      return '$fontDir [本地fonts]';
     }
-    return videoState.subtitleFontDir;
   }
 
   void _syncSubtitleDelayController(VideoPlayerState videoState) {

--- a/lib/themes/cupertino/widgets/player_menu/cupertino_subtitle_settings_pane.dart
+++ b/lib/themes/cupertino/widgets/player_menu/cupertino_subtitle_settings_pane.dart
@@ -107,7 +107,7 @@ class _CupertinoSubtitleSettingsPaneState
 
   String _getFontDirDisplayText(VideoPlayerState videoState) {
     final fontDir = videoState.subtitleFontDir;
-    if (fontDir.isEmpty) return '无';
+    if (fontDir.isEmpty) return '未配置过字体库，使用默认设置';
 
     // 根据路径特征动态推断来源
     if (fontDir.contains('subtitle_fonts')) {

--- a/lib/themes/cupertino/widgets/player_menu/cupertino_subtitle_settings_pane.dart
+++ b/lib/themes/cupertino/widgets/player_menu/cupertino_subtitle_settings_pane.dart
@@ -34,6 +34,7 @@ class _CupertinoSubtitleSettingsPaneState
   final FocusNode _shadowColorFocus = FocusNode();
   bool _subtitleDelayDirty = false;
   double? _subtitleDelayPreviewValue;
+  String? _fontImportMessage;
 
   @override
   void dispose() {
@@ -84,8 +85,34 @@ class _CupertinoSubtitleSettingsPaneState
     await videoState.importSubtitleFontFile(file.path);
   }
 
+  Future<void> _pickFontDirectory(VideoPlayerState videoState) async {
+    final directory = await getDirectoryPath();
+    if (directory == null) return;
+    final count = await videoState.importSubtitleFontDirectory(directory);
+    if (!mounted) return;
+    if (count > 0) {
+      setState(() {
+        _fontImportMessage = '已从该文件夹导入 $count 个字体文件';
+      });
+    } else if (count == 0) {
+      setState(() {
+        _fontImportMessage = '未在目录中找到字体文件';
+      });
+    }
+  }
+
   double _currentSubtitleDelayDisplayValue(VideoPlayerState videoState) {
     return _subtitleDelayPreviewValue ?? videoState.subtitleDelaySeconds;
+  }
+
+  String _getFontDirDisplayText(VideoPlayerState videoState) {
+    final source = videoState.subtitleFontDirSource;
+    if (source == SubtitleFontDirSource.localFonts) {
+      return '${videoState.subtitleFontDir} [本地fonts]';
+    } else if (source == SubtitleFontDirSource.customLibrary) {
+      return '${videoState.subtitleFontDir} [字体库]';
+    }
+    return videoState.subtitleFontDir;
   }
 
   void _syncSubtitleDelayController(VideoPlayerState videoState) {
@@ -444,6 +471,40 @@ class _CupertinoSubtitleSettingsPaneState
                       padding: EdgeInsets.zero,
                       onPressed: () => _pickFontFile(videoState),
                       child: const Text('选择'),
+                    ),
+                  ),
+                  CupertinoListTile(
+                    title: const Text('导入字体文件夹'),
+                    trailing: CupertinoButton(
+                      padding: EdgeInsets.zero,
+                      onPressed: () => _pickFontDirectory(videoState),
+                      child: const Text('选择'),
+                    ),
+                  ),
+                  if (_fontImportMessage != null)
+                    CupertinoListTile(
+                      title: Text(
+                        _fontImportMessage!,
+                        style: TextStyle(
+                          color: CupertinoColors.activeBlue,
+                          fontSize: 13,
+                        ),
+                      ),
+                    ),
+                  if (videoState.subtitleFontDir.isNotEmpty)
+                    CupertinoListTile(
+                      title: const Text('当前字体目录'),
+                      subtitle: Text(_getFontDirDisplayText(videoState)),
+                    ),
+                  CupertinoListTile(
+                    title: const Text('清除字体设置'),
+                    trailing: CupertinoButton(
+                      padding: EdgeInsets.zero,
+                      onPressed: () {
+                        videoState.setSubtitleFontName('');
+                        videoState.setSubtitleFontDir('');
+                      },
+                      child: const Text('清除'),
                     ),
                   ),
                 ],

--- a/lib/themes/nipaplay/widgets/subtitle_settings_menu.dart
+++ b/lib/themes/nipaplay/widgets/subtitle_settings_menu.dart
@@ -42,6 +42,7 @@ class _SubtitleSettingsMenuState extends State<SubtitleSettingsMenu> {
   String? _subtitleDelayError;
   bool _subtitleDelayDirty = false;
   double? _subtitleDelayPreviewValue;
+  String? _fontImportMessage;
 
   @override
   void dispose() {
@@ -95,8 +96,34 @@ class _SubtitleSettingsMenuState extends State<SubtitleSettingsMenu> {
     await videoState.importSubtitleFontFile(file.path);
   }
 
+  Future<void> _pickFontDirectory(VideoPlayerState videoState) async {
+    final directory = await getDirectoryPath();
+    if (directory == null) return;
+    final count = await videoState.importSubtitleFontDirectory(directory);
+    if (!mounted) return;
+    if (count > 0) {
+      setState(() {
+        _fontImportMessage = '已从该文件夹导入 $count 个字体文件';
+      });
+    } else if (count == 0) {
+      setState(() {
+        _fontImportMessage = '未在目录中找到字体文件';
+      });
+    }
+  }
+
   double _currentSubtitleDelayDisplayValue(VideoPlayerState videoState) {
     return _subtitleDelayPreviewValue ?? videoState.subtitleDelaySeconds;
+  }
+
+  String _getFontDirDisplayText(VideoPlayerState videoState) {
+    final source = videoState.subtitleFontDirSource;
+    if (source == SubtitleFontDirSource.localFonts) {
+      return '当前字体目录: ${videoState.subtitleFontDir} [本地fonts]';
+    } else if (source == SubtitleFontDirSource.customLibrary) {
+      return '当前字体目录: ${videoState.subtitleFontDir} [字体库]';
+    }
+    return '当前字体目录: ${videoState.subtitleFontDir}';
   }
 
   void _syncSubtitleDelayController(VideoPlayerState videoState) {
@@ -667,14 +694,40 @@ class _SubtitleSettingsMenuState extends State<SubtitleSettingsMenu> {
               const SizedBox(width: 8),
               Expanded(
                 child: BlurButton(
-                  text: '清除字体',
-                  icon: Icons.clear,
-                  onTap: () => videoState.setSubtitleFontName(''),
+                  text: '导入字体文件夹',
+                  icon: Icons.folder_outlined,
+                  onTap: () => _pickFontDirectory(videoState),
                   expandHorizontally: true,
                 ),
               ),
             ],
           ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: BlurButton(
+                  text: '清除字体设置',
+                  icon: Icons.clear,
+                  onTap: () {
+                    videoState.setSubtitleFontName('');
+                    videoState.setSubtitleFontDir('');
+                  },
+                  expandHorizontally: true,
+                ),
+              ),
+            ],
+          ),
+          if (_fontImportMessage != null) ...[
+            const SizedBox(height: 4),
+            SettingsHintText(_fontImportMessage!),
+          ],
+          if (videoState.subtitleFontDir.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            SettingsHintText(
+              _getFontDirDisplayText(videoState),
+            ),
+          ],
           const SizedBox(height: 4),
           const SettingsHintText('字体名称需与系统或导入字体匹配'),
         ],

--- a/lib/themes/nipaplay/widgets/subtitle_settings_menu.dart
+++ b/lib/themes/nipaplay/widgets/subtitle_settings_menu.dart
@@ -118,7 +118,7 @@ class _SubtitleSettingsMenuState extends State<SubtitleSettingsMenu> {
 
   String _getFontDirDisplayText(VideoPlayerState videoState) {
     final fontDir = videoState.subtitleFontDir;
-    if (fontDir.isEmpty) return '当前字体目录: 无';
+    if (fontDir.isEmpty) return '未导入过字体文件，使用默认设置';
 
     // 根据路径特征动态推断来源
     if (fontDir.contains('subtitle_fonts')) {

--- a/lib/themes/nipaplay/widgets/subtitle_settings_menu.dart
+++ b/lib/themes/nipaplay/widgets/subtitle_settings_menu.dart
@@ -117,13 +117,15 @@ class _SubtitleSettingsMenuState extends State<SubtitleSettingsMenu> {
   }
 
   String _getFontDirDisplayText(VideoPlayerState videoState) {
-    final source = videoState.subtitleFontDirSource;
-    if (source == SubtitleFontDirSource.localFonts) {
-      return '当前字体目录: ${videoState.subtitleFontDir} [本地fonts]';
-    } else if (source == SubtitleFontDirSource.customLibrary) {
-      return '当前字体目录: ${videoState.subtitleFontDir} [字体库]';
+    final fontDir = videoState.subtitleFontDir;
+    if (fontDir.isEmpty) return '当前字体目录: 无';
+
+    // 根据路径特征动态推断来源
+    if (fontDir.contains('subtitle_fonts')) {
+      return '当前字体目录: $fontDir [字体库]';
+    } else {
+      return '当前字体目录: $fontDir [本地fonts]';
     }
-    return '当前字体目录: ${videoState.subtitleFontDir}';
   }
 
   void _syncSubtitleDelayController(VideoPlayerState videoState) {

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -105,6 +105,8 @@ part 'video_player_state/video_player_state_lifecycle.dart';
 
 enum SubtitleStyleOverrideMode { auto, none, scale, force }
 
+enum SubtitleFontDirSource { none, localFonts, customLibrary }
+
 enum SubtitleAlignX { left, center, right }
 
 enum SubtitleAlignY { top, center, bottom }
@@ -515,6 +517,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   int _subtitleShadowColorValue = defaultSubtitleShadowColorValue;
   String _subtitleFontName = '';
   String _subtitleFontDir = '';
+  SubtitleFontDirSource _subtitleFontDirSource = SubtitleFontDirSource.none;
   SubtitleStyleOverrideMode _subtitleOverrideMode = defaultSubtitleOverrideMode;
 
   // 弹幕轨道显示区域设置
@@ -1162,6 +1165,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   Color get subtitleShadowColor => Color(_subtitleShadowColorValue);
   String get subtitleFontName => _subtitleFontName;
   String get subtitleFontDir => _subtitleFontDir;
+  SubtitleFontDirSource get subtitleFontDirSource => _subtitleFontDirSource;
   SubtitleStyleOverrideMode get subtitleOverrideMode => _subtitleOverrideMode;
   double get danmakuDisplayArea => _danmakuDisplayArea;
   double get danmakuSpeedMultiplier => _danmakuSpeedMultiplier;

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -105,8 +105,6 @@ part 'video_player_state/video_player_state_lifecycle.dart';
 
 enum SubtitleStyleOverrideMode { auto, none, scale, force }
 
-enum SubtitleFontDirSource { none, localFonts, customLibrary }
-
 enum SubtitleAlignX { left, center, right }
 
 enum SubtitleAlignY { top, center, bottom }
@@ -517,7 +515,6 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   int _subtitleShadowColorValue = defaultSubtitleShadowColorValue;
   String _subtitleFontName = '';
   String _subtitleFontDir = '';
-  SubtitleFontDirSource _subtitleFontDirSource = SubtitleFontDirSource.none;
   SubtitleStyleOverrideMode _subtitleOverrideMode = defaultSubtitleOverrideMode;
 
   // 弹幕轨道显示区域设置
@@ -1165,7 +1162,6 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   Color get subtitleShadowColor => Color(_subtitleShadowColorValue);
   String get subtitleFontName => _subtitleFontName;
   String get subtitleFontDir => _subtitleFontDir;
-  SubtitleFontDirSource get subtitleFontDirSource => _subtitleFontDirSource;
   SubtitleStyleOverrideMode get subtitleOverrideMode => _subtitleOverrideMode;
   double get danmakuDisplayArea => _danmakuDisplayArea;
   double get danmakuSpeedMultiplier => _danmakuSpeedMultiplier;

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -257,11 +257,16 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
       final localFontsFolder = await _detectLocalFontsFolder(videoPath);
       debugPrint('[VideoPlayerState] 自动检测本地fonts结果: $localFontsFolder');
       if (localFontsFolder != null) {
-        // 检测到本地 fonts 文件夹，直接设置路径
+        // 检测到本地 fonts 文件夹，直接设置路径并立即应用
         _subtitleFontDir = localFontsFolder;
         _statusMessages.add('发现Fonts目录，已自动配置字幕字体');
         _notifyListeners();
         debugPrint('[VideoPlayerState] 已设置本地fonts: $_subtitleFontDir');
+        // 立即设置mpv字体目录，确保自动配置生效
+        player.setProperty('sub-fonts-dir', localFontsFolder);
+        if (defaultTargetPlatform == TargetPlatform.iOS) {
+          player.setProperty('sub-file-paths', localFontsFolder);
+        }
       }
     }
     try {

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -251,6 +251,21 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
       message = '正在初始化播放器: $_animeTitle $_episodeTitle';
     }
     _setStatus(PlayerStatus.loading, message: message);
+
+    // 检测本地 fonts 文件夹
+    if (!kIsWeb && !isNetworkUrl && !isJellyfinStream && !isEmbyStream) {
+      final localFontsFolder = await _detectLocalFontsFolder(videoPath);
+      debugPrint('[VideoPlayerState] 自动检测本地fonts结果: $localFontsFolder');
+      if (localFontsFolder != null) {
+        // 检测到本地 fonts 文件夹，直接设置路径和来源
+        _subtitleFontDir = localFontsFolder;
+        _subtitleFontDirSource = SubtitleFontDirSource.localFonts;
+        _statusMessages.add('发现Fonts目录，已自动配置字幕字体');
+        _notifyListeners();
+        debugPrint(
+            '[VideoPlayerState] 已设置本地fonts: $_subtitleFontDir, 来源: $_subtitleFontDirSource');
+      }
+    }
     try {
       debugPrint(
         'VideoPlayerState: initializePlayer CALLED for path: $videoPath',

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -257,13 +257,11 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
       final localFontsFolder = await _detectLocalFontsFolder(videoPath);
       debugPrint('[VideoPlayerState] 自动检测本地fonts结果: $localFontsFolder');
       if (localFontsFolder != null) {
-        // 检测到本地 fonts 文件夹，直接设置路径和来源
+        // 检测到本地 fonts 文件夹，直接设置路径
         _subtitleFontDir = localFontsFolder;
-        _subtitleFontDirSource = SubtitleFontDirSource.localFonts;
         _statusMessages.add('发现Fonts目录，已自动配置字幕字体');
         _notifyListeners();
-        debugPrint(
-            '[VideoPlayerState] 已设置本地fonts: $_subtitleFontDir, 来源: $_subtitleFontDirSource');
+        debugPrint('[VideoPlayerState] 已设置本地fonts: $_subtitleFontDir');
       }
     }
     try {

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -1551,14 +1551,12 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
         VideoPlayerState.defaultSubtitleShadowColorValue;
     _subtitleFontName = prefs.getString(_subtitleFontNameKey) ?? '';
     _subtitleFontDir = prefs.getString(_subtitleFontDirKey) ?? '';
-    debugPrint('[VideoPlayerState] loadSettings: _subtitleFontDir=$_subtitleFontDir, _subtitleFontDirSource=$_subtitleFontDirSource');
     _subtitleOverrideMode = SubtitleStyleOverrideMode.values[(prefs.getInt(
               _subtitleOverrideModeKey,
             ) ??
             VideoPlayerState.defaultSubtitleOverrideMode.index)
         .clamp(0, SubtitleStyleOverrideMode.values.length - 1)];
     await applySubtitleStylePreference();
-    debugPrint('[VideoPlayerState] loadSettings after apply: _subtitleFontDirSource=$_subtitleFontDirSource');
     _notifyListeners();
   }
 
@@ -1738,7 +1736,6 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       await File(sourcePath).copy(destPath);
       _subtitleFontDir = fontsDir.path;
       _subtitleFontName = p.basenameWithoutExtension(destPath);
-      _subtitleFontDirSource = SubtitleFontDirSource.customLibrary;
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_subtitleFontDirKey, _subtitleFontDir);
       await prefs.setString(_subtitleFontNameKey, _subtitleFontName);
@@ -1756,38 +1753,44 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       final fontsDir = Directory(p.join(baseDir.path, 'subtitle_fonts'));
       await fontsDir.create(recursive: true);
 
+      final sourceDir = Directory(sourceDirPath);
+      final List<File> fontFiles = [];
+
+      await for (final entity in sourceDir.list()) {
+        if (entity is File) {
+          final ext = p.extension(entity.path).toLowerCase();
+          if (ext == '.ttf' || ext == '.otf' || ext == '.ttc') {
+            fontFiles.add(entity);
+          }
+        }
+      }
+
+      if (fontFiles.isEmpty) {
+        debugPrint('[VideoPlayerState] 未在目录中找到字体文件');
+        return 0;
+      }
+
       await for (final entity in fontsDir.list()) {
         if (entity is File) {
           await entity.delete();
         }
       }
 
-      final sourceDir = Directory(sourceDirPath);
       int copiedCount = 0;
-
-      await for (final entity in sourceDir.list()) {
-        if (entity is File) {
-          final ext = p.extension(entity.path).toLowerCase();
-          if (ext == '.ttf' || ext == '.otf' || ext == '.ttc') {
-            final fileName = p.basename(entity.path);
-            final destPath = p.join(fontsDir.path, fileName);
-            await entity.copy(destPath);
-            copiedCount++;
-          }
-        }
+      for (final file in fontFiles) {
+        final fileName = p.basename(file.path);
+        final destPath = p.join(fontsDir.path, fileName);
+        await file.copy(destPath);
+        copiedCount++;
       }
 
-      if (copiedCount > 0) {
-        _subtitleFontDir = fontsDir.path;
-        _subtitleFontDirSource = SubtitleFontDirSource.customLibrary;
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setString(_subtitleFontDirKey, _subtitleFontDir);
-        await applySubtitleStylePreference();
-        _notifyListeners();
-        debugPrint('[VideoPlayerState] 成功从 $sourceDirPath 导入了 $copiedCount 个字体文件到 $fontsDir.path');
-      } else {
-        debugPrint('[VideoPlayerState] 未在目录中找到字体文件');
-      }
+      _subtitleFontDir = fontsDir.path;
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_subtitleFontDirKey, _subtitleFontDir);
+      await applySubtitleStylePreference();
+      _notifyListeners();
+      debugPrint(
+          '[VideoPlayerState] 成功从 $sourceDirPath 导入了 $copiedCount 个字体文件到 $fontsDir.path');
       return copiedCount;
     } catch (e) {
       debugPrint('[VideoPlayerState] 导入字幕字体目录失败: $e');
@@ -1922,7 +1925,8 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       String? effectiveFontDir;
       String? localFontsFolder;
 
-      if (_currentVideoPath != null && !_currentVideoPath!.startsWith('http') &&
+      if (_currentVideoPath != null &&
+          !_currentVideoPath!.startsWith('http') &&
           !_currentVideoPath!.startsWith('jellyfin://') &&
           !_currentVideoPath!.startsWith('emby://')) {
         localFontsFolder = await _detectLocalFontsFolder(_currentVideoPath!);
@@ -1930,11 +1934,15 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
 
       if (localFontsFolder != null) {
         effectiveFontDir = localFontsFolder;
-        _subtitleFontDirSource = SubtitleFontDirSource.localFonts;
+        _subtitleFontDir = localFontsFolder;
         debugPrint('[VideoPlayerState] 使用本地 fonts 文件夹: $effectiveFontDir');
-      } else if (_subtitleFontDir.isNotEmpty &&
-          _subtitleFontDirSource != SubtitleFontDirSource.localFonts) {
-        effectiveFontDir = _subtitleFontDir;
+      } else {
+        final prefs = await SharedPreferences.getInstance();
+        final savedFontDir = prefs.getString(_subtitleFontDirKey) ?? '';
+        if (savedFontDir.isNotEmpty) {
+          effectiveFontDir = savedFontDir;
+          _subtitleFontDir = savedFontDir;
+        }
       }
 
       if (effectiveFontDir != null) {

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -1551,12 +1551,14 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
         VideoPlayerState.defaultSubtitleShadowColorValue;
     _subtitleFontName = prefs.getString(_subtitleFontNameKey) ?? '';
     _subtitleFontDir = prefs.getString(_subtitleFontDirKey) ?? '';
+    debugPrint('[VideoPlayerState] loadSettings: _subtitleFontDir=$_subtitleFontDir, _subtitleFontDirSource=$_subtitleFontDirSource');
     _subtitleOverrideMode = SubtitleStyleOverrideMode.values[(prefs.getInt(
               _subtitleOverrideModeKey,
             ) ??
             VideoPlayerState.defaultSubtitleOverrideMode.index)
         .clamp(0, SubtitleStyleOverrideMode.values.length - 1)];
     await applySubtitleStylePreference();
+    debugPrint('[VideoPlayerState] loadSettings after apply: _subtitleFontDirSource=$_subtitleFontDirSource');
     _notifyListeners();
   }
 
@@ -1736,6 +1738,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       await File(sourcePath).copy(destPath);
       _subtitleFontDir = fontsDir.path;
       _subtitleFontName = p.basenameWithoutExtension(destPath);
+      _subtitleFontDirSource = SubtitleFontDirSource.customLibrary;
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_subtitleFontDirKey, _subtitleFontDir);
       await prefs.setString(_subtitleFontNameKey, _subtitleFontName);
@@ -1743,6 +1746,52 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       _notifyListeners();
     } catch (e) {
       debugPrint('[VideoPlayerState] 导入字幕字体失败: $e');
+    }
+  }
+
+  Future<int> importSubtitleFontDirectory(String sourceDirPath) async {
+    if (sourceDirPath.isEmpty) return 0;
+    try {
+      final baseDir = await StorageService.getAppStorageDirectory();
+      final fontsDir = Directory(p.join(baseDir.path, 'subtitle_fonts'));
+      await fontsDir.create(recursive: true);
+
+      await for (final entity in fontsDir.list()) {
+        if (entity is File) {
+          await entity.delete();
+        }
+      }
+
+      final sourceDir = Directory(sourceDirPath);
+      int copiedCount = 0;
+
+      await for (final entity in sourceDir.list()) {
+        if (entity is File) {
+          final ext = p.extension(entity.path).toLowerCase();
+          if (ext == '.ttf' || ext == '.otf' || ext == '.ttc') {
+            final fileName = p.basename(entity.path);
+            final destPath = p.join(fontsDir.path, fileName);
+            await entity.copy(destPath);
+            copiedCount++;
+          }
+        }
+      }
+
+      if (copiedCount > 0) {
+        _subtitleFontDir = fontsDir.path;
+        _subtitleFontDirSource = SubtitleFontDirSource.customLibrary;
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString(_subtitleFontDirKey, _subtitleFontDir);
+        await applySubtitleStylePreference();
+        _notifyListeners();
+        debugPrint('[VideoPlayerState] 成功从 $sourceDirPath 导入了 $copiedCount 个字体文件到 $fontsDir.path');
+      } else {
+        debugPrint('[VideoPlayerState] 未在目录中找到字体文件');
+      }
+      return copiedCount;
+    } catch (e) {
+      debugPrint('[VideoPlayerState] 导入字幕字体目录失败: $e');
+      return -1;
     }
   }
 
@@ -1799,6 +1848,40 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _notifyListeners();
   }
 
+  Future<String?> _detectLocalFontsFolder(String videoPath) async {
+    if (kIsWeb) return null;
+    try {
+      final videoFile = File(videoPath);
+      if (!await videoFile.exists()) return null;
+
+      final videoDir = videoFile.parent;
+      final possibleNames = ['fonts', 'Fonts', 'FONTS'];
+
+      for (final name in possibleNames) {
+        final fontsDir = Directory(p.join(videoDir.path, name));
+        if (await fontsDir.exists()) {
+          bool hasFontFiles = false;
+          await for (final entity in fontsDir.list()) {
+            if (entity is File) {
+              final ext = p.extension(entity.path).toLowerCase();
+              if (ext == '.ttf' || ext == '.otf' || ext == '.ttc') {
+                hasFontFiles = true;
+                break;
+              }
+            }
+          }
+          if (hasFontFiles) {
+            debugPrint('[VideoPlayerState] 检测到本地 fonts 文件夹: ${fontsDir.path}');
+            return fontsDir.path;
+          }
+        }
+      }
+    } catch (e) {
+      debugPrint('[VideoPlayerState] 检测本地 fonts 文件夹失败: $e');
+    }
+    return null;
+  }
+
   Future<void> applySubtitleStylePreference() async {
     if (kIsWeb || _isDisposed) return;
     try {
@@ -1835,12 +1918,32 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       );
       player.setProperty('sub-bold', _subtitleBold ? 'yes' : 'no');
       player.setProperty('sub-italic', _subtitleItalic ? 'yes' : 'no');
-      if (_subtitleFontDir.isNotEmpty) {
-        player.setProperty('sub-fonts-dir', _subtitleFontDir);
+
+      String? effectiveFontDir;
+      String? localFontsFolder;
+
+      if (_currentVideoPath != null && !_currentVideoPath!.startsWith('http') &&
+          !_currentVideoPath!.startsWith('jellyfin://') &&
+          !_currentVideoPath!.startsWith('emby://')) {
+        localFontsFolder = await _detectLocalFontsFolder(_currentVideoPath!);
+      }
+
+      if (localFontsFolder != null) {
+        effectiveFontDir = localFontsFolder;
+        _subtitleFontDir = localFontsFolder;
+        _subtitleFontDirSource = SubtitleFontDirSource.localFonts;
+        debugPrint('[VideoPlayerState] 使用本地 fonts 文件夹: $effectiveFontDir');
+      } else if (_subtitleFontDir.isNotEmpty) {
+        effectiveFontDir = _subtitleFontDir;
+      }
+
+      if (effectiveFontDir != null) {
+        player.setProperty('sub-fonts-dir', effectiveFontDir);
         if (defaultTargetPlatform == TargetPlatform.iOS) {
-          player.setProperty('sub-file-paths', _subtitleFontDir);
+          player.setProperty('sub-file-paths', effectiveFontDir);
         }
       }
+
       final resolvedFontName = _subtitleFontName.isNotEmpty
           ? _subtitleFontName
           : _defaultSubtitleFontNameForPlatform();

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -1930,10 +1930,10 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
 
       if (localFontsFolder != null) {
         effectiveFontDir = localFontsFolder;
-        _subtitleFontDir = localFontsFolder;
         _subtitleFontDirSource = SubtitleFontDirSource.localFonts;
         debugPrint('[VideoPlayerState] 使用本地 fonts 文件夹: $effectiveFontDir');
-      } else if (_subtitleFontDir.isNotEmpty) {
+      } else if (_subtitleFontDir.isNotEmpty &&
+          _subtitleFontDirSource != SubtitleFontDirSource.localFonts) {
         effectiveFontDir = _subtitleFontDir;
       }
 

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -1939,9 +1939,12 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       } else {
         final prefs = await SharedPreferences.getInstance();
         final savedFontDir = prefs.getString(_subtitleFontDirKey) ?? '';
-        if (savedFontDir.isNotEmpty) {
+        if (savedFontDir.isNotEmpty &&
+            savedFontDir.contains('subtitle_fonts')) {
           effectiveFontDir = savedFontDir;
           _subtitleFontDir = savedFontDir;
+        } else {
+          _subtitleFontDir = '';
         }
       }
 
@@ -1949,6 +1952,11 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
         player.setProperty('sub-fonts-dir', effectiveFontDir);
         if (defaultTargetPlatform == TargetPlatform.iOS) {
           player.setProperty('sub-file-paths', effectiveFontDir);
+        }
+      } else {
+        player.setProperty('sub-fonts-dir', '');
+        if (defaultTargetPlatform == TargetPlatform.iOS) {
+          player.setProperty('sub-file-paths', '');
         }
       }
 


### PR DESCRIPTION
## Summary

- 增加了配置字体文件夹用作字幕字体的功能
- 对于目录下含有Fonts(大小写兼容)的视频，将自动配置字体文件夹
- 若手动选择字体文件夹则将文件夹内的所有字体复制到应用存储的“subtitle_fonts”文件夹，避免访问限制

## Related Issue

- Closes #459 
- #374 

## What Changed

### 1. 核心功能实现

#### 添加了 `importSubtitleFontDirectory` 方法
- **位置**：`lib/utils/video_player_state/video_player_state_preferences.dart`
- **功能**：
  - 复制用户选择的文件夹中的所有字体文件（`.ttf`, `.otf`, `.ttc`）到应用内部存储
  - 导入前先清空字体库，避免存储空间浪费
  - 返回导入的字体文件数量

#### 添加了 `SubtitleFontDirSource` 枚举
- **位置**：`lib/utils/video_player_state.dart`
- **枚举值**：`none`、`localFonts`、`customLibrary`
- **作用**：追踪字体目录的来源

#### 修改了 `applySubtitleStylePreference` 方法
- **位置**：`lib/utils/video_player_state/video_player_state_preferences.dart`
- **功能**：
  - 检测本地视频目录下的 `fonts` 文件夹
  - 优先使用本地 fonts 文件夹，设置来源为 `localFonts`
  - 仅当没有本地 fonts 时才使用用户自定义目录

#### 修改了 `initializePlayer` 方法
- **位置**：`lib/utils/video_player_state/video_player_state_player_setup.dart`
- **功能**：
  - 在播放器初始化时检测本地 fonts 文件夹
  - 显示状态消息："发现Fonts目录，已自动配置字幕字体"

---

### 2. UI 界面实现

#### Material 主题 (`lib/themes/nipaplay/widgets/subtitle_settings_menu.dart`)
- 添加了"导入字体文件夹"按钮
- 添加了导入结果消息显示区域（按钮下方）
- 添加了 `_getFontDirDisplayText` 方法显示来源标签

#### Cupertino 主题 (`lib/themes/cupertino/widgets/player_menu/cupertino_subtitle_settings_pane.dart`)
- 添加了"导入字体文件夹"选项
- 添加了导入结果消息显示
- 添加了 `_getFontDirDisplayText` 方法显示来源标签

