### PR TITLE
feat: WebDAV快捷访问 新增 TMDB ID 快速匹配功能

### DIFF
--- a/lib/pages/webdav_browser_page.dart
+++ b/lib/pages/webdav_browser_page.dart
@@ -275,12 +275,39 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
               quickMatchAnimeTitle = bangumi['animeTitle'] as String?;
 
               final episodeNumber = _extractEpisodeNumber(file.name);
+              int targetNumber = episodeNumber ?? 0;
 
               if (episodes != null && episodeNumber != null) {
+
+                // 剧集漂移修正（实验功能）
+                if (provider.episodeOffsetEnabled) {
+                  final mainEps = episodes.where((ep) {
+                    final eid = ep['episodeId']?.toString() ?? '';
+                    return eid.length >= 4 && eid[eid.length - 4] == '0';
+                  }).toList();
+
+                  if (mainEps.isNotEmpty) {
+                    int minNum = 99999;
+                    for (final ep in mainEps) {
+                      final n = int.tryParse(
+                          ep['episodeNumber']?.toString() ?? '');
+                      if (n != null && n > 0 && n < minNum) {
+                        minNum = n;
+                      }
+                    }
+                    if (minNum != 99999) {
+                      final offset = minNum - 1;
+                      targetNumber = episodeNumber + offset;
+                      debugPrint(
+                          '[WebDAV] 剧集偏移: min=$minNum, offset=$offset, target=$targetNumber');
+                    }
+                  }
+                }
+
                 for (final ep in episodes) {
                   final epNum =
                       int.tryParse(ep['episodeNumber']?.toString() ?? '');
-                  if (epNum == episodeNumber) {
+                  if (epNum == targetNumber) {
                     quickMatchEpisodeId = ep['episodeId'] as int?;
                     break;
                   }
@@ -288,7 +315,7 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
               }
 
               debugPrint(
-                  '[WebDAV] tmdbId 快速匹配结果: tmdbId=$tmdbId, episodeNumber=$episodeNumber, episodeId=$quickMatchEpisodeId');
+                  '[WebDAV] tmdbId 快速匹配结果: tmdbId=$tmdbId, episodeNumber=$episodeNumber, targetNumber=$targetNumber, episodeId=$quickMatchEpisodeId');
             }
           }
         }

--- a/lib/pages/webdav_browser_page.dart
+++ b/lib/pages/webdav_browser_page.dart
@@ -253,6 +253,51 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
       }
     }
 
+    // ========== tmdbId 快速匹配（bgmid 未匹配成功时尝试） ==========
+    if (quickMatchEpisodeId == null && provider.tmdbIdQuickMatch) {
+      try {
+        final tmdbRegex = RegExp(provider.tmdbIdMatchPattern);
+        final tmdbMatch = tmdbRegex.firstMatch(videoUrl);
+
+        if (tmdbMatch != null && tmdbMatch.groupCount >= 1) {
+          final lastGroup = tmdbMatch.group(tmdbMatch.groupCount);
+          final tmdbId = int.tryParse(lastGroup ?? '');
+
+          if (tmdbId != null) {
+            final seasonNumber = _extractSeasonNumber(file.name);
+            final result = await DandanplayService.getBangumiByTmdbId(tmdbId, seasonNumber: seasonNumber);
+
+            if (result != null && result['bangumi'] != null) {
+              final bangumi = result['bangumi'] as Map<String, dynamic>;
+              final episodes = bangumi['episodes'] as List<dynamic>?;
+
+              quickMatchAnimeId = bangumi['animeId'] as int?;
+              quickMatchAnimeTitle = bangumi['animeTitle'] as String?;
+
+              final episodeNumber = _extractEpisodeNumber(file.name);
+
+              if (episodes != null && episodeNumber != null) {
+                for (final ep in episodes) {
+                  final epNum =
+                      int.tryParse(ep['episodeNumber']?.toString() ?? '');
+                  if (epNum == episodeNumber) {
+                    quickMatchEpisodeId = ep['episodeId'] as int?;
+                    break;
+                  }
+                }
+              }
+
+              debugPrint(
+                  '[WebDAV] tmdbId 快速匹配结果: tmdbId=$tmdbId, episodeNumber=$episodeNumber, episodeId=$quickMatchEpisodeId');
+            }
+          }
+        }
+      } catch (e) {
+        debugPrint(
+            '[WebDAV] tmdbId 快速匹配失败（使用规则: ${provider.tmdbIdMatchPattern}）: $e');
+      }
+    }
+
     // 创建观看历史项用于播放
     final historyItem = WatchHistoryItem(
       animeName: quickMatchAnimeTitle ??
@@ -312,6 +357,15 @@ class _WebDAVBrowserPageState extends State<WebDAVBrowserPage> {
       return int.tryParse(delimiterMatch.group(1)!);
     }
 
+    return null;
+  }
+
+  /// 从文件名中提取 Season 数字 (S01 → 1, S2 → 2)
+  int? _extractSeasonNumber(String fileName) {
+    final match = _seasonEpisodeRegex.firstMatch(fileName);
+    if (match != null) {
+      return int.tryParse(match.group(1)!);
+    }
     return null;
   }
 

