### PR TITLE
feat(player): hide top-right time/battery on tablet when not fullscreen

### DIFF
--- a/lib/pages/play_video_page.dart
+++ b/lib/pages/play_video_page.dart
@@ -564,7 +564,7 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
             ),
           ),
         ),
-        if (globals.isMobilePlatform)
+        if (globals.isMobilePlatform && (!globals.isTablet || videoState.isFullscreen))
           Positioned(
             top: 0,
             right: 0,


### PR DESCRIPTION
在平板非全屏模式下隐藏右上角的时间/电量显示，避免遮挡内容。