### PR TITLE
chore: update Flutter SDK from 3.38.5 to 3.41.9

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,5 +1,5 @@
 {
-  "flutterSdkVersion": "3.38.5",
-  "flutter": "3.38.5",
+  "flutterSdkVersion": "3.41.9",
+  "flutter": "3.41.9",
   "flavors": {}
 }


### PR DESCRIPTION
Updates `.fvmrc` to use Flutter 3.41.9 (latest 3.41.x stable).

Fixes black screen crash on Windows 11 25H2 (Insider build 26200) - the old Flutter 3.38.5 ANGLE rendering stack has compatibility issues with the newer Windows graphics stack.

Ref: QQ group debug session