--- a/lib/providers/webdav_quick_access_provider.dart
+++ b/lib/providers/webdav_quick_access_provider.dart
@@ -117,6 +117,8 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   static const String _keyShowPathBreadcrumb = 'webdav_show_path_breadcrumb';
   static const String _keyBgmIdQuickMatch = 'webdav_bgmid_quick_match';
   static const String _keyBgmIdMatchPattern = 'webdav_bgmid_match_pattern';
+  static const String _keyTmdbIdQuickMatch = 'webdav_tmdbid_quick_match';
+  static const String _keyTmdbIdMatchPattern = 'webdav_tmdbid_match_pattern';
   static const String _legacyDefaultPageIndexKey = 'default_page_index';
 
   // 搜索功能相关存储键名
@@ -157,6 +159,8 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   bool _showPathBreadcrumb = true;
   bool _bgmIdQuickMatch = false; // 默认关闭，用户需明确启用
   String _bgmIdMatchPattern = 'bgm(id)?[=-](\\d+)'; // 默认正则规则
+  bool _tmdbIdQuickMatch = false; // 默认关闭
+  String _tmdbIdMatchPattern = 'tmdb(id)?[=-](\\d+)'; // 默认正则规则
   bool _isLoaded = false;
 
   // 搜索功能相关状态
@@ -179,6 +183,8 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   bool get showPathBreadcrumb => _showPathBreadcrumb;
   bool get bgmIdQuickMatch => _bgmIdQuickMatch;
   String get bgmIdMatchPattern => _bgmIdMatchPattern;
+  bool get tmdbIdQuickMatch => _tmdbIdQuickMatch;
+  String get tmdbIdMatchPattern => _tmdbIdMatchPattern;
   bool get isLoaded => _isLoaded;
 
   // 搜索功能相关 Getters
@@ -292,6 +298,9 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
       _bgmIdQuickMatch = prefs.getBool(_keyBgmIdQuickMatch) ?? false;
       _bgmIdMatchPattern =
           prefs.getString(_keyBgmIdMatchPattern) ?? 'bgm(id)?[=-](\\d+)';
+      _tmdbIdQuickMatch = prefs.getBool(_keyTmdbIdQuickMatch) ?? false;
+      _tmdbIdMatchPattern =
+          prefs.getString(_keyTmdbIdMatchPattern) ?? 'tmdb(id)?[=-](\\d+)';
 
       // 加载搜索功能相关设置
       _enableSearch = prefs.getBool(_keyEnableSearch) ?? true;
@@ -493,9 +502,14 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   Future<void> setBgmIdMatchPattern(String pattern) async {
     if (_bgmIdMatchPattern == pattern) return;
 
-    // 验证正则是否有效
     try {
-      RegExp(pattern);
+      final regex = RegExp(pattern);
+      // 用测试字符串验证至少有一个捕获组
+      final testMatch = regex.firstMatch('bgmid=123');
+      if (testMatch == null || testMatch.groupCount < 1) {
+        debugPrint('正则表达式缺少捕获组: $pattern（需要用括号捕获数字，如 bgmid=(\\d+)）');
+        return;
+      }
     } catch (e) {
       debugPrint('无效的正则表达式: $pattern, 错误: $e');
       return;
@@ -509,6 +523,48 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
       notifyListeners();
     } catch (e) {
       debugPrint('保存 bgmid 匹配规则失败: $e');
+    }
+  }
+
+  /// 设置是否启用 tmdbId 快速匹配
+  Future<void> setTmdbIdQuickMatch(bool value) async {
+    if (_tmdbIdQuickMatch == value) return;
+
+    _tmdbIdQuickMatch = value;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_keyTmdbIdQuickMatch, value);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存 tmdbId 快速匹配设置失败: $e');
+    }
+  }
+
+  /// 设置 tmdbId 匹配正则表达式
+  Future<void> setTmdbIdMatchPattern(String pattern) async {
+    if (_tmdbIdMatchPattern == pattern) return;
+
+    try {
+      final regex = RegExp(pattern);
+      final testMatch = regex.firstMatch('tmdbid=123');
+      if (testMatch == null || testMatch.groupCount < 1) {
+        debugPrint('正则表达式缺少捕获组: $pattern（需要用括号捕获数字，如 tmdbid=(\\d+)）');
+        return;
+      }
+    } catch (e) {
+      debugPrint('无效的正则表达式: $pattern, 错误: $e');
+      return;
+    }
+
+    _tmdbIdMatchPattern = pattern;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keyTmdbIdMatchPattern, pattern);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存 tmdbId 匹配规则失败: $e');
     }
   }
 
