### PR TITLE
fix:use file picker on Android

### DIFF
--- a/lib/services/file_picker_service.dart
+++ b/lib/services/file_picker_service.dart
@@ -637,8 +637,7 @@ class FilePickerService {
           _saveLastDirectory(appDocDir.path, _lastDirKey);
           return _normalizePath(appDocDir.path);
         } catch (e) {
-          print("Error getting documents directory for iOS: $e");
-          return null;
+          throw Exception('获取iOS文档目录失败: $e');
         }
       } else {
         // 非iOS平台正常选择目录
@@ -661,8 +660,8 @@ class FilePickerService {
         return _normalizePath(selectedDirectory);
       }
     } catch (e) {
-      print('选择文件夹失败: $e');
-      return null;
+      if (e is Exception) rethrow;
+      throw Exception('选择文件夹失败: $e');
     }
   }
 

--- a/lib/themes/cupertino/pages/cupertino_media_library_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_media_library_page.dart
@@ -44,7 +44,6 @@ import 'package:nipaplay/services/playback_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/batch_danmaku_dialog.dart';
-import 'package:nipaplay/themes/nipaplay/widgets/custom_media_info_dialog.dart';
 import 'package:nipaplay/providers/jellyfin_provider.dart';
 import 'package:nipaplay/providers/emby_provider.dart';
 import 'package:nipaplay/themes/cupertino/pages/cupertino_media_server_detail_page.dart';
@@ -3318,55 +3317,6 @@ class _CupertinoLibraryManagementSheetState
       );
     }
 
-    children.add(
-      Padding(
-        padding: EdgeInsets.fromLTRB(indentation, 6, 12, 6),
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: () async {
-            final result =
-                await CustomMediaInfoDialog.show(context, folderPath);
-            if (result != null) {
-              _refreshExpandedFolderContents(folderPath);
-            }
-          },
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Icon(
-                CupertinoIcons.info,
-                size: 16,
-                color: accentColor,
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      '自定义媒体信息（实验性）',
-                      style: TextStyle(fontSize: 13, color: labelColor),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      '自定义媒体信息，并将当前文件夹添加到媒体库中',
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(fontSize: 11, color: subtitleColor),
-                    ),
-                  ],
-                ),
-              ),
-              Text(
-                '开始',
-                style: TextStyle(fontSize: 12, color: accentColor),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: children,
@@ -3498,24 +3448,6 @@ class _CupertinoLibraryManagementSheetState
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  CupertinoButton(
-                    padding: EdgeInsets.zero,
-                    minSize: 28,
-                    onPressed: () async {
-                      final result = await CustomMediaInfoDialog.show(
-                        context,
-                        p.dirname(file.path),
-                        initialVideoPath: file.path,
-                      );
-                      if (result != null) {
-                        _refreshExpandedFolderContents(p.dirname(file.path));
-                      }
-                    },
-                    child: Text(
-                      '自定义媒体信息',
-                      style: TextStyle(fontSize: 12, color: accentColor),
-                    ),
-                  ),
                   CupertinoButton(
                     padding: EdgeInsets.zero,
                     minSize: 28,
@@ -5671,10 +5603,29 @@ class _CupertinoLibraryManagementSheetState
       }
 
       if (Platform.isAndroid) {
-        final sdkVersion = await AndroidStorageHelper.getAndroidSDKVersion();
-        if (sdkVersion >= 33) {
-          await _handleScanAndroidMediaFolders(scanService);
+        final filePicker = FilePickerService();
+        try {
+          final selectedDirectory = await filePicker.pickDirectory();
+          if (selectedDirectory != null) {
+            await scanService.startDirectoryScan(
+              selectedDirectory,
+              skipPreviouslyMatchedUnwatched: false,
+            );
+            _showSnack('已提交扫描任务：${p.basename(selectedDirectory)}');
+            return;
+          }
           return;
+        } catch (e) {
+          AdaptiveSnackBar.show(
+            context,
+            message: '文件选择器不可用，使用应用默认目录',
+            type: AdaptiveSnackBarType.warning,
+          );
+          final sdkVersion = await AndroidStorageHelper.getAndroidSDKVersion();
+          if (sdkVersion >= 33) {
+            await _handleScanAndroidMediaFolders(scanService);
+            return;
+          }
         }
       }
 
@@ -5685,8 +5636,6 @@ class _CupertinoLibraryManagementSheetState
         return;
       }
 
-      // [修改] 自定义目录会影响安卓缓存，先注释
-      //await StorageService.saveCustomStoragePath(selectedDirectory);
       await scanService.startDirectoryScan(
         selectedDirectory,
         skipPreviouslyMatchedUnwatched: false,

--- a/lib/themes/cupertino/widgets/cupertino_library_browser_sheet.dart
+++ b/lib/themes/cupertino/widgets/cupertino_library_browser_sheet.dart
@@ -8,6 +8,7 @@ import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_modal_popup.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/custom_media_info_dialog.dart';
 import 'package:nipaplay/models/playable_item.dart';
 import 'package:nipaplay/models/watch_history_model.dart';
 import 'package:nipaplay/providers/shared_remote_library_provider.dart';
@@ -1265,6 +1266,29 @@ class _CupertinoLibraryFolderBrowserSheetState
                             ),
                           ),
                           Container(height: 0.5, color: separatorColor),
+                          if (entry.isDirectory)
+                            buildAction(
+                              title: '自定义媒体信息（本文件夹）',
+                              onPressed: () async {
+                                Navigator.of(context).pop();
+                                await CustomMediaInfoDialog.show(
+                                  context,
+                                  entry.path,
+                                );
+                              },
+                            ),
+                          if (!entry.isDirectory)
+                            buildAction(
+                              title: '自定义媒体信息',
+                              onPressed: () async {
+                                Navigator.of(context).pop();
+                                await CustomMediaInfoDialog.show(
+                                  context,
+                                  p.dirname(entry.path),
+                                  initialVideoPath: entry.path,
+                                );
+                              },
+                            ),
                           if (canManualMatch)
                             buildAction(
                               title: '手动选择弹幕',


### PR DESCRIPTION
## Summary

- 修改了设置媒体库的时的逻辑：先尝试调用文件选择器
- 修复了PR #458 中为cupertinoUI引入“自定义媒体信息”按钮位置错误的问题（应该引入`lib/themes/cupertino/widgets/cupertino_library_browser_sheet.dart`）
- **已通过实机测试**

## Related Issue

- Closes #468 

## Issue Analyze

### 原先逻辑

| Android 版本                | 行为                                                         |
| --------------------------- | ------------------------------------------------------------ |
| SDK < 33 (Android 12及以下) | 调用文件选择器，用户可以选择任意文件夹                       |
| SDK >= 33 (Android 13+)     | **绕过文件选择器**，直接扫描 `Android/data/包名/files/Movies` |

### 修改后逻辑

无论如何先尝试调用文件选择器，如果失败则消息提示(`AdaptiveSnackBar`)并扫描 `Android/data/包名/files/Movies`
