### PR TITLE
Support IPv6 remote access QR payloads

### DIFF
--- a/lib/danmaku_abstraction/positioned_danmaku_item.dart
+++ b/lib/danmaku_abstraction/positioned_danmaku_item.dart
@@ -1,14 +1,14 @@
-import 'package:flutter/material.dart';
 import 'danmaku_content_item.dart';
 
-/// A data class that represents a danmaku item with its calculated position.
-/// This is used to pass layout information from the CPU logic (DanmakuContainer)
-/// to the GPU renderer (GPUDanmakuOverlay).
+/// Mutable layout result for a danmaku item.
+///
+/// x/y/offstageX are intentionally mutable so layout results can be reused
+/// across frames without creating new objects every tick.
 class PositionedDanmakuItem {
   final DanmakuContentItem content;
-  final double x;
-  final double y;
-  final double offstageX; // The starting X position when it's off-screen
+  double x;
+  double y;
+  double offstageX;
   final double time; // The original time of the danmaku
 
   PositionedDanmakuItem({
@@ -18,4 +18,4 @@ class PositionedDanmakuItem {
     required this.offstageX,
     required this.time,
   });
-} 
+}

--- a/lib/danmaku_next/nipaplay_next_canvas_painter.dart
+++ b/lib/danmaku_next/nipaplay_next_canvas_painter.dart
@@ -1,22 +1,28 @@
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:nipaplay/danmaku_abstraction/danmaku_content_item.dart';
-import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
+
+import 'nipaplay_next_engine.dart';
 
 class NipaPlayNextCanvasPainter extends CustomPainter {
   NipaPlayNextCanvasPainter({
-    required this.items,
+    required this.engine,
+    required this.playbackTimeMs,
+    required this.timeOffsetSeconds,
     required this.fontSize,
     required this.fontFamily,
     required this.fontFamilyFallback,
     required this.locale,
     required this.outlineStyle,
     required this.shadowStyle,
-  });
+  }) : super(repaint: playbackTimeMs);
 
-  final List<PositionedDanmakuItem> items;
+  final NipaPlayNextEngine engine;
+  final ValueListenable<double> playbackTimeMs;
+  final double timeOffsetSeconds;
   final double fontSize;
   final String? fontFamily;
   final List<String>? fontFamilyFallback;
@@ -35,6 +41,8 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
+    final items =
+        engine.layout(playbackTimeMs.value / 1000.0 + timeOffsetSeconds);
     if (items.isEmpty) return;
 
     for (final item in items) {
@@ -355,8 +363,8 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
       fillPainter.width + expanded * 2,
       fillPainter.height + expanded * 2,
     );
-    final filterPaint =
-        Paint()..colorFilter = ColorFilter.mode(outlineColor, BlendMode.srcIn);
+    final filterPaint = Paint()
+      ..colorFilter = ColorFilter.mode(outlineColor, BlendMode.srcIn);
 
     for (final offset in _buildUniformOffsets(radius)) {
       canvas.saveLayer(baseBounds.shift(offset), filterPaint);
@@ -367,7 +375,8 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant NipaPlayNextCanvasPainter oldDelegate) {
-    return oldDelegate.items != items ||
+    return oldDelegate.engine != engine ||
+        oldDelegate.timeOffsetSeconds != timeOffsetSeconds ||
         oldDelegate.fontSize != fontSize ||
         oldDelegate.fontFamily != fontFamily ||
         oldDelegate.outlineStyle != outlineStyle ||

--- a/lib/danmaku_next/nipaplay_next_canvas_painter.dart
+++ b/lib/danmaku_next/nipaplay_next_canvas_painter.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
@@ -29,11 +30,19 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
   final Locale? locale;
   final DanmakuOutlineStyle outlineStyle;
   final DanmakuShadowStyle shadowStyle;
+  late final String? _fontFamilyFallbackKey =
+      fontFamilyFallback?.join('\u0000');
 
   static const int _cacheLimit = 2000;
-  static final Map<_TextCacheKey, TextPainter> _fillCache = {};
-  static final Map<_TextCacheKey, TextPainter> _strokeCache = {};
-  static final Map<_TextCacheKey, TextPainter> _shadowCache = {};
+  static const int _emojiCacheLimit = 4000;
+  static final LinkedHashMap<_TextCacheKey, TextPainter> _fillCache =
+      LinkedHashMap<_TextCacheKey, TextPainter>();
+  static final LinkedHashMap<_TextCacheKey, TextPainter> _strokeCache =
+      LinkedHashMap<_TextCacheKey, TextPainter>();
+  static final LinkedHashMap<_TextCacheKey, TextPainter> _shadowCache =
+      LinkedHashMap<_TextCacheKey, TextPainter>();
+  static final LinkedHashMap<String, bool> _emojiCache =
+      LinkedHashMap<String, bool>();
   static final Paint _selfSendPaint = Paint()
     ..style = PaintingStyle.stroke
     ..strokeWidth = 1.5
@@ -48,15 +57,6 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
     for (final item in items) {
       final content = item.content;
       final adjustedFontSize = fontSize * content.fontSizeMultiplier;
-      final containsEmoji = _containsEmoji(content.text);
-      final strokeColor = _getStrokeColor(
-        textColor: content.color,
-      );
-      final shadowConfig = _resolveShadowStyle(adjustedFontSize);
-      final strokeWidth = _resolveStrokeWidth(adjustedFontSize);
-      final uniformOutlineRadius =
-          _resolveUniformOutlineRadius(adjustedFontSize);
-
       final fillPainter = _getFillPainter(
         content: content,
         fontSize: adjustedFontSize,
@@ -64,20 +64,28 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
       );
 
       final baseOffset = Offset(item.x, item.y);
-      if (shadowConfig != null) {
-        final shadowPainter = _getShadowPainter(
-          content: content,
-          fontSize: adjustedFontSize,
-          color: Color.fromRGBO(0, 0, 0, shadowConfig.opacity),
-          blurSigma: shadowConfig.blurSigma,
-        );
-        shadowPainter.paint(canvas, baseOffset + shadowConfig.offset);
+      if (shadowStyle != DanmakuShadowStyle.none) {
+        final shadowConfig = _resolveShadowStyle(adjustedFontSize);
+        if (shadowConfig != null) {
+          final shadowPainter = _getShadowPainter(
+            content: content,
+            fontSize: adjustedFontSize,
+            color: Color.fromRGBO(0, 0, 0, shadowConfig.opacity),
+            blurSigma: shadowConfig.blurSigma,
+          );
+          shadowPainter.paint(canvas, baseOffset + shadowConfig.offset);
+        }
       }
 
       switch (outlineStyle) {
         case DanmakuOutlineStyle.none:
           break;
         case DanmakuOutlineStyle.stroke:
+          final containsEmoji = _containsEmojiCached(content.text);
+          final strokeColor = _getStrokeColor(
+            textColor: content.color,
+          );
+          final strokeWidth = _resolveStrokeWidth(adjustedFontSize);
           if (containsEmoji) {
             _paintEmojiOutline(
               canvas: canvas,
@@ -97,6 +105,12 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
           }
           break;
         case DanmakuOutlineStyle.uniform:
+          final containsEmoji = _containsEmojiCached(content.text);
+          final strokeColor = _getStrokeColor(
+            textColor: content.color,
+          );
+          final uniformOutlineRadius =
+              _resolveUniformOutlineRadius(adjustedFontSize);
           if (containsEmoji) {
             _paintEmojiOutline(
               canvas: canvas,
@@ -111,9 +125,12 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
               fontSize: adjustedFontSize,
               color: strokeColor,
             );
-            for (final offset in _buildUniformOffsets(uniformOutlineRadius)) {
-              outlinePainter.paint(canvas, baseOffset + offset);
-            }
+            _paintUniformOutline(
+              canvas: canvas,
+              painter: outlinePainter,
+              baseOffset: baseOffset,
+              radius: uniformOutlineRadius,
+            );
           }
           break;
       }
@@ -181,7 +198,6 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
     required _PainterVariant variant,
     double effectValue = 0.0,
   }) {
-    final fallbackKey = fontFamilyFallback?.join('\u0000');
     final key = _TextCacheKey(
       text: content.text,
       countText: content.countText,
@@ -190,7 +206,7 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
       variant: variant,
       effectValue: effectValue,
       fontFamily: fontFamily,
-      fontFamilyFallbackKey: fallbackKey,
+      fontFamilyFallbackKey: _fontFamilyFallbackKey,
       locale: locale,
     );
 
@@ -200,7 +216,11 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
       _PainterVariant.shadow => _shadowCache,
     };
     final cached = cache[key];
-    if (cached != null) return cached;
+    if (cached != null) {
+      cache.remove(key);
+      cache[key] = cached;
+      return cached;
+    }
 
     final paint = Paint()
       ..color = color
@@ -239,24 +259,20 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
       locale: locale,
     )..layout(minWidth: 0, maxWidth: double.infinity);
 
-    if (cache.length > _cacheLimit) {
-      cache.clear();
-    }
-    cache[key] = painter;
+    _insertWithBound(cache, key, painter, _cacheLimit);
     return painter;
   }
 