@@ -719,6 +775,8 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
     _showPathBreadcrumb = true;
     _bgmIdQuickMatch = false;
     _bgmIdMatchPattern = 'bgm(id)?[=-](\\d+)';
+    _tmdbIdQuickMatch = false;
+    _tmdbIdMatchPattern = 'tmdb(id)?[=-](\\d+)';
 
     // 重置搜索功能相关设置
     _enableSearch = true;
@@ -741,6 +799,8 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
       await prefs.remove(_keyShowPathBreadcrumb);
       await prefs.remove(_keyBgmIdQuickMatch);
       await prefs.remove(_keyBgmIdMatchPattern);
+      await prefs.remove(_keyTmdbIdQuickMatch);
+      await prefs.remove(_keyTmdbIdMatchPattern);
       // 清除搜索功能相关设置
       await prefs.remove(_keyEnableSearch);
       await prefs.remove(_keySearchScope);

--- a/lib/providers/webdav_quick_access_provider.dart
+++ b/lib/providers/webdav_quick_access_provider.dart
@@ -507,15 +507,21 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
     if (_bgmIdMatchPattern == pattern) return;
 
     try {
-      final regex = RegExp(pattern);
-      // 用测试字符串验证至少有一个捕获组
-      final testMatch = regex.firstMatch('bgmid=123');
-      if (testMatch == null || testMatch.groupCount < 1) {
-        debugPrint('正则表达式缺少捕获组: $pattern（需要用括号捕获数字，如 bgmid=(\\d+)）');
-        return;
-      }
+      RegExp(pattern);
     } catch (e) {
       debugPrint('无效的正则表达式: $pattern, 错误: $e');
+      return;
+    }
+
+    // 统计未转义的左括号来验证至少有 1 个捕获组
+    int groupCount = 0;
+    for (int i = 0; i < pattern.length; i++) {
+      if (pattern[i] == '(' && (i == 0 || pattern[i - 1] != '\\')) {
+        groupCount++;
+      }
+    }
+    if (groupCount < 1) {
+      debugPrint('正则表达式缺少捕获组: $pattern（需要用括号捕获数字，如 bgmid=(\\d+)）');
       return;
     }
 
@@ -550,14 +556,20 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
     if (_tmdbIdMatchPattern == pattern) return;
 
     try {
-      final regex = RegExp(pattern);
-      final testMatch = regex.firstMatch('tmdbid=123');
-      if (testMatch == null || testMatch.groupCount < 1) {
-        debugPrint('正则表达式缺少捕获组: $pattern（需要用括号捕获数字，如 tmdbid=(\\d+)）');
-        return;
-      }
+      RegExp(pattern);
     } catch (e) {
       debugPrint('无效的正则表达式: $pattern, 错误: $e');
+      return;
+    }
+
+    int groupCount = 0;
+    for (int i = 0; i < pattern.length; i++) {
+      if (pattern[i] == '(' && (i == 0 || pattern[i - 1] != '\\')) {
+        groupCount++;
+      }
+    }
+    if (groupCount < 1) {
+      debugPrint('正则表达式缺少捕获组: $pattern（需要用括号捕获数字，如 tmdbid=(\\d+)）');
       return;
     }
 

--- a/lib/providers/webdav_quick_access_provider.dart
+++ b/lib/providers/webdav_quick_access_provider.dart
@@ -119,6 +119,7 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   static const String _keyBgmIdMatchPattern = 'webdav_bgmid_match_pattern';
   static const String _keyTmdbIdQuickMatch = 'webdav_tmdbid_quick_match';
   static const String _keyTmdbIdMatchPattern = 'webdav_tmdbid_match_pattern';
