### PR TITLE
feat(plugin): add built-in mirror fallback for plugin marketplace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ docs/error.txt
 /packages/nipaplay_smb2/android/.cxx
 /packages/nipaplay_smb2/android/.cxx/Debug/6r64695b
 /rust/target
+/node_modules/
+/data/

--- a/lib/plugins/plugin_service.dart
+++ b/lib/plugins/plugin_service.dart
@@ -208,37 +208,59 @@ class PluginService extends ChangeNotifier {
 
   Future<void> fetchRemotePlugins({String? proxyUrl}) async {
     try {
-      late final String url;
-      if (proxyUrl == null || proxyUrl.trim().isEmpty) {
-        final resolved =
-            await GithubAccelResolver.resolveFirstReachable(_pluginsIndexUrl);
-        url = resolved ?? _pluginsIndexUrl;
-      } else {
-        url = _applyProxyIfNeeded(_pluginsIndexUrl, proxyUrl);
+      if (proxyUrl != null && proxyUrl.trim().isNotEmpty) {
+        final url = _applyProxyIfNeeded(_pluginsIndexUrl, proxyUrl);
+        await _fetchPluginsFromUrl(url);
+        return;
       }
-      final response = await http.get(Uri.parse(url));
-      if (response.statusCode == 200) {
-        final dynamic jsonData = json.decode(response.body);
-        List<dynamic> data;
-        if (jsonData is List) {
-          data = jsonData;
-        } else if (jsonData is Map) {
-          if (jsonData.containsKey('plugins')) {
-            data = jsonData['plugins'] as List;
-          } else if (jsonData.containsKey('data')) {
-            data = jsonData['data'] as List;
-          } else {
-            data = [];
-          }
-        } else {
-          data = [];
+
+      // Try canonical URL first, fall back to mirrors.
+      try {
+        final response =
+            await http.get(Uri.parse(_pluginsIndexUrl)).timeout(const Duration(seconds: 10));
+        if (response.statusCode == 200) {
+          _processPluginIndexResponse(response);
+          return;
         }
-        final remotePlugins = RemotePluginInfo.fromJsonList(data);
-        _remotePlugins = {
-          for (final plugin in remotePlugins) plugin.id: plugin,
-        };
+      } catch (_) {
+        // Direct fetch failed, try mirrors below.
+      }
+
+      final mirrorUrl =
+          await GithubAccelResolver.resolveFirstReachable(_pluginsIndexUrl);
+      if (mirrorUrl != null) {
+        await _fetchPluginsFromUrl(mirrorUrl);
       }
     } catch (_) {}
+  }
+
+  Future<void> _fetchPluginsFromUrl(String url) async {
+    final response = await http.get(Uri.parse(url));
+    if (response.statusCode == 200) {
+      _processPluginIndexResponse(response);
+    }
+  }
+
+  void _processPluginIndexResponse(http.Response response) {
+    final dynamic jsonData = json.decode(response.body);
+    List<dynamic> data;
+    if (jsonData is List) {
+      data = jsonData;
+    } else if (jsonData is Map) {
+      if (jsonData.containsKey('plugins')) {
+        data = jsonData['plugins'] as List;
+      } else if (jsonData.containsKey('data')) {
+        data = jsonData['data'] as List;
+      } else {
+        data = [];
+      }
+    } else {
+      data = [];
+    }
+    final remotePlugins = RemotePluginInfo.fromJsonList(data);
+    _remotePlugins = {
+      for (final plugin in remotePlugins) plugin.id: plugin,
+    };
   }
 
   String _applyProxyIfNeeded(String url, String? proxyUrl) {

--- a/lib/plugins/plugin_service.dart
+++ b/lib/plugins/plugin_service.dart
@@ -19,6 +19,7 @@ import 'package:nipaplay/plugins/models/remote_plugin_info.dart';
 import 'package:nipaplay/plugins/plugin_event_bus.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:nipaplay/utils/github_accel_resolver.dart';
 import 'package:http/http.dart' as http;
 
 class PluginService extends ChangeNotifier {
@@ -207,7 +208,14 @@ class PluginService extends ChangeNotifier {
 
   Future<void> fetchRemotePlugins({String? proxyUrl}) async {
     try {
-      final url = _applyProxyIfNeeded(_pluginsIndexUrl, proxyUrl);
+      late final String url;
+      if (proxyUrl == null || proxyUrl.trim().isEmpty) {
+        final resolved =
+            await GithubAccelResolver.resolveFirstReachable(_pluginsIndexUrl);
+        url = resolved ?? _pluginsIndexUrl;
+      } else {
+        url = _applyProxyIfNeeded(_pluginsIndexUrl, proxyUrl);
+      }
       final response = await http.get(Uri.parse(url));
       if (response.statusCode == 200) {
         final dynamic jsonData = json.decode(response.body);
@@ -234,7 +242,7 @@ class PluginService extends ChangeNotifier {
   }
 
   String _applyProxyIfNeeded(String url, String? proxyUrl) {
-    if (proxyUrl == null || proxyUrl.isEmpty) {
+    if (proxyUrl == null || proxyUrl.trim().isEmpty) {
       return url;
     }
     final normalizedProxy = proxyUrl.endsWith('/') ? proxyUrl : '$proxyUrl/';

--- a/lib/themes/nipaplay/widgets/plugin_market_dialog.dart
+++ b/lib/themes/nipaplay/widgets/plugin_market_dialog.dart
@@ -10,6 +10,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:nipaplay/widgets/adaptive_markdown.dart';
+import 'package:nipaplay/utils/github_accel_resolver.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 
@@ -54,9 +55,9 @@ class _PluginMarketDialogState extends State<PluginMarketDialog> {
   final TextEditingController _searchController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
 
-  String _applyProxyIfNeeded(String rawUrl, String proxyUrl, String? proxy) {
-    if (proxy == null || proxy.isEmpty) {
-      return rawUrl;
+  Future<String> _applyProxyIfNeeded(String rawUrl, String proxyUrl, String? proxy) async {
+    if (proxy == null || proxy.trim().isEmpty) {
+      return await GithubAccelResolver.resolveFirstReachable(rawUrl) ?? rawUrl;
     }
     final normalizedProxy = proxy.endsWith('/') ? proxy : '$proxy/';
     return '$normalizedProxy$proxyUrl';
@@ -109,7 +110,7 @@ class _PluginMarketDialogState extends State<PluginMarketDialog> {
       final settingsProvider =
           Provider.of<SettingsProvider>(context, listen: false);
       final proxyUrl = settingsProvider.githubProxyUrl;
-      final url = _applyProxyIfNeeded(
+      final url = await _applyProxyIfNeeded(
           _pluginsIndexUrl, _pluginsIndexUrlForProxy, proxyUrl);
       final response = await http.get(Uri.parse(url));
       if (response.statusCode == 200) {
@@ -229,7 +230,7 @@ class _PluginMarketDialogState extends State<PluginMarketDialog> {
     final proxyUrl = settingsProvider.githubProxyUrl;
     final rawReadmeUrl = '$_readmeBaseUrl/${plugin.id}/README.md';
     final proxyReadmeUrl = '${_repoBaseUrlForProxy}/plugins/${plugin.id}/README.md';
-    final url = _applyProxyIfNeeded(rawReadmeUrl, proxyReadmeUrl, proxyUrl);
+    final url = await _applyProxyIfNeeded(rawReadmeUrl, proxyReadmeUrl, proxyUrl);
 
     try {
       final response = await http.get(Uri.parse(url));
@@ -281,7 +282,7 @@ class _PluginMarketDialogState extends State<PluginMarketDialog> {
       final settingsProvider =
           Provider.of<SettingsProvider>(context, listen: false);
       final proxyUrl = settingsProvider.githubProxyUrl;
-      final url = _applyProxyIfNeeded(
+      final url = await _applyProxyIfNeeded(
           plugin.downloadUrl, plugin.proxyDownloadUrl, proxyUrl);
       final response = await http.get(Uri.parse(url));
       if (response.statusCode == 200) {

--- a/lib/utils/github_accel_resolver.dart
+++ b/lib/utils/github_accel_resolver.dart
@@ -12,7 +12,7 @@ class GithubAccelResolver {
       try {
         final normalized = source.endsWith('/') ? source : '${source}/';
         final url = '${normalized}$rawUrl';
-        final response = await http.get(Uri.parse(url)).timeout(const Duration(seconds: 5));
+        final response = await http.head(Uri.parse(url)).timeout(const Duration(seconds: 5));
         if (response.statusCode == 200) return url;
       } catch (_) {}
     }

--- a/lib/utils/github_accel_resolver.dart
+++ b/lib/utils/github_accel_resolver.dart
@@ -1,0 +1,21 @@
+import 'package:http/http.dart' as http;
+
+class GithubAccelResolver {
+  static const List<String> defaultSources = <String>[
+    'https://gh-proxy.com/',
+    'https://ghfast.top/',
+    'https://ghproxy.net/',
+  ];
+
+  static Future<String?> resolveFirstReachable(String rawUrl) async {
+    for (final source in defaultSources) {
+      try {
+        final normalized = source.endsWith('/') ? source : '${source}/';
+        final url = '${normalized}$rawUrl';
+        final response = await http.get(Uri.parse(url)).timeout(const Duration(seconds: 5));
+        if (response.statusCode == 200) return url;
+      } catch (_) {}
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
为插件市场添加内置镜像源回退功能。

- 新增 lib/utils/github_accel_resolver.dart，内置3个镜像源
- PluginService.fetchRemotePlugins: 先试官方URL，失败再回退镜像
- PluginMarketDialog: 无代理时自动回退镜像
- 文案提示从“留空不启用”改为“留空自动使用内置加速源”

修复了上版PR中误提交 node_modules/ 和 data/ 的问题。