-  List<Offset> _buildUniformOffsets(double radius) {
-    return <Offset>[
-      Offset(-radius, 0),
-      Offset(radius, 0),
-      Offset(0, -radius),
-      Offset(0, radius),
-      Offset(-radius, -radius),
-      Offset(radius, -radius),
-      Offset(-radius, radius),
-      Offset(radius, radius),
-    ];
+  static void _insertWithBound<K, V>(
+    LinkedHashMap<K, V> cache,
+    K key,
+    V value,
+    int limit,
+  ) {
+    if (cache.length >= limit && cache.isNotEmpty) {
+      cache.remove(cache.keys.first);
+    }
+    cache[key] = value;
   }
 
   _ShadowConfig? _resolveShadowStyle(double targetFontSize) {
@@ -334,6 +350,18 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
     return color.r <= epsilon && color.g <= epsilon && color.b <= epsilon;
   }
 
+  bool _containsEmojiCached(String text) {
+    final cached = _emojiCache[text];
+    if (cached != null) {
+      _emojiCache.remove(text);
+      _emojiCache[text] = cached;
+      return cached;
+    }
+    final result = _containsEmoji(text);
+    _insertWithBound(_emojiCache, text, result, _emojiCacheLimit);
+    return result;
+  }
+
   bool _containsEmoji(String text) {
     for (final rune in text.runes) {
       if (_isEmojiRune(rune)) return true;
@@ -366,11 +394,121 @@ class NipaPlayNextCanvasPainter extends CustomPainter {
     final filterPaint = Paint()
       ..colorFilter = ColorFilter.mode(outlineColor, BlendMode.srcIn);
 
-    for (final offset in _buildUniformOffsets(radius)) {
-      canvas.saveLayer(baseBounds.shift(offset), filterPaint);
-      fillPainter.paint(canvas, baseOffset + offset);
-      canvas.restore();
-    }
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: -radius,
+      dy: 0,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: radius,
+      dy: 0,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: 0,
+      dy: -radius,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: 0,
+      dy: radius,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: -radius,
+      dy: -radius,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: radius,
+      dy: -radius,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: -radius,
+      dy: radius,
+    );
+    _paintEmojiOutlineDirection(
+      canvas: canvas,
+      fillPainter: fillPainter,
+      baseOffset: baseOffset,
+      baseBounds: baseBounds,
+      filterPaint: filterPaint,
+      dx: radius,
+      dy: radius,
+    );
+  }
+
+  void _paintUniformOutline({
+    required Canvas canvas,
+    required TextPainter painter,
+    required Offset baseOffset,
+    required double radius,
+  }) {
+    painter.paint(canvas, Offset(baseOffset.dx - radius, baseOffset.dy));
+    painter.paint(canvas, Offset(baseOffset.dx + radius, baseOffset.dy));
+    painter.paint(canvas, Offset(baseOffset.dx, baseOffset.dy - radius));
+    painter.paint(canvas, Offset(baseOffset.dx, baseOffset.dy + radius));
+    painter.paint(
+      canvas,
+      Offset(baseOffset.dx - radius, baseOffset.dy - radius),
+    );
+    painter.paint(
+      canvas,
+      Offset(baseOffset.dx + radius, baseOffset.dy - radius),
+    );
+    painter.paint(
+      canvas,
+      Offset(baseOffset.dx - radius, baseOffset.dy + radius),
+    );
+    painter.paint(
+      canvas,
+      Offset(baseOffset.dx + radius, baseOffset.dy + radius),
+    );
+  }
+
+  void _paintEmojiOutlineDirection({
+    required Canvas canvas,
+    required TextPainter fillPainter,
+    required Offset baseOffset,
+    required Rect baseBounds,
+    required Paint filterPaint,
+    required double dx,
+    required double dy,
+  }) {
+    final shift = Offset(dx, dy);
+    canvas.saveLayer(baseBounds.shift(shift), filterPaint);
+    fillPainter.paint(canvas, baseOffset + shift);
+    canvas.restore();
   }
 
   @override

--- a/lib/danmaku_next/nipaplay_next_engine.dart
+++ b/lib/danmaku_next/nipaplay_next_engine.dart
@@ -28,6 +28,7 @@ class NipaPlayNextEngine {
 
   final List<_NextItem> _items = [];
   final List<double> _itemTimes = [];
+  final List<PositionedDanmakuItem> _positionedBuffer = [];
   bool _layoutDirty = true;
 
   void configure({
@@ -109,7 +110,7 @@ class NipaPlayNextEngine {
     final left = _lowerBound(windowStart);
     final right = _upperBound(currentTimeSeconds);
 
-    final List<PositionedDanmakuItem> positioned = [];
+    _positionedBuffer.clear();
 
     for (int i = left; i < right; i++) {
       final item = _items[i];
@@ -122,29 +123,23 @@ class NipaPlayNextEngine {
         case DanmakuItemType.scroll:
           if (elapsed > _scrollDurationSeconds) continue;
           final x = _size.width - item.scrollSpeed * elapsed;
-          positioned.add(
-            PositionedDanmakuItem(
-              content: item.content,
-              x: x,
-              y: item.yPosition,
-              offstageX: _size.width + item.width,
-              time: item.timeSeconds,
-            ),
-          );
+          _positionedBuffer.add(_toPositionedItem(
+            source: item,
+            x: x,
+            y: item.yPosition,
+            offstageX: _size.width + item.width,
+          ));
           break;
         case DanmakuItemType.top:
         case DanmakuItemType.bottom:
           if (elapsed > _staticDurationSeconds) continue;
           final x = (_size.width - item.width) / 2;
-          positioned.add(
-            PositionedDanmakuItem(
-              content: item.content,
-              x: x,
-              y: item.yPosition,
-              offstageX: _size.width,
-              time: item.timeSeconds,
-            ),
-          );
+          _positionedBuffer.add(_toPositionedItem(
+            source: item,
+            x: x,
+            y: item.yPosition,
+            offstageX: _size.width,
+          ));
           break;
       }
     }
@@ -152,10 +147,35 @@ class NipaPlayNextEngine {
     DanmakuNextLog.d(
       'Engine',
       'layout time=${currentTimeSeconds.toStringAsFixed(2)} window=[$windowStart..$currentTimeSeconds] '
-      'range=[$left,$right) out=${positioned.length}',
+          'range=[$left,$right) out=${_positionedBuffer.length}',
       throttle: const Duration(seconds: 1),
     );
-    return positioned;
+    return _positionedBuffer;
+  }
+
+  PositionedDanmakuItem _toPositionedItem({
+    required _NextItem source,
+    required double x,
+    required double y,
+    required double offstageX,
+  }) {
+    final existing = source.positionedItem;
+    if (existing == null) {
+      final created = PositionedDanmakuItem(
+        content: source.content,
+        x: x,
+        y: y,
+        offstageX: offstageX,
+        time: source.timeSeconds,
+      );
+      source.positionedItem = created;
+      return created;
+    }
+
+    existing.x = x;
+    existing.y = y;
+    existing.offstageX = offstageX;
+    return existing;
   }
 
   void _parseDanmakuList(List<Map<String, dynamic>> danmakuList) {
@@ -182,9 +202,8 @@ class NipaPlayNextEngine {
         type: type,
         color: color,
         isMe: isMe,
-        fontSizeMultiplier: isMerged
-            ? _calcMergedFontSizeMultiplier(mergeCount)
-            : 1.0,
+        fontSizeMultiplier:
+            isMerged ? _calcMergedFontSizeMultiplier(mergeCount) : 1.0,
         countText: isMerged ? 'x$mergeCount' : null,
       );
 
@@ -246,7 +265,7 @@ class NipaPlayNextEngine {
     DanmakuNextLog.d(
       'Engine',
       'layout rebuild tracks=$trackCount font=${_fontSize.toStringAsFixed(1)} area=${_displayArea.toStringAsFixed(2)} '
-      'scroll=${_scrollDurationSeconds.toStringAsFixed(1)} stacking=$_allowStacking',
+          'scroll=${_scrollDurationSeconds.toStringAsFixed(1)} stacking=$_allowStacking',
       throttle: Duration.zero,
     );
 
@@ -334,8 +353,7 @@ class NipaPlayNextEngine {
 
     final List<double> scrollTrackOffsets =
         List<double>.filled(trackCount, 0.0);
-    final List<double> topTrackOffsets =
-        List<double>.filled(trackCount, 0.0);
+    final List<double> topTrackOffsets = List<double>.filled(trackCount, 0.0);
     final List<double> bottomTrackOffsets =
         List<double>.filled(trackCount, 0.0);
 
@@ -697,6 +715,7 @@ class _NextItem {
   final DanmakuContentItem content;
   final DanmakuItemType type;
 
+  PositionedDanmakuItem? positionedItem;
   int trackIndex = -1;
   double yPosition = 0.0;
   double width = 0.0;

--- a/lib/danmaku_next/nipaplay_next_engine.dart
+++ b/lib/danmaku_next/nipaplay_next_engine.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -20,7 +21,8 @@ class NipaPlayNextEngine {
   Locale? _locale;
   int _sourceListIdentity = 0;
 
-  final Map<String, double> _textWidthCache = {};
+  final LinkedHashMap<String, double> _textWidthCache =
+      LinkedHashMap<String, double>();
   static const int _textWidthCacheLimit = 5000;
   static const double _mergeWindowSeconds = 45.0;
   static const double _minTrackGap = 2.0;
@@ -633,7 +635,11 @@ class NipaPlayNextEngine {
   double _measureTextWidth(String text, double fontSize) {
     final key = '$fontSize|$text';
     final cached = _textWidthCache[key];
-    if (cached != null) return cached;
+    if (cached != null) {
+      _textWidthCache.remove(key);
+      _textWidthCache[key] = cached;
+      return cached;
+    }
 
     final tp = TextPainter(
       text: TextSpan(
@@ -650,8 +656,9 @@ class NipaPlayNextEngine {
     )..layout(minWidth: 0, maxWidth: double.infinity);
 
     final width = tp.size.width;
-    if (_textWidthCache.length > _textWidthCacheLimit) {
-      _textWidthCache.clear();
+    if (_textWidthCache.length >= _textWidthCacheLimit &&
+        _textWidthCache.isNotEmpty) {
+      _textWidthCache.remove(_textWidthCache.keys.first);
     }
     _textWidthCache[key] = width;
     return width;

--- a/lib/danmaku_next/nipaplay_next_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
 import 'package:nipaplay/danmaku_next/nipaplay_next_canvas_painter.dart';
 import 'package:nipaplay/danmaku_next/nipaplay_next_engine.dart';
@@ -13,6 +14,7 @@ const Locale _danmakuLocale = Locale.fromSubtags(
 
 class NipaPlayNextOverlay extends StatefulWidget {
   final List<Map<String, dynamic>> danmakuList;
+  final ValueListenable<double> playbackTimeMs;
   final double currentTimeSeconds;
   final double fontSize;
   final bool isVisible;
@@ -30,6 +32,7 @@ class NipaPlayNextOverlay extends StatefulWidget {
   const NipaPlayNextOverlay({
     super.key,
     required this.danmakuList,
+    required this.playbackTimeMs,
     required this.currentTimeSeconds,
     required this.fontSize,
     required this.isVisible,
@@ -52,11 +55,14 @@ class NipaPlayNextOverlay extends StatefulWidget {
 class _NipaPlayNextOverlayState extends State<NipaPlayNextOverlay> {
   final NipaPlayNextEngine _engine = NipaPlayNextEngine();
   int _listIdentity = 0;
+  Size _lastConfiguredSize = Size.zero;
+  bool _layoutSnapshotPending = false;
 
   @override
   void initState() {
     super.initState();
     _listIdentity = identityHashCode(widget.danmakuList);
+    _layoutSnapshotPending = true;
     DanmakuNextLog.d(
       'Overlay',
       'init list=${widget.danmakuList.length} font=${widget.fontSize} visible=${widget.isVisible}',
@@ -79,6 +85,7 @@ class _NipaPlayNextOverlayState extends State<NipaPlayNextOverlay> {
     final listIdentity = identityHashCode(widget.danmakuList);
     if (listIdentity != _listIdentity) {
       _listIdentity = listIdentity;
+      _layoutSnapshotPending = true;
       DanmakuNextLog.d(
         'Overlay',
         'danmaku list changed size=${widget.danmakuList.length}',
@@ -120,6 +127,9 @@ class _NipaPlayNextOverlayState extends State<NipaPlayNextOverlay> {
           return const SizedBox.expand();
         }
 
+        final previousSize = _lastConfiguredSize;
+        _lastConfiguredSize = size;
+
         _engine.configure(
           danmakuList: widget.danmakuList,
           size: size,
@@ -133,18 +143,12 @@ class _NipaPlayNextOverlayState extends State<NipaPlayNextOverlay> {
           locale: _danmakuLocale,
         );
 
-        final effectiveTime = widget.currentTimeSeconds + widget.timeOffset;
-        final positioned = _engine.layout(effectiveTime);
-
-        DanmakuNextLog.d(
-          'Overlay',
-          'build size=${size.width.toStringAsFixed(1)}x${size.height.toStringAsFixed(1)} '
-              'time=${effectiveTime.toStringAsFixed(2)} items=${positioned.length}',
-          throttle: const Duration(seconds: 1),
-        );
-
-        if (widget.onLayoutCalculated != null) {
-          final snapshot = positioned;
+        if (widget.onLayoutCalculated != null &&
+            (_layoutSnapshotPending || previousSize != size)) {
+          final snapshot = List<PositionedDanmakuItem>.from(
+            _engine.layout(widget.currentTimeSeconds + widget.timeOffset),
+          );
+          _layoutSnapshotPending = false;
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (!mounted) return;
             widget.onLayoutCalculated?.call(snapshot);
@@ -155,7 +159,9 @@ class _NipaPlayNextOverlayState extends State<NipaPlayNextOverlay> {
           opacity: widget.opacity.clamp(0.0, 1.0),
           child: CustomPaint(
             painter: NipaPlayNextCanvasPainter(
-              items: positioned,
+              engine: _engine,
+              playbackTimeMs: widget.playbackTimeMs,
+              timeOffsetSeconds: widget.timeOffset,
               fontSize: widget.fontSize,
               fontFamily: fontFamily,
               fontFamilyFallback: fontFamilyFallback,

--- a/lib/services/remote_access_qr_service.dart
+++ b/lib/services/remote_access_qr_service.dart
@@ -10,11 +10,39 @@ import 'package:zxing2/qrcode.dart';
 class RemoteAccessQrPayload {
   const RemoteAccessQrPayload({
     required this.baseUrl,
+    this.candidateBaseUrls = const <String>[],
     this.displayName,
   });
 
   final String baseUrl;
+  final List<String> candidateBaseUrls;
   final String? displayName;
+
+  List<String> get allCandidateBaseUrls {
+    final normalized = <String>[];
+    final seen = <String>{};
+
+    void add(String value) {
+      final trimmed = value.trim();
+      if (trimmed.isEmpty) return;
+      try {
+        final normalizedUrl = RemoteAccessQrService.normalizeRemoteAccessUrl(
+          trimmed,
+        );
+        if (seen.add(normalizedUrl)) {
+          normalized.add(normalizedUrl);
+        }
+      } catch (_) {
+        // ignore invalid candidate
+      }
+    }
+
+    add(baseUrl);
+    for (final url in candidateBaseUrls) {
+      add(url);
+    }
+    return normalized;
+  }
 }
 
 class RemoteAccessServerInfo {
@@ -40,8 +68,38 @@ class RemoteAccessQrService {
   static const String payloadType = 'nipaplay_remote_access';
   static const int defaultPort = 1180;
 
-  static String buildPayload({required String baseUrl}) {
-    return normalizeRemoteAccessUrl(baseUrl);
+  static String buildPayload({
+    required String baseUrl,
+    List<String> candidateBaseUrls = const <String>[],
+    String? displayName,
+  }) {
+    final normalizedBaseUrl = normalizeRemoteAccessUrl(baseUrl);
+    final normalizedCandidates = <String>[];
+    final seen = <String>{normalizedBaseUrl};
+
+    for (final candidate in candidateBaseUrls) {
+      try {
+        final normalized = normalizeRemoteAccessUrl(candidate);
+        if (seen.add(normalized)) {
+          normalizedCandidates.add(normalized);
+        }
+      } catch (_) {
+        // ignore invalid candidate
+      }
+    }
+
+    if (normalizedCandidates.isEmpty && (displayName?.trim().isEmpty ?? true)) {
+      return normalizedBaseUrl;
+    }
+
+    final payload = <String, dynamic>{
+      'type': payloadType,
+      'baseUrl': normalizedBaseUrl,
+      if (normalizedCandidates.isNotEmpty) 'urls': normalizedCandidates,
+      if (displayName?.trim().isNotEmpty == true)
+        'displayName': displayName!.trim(),
+    };
+    return json.encode(payload);
   }
 
   static RemoteAccessQrPayload parseScannedText(String text) {
@@ -60,8 +118,15 @@ class RemoteAccessQrService {
       final baseUrl =
           uri.queryParameters['baseUrl'] ?? uri.queryParameters['url'] ?? '';
       if (baseUrl.trim().isNotEmpty) {
+        final multiUrlsRaw = uri.queryParametersAll['url'];
+        final candidates = <String>[];
+        if (multiUrlsRaw != null && multiUrlsRaw.isNotEmpty) {
+          candidates
+              .addAll(multiUrlsRaw.where((item) => item.trim().isNotEmpty));
+        }
         return RemoteAccessQrPayload(
           baseUrl: normalizeRemoteAccessUrl(baseUrl),
+          candidateBaseUrls: candidates,
           displayName: uri.queryParameters['name'],
         );
       }
@@ -87,7 +152,7 @@ class RemoteAccessQrService {
       throw const FormatException('不是有效的访问地址');
     }
 
-    uri = uri.replace(path: '', query: '', fragment: '');
+    uri = uri.replace(path: '', query: null, fragment: null);
 
     if (!uri.hasPort && uri.scheme == 'http') {
       uri = uri.replace(port: defaultPort);
@@ -182,8 +247,21 @@ class RemoteAccessQrService {
       if (baseUrl.isEmpty) return null;
       final displayName =
           decoded['name']?.toString() ?? decoded['displayName']?.toString();
+      final candidateUrls = <String>[];
+      final rawUrls = decoded['urls'];
+      if (rawUrls is List) {
+        for (final value in rawUrls) {
+          final text = value?.toString().trim();
+          if (text != null && text.isNotEmpty) {
+            candidateUrls.add(text);
+          }
+        }
+      } else if (rawUrls is String && rawUrls.trim().isNotEmpty) {
+        candidateUrls.add(rawUrls.trim());
+      }
       return RemoteAccessQrPayload(
         baseUrl: normalizeRemoteAccessUrl(baseUrl),
+        candidateBaseUrls: candidateUrls,
         displayName: displayName,
       );
     } catch (_) {

--- a/lib/services/web_server_service.dart
+++ b/lib/services/web_server_service.dart
@@ -15,7 +15,7 @@ class WebServerService {
   static const String _autoStartKey = 'web_server_auto_start';
   static const String _portKey = 'web_server_port';
   static const String _webAssetsRelativePath = 'assets/web';
-  
+
   HttpServer? _server;
   int _port = 1180;
   bool _isRunning = false;
@@ -31,6 +31,16 @@ class WebServerService {
   int get port => _port;
   bool get autoStart => _autoStart;
   String? get lastStartErrorMessage => _lastStartErrorMessage;
+
+  String _buildHttpUrlForHost(String host, int port) {
+    final normalizedHost = host.trim();
+    final parsed = InternetAddress.tryParse(normalizedHost);
+    if (parsed != null) {
+      final addressText = parsed.address;
+      return Uri(scheme: 'http', host: addressText, port: port).toString();
+    }
+    return Uri(scheme: 'http', host: normalizedHost, port: port).toString();
+  }
 
   Directory? _resolveWebUiRoot() {
     final candidates = <String>[
@@ -100,7 +110,8 @@ class WebServerService {
     final origin = request.requestedUri.origin;
     final updatedQuery = Map<String, String>.from(request.url.queryParameters);
     updatedQuery['api'] = origin;
-    final redirectUri = request.requestedUri.replace(queryParameters: updatedQuery);
+    final redirectUri =
+        request.requestedUri.replace(queryParameters: updatedQuery);
     return Response.found(redirectUri.toString());
   }
 
@@ -118,7 +129,8 @@ class WebServerService {
     if (patchedIndex != null) {
       return patchedIndex;
     }
-    final patchedBootstrap = await _tryServePatchedBootstrap(request, indexFile);
+    final patchedBootstrap =
+        await _tryServePatchedBootstrap(request, indexFile);
     if (patchedBootstrap != null) {
       return patchedBootstrap;
     }
@@ -203,8 +215,7 @@ class WebServerService {
 
   String _patchIndexForRemote(String original) {
     const bootstrapTag = '<script src="flutter_bootstrap.js" async></script>';
-    const patchedTag =
-        '<script>'
+    const patchedTag = '<script>'
         "if ('serviceWorker' in navigator) {"
         'navigator.serviceWorker.getRegistrations().then((regs) => {'
         'if (!regs.length) { return; }'
@@ -270,7 +281,8 @@ class WebServerService {
     );
   }
 
-  void _logStaticRouting(Request request, File indexFile, {required String prefix}) {
+  void _logStaticRouting(Request request, File indexFile,
+      {required String prefix}) {
     final pathValue = request.url.path;
     final accept = request.headers[HttpHeaders.acceptHeader] ?? '';
     final rootDir = indexFile.parent;
@@ -358,14 +370,14 @@ class WebServerService {
       final Handler rootHandler = (Request request) async {
         final path = request.url.path;
         //print('[WebServer] 收到请求: "$path", handlerPath: "${request.handlerPath}"');
-        
+
         if (path == 'api' || path.startsWith('api/')) {
           //print('[WebServer] 匹配到API路径，尝试分发...');
           try {
             final response = await apiRouter.call(request);
             //print('[WebServer] API路由器响应状态码: ${response.statusCode}');
             if (response.statusCode == 404) {
-               //print('[WebServer] 警告：API路由器返回404。请检查 web_api_service.dart 中的路由定义是否与请求路径匹配。');
+              //print('[WebServer] 警告：API路由器返回404。请检查 web_api_service.dart 中的路由定义是否与请求路径匹配。');
             }
             return response;
           } catch (e) {
@@ -383,8 +395,20 @@ class WebServerService {
           .addMiddleware(corsHeaders())
           .addMiddleware(logRequests())
           .addHandler(rootHandler);
-          
-      _server = await shelf_io.serve(handler, '0.0.0.0', _port);
+
+      try {
+        final v6Server = await HttpServer.bind(
+          InternetAddress.anyIPv6,
+          _port,
+          v6Only: false,
+        );
+        shelf_io.serveRequests(v6Server, handler);
+        _server = v6Server;
+      } on SocketException {
+        final v4Server = await HttpServer.bind(InternetAddress.anyIPv4, _port);
+        shelf_io.serveRequests(v4Server, handler);
+        _server = v4Server;
+      }
       _isRunning = true;
       _lastStartErrorMessage = null;
       print('Remote access server started on port ${_server!.port}');
@@ -418,7 +442,12 @@ class WebServerService {
       return 2;
     }
     final address = InternetAddress.tryParse(host);
-    if (address != null && address.type == InternetAddressType.IPv4) {
+    if (address == null) {
+      return 1;
+    }
+    if (address.isLoopback) return 2;
+
+    if (address.type == InternetAddressType.IPv4) {
       final bytes = address.rawAddress;
       if (bytes.length == 4) {
         final first = bytes[0];
@@ -426,39 +455,84 @@ class WebServerService {
         if (first == 10 ||
             (first == 172 && second >= 16 && second <= 31) ||
             (first == 192 && second == 168) ||
-            (first == 169 && second == 254)) {
+            (first == 169 && second == 254) ||
+            (first == 100 && second >= 64 && second <= 127)) {
           return 0;
         }
       }
+      return 1;
     }
+
+    if (address.type == InternetAddressType.IPv6) {
+      if (address.isLinkLocal || _isUniqueLocalIpv6(address)) {
+        return 0;
+      }
+      return 1;
+    }
+
     return 1;
   }
-  
+
+  bool _isUniqueLocalIpv6(InternetAddress address) {
+    if (address.type != InternetAddressType.IPv6 ||
+        address.rawAddress.isEmpty) {
+      return false;
+    }
+    return (address.rawAddress[0] & 0xfe) == 0xfc;
+  }
+
   Future<List<String>> getAccessUrls() async {
     if (!_isRunning || _server == null) return [];
 
-    final urls = <String>[];
+    final urls = <String>{};
+
+    void addUrl(String host) {
+      if (host.trim().isEmpty) return;
+      urls.add(_buildHttpUrlForHost(host, _server!.port));
+    }
 
     try {
-      for (var interface in await NetworkInterface.list()) {
+      for (var interface in await NetworkInterface.list(
+        includeLoopback: true,
+        includeLinkLocal: true,
+        type: InternetAddressType.any,
+      )) {
         for (var addr in interface.addresses) {
           if (addr.type == InternetAddressType.IPv4) {
-            urls.add('http://${addr.address}:${_server!.port}');
+            addUrl(addr.address);
+            continue;
           }
+
+          if (addr.type != InternetAddressType.IPv6) {
+            continue;
+          }
+
+          if (addr.isMulticast) {
+            continue;
+          }
+
+          // 链路本地地址依赖网卡 scope，跨设备扫码连接成功率低，默认不展示。
+          if (addr.isLinkLocal) {
+            continue;
+          }
+
+          addUrl(addr.address);
         }
       }
     } catch (e) {
       print('Error getting network interfaces: $e');
     }
-    urls.add('http://localhost:${_server!.port}');
-    urls.add('http://127.0.0.1:${_server!.port}');
-    urls.sort((a, b) {
+    addUrl('localhost');
+    addUrl('127.0.0.1');
+    addUrl('::1');
+    final urlList = urls.toList();
+    urlList.sort((a, b) {
       final weightCompare =
           _accessUrlSortWeight(a).compareTo(_accessUrlSortWeight(b));
       if (weightCompare != 0) return weightCompare;
       return a.compareTo(b);
     });
-    return urls;
+    return urlList;
   }
 
   Future<void> setPort(int newPort) async {
@@ -479,4 +553,4 @@ class WebServerService {
     // 写回旧Key，便于降级/旧版本读取
     await prefs.setBool(_legacyAutoStartKey, enabled);
   }
-} 
+}

--- a/lib/themes/cupertino/pages/cupertino_media_library_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_media_library_page.dart
@@ -1265,7 +1265,12 @@ class _CupertinoMediaLibraryPageState extends State<CupertinoMediaLibraryPage> {
       final payload = await RemoteAccessQrCameraScanner.scan();
       if (payload == null) return;
 
-      final info = await RemoteAccessQrService.fetchServerInfo(payload.baseUrl);
+      final candidates = payload.allCandidateBaseUrls;
+      RemoteAccessServerInfo? info;
+      for (final candidate in candidates) {
+        info = await RemoteAccessQrService.fetchServerInfo(candidate);
+        if (info != null) break;
+      }
       if (!mounted) return;
       if (info == null) {
         AdaptiveSnackBar.show(

--- a/lib/themes/cupertino/pages/cupertino_play_video_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_play_video_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart' hide Text;
 import 'package:flutter/services.dart';
+import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 import 'package:provider/provider.dart';
 import 'package:nipaplay/services/system_share_service.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
@@ -90,6 +91,41 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
     final focusedContext = FocusManager.instance.primaryFocus?.context;
     if (focusedContext == null) return false;
     return focusedContext.widget is EditableText;
+  }
+
+  Widget _buildDanmakuOverlay(VideoPlayerState videoState) {
+    final isNextKernel = DanmakuKernelFactory.getKernelType() ==
+        DanmakuRenderEngine.nipaplayNext;
+    return ValueListenableBuilder<double>(
+      valueListenable: videoState.playbackTimeMs,
+      child: DanmakuOverlay(
+        key: ValueKey(
+          'danmaku_${videoState.danmakuOverlayKey}',
+        ),
+        currentPosition: videoState.playbackTimeMs.value,
+        videoDuration: videoState.duration.inMilliseconds.toDouble(),
+        isPlaying: videoState.status == PlayerStatus.playing,
+        fontSize: videoState.actualDanmakuFontSize,
+        isVisible: videoState.danmakuVisible,
+        opacity: videoState.mappedDanmakuOpacity,
+      ),
+      builder: (context, posMs, child) {
+        if (isNextKernel && child != null) {
+          return child;
+        }
+        return DanmakuOverlay(
+          key: ValueKey(
+            'danmaku_${videoState.danmakuOverlayKey}',
+          ),
+          currentPosition: posMs,
+          videoDuration: videoState.duration.inMilliseconds.toDouble(),
+          isPlaying: videoState.status == PlayerStatus.playing,
+          fontSize: videoState.actualDanmakuFontSize,
+          isVisible: videoState.danmakuVisible,
+          opacity: videoState.mappedDanmakuOpacity,
+        );
+      },
+    );
   }
 
   KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
@@ -337,9 +373,8 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
           AdaptiveSnackBar.show(
             context,
             message: ok ? '截图已保存到相册' : '截图失败',
-            type: ok
-                ? AdaptiveSnackBarType.success
-                : AdaptiveSnackBarType.error,
+            type:
+                ok ? AdaptiveSnackBarType.success : AdaptiveSnackBarType.error,
           );
           return;
         }
@@ -518,8 +553,7 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
             debugLabel: videoState.currentVideoPath?.split('/').last,
           )
         : null;
-    final hasVideo =
-        videoState.hasVideo &&
+    final hasVideo = videoState.hasVideo &&
         (kIsWeb ||
             videoState.player.prefersPlatformVideoSurface ||
             (textureId != null && textureId >= 0));
@@ -599,8 +633,8 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
                             aspectRatio: videoState.aspectRatio,
                             child: kIsWeb
                                 ? (controller == null
-                                      ? const SizedBox.shrink()
-                                      : VideoPlayer(controller))
+                                    ? const SizedBox.shrink()
+                                    : VideoPlayer(controller))
                                 : (nativeVideoView ??
                                     (textureId == null
                                         ? const SizedBox.shrink()
@@ -614,23 +648,7 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
                 Positioned.fill(
                   child: IgnorePointer(
                     ignoring: true,
-                    child: ValueListenableBuilder<double>(
-                      valueListenable: videoState.playbackTimeMs,
-                      builder: (context, posMs, __) {
-                        return DanmakuOverlay(
-                          key: ValueKey(
-                            'danmaku_${videoState.danmakuOverlayKey}',
-                          ),
-                          currentPosition: posMs,
-                          videoDuration:
-                              videoState.duration.inMilliseconds.toDouble(),
-                          isPlaying: videoState.status == PlayerStatus.playing,
-                          fontSize: videoState.actualDanmakuFontSize,
-                          isVisible: videoState.danmakuVisible,
-                          opacity: videoState.mappedDanmakuOpacity,
-                        );
-                      },
-                    ),
+                    child: _buildDanmakuOverlay(videoState),
                   ),
                 ),
               if (videoState.hasVideo)
@@ -640,7 +658,8 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
                     child: ValueListenableBuilder<double>(
                       valueListenable: videoState.playbackTimeMs,
                       builder: (context, posMs, __) {
-                        return ExternalSubtitleOverlay(currentPositionMs: posMs);
+                        return ExternalSubtitleOverlay(
+                            currentPositionMs: posMs);
                       },
                     ),
                   ),
@@ -675,8 +694,7 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
 
   Widget _buildNipaplayControls(VideoPlayerState videoState) {
     final bool uiLocked = globals.isPhone ? _isUiLocked : false;
-    final bool showLockButton =
-        globals.isPhone &&
+    final bool showLockButton = globals.isPhone &&
         (videoState.showControls || (uiLocked && _showUiLockButton));
     final bool showShareButton =
         SystemShareService.isSupported && !globals.isDesktop;
@@ -818,14 +836,12 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
                           if (showShareButton) ...[
                             const SizedBox(width: 12),
                             ShadowActionButton(
-                              tooltip:
-                                  (!kIsWeb &&
+                              tooltip: (!kIsWeb &&
                                       defaultTargetPlatform ==
                                           TargetPlatform.iOS)
                                   ? '分享 / AirDrop'
                                   : '分享',
-                              icon:
-                                  (!kIsWeb &&
+                              icon: (!kIsWeb &&
                                       defaultTargetPlatform ==
                                           TargetPlatform.iOS)
                                   ? Icons.ios_share_rounded
@@ -963,8 +979,8 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
 
     final TabController? tabController =
         context.findAncestorWidgetOfExactType<DefaultTabController>() != null
-        ? DefaultTabController.of(context)
-        : null;
+            ? DefaultTabController.of(context)
+            : null;
 
     if (tabController == null) {
       _horizontalDragDistance = 0.0;
@@ -1539,9 +1555,8 @@ class _CupertinoPlayVideoPageState extends State<CupertinoPlayVideoPage> {
                   ),
                   SizedBox(height: isPhone ? 6 : 8),
                   AdaptiveSlider(
-                    value: totalMillis > 0
-                        ? progressValue.clamp(0.0, 1.0)
-                        : 0.0,
+                    value:
+                        totalMillis > 0 ? progressValue.clamp(0.0, 1.0) : 0.0,
                     min: 0.0,
                     max: 1.0,
                     activeColor: CupertinoColors.activeBlue,

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_remote_controller_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_remote_controller_settings_page.dart
@@ -94,7 +94,12 @@ class _CupertinoRemoteControllerSettingsPageState
       final payload = await RemoteAccessQrCameraScanner.scan();
       if (payload == null) return;
 
-      final info = await RemoteAccessQrService.fetchServerInfo(payload.baseUrl);
+      final candidates = payload.allCandidateBaseUrls;
+      RemoteAccessServerInfo? info;
+      for (final candidate in candidates) {
+        info = await RemoteAccessQrService.fetchServerInfo(candidate);
+        if (info != null) break;
+      }
       if (!mounted) return;
       if (info == null) {
         AdaptiveSnackBar.show(
@@ -104,20 +109,22 @@ class _CupertinoRemoteControllerSettingsPageState
         return;
       }
 
+      final resolvedInfo = info;
       final hostname = payload.displayName?.trim().isNotEmpty == true
           ? payload.displayName!.trim()
-          : info.hostname;
+          : resolvedInfo.hostname;
+      final resolvedBaseUrl = resolvedInfo.baseUrl;
       await RemoteControlSettings.saveMatchedTarget(
-        baseUrl: info.baseUrl,
+        baseUrl: resolvedBaseUrl,
         hostname: hostname,
       );
       await _syncSharedLibraryTarget(
-        baseUrl: info.baseUrl,
+        baseUrl: resolvedBaseUrl,
         hostname: hostname,
       );
       if (!mounted) return;
       setState(() {
-        _matchedBaseUrl = info.baseUrl;
+        _matchedBaseUrl = resolvedBaseUrl;
         _matchedHostname = hostname;
       });
       await _refreshRemoteState();

--- a/lib/themes/nipaplay/pages/settings/remote_access_page.dart
+++ b/lib/themes/nipaplay/pages/settings/remote_access_page.dart
@@ -512,6 +512,25 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
         (_accessUrls.isNotEmpty ? _accessUrls.first : null);
   }
 
+  List<String> get _qrCandidateUrls {
+    final ordered = <String>[];
+    final seen = <String>{};
+
+    for (final url in _accessUrls) {
+      if (seen.add(url)) {
+        ordered.add(url);
+      }
+    }
+
+    if (_publicIpUrl != null &&
+        _publicIpUrl!.isNotEmpty &&
+        seen.add(_publicIpUrl!)) {
+      ordered.add(_publicIpUrl!);
+    }
+
+    return ordered;
+  }
+
   Widget _buildAccessAddressSection() {
     final colorScheme = Theme.of(context).colorScheme;
     return Padding(
@@ -597,6 +616,7 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
   Widget _buildRemoteAccessQrSection() {
     final colorScheme = Theme.of(context).colorScheme;
     final qrUrl = _recommendedQrUrl;
+    final qrCandidateUrls = _qrCandidateUrls;
 
     return Padding(
       padding: const EdgeInsets.only(top: 14.0, bottom: 8.0),
@@ -623,7 +643,7 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
                 ),
                 SizedBox(height: 6),
                 Text(
-                  '手机端在共享媒体库或远程访问页面点击扫码，拍摄此二维码后会同时连接共享媒体库与遥控器。',
+                  '手机端在共享媒体库或远程访问页面点击扫码，拍摄此二维码后会同时连接共享媒体库与遥控器；若网络环境复杂会自动按顺序尝试多个地址。',
                   style: TextStyle(
                     color: colorScheme.onSurface.withValues(alpha: 0.7),
                     fontSize: 13,
@@ -653,6 +673,7 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
                         child: QrImageView(
                           data: RemoteAccessQrService.buildPayload(
                             baseUrl: qrUrl,
+                            candidateBaseUrls: qrCandidateUrls,
                           ),
                           version: QrVersions.auto,
                           size: 168,
@@ -681,6 +702,31 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
                                 colorScheme.onSurface.withValues(alpha: 0.75),
                               ).copyWith(fontSize: 13),
                             ),
+                            if (qrCandidateUrls.isNotEmpty) ...[
+                              SizedBox(height: 10),
+                              Text(
+                                '候选地址（扫码后将按顺序自动重试）',
+                                style: TextStyle(
+                                  color: colorScheme.onSurface
+                                      .withValues(alpha: 0.55),
+                                  fontSize: 12,
+                                ),
+                              ),
+                              SizedBox(height: 6),
+                              ...qrCandidateUrls.map(
+                                (candidate) => Padding(
+                                  padding: const EdgeInsets.only(bottom: 3),
+                                  child: SelectableText(
+                                    candidate,
+                                    style: _monospaceStyle(
+                                      context,
+                                      colorScheme.onSurface
+                                          .withValues(alpha: 0.72),
+                                    ).copyWith(fontSize: 12),
+                                  ),
+                                ),
+                              ),
+                            ],
                             SizedBox(height: 8),
                             HoverScaleTextButton(
                               text: '复制地址',

--- a/lib/themes/nipaplay/widgets/shared_remote_library_settings_section.dart
+++ b/lib/themes/nipaplay/widgets/shared_remote_library_settings_section.dart
@@ -272,7 +272,13 @@ class SharedRemoteLibrarySettingsSection extends StatelessWidget {
       final payload = await RemoteAccessQrCameraScanner.scan();
       if (payload == null) return;
 
-      final info = await RemoteAccessQrService.fetchServerInfo(payload.baseUrl);
+      final candidates = payload.allCandidateBaseUrls;
+      RemoteAccessServerInfo? info;
+      for (final candidate in candidates) {
+        info = await RemoteAccessQrService.fetchServerInfo(candidate);
+        if (info != null) break;
+      }
+
       if (info == null) {
         if (context.mounted) {
           BlurSnackBar.show(context, '未识别到可访问的 NipaPlay 远程访问服务');

--- a/lib/themes/nipaplay/widgets/video_player_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_player_ui.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 import 'package:nipaplay/services/system_share_service.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/platform_utils.dart';
@@ -88,6 +89,41 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
     return kind == PointerDeviceKind.touch ||
         kind == PointerDeviceKind.stylus ||
         kind == PointerDeviceKind.invertedStylus;
+  }
+
+  Widget _buildDanmakuOverlay(VideoPlayerState videoState) {
+    final isNextKernel = DanmakuKernelFactory.getKernelType() ==
+        DanmakuRenderEngine.nipaplayNext;
+    return ValueListenableBuilder<double>(
+      valueListenable: videoState.playbackTimeMs,
+      child: DanmakuOverlay(
+        key: ValueKey(
+          'danmaku_${videoState.danmakuOverlayKey}',
+        ),
+        currentPosition: videoState.playbackTimeMs.value,
+        videoDuration: videoState.videoDuration.inMilliseconds.toDouble(),
+        isPlaying: videoState.status == PlayerStatus.playing,
+        fontSize: getFontSize(videoState),
+        isVisible: videoState.danmakuVisible,
+        opacity: videoState.mappedDanmakuOpacity,
+      ),
+      builder: (context, posMs, child) {
+        if (isNextKernel && child != null) {
+          return child;
+        }
+        return DanmakuOverlay(
+          key: ValueKey(
+            'danmaku_${videoState.danmakuOverlayKey}',
+          ),
+          currentPosition: posMs,
+          videoDuration: videoState.videoDuration.inMilliseconds.toDouble(),
+          isPlaying: videoState.status == PlayerStatus.playing,
+          fontSize: getFontSize(videoState),
+          isVisible: videoState.danmakuVisible,
+          opacity: videoState.mappedDanmakuOpacity,
+        );
+      },
+    );
   }
 
   bool _isShiftPressed() {
@@ -898,33 +934,8 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                                           ignoring: true,
                                           child: Consumer<VideoPlayerState>(
                                             builder: (context, videoState, _) {
-                                              // 使用高频时间轴驱动弹幕帧率
-                                              return ValueListenableBuilder<
-                                                  double>(
-                                                valueListenable:
-                                                    videoState.playbackTimeMs,
-                                                builder: (context, posMs, __) {
-                                                  return DanmakuOverlay(
-                                                    key: ValueKey(
-                                                      'danmaku_${videoState.danmakuOverlayKey}',
-                                                    ),
-                                                    currentPosition: posMs,
-                                                    videoDuration: videoState
-                                                        .videoDuration
-                                                        .inMilliseconds
-                                                        .toDouble(),
-                                                    isPlaying: videoState
-                                                            .status ==
-                                                        PlayerStatus.playing,
-                                                    fontSize: getFontSize(
-                                                      videoState,
-                                                    ),
-                                                    isVisible: videoState
-                                                        .danmakuVisible,
-                                                    opacity: videoState
-                                                        .mappedDanmakuOpacity,
-                                                  );
-                                                },
+                                              return _buildDanmakuOverlay(
+                                                videoState,
                                               );
                                             },
                                           ),
@@ -1006,34 +1017,8 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                                             child: Consumer<VideoPlayerState>(
                                               builder:
                                                   (context, videoState, _) {
-                                                // 使用高频时间轴驱动弹幕帧率
-                                                return ValueListenableBuilder<
-                                                    double>(
-                                                  valueListenable:
-                                                      videoState.playbackTimeMs,
-                                                  builder:
-                                                      (context, posMs, __) {
-                                                    return DanmakuOverlay(
-                                                      key: ValueKey(
-                                                        'danmaku_${videoState.danmakuOverlayKey}',
-                                                      ),
-                                                      currentPosition: posMs,
-                                                      videoDuration: videoState
-                                                          .videoDuration
-                                                          .inMilliseconds
-                                                          .toDouble(),
-                                                      isPlaying: videoState
-                                                              .status ==
-                                                          PlayerStatus.playing,
-                                                      fontSize: getFontSize(
-                                                        videoState,
-                                                      ),
-                                                      isVisible: videoState
-                                                          .danmakuVisible,
-                                                      opacity: videoState
-                                                          .mappedDanmakuOpacity,
-                                                    );
-                                                  },
+                                                return _buildDanmakuOverlay(
+                                                  videoState,
                                                 );
                                               },
                                             ),

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -460,7 +460,9 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   final String _danmakuFontFamilyKey = 'danmaku_font_family';
   String _danmakuFontFamily = '';
   final String _danmakuOutlineStyleKey = 'danmaku_outline_style';
-  DanmakuOutlineStyle _danmakuOutlineStyle = DanmakuOutlineStyle.uniform;
+  DanmakuOutlineStyle _danmakuOutlineStyle = globals.isMobilePlatform
+      ? DanmakuOutlineStyle.stroke
+      : DanmakuOutlineStyle.uniform;
   final String _danmakuShadowStyleKey = 'danmaku_shadow_style';
   DanmakuShadowStyle _danmakuShadowStyle = globals.isMobilePlatform
       ? DanmakuShadowStyle.none

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -1198,7 +1198,9 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   }
 
   DanmakuOutlineStyle _resolveDanmakuOutlineStyle(int? index) {
-    const DanmakuOutlineStyle fallback = DanmakuOutlineStyle.uniform;
+    final DanmakuOutlineStyle fallback = globals.isMobilePlatform
+        ? DanmakuOutlineStyle.stroke
+        : DanmakuOutlineStyle.uniform;
     if (index == null ||
         index < 0 ||
         index >= DanmakuOutlineStyle.values.length) {

--- a/lib/widgets/danmaku_overlay.dart
+++ b/lib/widgets/danmaku_overlay.dart
@@ -122,6 +122,7 @@ class _DanmakuOverlayState extends State<DanmakuOverlay> {
         if (kernelType == DanmakuRenderEngine.nipaplayNext) {
           return NipaPlayNextOverlay(
             danmakuList: activeDanmakuList,
+            playbackTimeMs: videoState.playbackTimeMs,
             currentTimeSeconds: widget.currentPosition / 1000,
             fontSize: widget.fontSize,
             isVisible: widget.isVisible,

--- a/test/remote_access_qr_service_test.dart
+++ b/test/remote_access_qr_service_test.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/services/remote_access_qr_service.dart';
+
+void main() {
+  group('RemoteAccessQrService', () {
+    test('buildPayload includes all candidate urls in JSON payload', () {
+      final payload = RemoteAccessQrService.buildPayload(
+        baseUrl: 'http://192.168.1.10:1180',
+        candidateBaseUrls: const [
+          '192.168.1.11',
+          'http://[2001:db8::1]:1180',
+          'http://192.168.1.10:1180',
+        ],
+        displayName: 'Living Room PC',
+      );
+
+      final decoded = json.decode(payload) as Map<String, dynamic>;
+      expect(decoded['type'], RemoteAccessQrService.payloadType);
+      expect(decoded['baseUrl'], 'http://192.168.1.10:1180');
+      expect(decoded['displayName'], 'Living Room PC');
+      expect(
+        decoded['urls'],
+        <String>[
+          'http://192.168.1.11:1180',
+          'http://[2001:db8::1]:1180',
+        ],
+      );
+    });
+
+    test('parseScannedText reads candidate urls from JSON payload', () {
+      const text =
+          '{"type":"nipaplay_remote_access","baseUrl":"192.168.1.8","urls":["http://[2001:db8::2]:1180","192.168.1.9"],"displayName":"Home NAS"}';
+      final payload = RemoteAccessQrService.parseScannedText(text);
+
+      expect(payload.baseUrl, 'http://192.168.1.8:1180');
+      expect(
+        payload.allCandidateBaseUrls,
+        <String>[
+          'http://192.168.1.8:1180',
+          'http://[2001:db8::2]:1180',
+          'http://192.168.1.9:1180',
+        ],
+      );
+      expect(payload.displayName, 'Home NAS');
+    });
+
+    test('allCandidateBaseUrls removes duplicates and keeps order', () {
+      final payload = RemoteAccessQrPayload(
+        baseUrl: 'http://192.168.1.7:1180',
+        candidateBaseUrls: const [
+          '192.168.1.7',
+          'http://[2001:db8::7]:1180',
+          'http://192.168.1.7:1180',
+        ],
+      );
+
+      expect(
+        payload.allCandidateBaseUrls,
+        <String>[
+          'http://192.168.1.7:1180',
+          'http://[2001:db8::7]:1180',
+        ],
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary\n- Show IPv4/IPv6 local access URLs when remote access is enabled\n- Bind the web server on IPv6 first with IPv4 fallback\n- Encode all candidate URLs into the QR payload and try them one by one when scanning\n\n## Verification\n- flutter test test/remote_access_qr_service_test.dart\n- flutter analyze lib/themes/cupertino/pages/settings/pages/cupertino_remote_controller_settings_page.dart