+  static const String _keyEpisodeOffset = 'webdav_episode_offset';
   static const String _legacyDefaultPageIndexKey = 'default_page_index';
 
   // 搜索功能相关存储键名
@@ -161,6 +162,7 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   String _bgmIdMatchPattern = 'bgm(id)?[=-](\\d+)'; // 默认正则规则
   bool _tmdbIdQuickMatch = false; // 默认关闭
   String _tmdbIdMatchPattern = 'tmdb(id)?[=-](\\d+)'; // 默认正则规则
+  bool _episodeOffsetEnabled = false; // 默认关闭，实验功能
   bool _isLoaded = false;
 
   // 搜索功能相关状态
@@ -185,6 +187,7 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
   String get bgmIdMatchPattern => _bgmIdMatchPattern;
   bool get tmdbIdQuickMatch => _tmdbIdQuickMatch;
   String get tmdbIdMatchPattern => _tmdbIdMatchPattern;
+  bool get episodeOffsetEnabled => _episodeOffsetEnabled;
   bool get isLoaded => _isLoaded;
 
   // 搜索功能相关 Getters
@@ -301,6 +304,7 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
       _tmdbIdQuickMatch = prefs.getBool(_keyTmdbIdQuickMatch) ?? false;
       _tmdbIdMatchPattern =
           prefs.getString(_keyTmdbIdMatchPattern) ?? 'tmdb(id)?[=-](\\d+)';
+      _episodeOffsetEnabled = prefs.getBool(_keyEpisodeOffset) ?? false;
 
       // 加载搜索功能相关设置
       _enableSearch = prefs.getBool(_keyEnableSearch) ?? true;
@@ -568,6 +572,21 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
     }
   }
 
+  /// 设置是否启用剧集偏移（实验功能）
+  Future<void> setEpisodeOffsetEnabled(bool value) async {
+    if (_episodeOffsetEnabled == value) return;
+
+    _episodeOffsetEnabled = value;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_keyEpisodeOffset, value);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('保存剧集偏移设置失败: $e');
+    }
+  }
+
   // ==================== 搜索功能相关 Setter ====================
 
   /// 设置是否启用搜索功能
@@ -777,6 +796,7 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
     _bgmIdMatchPattern = 'bgm(id)?[=-](\\d+)';
     _tmdbIdQuickMatch = false;
     _tmdbIdMatchPattern = 'tmdb(id)?[=-](\\d+)';
+    _episodeOffsetEnabled = false;
 
     // 重置搜索功能相关设置
     _enableSearch = true;
@@ -801,6 +821,7 @@ class WebDAVQuickAccessProvider extends ChangeNotifier {
       await prefs.remove(_keyBgmIdMatchPattern);
       await prefs.remove(_keyTmdbIdQuickMatch);
       await prefs.remove(_keyTmdbIdMatchPattern);
+      await prefs.remove(_keyEpisodeOffset);
       // 清除搜索功能相关设置
       await prefs.remove(_keyEnableSearch);
       await prefs.remove(_keySearchScope);

--- a/lib/services/dandanplay_service_io.dart
+++ b/lib/services/dandanplay_service_io.dart
@@ -1874,6 +1874,109 @@ class DandanplayService {
     }
   }
 
