### PR TITLE
fix(ci): fix linux rust manifest path and windows rust linkage

### DIFF
--- a/rust_builder/linux/CMakeLists.txt
+++ b/rust_builder/linux/CMakeLists.txt
@@ -12,21 +12,12 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
 
 include("../cargokit/cmake/cargokit.cmake")
-set(_RUST_MANIFEST_DIR "")
-set(_RUST_MANIFEST_CANDIDATES
-  "${CMAKE_CURRENT_SOURCE_DIR}/../../rust"
-  "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../rust"
-)
-foreach(_candidate IN LISTS _RUST_MANIFEST_CANDIDATES)
-  if (EXISTS "${_candidate}/Cargo.toml")
-    get_filename_component(_RUST_MANIFEST_DIR "${_candidate}" ABSOLUTE)
-    break()
-  endif()
-endforeach()
-if (NOT _RUST_MANIFEST_DIR)
-  message(FATAL_ERROR "Failed to locate rust/Cargo.toml from ${CMAKE_CURRENT_SOURCE_DIR}")
+set(_RUST_MANIFEST_REL "../../rust")
+if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_RUST_MANIFEST_REL}/Cargo.toml")
+  message(FATAL_ERROR
+    "Failed to locate rust/Cargo.toml at ${CMAKE_CURRENT_SOURCE_DIR}/${_RUST_MANIFEST_REL}")
 endif()
-apply_cargokit(${PROJECT_NAME} "${_RUST_MANIFEST_DIR}" rust_lib_nipaplay "")
+apply_cargokit(${PROJECT_NAME} "${_RUST_MANIFEST_REL}" rust_lib_nipaplay "")
 
 add_library(
   ${PLUGIN_NAME} SHARED

--- a/rust_builder/windows/CMakeLists.txt
+++ b/rust_builder/windows/CMakeLists.txt
@@ -57,7 +57,6 @@ target_link_libraries(
   flutter
   flutter_wrapper_plugin
   dwmapi
-  "${${PROJECT_NAME}_cargokit_lib}"
 )
 
 # List of absolute paths to libraries that should be bundled with the plugin.


### PR DESCRIPTION
Summary:
- fix Linux desktop rust manifest resolution in rust_builder/linux/CMakeLists.txt
- fix Windows desktop rust linkage in rust_builder/windows/CMakeLists.txt

Root cause:
- Linux CI failed with PathNotFoundException on linux/flutter/ephemeral/.plugin_symlinks/rust/Cargo.toml due to manifest path normalization logic.
- Windows CI failed with LNK1107 because the Rust DLL path was manually linked as a library input.

Changes:
- Linux: use stable relative manifest path ../../rust with explicit existence check.
- Windows: remove manual link to PROJECT_NAME cargokit output from plugin target and rely on apply_cargokit linkage behavior.

Validation:
- intended to unblock GitHub Actions run #963 failures for Linux amd64 and arm64 and Windows.
