### PR TITLE
feat: Libmpv Android 音频后端可配置选项

### DIFF
--- a/lib/player_abstraction/media_kit_player_adapter.dart
+++ b/lib/player_abstraction/media_kit_player_adapter.dart
@@ -19,6 +19,7 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
   static bool _disableMpvLogs = false;
   static int? _cachedMacosMajor;
   static bool _macOSNativeVideoPreference = false;
+  final String? _androidAudioOutput;
   static const int _defaultBufferSize = 32 * 1024 * 1024;
   static const String _hdrValidationFlag = 'NIPAPLAY_MACOS_HDR_VALIDATE';
   static const MethodChannel _macOSNativeVideoChannel =
@@ -225,10 +226,11 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
   int _platformVideoSurfaceBindingGeneration = 0;
   Media? _pendingPlatformMedia;
 
-  MediaKitPlayerAdapter({int? bufferSize})
+  MediaKitPlayerAdapter({int? bufferSize, String? androidAudioOutput})
       : _mpvDiagnosticsEnabled = _shouldEnableMpvDiagnostics(),
         _enableHardwareAcceleration = !_shouldDisableHardwareAcceleration(),
         _prefersPlatformVideoSurface = _shouldUseMacOSNativeVideoSurface(),
+        _androidAudioOutput = androidAudioOutput,
         _player = Player(
           configuration: PlayerConfiguration(
             libass: true,
@@ -247,6 +249,7 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
     _applyMpvLogLevelOverride();
     _applyMacOSHdrOutputOptions();
     _applyMpvDiagnosticOptions();
+    _applyAndroidAudioOutput();
     _bootstrapMacOSPlatformVideoSurface();
     if (!_prefersPlatformVideoSurface) {
       _controller = VideoController(
@@ -278,6 +281,15 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
     } catch (e) {
       debugPrint('MediaKit: 设置MPV日志级别为none失败: $e');
     }
+  }
+
+  void _applyAndroidAudioOutput() {
+    if (_androidAudioOutput == null ||
+        defaultTargetPlatform != TargetPlatform.android) {
+      return;
+    }
+    _setMpvPropertyOption('ao', _androidAudioOutput!);
+    debugPrint('MediaKit: Android 音频后端设置为 $_androidAudioOutput');
   }
 
   void _applyMpvDiagnosticOptions() {

--- a/lib/player_abstraction/player_factory.dart
+++ b/lib/player_abstraction/player_factory.dart
@@ -24,12 +24,14 @@ class PlayerFactory {
   static const String _precacheBufferSizeKey = 'player_precache_buffer_size_mb';
   static const String _macOSNativeVideoEnabledKey =
       'macos_native_video_enabled';
+  static const String _androidAudioOutputKey = 'android_audio_output';
   static const int defaultPrecacheBufferSizeMb = 32;
   static const int minPrecacheBufferSizeMb = 4;
   static const int maxPrecacheBufferSizeMb = 512;
   static PlayerKernelType? _cachedKernelType;
   static int _cachedPrecacheBufferSizeMb = defaultPrecacheBufferSizeMb;
   static bool _cachedMacOSNativeVideoEnabled = false;
+  static String _cachedAndroidAudioOutput = 'opensles';
   static bool _hasLoadedSettings = false;
 
   // 添加一个StreamController来广播内核切换事件
@@ -53,6 +55,8 @@ class PlayerFactory {
       final bufferSizeMb = prefs.getInt(_precacheBufferSizeKey);
       final macOSNativeVideoEnabled =
           prefs.getBool(_macOSNativeVideoEnabledKey) ?? false;
+      final androidAudioOutput =
+          prefs.getString(_androidAudioOutputKey) ?? 'opensles';
 
       if (kernelTypeIndex != null &&
           kernelTypeIndex < PlayerKernelType.values.length) {
@@ -69,6 +73,7 @@ class PlayerFactory {
       MediaKitPlayerAdapter.setMacOSNativeVideoPreference(
         _cachedMacOSNativeVideoEnabled,
       );
+      _cachedAndroidAudioOutput = androidAudioOutput;
 
       _hasLoadedSettings = true;
     } catch (e) {
@@ -76,6 +81,7 @@ class PlayerFactory {
       _cachedKernelType = PlayerKernelType.mdk;
       _cachedPrecacheBufferSizeMb = defaultPrecacheBufferSizeMb;
       _cachedMacOSNativeVideoEnabled = false;
+      _cachedAndroidAudioOutput = 'opensles';
       MediaKitPlayerAdapter.setMacOSNativeVideoPreference(false);
       _hasLoadedSettings = true;
     }
@@ -88,6 +94,7 @@ class PlayerFactory {
       _cachedKernelType = PlayerKernelType.mdk;
       _cachedPrecacheBufferSizeMb = defaultPrecacheBufferSizeMb;
       _cachedMacOSNativeVideoEnabled = false;
+      _cachedAndroidAudioOutput = 'opensles';
       MediaKitPlayerAdapter.setMacOSNativeVideoPreference(false);
       _hasLoadedSettings = true;
 
@@ -97,6 +104,8 @@ class PlayerFactory {
         final bufferSizeMb = prefs.getInt(_precacheBufferSizeKey);
         final macOSNativeVideoEnabled =
             prefs.getBool(_macOSNativeVideoEnabledKey) ?? false;
+        final androidAudioOutput =
+            prefs.getString(_androidAudioOutputKey) ?? 'opensles';
         if (kernelTypeIndex != null &&
             kernelTypeIndex < PlayerKernelType.values.length) {
           _cachedKernelType = PlayerKernelType.values[kernelTypeIndex];
@@ -111,6 +120,7 @@ class PlayerFactory {
         MediaKitPlayerAdapter.setMacOSNativeVideoPreference(
           _cachedMacOSNativeVideoEnabled,
         );
+        _cachedAndroidAudioOutput = androidAudioOutput;
       });
 
       debugPrint('[PlayerFactory] 同步设置临时默认值: MDK');
@@ -118,6 +128,7 @@ class PlayerFactory {
       debugPrint('[PlayerFactory] 同步加载设置出错: $e');
       _cachedKernelType = PlayerKernelType.mdk;
       _cachedPrecacheBufferSizeMb = defaultPrecacheBufferSizeMb;
+      _cachedAndroidAudioOutput = 'opensles';
     }
   }
 
@@ -180,6 +191,24 @@ class PlayerFactory {
     }
   }
 
+  static String getAndroidAudioOutput() {
+    if (!_hasLoadedSettings) {
+      _loadSettingsSync();
+    }
+    return _cachedAndroidAudioOutput;
+  }
+
+  static Future<void> saveAndroidAudioOutput(String output) async {
+    final resolved = (output == 'audiotrack') ? 'audiotrack' : 'opensles';
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_androidAudioOutputKey, resolved);
+      _cachedAndroidAudioOutput = resolved;
+    } catch (e) {
+      debugPrint('[PlayerFactory] 保存 Android 音频后端设置出错: $e');
+    }
+  }
+
   // 创建播放器实例
   AbstractPlayer createPlayer({PlayerKernelType? kernelType}) {
     // 如果是Web平台，强制使用VideoPlayer
@@ -201,6 +230,7 @@ class PlayerFactory {
       case PlayerKernelType.mediaKit:
         return MediaKitPlayerAdapter(
           bufferSize: getPrecacheBufferSizeBytes(),
+          androidAudioOutput: getAndroidAudioOutput(),
         );
       // case PlayerKernelType.otherPlayer:
       //   // return OtherPlayerAdapter(ThirdPartyPlayerApi());
@@ -210,6 +240,7 @@ class PlayerFactory {
         debugPrint('[PlayerFactory] 未知播放器内核类型，默认使用 MediaKit');
         return MediaKitPlayerAdapter(
           bufferSize: getPrecacheBufferSizeBytes(),
+          androidAudioOutput: getAndroidAudioOutput(),
         );
     }
   }

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_player_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_player_settings_page.dart
@@ -55,6 +55,7 @@ class _CupertinoPlayerSettingsPageState
   double _spoilerAiTemperatureDraft = 0.5;
   Anime4KProfile? _anime4kSelectionOverride;
   CrtProfile? _crtSelectionOverride;
+  String _androidAudioOutput = 'opensles';
 
   @override
   void didChangeDependencies() {
@@ -92,6 +93,7 @@ class _CupertinoPlayerSettingsPageState
     }
     await _loadPlayerKernelSettings();
     await _loadDanmakuRenderEngineSettings();
+    await _loadAndroidAudioOutputSettings();
 
     if (mounted) {
       setState(() {
@@ -117,6 +119,28 @@ class _CupertinoPlayerSettingsPageState
     setState(() {
       _selectedKernelType = kernelType;
     });
+  }
+
+  Future<void> _loadAndroidAudioOutputSettings() async {
+    final output = PlayerFactory.getAndroidAudioOutput();
+    if (!mounted) return;
+    setState(() {
+      _androidAudioOutput = output;
+    });
+  }
+
+  Future<void> _saveAndroidAudioOutputSettings(String output) async {
+    await PlayerFactory.saveAndroidAudioOutput(output);
+    if (!mounted) return;
+    setState(() {
+      _androidAudioOutput = output;
+    });
+    final displayName = output == 'audiotrack' ? 'AudioTrack' : 'OpenSL ES';
+    AdaptiveSnackBar.show(
+      context,
+      message: 'Android 音频后端已切换为 $displayName，需重启APP生效',
+      type: AdaptiveSnackBarType.success,
+    );
   }
 
   Future<void> _loadDecoderSettings() async {
@@ -794,6 +818,50 @@ class _CupertinoPlayerSettingsPageState
               ],
             );
           },
+        ),
+      ],
+      if (!kIsWeb &&
+          Platform.isAndroid &&
+          _selectedKernelType == PlayerKernelType.mediaKit) ...[
+        const SizedBox(height: 16),
+        CupertinoSettingsGroupCard(
+          margin: EdgeInsets.zero,
+          backgroundColor: sectionBackground,
+          addDividers: true,
+          dividerIndent: 16,
+          children: [
+            CupertinoSettingsTile(
+              leading: Icon(
+                CupertinoIcons.music_note,
+                color: resolveSettingsIconColor(context),
+              ),
+              title: const Text('Android 音频后端'),
+              subtitle: const Text(
+                  '音频后端切换为 AudioTrack 可支持某些Android机型杜比全景声等系统音效（实验性，需重启APP生效）'),
+              trailing: AdaptivePopupMenuButton.widget<String>(
+                items: [
+                  AdaptivePopupMenuItem<String>(
+                    value: 'opensles',
+                    label: 'OpenSL ES',
+                  ),
+                  AdaptivePopupMenuItem<String>(
+                    value: 'audiotrack',
+                    label: 'AudioTrack',
+                  ),
+                ],
+                buttonStyle: PopupButtonStyle.gray,
+                child: _buildMenuChip(context,
+                    _androidAudioOutput == 'audiotrack' ? 'AudioTrack' : 'OpenSL ES'),
+                onSelected: (index, entry) {
+                  final output = entry.value!;
+                  if (output != _androidAudioOutput) {
+                    _saveAndroidAudioOutputSettings(output);
+                  }
+                },
+              ),
+              backgroundColor: tileBackground,
+            ),
+          ],
         ),
       ],
       if (globals.isPhone) ...[

--- a/lib/themes/nipaplay/pages/settings/player_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/player_settings_page.dart
@@ -48,11 +48,13 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
   PlayerKernelType _selectedKernelType = PlayerKernelType.mdk;
   DanmakuRenderEngine _selectedDanmakuRenderEngine = DanmakuRenderEngine.canvas;
   bool _macOSNativeVideoEnabled = false;
+  String _androidAudioOutput = 'opensles';
 
   // 为BlurDropdown添加GlobalKey
   final GlobalKey _playerKernelDropdownKey = GlobalKey();
   final GlobalKey _danmakuRenderEngineDropdownKey = GlobalKey();
   final GlobalKey _spoilerAiApiFormatDropdownKey = GlobalKey();
+  final GlobalKey _androidAudioOutputDropdownKey = GlobalKey();
 
   final TextEditingController _spoilerAiUrlController = TextEditingController();
   final TextEditingController _spoilerAiModelController =
@@ -92,6 +94,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
     _loadPlayerKernelSettings();
     _loadDanmakuRenderEngineSettings();
     _loadMacOSNativeVideoSettings();
+    _loadAndroidAudioOutputSettings();
 
     if (!_spoilerAiControllersInitialized) {
       _spoilerAiApiFormatDraft = playerState.spoilerAiApiFormat;
@@ -167,6 +170,24 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
       context,
       enabled ? '已开启实验性 HDR 原生视频输出' : '已切回 Flutter 纹理视频输出',
     );
+  }
+
+  Future<void> _loadAndroidAudioOutputSettings() async {
+    final output = PlayerFactory.getAndroidAudioOutput();
+    if (!mounted) return;
+    setState(() {
+      _androidAudioOutput = output;
+    });
+  }
+
+  Future<void> _saveAndroidAudioOutputSettings(String output) async {
+    await PlayerFactory.saveAndroidAudioOutput(output);
+    if (!mounted) return;
+    setState(() {
+      _androidAudioOutput = output;
+    });
+    final displayName = output == 'audiotrack' ? 'AudioTrack' : 'OpenSL ES';
+    BlurSnackBar.show(context, 'Android 音频后端已切换为 $displayName，需重启APP生效');
   }
 
   void _showRestartDialog() {
@@ -524,6 +545,36 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
                 },
               );
             },
+          ),
+          Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+        ],
+        if (!kIsWeb &&
+            Platform.isAndroid &&
+            _selectedKernelType == PlayerKernelType.mediaKit) ...[
+          SettingsItem.dropdown(
+            title: 'Android 音频后端',
+            subtitle: '音频后端切换为 AudioTrack 可支持某些Android机型杜比全景声等系统音效（实验性，需重启APP生效）',
+            icon: Ionicons.musical_notes_outline,
+            items: [
+              DropdownMenuItemData(
+                title: 'OpenSL ES',
+                value: 'opensles',
+                isSelected: _androidAudioOutput == 'opensles',
+                description: '默认，兼容性较好',
+              ),
+              DropdownMenuItemData(
+                title: 'AudioTrack',
+                value: 'audiotrack',
+                isSelected: _androidAudioOutput == 'audiotrack',
+                description: '支持系统音效（如杜比全景声）',
+              ),
+            ],
+            onChanged: (output) {
+              if (output is String) {
+                _saveAndroidAudioOutputSettings(output);
+              }
+            },
+            dropdownKey: _androidAudioOutputDropdownKey,
           ),
           Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
         ],