+  /// 通过 TMDB ID 获取番剧详情（两步调用）
+  ///
+  /// 1. /api/v2/search/episodes?tmdbId={tmdbId} → 获取正确的 animeId
+  /// 2. /api/v2/bangumi/{animeId} → 获取含 episodeNumber 的剧集列表
+  ///
+  /// [seasonNumber] 可选，用于多 anime 结果时按季度选择（S1→第1个, S2→第2个）
+  /// 返回与 bgmid API 结构一致的 bangumi 数据
+  static Future<Map<String, dynamic>?> getBangumiByTmdbId(int tmdbId, {int? seasonNumber}) async {
+    try {
+      final appSecret = await getAppSecret();
+      final baseUrl = await getApiBaseUrl();
+
+      // 第一步：通过 tmdbId 搜索正确的 animeId
+      final timestamp1 = (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
+      const searchApiPath = '/api/v2/search/episodes';
+      final searchQuery = Uri(queryParameters: {'tmdbId': tmdbId.toString()}).query;
+      final searchUrl = '$baseUrl$searchApiPath?$searchQuery';
+
+      debugPrint('[弹弹play服务] 通过 tmdbId 搜索剧集: $tmdbId');
+
+      final searchResponse = await http.get(
+        Uri.parse(searchUrl),
+        headers: {
+          'Accept': 'application/json',
+          'User-Agent': userAgent,
+          'X-AppId': appId,
+          'X-Signature': generateSignature(appId, timestamp1, searchApiPath, appSecret),
+          'X-Timestamp': '$timestamp1',
+          if (_isLoggedIn && _token != null) 'Authorization': 'Bearer $_token',
+        },
+      ).timeout(const Duration(seconds: 10));
+
+      if (searchResponse.statusCode != 200) {
+        debugPrint('[弹弹play服务] tmdbId 搜索失败: HTTP ${searchResponse.statusCode}');
+        return null;
+      }
+
+      final searchData = json.decode(searchResponse.body);
+      if (searchData['success'] != true || searchData['animes'] == null) {
+        debugPrint('[弹弹play服务] tmdbId 搜索未找到对应番剧');
+        return null;
+      }
+
+      final animes = searchData['animes'] as List<dynamic>;
+      if (animes.isEmpty) {
+        debugPrint('[弹弹play服务] tmdbId 搜索结果为空');
+        return null;
+      }
+
+      final candidates = animes.cast<Map<String, dynamic>>().toList();
+      int selectedIndex = 0;
+      if (candidates.length > 1) {
+        candidates.sort((a, b) => (a['animeId'] as int).compareTo(b['animeId'] as int));
+        selectedIndex = seasonNumber != null &&
+                seasonNumber >= 1 &&
+                seasonNumber <= candidates.length
+            ? seasonNumber! - 1
+            : 0;
+        debugPrint('[弹弹play服务] tmdbId 搜索到 ${candidates.length} 个番剧，选择第 ${selectedIndex + 1} 个');
+      }
+
+      final animeId = candidates[selectedIndex]['animeId'] as int?;
+      if (animeId == null) {
+        debugPrint('[弹弹play服务] tmdbId 搜索结果中缺少 animeId');
+        return null;
+      }
+
+      debugPrint('[弹弹play服务] tmdbId 搜索到 animeId: $animeId');
+
+      // 第二步：通过 animeId 获取完整番剧详情（含 episodeNumber）
+      final timestamp2 = (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
+      final detailApiPath = '/api/v2/bangumi/$animeId';
+
+      final detailResponse = await http.get(
+        Uri.parse('$baseUrl$detailApiPath'),
+        headers: {
+          'Accept': 'application/json',
+          'User-Agent': userAgent,
+          'X-AppId': appId,
+          'X-Signature': generateSignature(appId, timestamp2, detailApiPath, appSecret),
+          'X-Timestamp': '$timestamp2',
+          if (_isLoggedIn && _token != null) 'Authorization': 'Bearer $_token',
+        },
+      ).timeout(const Duration(seconds: 10));
+
+      if (detailResponse.statusCode == 200) {
+        final data = json.decode(detailResponse.body);
+        if (data['success'] == true && data['bangumi'] != null) {
+          return data;
+        }
+      }
+
+      debugPrint('[弹弹play服务] tmdbId 获取番剧详情失败: HTTP ${detailResponse.statusCode}');
+      return null;
+    } on TimeoutException {
+      debugPrint('[弹弹play服务] tmdbId 匹配超时');
+      return null;
+    } catch (e) {
+      debugPrint('[弹弹play服务] 通过 tmdbId 获取番剧详情出错: $e');
+      return null;
+    }
+  }
+
   // 获取用户对特定剧集的观看状态
   static Future<Map<int, bool>> getEpisodesWatchStatus(
     List<int> episodeIds,

--- a/lib/services/dandanplay_service_stub.dart
+++ b/lib/services/dandanplay_service_stub.dart
@@ -1307,6 +1307,12 @@ class DandanplayService {
     return null;
   }
 
+  /// 通过 TMDB ID 获取番剧详情（Web stub — 不支持）
+  static Future<Map<String, dynamic>?> getBangumiByTmdbId(int tmdbId, {int? seasonNumber}) async {
+    debugPrint('[弹弹play服务-Web] getBangumiByTmdbId not supported on web');
+    return null;
+  }
+
   static Future<Map<int, bool>> getEpisodesWatchStatus(
       List<int> episodeIds) async {
     try {

--- a/lib/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart
@@ -773,6 +773,20 @@ class _CupertinoWebDAVQuickSettingsPageState
                   '最后一个捕获组应为数字，如 tmdbid=(\\d+) 或 tmdb-(\\d+)',
                   style: TextStyle(color: secondaryColor.withOpacity(0.7), fontSize: 10),
                 ),
+                SizedBox(height: 12),
+                CupertinoSettingsTile(
+                  leading: Icon(CupertinoIcons.arrow_right_arrow_left, color: iconColor),
+                  title: const Text('匹配弹幕自动剧集偏移（实验中）'),
+                  subtitle: const Text('自动计算跨季剧集编号偏移量'),
+                  backgroundColor: tileColor,
+                  trailing: CupertinoSwitch(
+                    value: provider.episodeOffsetEnabled,
+                    activeColor: CupertinoColors.activeBlue,
+                    onChanged: (value) {
+                      provider.setEpisodeOffsetEnabled(value);
+                    },
+                  ),
+                ),
               ],
             ),
           ),

--- a/lib/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/webdav_quick_settings_page.dart
@@ -21,17 +21,20 @@ class _CupertinoWebDAVQuickSettingsPageState
     extends State<CupertinoWebDAVQuickSettingsPage> {
   late final TextEditingController _directoryController;
   late final TextEditingController _patternController;
+  late final TextEditingController _tmdbPatternController;
 
   @override
   void initState() {
     super.initState();
     _directoryController = TextEditingController();
     _patternController = TextEditingController();
+    _tmdbPatternController = TextEditingController();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final provider =
           Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
       provider.loadSettings().then((_) {
         _patternController.text = provider.bgmIdMatchPattern;
+        _tmdbPatternController.text = provider.tmdbIdMatchPattern;
       });
     });
   }
