### PR TITLE
fix: SRT 内封字幕无法渲染

### DIFF
--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -1928,6 +1928,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
 
       String? effectiveFontDir;
       String? localFontsFolder;
+      final hadPreviousFontDir = _subtitleFontDir.isNotEmpty;
 
       if (_currentVideoPath != null &&
           !_currentVideoPath!.startsWith('http') &&
@@ -1957,7 +1958,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
         if (defaultTargetPlatform == TargetPlatform.iOS) {
           player.setProperty('sub-file-paths', effectiveFontDir);
         }
-      } else {
+      } else if (hadPreviousFontDir) {
         player.setProperty('sub-fonts-dir', '');
         if (defaultTargetPlatform == TargetPlatform.iOS) {
           player.setProperty('sub-file-paths', '');


### PR DESCRIPTION
## Summary

- 修复 MediaKit (libmpv) 内核下 MKV 内封 SRT/subrip 字幕无法渲染的问题
- ASS 内封字幕不受影响（使用 MKV 内嵌字体，不依赖外部字体配置）

## Related Issue

- 无

## What Changed

- `lib/utils/video_player_state/video_player_state_preferences.dart` (+2 −1):
  `applySubtitleStylePreference()` 中，将无条件清空 `sub-fonts-dir` 改为仅在之前确实设置过字体目录时才清空。通过局部变量快照 `_subtitleFontDir` 原始状态来判断。