### PR DESCRIPTION
## 背景

在部分 Android 机型（如小米）上，libmpv 播放器无法使用系统音效（如杜比全景声）。原因是 mpv 默认使用 OpenSL ES 作为音频输出后端，该底层 API 绕过了 Android 的 AudioEffect 框架。

## 方案

新增"Android 音频后端"设置项，允许用户在 OpenSL ES 和 AudioTrack 之间切换。AudioTrack 经过 Android 音效框架处理，可正确应用系统音效。

当前预编译 libmpv 仅包含 `opensles` 和 `audiotrack` 两种音频驱动。后续若上游 libmpv 启用 AAudio 编译，可直接追加为第三个选项。

## 改动

| 文件 | 内容 |
|------|------|
| `lib/player_abstraction/player_factory.dart` | 新增 `android_audio_output` 持久化：key 常量、读写守卫、输入验证、同步/异步两条加载路径 |
| `lib/player_abstraction/media_kit_player_adapter.dart` | 通过构造函数参数接收配置，播放器初始化时通过 `setProperty('ao', value)` 动态设置 mpv 音频后端 |
| `lib/themes/nipaplay/pages/settings/player_settings_page.dart` | NipaPlay 主题新增下拉选项 |
| `lib/themes/cupertino/pages/settings/pages/cupertino_player_settings_page.dart` | Cupertino 主题新增下拉选项 |

## 行为

- 默认 **OpenSL ES**，与修改前行为一致
- 选项仅在选择 **Libmpv 内核的 Android 设备**上显示
- 切换后提示"需重启 APP 生效"

## 测试

在小米手机上验证：切换为 AudioTrack 后重启 APP，杜比全景声音效正常生效。