@@ -40,6 +43,7 @@ class _CupertinoWebDAVQuickSettingsPageState
   void dispose() {
     _directoryController.dispose();
     _patternController.dispose();
+    _tmdbPatternController.dispose();
     super.dispose();
   }
 
@@ -90,6 +94,8 @@ class _CupertinoWebDAVQuickSettingsPageState
                   _buildAutoEnterSeasonCard(context, provider),
                   const SizedBox(height: 24),
                   _buildBgmIdQuickMatchCard(context, provider),
+                  const SizedBox(height: 24),
+                  _buildTmdbIdQuickMatchCard(context, provider),
                   const SizedBox(height: 24),
                   _buildSearchConfigCard(context, provider),
                   const SizedBox(height: 24),
@@ -697,6 +703,74 @@ class _CupertinoWebDAVQuickSettingsPageState
                 SizedBox(height: 4),
                 Text(
                   '最后一个捕获组应为数字，如 bgmid=(\\d+) 或 bgm-(\\d+)',
+                  style: TextStyle(color: secondaryColor.withOpacity(0.7), fontSize: 10),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildTmdbIdQuickMatchCard(BuildContext context, WebDAVQuickAccessProvider provider) {
+    final Color tileColor = resolveSettingsTileBackground(context);
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color textColor = resolveSettingsPrimaryTextColor(context);
+    final Color secondaryColor = resolveSettingsSecondaryTextColor(context);
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      children: [
+        CupertinoSettingsTile(
+          leading: Icon(CupertinoIcons.film_fill, color: iconColor),
+          title: const Text('tmdbId 快速匹配'),
+          subtitle: const Text('从 URL 中提取 tmdbId，通过 TMDB ID 直接获取番剧信息'),
+          backgroundColor: tileColor,
+          trailing: CupertinoSwitch(
+            value: provider.tmdbIdQuickMatch,
+            activeColor: CupertinoColors.activeBlue,
+            onChanged: (value) {
+              provider.setTmdbIdQuickMatch(value);
+            },
+          ),
+        ),
+        if (provider.tmdbIdQuickMatch)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '匹配规则（正则表达式）',
+                  style: TextStyle(color: textColor, fontSize: 13),
+                ),
+                SizedBox(height: 4),
+                Text(
+                  '从完整 URL 中匹配 tmdbId 数字，支持 tmdbid=123 或 tmdb-123 格式',
+                  style: TextStyle(color: secondaryColor, fontSize: 11),
+                ),
+                SizedBox(height: 8),
+                CupertinoTextField(
+                  controller: _tmdbPatternController,
+                  placeholder: 'tmdb(id)?[=-](\\d+)',
+                  style: TextStyle(color: textColor, fontSize: 13),
+                  decoration: BoxDecoration(
+                    color: tileColor,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: secondaryColor.withOpacity(0.3)),
+                  ),
+                  padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  onSubmitted: (value) {
+                    if (value.isNotEmpty) {
+                      provider.setTmdbIdMatchPattern(value);
+                    }
+                  },
+                ),
+                SizedBox(height: 4),
+                Text(
+                  '最后一个捕获组应为数字，如 tmdbid=(\\d+) 或 tmdb-(\\d+)',
                   style: TextStyle(color: secondaryColor.withOpacity(0.7), fontSize: 10),
                 ),
               ],

