### PR TITLE
fix:tooltip flicker on windows

### DIFF
--- a/lib/themes/nipaplay/widgets/tooltip_bubble.dart
+++ b/lib/themes/nipaplay/widgets/tooltip_bubble.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
@@ -39,26 +40,21 @@ class _TooltipBubbleState extends State<TooltipBubble> {
   OverlayEntry? _overlayEntry;
   Offset? _mousePosition;
 
-  void _updateOverlay(BuildContext context, [Offset? newMousePosition]) {
-    if (newMousePosition != null) {
-      _mousePosition = newMousePosition;
-    }
-    _hideOverlay();
-    if (_isHovered && widget.text.isNotEmpty) {
-      _showOverlay(context);
-    }
-  }
+  // Cached overlay position for in-place updates
+  Offset _overlayOffset = Offset.zero;
+  double _overlayWidth = 0;
 
-  void _showOverlay(BuildContext context) {
+  // Debounce timers for filtering spurious enter/exit events on Windows
+  Timer? _enterTimer;
+  Timer? _exitTimer;
+
+  void _recalculatePosition() {
     final RenderBox renderBox =
         _childKey.currentContext?.findRenderObject() as RenderBox;
     final position = renderBox.localToGlobal(Offset.zero);
     final size = renderBox.size;
     final bubbleWidth = _getBubbleWidth();
     final bubbleHeight = _getBubbleHeight();
-
-    // 添加调试日志
-    //debugPrint('[TooltipBubble] 显示气泡，文本: "${widget.text}", 宽度: $bubbleWidth');
 
     double left;
     double top;
@@ -97,18 +93,38 @@ class _TooltipBubbleState extends State<TooltipBubble> {
       top = top.clamp(10.0, maxTop);
     }
 
-    _overlayEntry = OverlayEntry(
-      builder: (context) => Positioned(
-        left: left,
-        top: top,
-        child: Material(
-          color: Colors.transparent,
-          child: _buildBubble(bubbleWidth),
-        ),
-      ),
-    );
+    _overlayOffset = Offset(left, top);
+    _overlayWidth = bubbleWidth;
+  }
 
-    Overlay.of(context).insert(_overlayEntry!);
+  void _updateOverlay(BuildContext context, [Offset? newMousePosition]) {
+    if (newMousePosition != null) {
+      _mousePosition = newMousePosition;
+    }
+
+    if (!_isHovered || widget.text.isEmpty) {
+      _hideOverlay();
+      return;
+    }
+
+    _recalculatePosition();
+
+    if (_overlayEntry != null) {
+      // Overlay already exists — update in place without removing/reinserting
+      _overlayEntry!.markNeedsBuild();
+    } else {
+      _overlayEntry = OverlayEntry(
+        builder: (context) => Positioned(
+          left: _overlayOffset.dx,
+          top: _overlayOffset.dy,
+          child: Material(
+            color: Colors.transparent,
+            child: _buildBubble(_overlayWidth),
+          ),
+        ),
+      );
+      Overlay.of(context).insert(_overlayEntry!);
+    }
   }
 
   double _getBubbleWidth() {
@@ -172,6 +188,8 @@ class _TooltipBubbleState extends State<TooltipBubble> {
 
   @override
   void dispose() {
+    _enterTimer?.cancel();
+    _exitTimer?.cancel();
     _hideOverlay();
     super.dispose();
   }
@@ -196,12 +214,20 @@ class _TooltipBubbleState extends State<TooltipBubble> {
         }
       },
       onEnter: (event) {
-        setState(() => _isHovered = true);
-        _updateOverlay(context, event.position);
+        _exitTimer?.cancel();
+        _enterTimer = Timer(const Duration(milliseconds: 80), () {
+          if (!mounted) return;
+          setState(() => _isHovered = true);
+          _updateOverlay(context, event.position);
+        });
       },
       onExit: (_) {
-        setState(() => _isHovered = false);
-        _hideOverlay();
+        _enterTimer?.cancel();
+        _exitTimer = Timer(const Duration(milliseconds: 50), () {
+          if (!mounted) return;
+          setState(() => _isHovered = false);
+          _hideOverlay();
+        });
       },
       child: KeyedSubtree(
         key: _childKey,


### PR DESCRIPTION
## Summary

- 修复了Windows平台上播放界面控件 tooltip 频闪的问题

## Related Issue

无

## What Changed

### 1. Overlay原地更新
将位置计算逻辑提取到`_recalculatePosition()`方法中，计算结果存储在`_overlayOffset`和`_overlayWidth`变量中。`_updateOverlay`现在对已存在的`OverlayEntry`调用`markNeedsBuild()`方法，而非先移除再重新插入。仅当Overlay不存在时才会重新创建。

### 2. 防抖定时器
- `onEnter`事件会等待80毫秒后再激活（同时取消所有待执行的退出定时器）
- `onExit`事件会等待50毫秒后再隐藏（同时取消所有待执行的进入定时器）
- 两者在执行前都会检查组件是否已挂载

这可以过滤掉Windows系统在动画帧触发的Widget树重建过程中产生的虚假`onExit/onEnter`事件。

### 3. 代码清理
- 移除了旧的`_showOverlay`方法（其逻辑已整合到`_recalculatePosition`和`_updateOverlay`中）
- 在`dispose()`方法中取消所有定时器
- 添加了`dart:async`导入以使用`Timer`类
- 所有现有参数（`followMouse`、`showOnTop`、`showOnRight`、`position`）以及`_buildBubble`渲染逻辑均保持不变
