### PR TITLE
fix(ci): link Rust library in Windows plugin

### DIFF
--- a/rust_builder/windows/CMakeLists.txt
+++ b/rust_builder/windows/CMakeLists.txt
@@ -57,6 +57,7 @@ target_link_libraries(
   flutter
   flutter_wrapper_plugin
   dwmapi
+  "${${PROJECT_NAME}_cargokit_lib}"
 )
 
 # List of absolute paths to libraries that should be bundled with the plugin.


### PR DESCRIPTION
## Summary
- link the cargokit-built Rust library into the Windows rust_lib_nipaplay plugin target
- fixes unresolved next2_engine_* symbols during flutter build windows

## Verification
- git diff --check

Note: full Windows build verification needs a Windows runner.