### PR TITLE
ci/fix-path-error-in-cargokit.cmake

### DIFF
--- a/rust_builder/cargokit/cmake/cargokit.cmake
+++ b/rust_builder/cargokit/cmake/cargokit.cmake
@@ -33,10 +33,17 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
         set(CARGOKIT_TARGET_PLATFORM "windows-x64")
     endif()
 
+    # Check if manifest_dir is already an absolute path
+    if(IS_ABSOLUTE "${manifest_dir}")
+        set(CARGOKIT_MANIFEST_DIR "${manifest_dir}")
+    else()
+        set(CARGOKIT_MANIFEST_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${manifest_dir}")
+    endif()
+
     set(CARGOKIT_ENV
         "CARGOKIT_CMAKE=${CMAKE_COMMAND}"
         "CARGOKIT_CONFIGURATION=$<CONFIG>"
-        "CARGOKIT_MANIFEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/${manifest_dir}"
+        "CARGOKIT_MANIFEST_DIR=${CARGOKIT_MANIFEST_DIR}"
         "CARGOKIT_TARGET_TEMP_DIR=${CARGOKIT_TEMP_DIR}"
         "CARGOKIT_OUTPUT_DIR=${CARGOKIT_OUTPUT_DIR}"
         "CARGOKIT_TARGET_PLATFORM=${CARGOKIT_TARGET_PLATFORM}"


### PR DESCRIPTION
## Summary

- 修复了`rust_builder\cargokit\cmake\cargokit.cmake`中路径错误导致的Windows端build失败问题