--- a/lib/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart
@@ -18,16 +18,19 @@ class WebDAVQuickSettingsPage extends StatefulWidget {
 
 class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
   late TextEditingController _patternController;
+  late TextEditingController _tmdbPatternController;
 
   @override
   void initState() {
     super.initState();
     _patternController = TextEditingController();
+    _tmdbPatternController = TextEditingController();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final provider =
           Provider.of<WebDAVQuickAccessProvider>(context, listen: false);
       provider.loadSettings().then((_) {
         _patternController.text = provider.bgmIdMatchPattern;
+        _tmdbPatternController.text = provider.tmdbIdMatchPattern;
       });
     });
   }
@@ -35,6 +38,7 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
   @override
   void dispose() {
     _patternController.dispose();
+    _tmdbPatternController.dispose();
     super.dispose();
   }
 
@@ -522,9 +526,6 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
                         provider.setBgmIdQuickMatch(value);
                       },
                     ),
-                    onTap: () {
-                      provider.setBgmIdQuickMatch(!provider.bgmIdQuickMatch);
-                    },
                   ),
                   if (provider.bgmIdQuickMatch) ...[
                     Divider(height: 1, color: secondaryTextColor.withOpacity(0.2)),
@@ -578,6 +579,100 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
                           SizedBox(height: 4),
                           Text(
                             '最后一个捕获组应为数字，如 bgmid=(\\d+) 或 bgm-(\\d+)',
+                            style: TextStyle(
+                              color: secondaryTextColor.withOpacity(0.7),
+                              fontSize: 10,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+
+            SizedBox(height: 16),
+
+            // tmdbId 快速匹配开关
+            _buildSettingsCard(
+              cardColor: cardColor,
+              child: Column(
+                children: [
+                  ListTile(
+                    leading: Icon(Ionicons.film_outline, color: textColor.withOpacity(0.7)),
+                    title: Text(
+                      'tmdbId 快速匹配',
+                      style: TextStyle(
+                        color: textColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    subtitle: Text(
+                      '从 URL 中提取 tmdbId，通过 TMDB ID 直接获取番剧信息',
+                      style: TextStyle(
+                        color: secondaryTextColor,
+                      ),
+                    ),
+                    trailing: FluentSettingsSwitch(
+                      value: provider.tmdbIdQuickMatch,
+                      onChanged: (value) {
+                        provider.setTmdbIdQuickMatch(value);
+                      },
+                    ),
+                  ),
+                  if (provider.tmdbIdQuickMatch) ...[
+                    Divider(height: 1, color: secondaryTextColor.withOpacity(0.2)),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '匹配规则（正则表达式）',
+                            style: TextStyle(
+                              color: textColor,
+                              fontSize: 13,
+                            ),
+                          ),
+                          SizedBox(height: 4),
+                          Text(
+                            '从完整 URL 中匹配 tmdbId 数字，支持 tmdbid=123 或 tmdb-123 格式',
+                            style: TextStyle(
+                              color: secondaryTextColor,
+                              fontSize: 11,
+                            ),
+                          ),
+                          SizedBox(height: 8),
+                          TextField(
+                            controller: _tmdbPatternController,
+                            style: TextStyle(color: textColor, fontSize: 13),
+                            decoration: InputDecoration(
+                              hintText: 'tmdb(id)?[=-](\\d+)',
+                              hintStyle: TextStyle(color: secondaryTextColor.withOpacity(0.5)),
+                              contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(8),
+                                borderSide: BorderSide(color: secondaryTextColor.withOpacity(0.3)),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(8),
+                                borderSide: BorderSide(color: accentColor),
+                              ),
+                              isDense: true,
+                            ),
+                            onSubmitted: (value) {
+                              if (value.isNotEmpty) {
+                                provider.setTmdbIdMatchPattern(value);
+                              }
+                            },
+                          ),
+                          SizedBox(height: 4),
+                          Text(
+                            '最后一个捕获组应为数字，如 tmdbid=(\\d+) 或 tmdb-(\\d+)',
                             style: TextStyle(
                               color: secondaryTextColor.withOpacity(0.7),
                               fontSize: 10,

--- a/lib/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart
@@ -678,6 +678,30 @@ class _WebDAVQuickSettingsPageState extends State<WebDAVQuickSettingsPage> {
                               fontSize: 10,
                             ),
                           ),
+                          SizedBox(height: 12),
+                          ListTile(
+                            contentPadding: EdgeInsets.zero,
+                            title: Text(
+                              '匹配弹幕自动剧集偏移（实验中）',
+                              style: TextStyle(
+                                color: textColor,
+                                fontSize: 14,
+                              ),
+                            ),
+                            subtitle: Text(
+                              '自动计算跨季剧集编号偏移量，修复 SxEx 季内编号与弹幕库绝对编号不匹配的问题',
+                              style: TextStyle(
+                                color: secondaryTextColor,
+                                fontSize: 11,
+                              ),
+                            ),
+                            trailing: FluentSettingsSwitch(
+                              value: provider.episodeOffsetEnabled,
+                              onChanged: (value) {
+                                provider.setEpisodeOffsetEnabled(value);
+                              },
+                            ),
+                          ),
                         ],
                       ),
                     ),


### PR DESCRIPTION
## 做了什么

在现有 bgmid 快速匹配基础上，新增 TMDB ID 快速匹配。用户在文件名中嵌入 `tmdbid=xxxx` 后，通过弹弹play API 直接获取番剧信息，跳过 16MB 下载和哈希计算。

## 为什么

之前设计的 bgmid 依赖 Bangumi.tv 的 subjectId，部分用户可能有 TMDB ID 但不知道 bgmid。增加 tmdbId 作为备选匹配方式，让更多文件命名风格都能享受快速匹配。

## 怎么实现的

两步 API 调用：
1. `/api/v2/search/episodes?tmdbId={id}` → 获取正确的 animeId
2. `/api/v2/bangumi/{animeId}` → 获取含 episodeNumber 的剧集列表

多季度 animeId 时按文件名 SxEx 的 season 数字 + animeId 升序选择。

## 修改文件

| 文件 | 改动 |
|------|------|
| `lib/providers/webdav_quick_access_provider.dart` | 新增 tmdbIdQuickMatch 开关、正则配置、剧集偏移开关 |
| `lib/services/dandanplay_service_io.dart` | 新增 getBangumiByTmdbId() |
| `lib/services/dandanplay_service_stub.dart` | Web 桩 |
| `lib/pages/webdav_browser_page.dart` | _playVideo() 添加 tmdbId 匹配逻辑 + 剧集偏移计算 |
| Nipaplay / Cupertino 设置页 | tmdbId 开关 UI + 剧集偏移开关 |

## 关键设计

- **优先级**: bgmid 优先 → tmdbId 备选 → 自动回退哈希匹配
- **严格隔离**: 仅 WebDAV 快捷播放生效，不影响 Jellyfin/Emby/本地文件
- **开关独立**: bgmid 和 tmdbId 各自可单独启用/关闭
- **默认关闭**: 两个开关默认均为关闭
- **错误静默回退**: 任何失败都自动走原有 16MB 匹配流程，用户无感知

## 新功能：匹配弹幕自动剧集偏移（实验中）

dandanplay 的 episodeNumber 为跨季累加的绝对编号（如 S2 第一集 = "29"），与文件名中的季内编号（S02E01）不一致。

开启此开关后，自动计算漂移偏移量：
- 过滤正片（episodeId 倒数第4位=0）
- `offset = min(episodeNumber) - 1`
- 匹配时用 `文件集数 + offset` 修正

默认关闭，仅 tmdbId 匹配路径生效，为实验性功能。

## 验证

- `flutter analyze` 零 lib/ 错误
- Linux / Android release 构建成功
- Android 真机测试效果符合预期
- 回退链路确认：`quickMatchEpisodeId` 为 null → `VideoPlayerState._recognizeVideo()` → `RemoteMediaFetcher.fetchHead()` 16MB 哈希匹配