### PR TITLE
Feat/add danmaku modify plugin pipeline

### DIFF
--- a/Documentation/js-plugin-api.md
+++ b/Documentation/js-plugin-api.md
@@ -32,7 +32,8 @@ const pluginManifest = {
   description: '内置常用敏感词与辱骂词，启用后自动屏蔽命中的弹幕。',
   author: 'NipaPlay Team',
   github: 'https://github.com/xxx/xxx', // 可选
-  permissions: ['danmaku.modify'] // 可选，权限声明
+  permissions: ['danmaku.modify'], // 可选，权限声明
+  priority: 50 // 可选，插件处理顺序，默认 50
 };
 ```
 
@@ -46,6 +47,7 @@ const pluginManifest = {
 - `author`：选填，作者字符串。
 - `github`：选填，GitHub 链接字符串，可为空。
 - `permissions`：选填，权限字符串数组。
+- `priority`：选填，整数，默认 `50`。用于控制插件在 `danmakuLoaded` 事件链式处理中的执行顺序。数值越小越先执行。建议范围 `0-100`，`0` 为最先执行，`100` 为最后执行。
 
 若 `id/name/version/minHostVersion` 任一为空，插件会被判定为无效。
 
@@ -215,6 +217,22 @@ function pluginOnEvent(event) {
 | `appPaused` | 应用暂停 | 空对象 |
 
 > `danmakuLoaded` 事件中的 `danmaku` 数组为已解析格式，`time` 为秒（double），`content` 为弹幕文本，`type` 为弹幕类型（`scroll`/`top`/`bottom`），`color` 为颜色值。调用 `danmaku.replace()` 替换数据时应保持相同格式。
+
+#### 弹幕事件链式处理（Pipeline）
+
+当启用多个具有 `danmaku.modify` 权限的插件时，`danmakuLoaded` 事件会按 `manifest.priority` 升序依次触发每个插件的 `pluginOnEvent`，并以**链式管道**方式传递弹幕数据：
+
+1. 宿主加载原始弹幕数据
+2. 按 `priority` 从低到高排序所有拥有 `danmaku.modify` 权限的已启用插件
+3. 依次触发每个插件的 `pluginOnEvent`，`event.data.danmaku` 始终为**当前累积结果**（即前序插件处理后的数据）
+4. 如果插件调用了 `danmaku.replace()`，替换后的数据将作为下一个插件的输入
+5. 如果插件未调用 `danmaku.replace()`，当前数据透传给下一个插件
+
+这意味着：
+
+- 低 `priority` 的插件（如基础过滤）先执行，高 `priority` 的插件（如精选/定制）后执行
+- 每个插件拿到的 `event.data.danmaku` 是前序插件处理后的结果，**而非原始弹幕**
+- 不调用 `danmaku.replace()` 的插件不影响数据流，行为与之前完全一致
 
 ### 3.6 生命周期函数（可选）
 
@@ -467,7 +485,8 @@ const pluginManifest = {
   minHostVersion: '1.11.0',
   description: '一个最小可用插件',
   author: 'You',
-  permissions: ['ui.dialog']
+  permissions: ['ui.dialog'],
+  priority: 50 // 可选，处理顺序，默认 50
 };
 
 const pluginBlockWords = ['示例屏蔽词'];
@@ -715,7 +734,8 @@ const pluginManifest = {
   minHostVersion: '1.11.0',
   description: '智能精选弹幕，过滤低质量弹幕',
   author: 'You',
-  permissions: ['danmaku.modify', 'ui.dialog']
+  permissions: ['danmaku.modify', 'ui.dialog'],
+  priority: 80 // 高优先级（后执行），基于基础过滤后的结果做精选
 };
 
 var params = {
@@ -774,8 +794,9 @@ function filterDanmaku(danmaku) {
 
 function pluginOnEvent(event) {
   if (event.name === 'danmakuLoaded') {
-    var originalDanmaku = event.data.danmaku; // [{time, content, type, color}, ...]
-    var filteredDanmaku = filterDanmaku(originalDanmaku);
+    // event.data.danmaku 是链式处理的当前结果（前序插件处理后的数据）
+    var currentDanmaku = event.data.danmaku; // [{time, content, type, color}, ...]
+    var filteredDanmaku = filterDanmaku(currentDanmaku);
 
     // replace 参数必须是 { count, comments } 格式
     danmaku.replace({
@@ -783,7 +804,7 @@ function pluginOnEvent(event) {
       comments: filteredDanmaku
     });
 
-    dev.log('弹幕精选: ' + originalDanmaku.length + ' -> ' + filteredDanmaku.length);
+    dev.log('弹幕精选: ' + currentDanmaku.length + ' -> ' + filteredDanmaku.length);
   }
 }
 
@@ -795,8 +816,9 @@ function pluginHandleUIAction(actionId) {
 
 要点：
 
-- 监听 `danmakuLoaded` 事件获取弹幕数据（`event.data.danmaku` 为弹幕数组）
+- 监听 `danmakuLoaded` 事件获取弹幕数据（`event.data.danmaku` 为当前链式处理结果）
 - 使用 `danmaku.replace({ count, comments })` 替换弹幕数据，**参数必须是包含 `count` 和 `comments` 字段的对象**
 - `danmaku.replace()` 之后宿主会自动应用修改并刷新弹幕显示
 - 通过 `pluginUIEntries` 提供可配置的参数
 - 使用 `settings.getText()` 读取用户配置
+- 通过 `priority` 控制处理顺序：低值先执行（如基础过滤 `priority: 30`），高值后执行（如精选 `priority: 80`）

--- a/lib/plugins/models/plugin_manifest.dart
+++ b/lib/plugins/models/plugin_manifest.dart
@@ -10,6 +10,7 @@ class PluginManifest {
     this.github,
     this.minHostVersion = '1.0.0',
     this.permissions = const [],
+    this.priority = 50,
   });
 
   final String id;
@@ -20,6 +21,7 @@ class PluginManifest {
   final String? github;
   final String minHostVersion;
   final List<PluginPermission> permissions;
+  final int priority;
 
   factory PluginManifest.fromJson(Map<String, dynamic> json) {
     final id = (json['id'] ?? '').toString().trim();
@@ -43,6 +45,9 @@ class PluginManifest {
       }
     }
 
+    final priority = json['priority'];
+    final priorityValue = priority is num ? priority.toInt() : 50;
+
     return PluginManifest(
       id: id,
       name: name,
@@ -52,6 +57,7 @@ class PluginManifest {
       github: (githubRaw == null || githubRaw.isEmpty) ? null : githubRaw,
       minHostVersion: minHostVersion,
       permissions: permissions,
+      priority: priorityValue,
     );
   }
 }

--- a/lib/plugins/plugin_service.dart
+++ b/lib/plugins/plugin_service.dart
@@ -507,13 +507,23 @@ class PluginService extends ChangeNotifier {
     } else {
       _pendingDanmakuData = null;
     }
-    for (final plugin in _plugins) {
-      if (!plugin.enabled || !plugin.loaded) continue;
-      if (!plugin.manifest.permissions.any((p) => p.id == 'danmaku.modify')) {
-        continue;
+    // 按 priority 升序排列插件，低优先级先执行
+    final sortedPlugins = _plugins
+        .where((p) =>
+            p.enabled &&
+            p.loaded &&
+            p.manifest.permissions.any((perm) => perm.id == 'danmaku.modify') &&
+            _runtimeByPluginId[p.manifest.id] != null)
+        .toList()
+      ..sort((a, b) => a.manifest.priority.compareTo(b.manifest.priority));
+
+    for (final plugin in sortedPlugins) {
+      final runtime = _runtimeByPluginId[plugin.manifest.id]!;
+
+      // 链式管道：将前序插件的累积结果作为本次事件数据传递
+      if (_pendingDanmakuData != null) {
+        event.data['danmaku'] = _pendingDanmakuData;
       }
-      final runtime = _runtimeByPluginId[plugin.manifest.id];
-      if (runtime == null) continue;
 
       try {
         final eventJson = event.toJson();

--- a/lib/themes/nipaplay/widgets/nipaplay_window.dart
+++ b/lib/themes/nipaplay/widgets/nipaplay_window.dart
@@ -417,8 +417,7 @@ class NipaplayWindow {
     final bool useLargeScreenSubPage =
         NipaplayLargeScreenModeScope.isActiveOf(context);
 
-    HotkeyService.incrementOverlay();
-    HotkeyService().unregisterHotkeys();
+    HotkeyService.overlayPush();
 
     Future<T?> result;
     if (useLargeScreenSubPage) {
@@ -461,9 +460,6 @@ class NipaplayWindow {
       );
     }
 
-    return result.whenComplete(() {
-      HotkeyService.decrementOverlay();
-      HotkeyService().registerHotkeys();
-    });
+    return result.whenComplete(() => HotkeyService.overlayPop());
   }
 }

--- a/lib/themes/nipaplay/widgets/nipaplay_window.dart
+++ b/lib/themes/nipaplay/widgets/nipaplay_window.dart
@@ -7,6 +7,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/cached_network_image_widget.dar
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_mode_scope.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_window_page.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
+import 'package:nipaplay/utils/hotkey_service.dart';
 import 'package:provider/provider.dart';
 
 /// 一个通用的窗口脚手架，提供 Nipaplay 风格的视觉外观。
@@ -415,44 +416,54 @@ class NipaplayWindow {
   }) {
     final bool useLargeScreenSubPage =
         NipaplayLargeScreenModeScope.isActiveOf(context);
+
+    HotkeyService.incrementOverlay();
+    HotkeyService().unregisterHotkeys();
+
+    Future<T?> result;
     if (useLargeScreenSubPage) {
-      return Navigator.of(context).push<T>(
+      result = Navigator.of(context).push<T>(
         NipaplayLargeScreenWindowPageRoute<T>(
           builder: (_) => child,
           enableAnimation: enableAnimation,
           dismissible: barrierDismissible,
         ),
       );
+    } else {
+      result = showGeneralDialog<T>(
+        context: context,
+        barrierDismissible: barrierDismissible,
+        barrierColor: barrierColor,
+        barrierLabel: 'Close',
+        transitionDuration: const Duration(milliseconds: 250),
+        pageBuilder: (context, animation, secondaryAnimation) => child,
+        transitionBuilder: (context, animation, secondaryAnimation, child) {
+          if (!enableAnimation) {
+            return FadeTransition(
+              opacity: Tween<double>(begin: 0.0, end: 1.0).animate(
+                CurvedAnimation(parent: animation, curve: Curves.easeOut),
+              ),
+              child: child,
+            );
+          }
+          final curvedAnimation = CurvedAnimation(
+            parent: animation,
+            curve: Curves.easeOutBack,
+          );
+          return ScaleTransition(
+            scale: Tween<double>(begin: 0.8, end: 1.0).animate(curvedAnimation),
+            child: FadeTransition(
+              opacity: animation,
+              child: child,
+            ),
+          );
+        },
+      );
     }
 
-    return showGeneralDialog<T>(
-      context: context,
-      barrierDismissible: barrierDismissible,
-      barrierColor: barrierColor,
-      barrierLabel: 'Close',
-      transitionDuration: const Duration(milliseconds: 250),
-      pageBuilder: (context, animation, secondaryAnimation) => child,
-      transitionBuilder: (context, animation, secondaryAnimation, child) {
-        if (!enableAnimation) {
-          return FadeTransition(
-            opacity: Tween<double>(begin: 0.0, end: 1.0).animate(
-              CurvedAnimation(parent: animation, curve: Curves.easeOut),
-            ),
-            child: child,
-          );
-        }
-        final curvedAnimation = CurvedAnimation(
-          parent: animation,
-          curve: Curves.easeOutBack,
-        );
-        return ScaleTransition(
-          scale: Tween<double>(begin: 0.8, end: 1.0).animate(curvedAnimation),
-          child: FadeTransition(
-            opacity: animation,
-            child: child,
-          ),
-        );
-      },
-    );
+    return result.whenComplete(() {
+      HotkeyService.decrementOverlay();
+      HotkeyService().registerHotkeys();
+    });
   }
 }

--- a/lib/utils/hotkey_service.dart
+++ b/lib/utils/hotkey_service.dart
@@ -46,6 +46,13 @@ class HotkeyService extends ChangeNotifier {
   // 上下文，用于访问Provider
   BuildContext? _context;
 
+  // overlay 计数器，>0 时表示有对话框/overlay 在视频播放界面上方
+  static int _overlayCount = 0;
+  static void incrementOverlay() => _overlayCount++;
+  static void decrementOverlay() {
+    if (_overlayCount > 0) _overlayCount--;
+  }
+
   // 长按检测
   Timer? _longPressTimer;
   bool _isForwardKeyPressed = false;
@@ -253,6 +260,11 @@ class HotkeyService extends ChangeNotifier {
 
   bool _shouldBlockHotkeyInTextInput() {
     if (_isEditableTextFocused()) {
+      return true;
+    }
+    // 播放器内菜单打开时禁用热键
+    final videoState = _getVideoPlayerState();
+    if (videoState != null && videoState.hotkeysSuppressed) {
       return true;
     }
     return false;

--- a/lib/utils/hotkey_service.dart
+++ b/lib/utils/hotkey_service.dart
@@ -48,9 +48,21 @@ class HotkeyService extends ChangeNotifier {
 
   // overlay 计数器，>0 时表示有对话框/overlay 在视频播放界面上方
   static int _overlayCount = 0;
-  static void incrementOverlay() => _overlayCount++;
-  static void decrementOverlay() {
+
+  /// overlay 打开时调用：0→1 时注销热键
+  static void overlayPush() {
+    _overlayCount++;
+    if (_overlayCount == 1) {
+      HotkeyService().unregisterHotkeys();
+    }
+  }
+
+  /// overlay 关闭时调用：1→0 时恢复热键
+  static void overlayPop() {
     if (_overlayCount > 0) _overlayCount--;
+    if (_overlayCount == 0) {
+      HotkeyService().registerHotkeys();
+    }
   }
 
   // 长按检测

--- a/lib/utils/video_player_state/video_player_state_playback_controls.dart
+++ b/lib/utils/video_player_state/video_player_state_playback_controls.dart
@@ -784,6 +784,8 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
     _notifyListeners();
   }
 
+  bool get hotkeysSuppressed => _controlsVisibilityLocked;
+
   void setControlsVisibilityLocked(bool value) {
     if (_controlsVisibilityLocked == value) {
       return;


### PR DESCRIPTION
## Summary

- 为插件系统的 `danmaku.modify` 权限增加了先后性处理的 pipeline，保证多插件同时工作
- 修改了插件 manifest 模板，使用 `danmakuloaded` 事件的插件现在需要声明 priority 优先级
- 为所有 `nipaplay.window` 窗口注销了播放器快捷键（发送弹幕弹窗同款逻辑），防止在进行输入操作时误触发快捷键或输入内容被吞
- 更新了插件 api 接口文档
## Related Issue

- Closes #536 
- Closes #528 

## What Changed

一、插件弹幕处理链式管道（commit 87d62a60）
  
  问题：多个弹幕过滤插件同时启用时，每个插件拿到的都是原始弹幕数据，`danmaku.replace()` 是
  last-write-wins，前面插件的修改被后面覆盖。

  改动 3 个文件：
  
  `lib/plugins/models/plugin_manifest.dart` — 新增 priority 字段
  - PluginManifest 构造函数增加 `this.priority = 50`
  - fromJson 解析 JS 传入的 priority，默认 50
  
  `lib/plugins/plugin_service.dart` — 链式管道核心
  - `_handleDanmakuLoadedEvent` 改为按 priority 升序排序插件
  - 每次循环迭代前，将前序插件的累积结果（`_pendingDanmakuData`）回写到
  `event.data['danmaku']`
  - 插件拿到的始终是链式处理的当前结果，输出自动成为下一个插件的输入

  `Documentation/js-plugin-api.md` — 文档更新
  - manifest 字段说明新增 priority
  - 新增「弹幕事件链式处理（Pipeline）」章节
  - 示例插件补充 priority 用法

  ---
  二、对话框打开时禁用快捷键（commit fcc76873）
  
  问题：播放视频时打开设置等对话框，输入文字会触发视频控制快捷键（空格=播放暂停等）。

  改动 3 个文件：

  `lib/utils/video_player_state/video_player_state_playback_controls.dart` — 暴露 overlay
  状态
  - 新增 `bool get hotkeysSuppressed => 
  _controlsVisibilityLocked`，复用已有的播放器内菜单开关状态

  `lib/utils/hotkey_service.dart` — 热键拦截逻辑
  - 新增静态 `_overlayCount` 计数器 + `incrementOverlay() / decrementOverlay()`
  - `_shouldBlockHotkeyInTextInput()` 增加 `hotkeysSuppressed` 检查（覆盖播放器内菜单场景）
  
  `lib/themes/nipaplay/widgets/nipaplay_window.dart` — 对话框统一入口
  - `NipaplayWindow.show()` 入口：`incrementOverlay()` + `unregisterHotkeys()`（OS
  层不再拦截按键）
  - whenComplete：`decrementOverlay()` + `registerHotkeys()`（对话框关闭后恢复热键）
  - 覆盖所有通过 `BlurDialog / NipaplayWindow.show` 弹出的对话框
