### PR TITLE
修复 “请选择视频来源” 弹窗里两个选项文字硬编码白色的问题

### DIFF
--- a/lib/themes/nipaplay/widgets/video_upload_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_upload_ui.dart
@@ -565,13 +565,13 @@ class _VideoUploadUIState extends State<VideoUploadUI>
               onPressed: () {
                 Navigator.of(context).pop('album');
               },
-              child: const Text('相册', style: TextStyle(color: Colors.white)),
+              child: const Text('相册'),
             ),
             HoverScaleTextButton(
               onPressed: () {
                 Navigator.of(context).pop('file'); // 先 pop
               },
-              child: const Text('文件管理器', style: TextStyle(color: Colors.white)),
+              child: const Text('文件管理器'),
             ),
           ],
         );


### PR DESCRIPTION
修复 “请选择视频来源” 弹窗里两个选项文字硬编码白色的问题，改为使用默认主题文字色（浅色模式下可见）。

  修改位置：

  - lib/themes/nipaplay/widgets/video_upload_ui.dart:564

  具体改动：

  - 相册：TextStyle(color: Colors.white) 已移除
  - 文件管理器：TextStyle(color: Colors.white) 已移除