### PR TITLE
Feat/add comment system

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <img src="https://count.getloli.com/get/@nipaplay?theme=moebooru" alt="访问统计" />
 
 <br>
- 
+
 ![GitHub release](https://img.shields.io/github/v/release/aimessoft/nipaplay-reload?style=flat-square&color=blue)
 ![GitHub downloads](https://img.shields.io/github/downloads/aimessoft/nipaplay-reload/total?style=flat-square&color=green)
 ![Platform support](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux%20%7C%20Android%20%7C%20iOS-lightgrey?style=flat-square)
@@ -176,11 +176,11 @@ ebuild gentoo/media-video/nipaplay-bin/nipaplay-bin-1.8.11.ebuild merge
 
 ## 开发计划 (Roadmap)
 
-- [ ] 评论区功能完善
+- [x] 评论区功能完善
 - [ ] 云媒体库挂载 (FTP)
 - [ ] 视频片段导出 (GIF)
-- [ ] 内置下载器及远程控制
-- [ ] 在线 URL 播放优化
+- [x] 内置下载器及远程控制
+- [x] 在线 URL 播放优化
 - [ ] Webview 弹幕刮削
 - [ ] 补帧功能 (SVP/Other)
 - [ ] HDR 和杜比视界支持

--- a/lib/models/bangumi_comment_model.dart
+++ b/lib/models/bangumi_comment_model.dart
@@ -1,0 +1,33 @@
+class BangumiComment {
+  final int userId;
+  final String username;
+  final String nickname;
+  final String avatarUrl;
+  final int rate;
+  final String comment;
+  final int updatedAt;
+
+  BangumiComment({
+    required this.userId,
+    required this.username,
+    required this.nickname,
+    required this.avatarUrl,
+    required this.rate,
+    required this.comment,
+    required this.updatedAt,
+  });
+
+  factory BangumiComment.fromJson(Map<String, dynamic> json) {
+    final user = json['user'] as Map<String, dynamic>? ?? {};
+    final avatar = user['avatar'] as Map<String, dynamic>? ?? {};
+    return BangumiComment(
+      userId: user['id'] as int? ?? 0,
+      username: user['username'] as String? ?? '',
+      nickname: user['nickname'] as String? ?? '',
+      avatarUrl: avatar['medium'] as String? ?? avatar['large'] as String? ?? '',
+      rate: json['rate'] as int? ?? 0,
+      comment: json['comment'] as String? ?? '',
+      updatedAt: json['updatedAt'] as int? ?? 0,
+    );
+  }
+}

--- a/lib/pages/anime_detail_page.dart
+++ b/lib/pages/anime_detail_page.dart
@@ -21,6 +21,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/tag_search_widget.dart'; // 添
 import 'package:nipaplay/themes/nipaplay/widgets/rating_dialog.dart'; // 添加评分对话框
 import 'package:nipaplay/models/bangumi_collection_submit_result.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/bangumi_collection_dialog.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/bangumi_comment_dialog.dart';
 import 'package:nipaplay/services/playback_service.dart';
 import 'package:nipaplay/models/playable_item.dart';
 import 'dart:convert';
@@ -40,6 +41,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_window_page.dart';
 import 'package:nipaplay/services/web_remote_access_service.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/bangumi_comments_widget.dart';
 
 enum _EpisodeCleanupAction {
   clearScanResults,
@@ -120,7 +122,7 @@ class AnimeDetailPage extends StatefulWidget {
 }
 
 class _AnimeDetailPageState extends State<AnimeDetailPage>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
   static BuildContext? _openPageContext;
   final BangumiService _bangumiService = BangumiService.instance;
   BangumiAnime? _detailedAnime;
@@ -136,6 +138,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
   bool _isLoading = true;
   String? _error;
   TabController? _tabController;
+  TabController? _detailTabController;
   // 添加外观设置
   AppearanceSettingsProvider? _appearanceSettings;
   bool _isEpisodeListReversed = false;
@@ -180,6 +183,9 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
   int _bangumiCollectionType = 0;
   int _bangumiEpisodeStatus = 0;
   bool _isSavingBangumiCollection = false;
+  int _commentsVersion = 0;
+  final GlobalKey _commentsWidgetKey = GlobalKey();
+  int _myCommentTimestamp = 0;
 
   // 上次观看的剧集信息
   WatchHistoryItem? _lastWatchedEpisode;
@@ -257,6 +263,8 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
     // 添加TabController监听
     _tabController!.addListener(_handleTabChange);
 
+    _detailTabController = TabController(length: 2, vsync: this);
+
     // 添加Bangumi登录状态监听
     BangumiApiService.loginStatusNotifier
         .addListener(_onBangumiLoginStatusChanged);
@@ -328,6 +336,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
         .removeListener(_onBangumiLoginStatusChanged);
     _tabController?.removeListener(_handleTabChange);
     _tabController?.dispose();
+    _detailTabController?.dispose();
     _largeScreenDetailsFocusNode.dispose();
     super.dispose();
   }
@@ -373,6 +382,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
       _bangumiCollectionType = 0;
       _bangumiEpisodeStatus = 0;
       _isSavingBangumiCollection = false;
+      _myCommentTimestamp = 0;
     });
     try {
       BangumiAnime anime;
@@ -526,30 +536,10 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
   }
 
   Future<void> _loadBangumiUserData(BangumiAnime anime) async {
-    if (!BangumiApiService.isLoggedIn) {
-      try {
-        await BangumiApiService.initialize();
-      } catch (e) {
-        debugPrint('[番剧详情] 初始化Bangumi API失败: $e');
-      }
-    }
-
-    if (!BangumiApiService.isLoggedIn) {
-      if (mounted) {
-        setState(() {
-          _bangumiSubjectId = null;
-          _bangumiComment = null;
-          _isLoadingBangumiCollection = false;
-          _hasBangumiCollection = false;
-          _bangumiUserRating = 0;
-          _bangumiCollectionType = 0;
-          _bangumiEpisodeStatus = 0;
-        });
-      }
-      return;
-    }
-
+    // 先提取Bangumi subject ID（评论功能不需要登录）
     final subjectId = _extractBangumiSubjectId(anime);
+    debugPrint('[番剧详情] Bangumi subjectId=$subjectId, bangumiUrl=${anime.bangumiUrl}');
+
     if (subjectId == null) {
       if (mounted) {
         setState(() {
@@ -563,6 +553,36 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
         });
       }
       debugPrint('[番剧详情] 未能解析Bangumi条目ID: ${anime.bangumiUrl}');
+      return;
+    }
+
+    // 设置 subjectId（评论功能可用）
+    if (mounted) {
+      setState(() {
+        _bangumiSubjectId = subjectId;
+      });
+    }
+
+    // 以下收藏相关功能需要登录
+    if (!BangumiApiService.isLoggedIn) {
+      try {
+        await BangumiApiService.initialize();
+      } catch (e) {
+        debugPrint('[番剧详情] 初始化Bangumi API失败: $e');
+      }
+    }
+
+    if (!BangumiApiService.isLoggedIn) {
+      if (mounted) {
+        setState(() {
+          _bangumiComment = null;
+          _isLoadingBangumiCollection = false;
+          _hasBangumiCollection = false;
+          _bangumiUserRating = 0;
+          _bangumiCollectionType = 0;
+          _bangumiEpisodeStatus = 0;
+        });
+      }
       return;
     }
 
@@ -644,6 +664,11 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
           _bangumiCollectionType = collectionType;
           _bangumiEpisodeStatus = episodeStatus;
           _isLoadingBangumiCollection = false;
+          if (_myCommentTimestamp == 0 &&
+              (userRating > 0 || (comment != null && comment.isNotEmpty))) {
+            _myCommentTimestamp =
+                DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          }
         });
       } else {
         setState(() {
@@ -827,6 +852,8 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
             if (ratingPayload != null) {
               _bangumiUserRating = ratingPayload;
             }
+            _myCommentTimestamp =
+                DateTime.now().millisecondsSinceEpoch ~/ 1000;
           });
         }
         if (episodeStatus != null) {
@@ -1129,7 +1156,17 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
       }
     }
 
-    return SingleChildScrollView(
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        if (notification is ScrollEndNotification) {
+          final metrics = notification.metrics;
+          if (metrics.pixels >= metrics.maxScrollExtent) {
+            (_commentsWidgetKey.currentState as dynamic)?.loadMore();
+          }
+        }
+        return false;
+      },
+      child: SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -1166,386 +1203,501 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
           SizedBox(height: 16),
           Divider(color: textColor.withOpacity(0.15)),
           SizedBox(height: 8),
-          if (bangumiRatingValue is num && bangumiRatingValue > 0) ...[
-            RichText(
-                text: TextSpan(
-                    style: valueStyle, // 基础样式
-                    children: [
-                  TextSpan(text: 'Bangumi评分: ', style: boldWhiteKeyStyle),
-                  WidgetSpan(
-                      child: _buildRatingStars(bangumiRatingValue.toDouble())),
-                  TextSpan(
-                      text: ' ${bangumiRatingValue.toStringAsFixed(1)} ',
-                      locale: const Locale("zh-Hans", "zh"),
-                      style: TextStyle(
-                          color: AppAccentColors.current,
-                          fontWeight: FontWeight.bold,
-                          fontSize: 14)),
-                  TextSpan(
-                      text: bangumiEvaluationText,
-                      locale: const Locale("zh-Hans", "zh"),
-                      style: TextStyle(color: secondaryTextColor, fontSize: 12))
-                ])),
-            SizedBox(height: 6),
-          ],
 
-          // Bangumi云端收藏信息
-          if (BangumiApiService.isLoggedIn) ...[
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                if (_isLoadingBangumiCollection)
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 1.5,
-                          valueColor:
-                              AlwaysStoppedAnimation<Color>(secondaryTextColor),
-                        ),
-                      ),
-                      SizedBox(width: 8),
-                      Text(
-                        '正在加载Bangumi收藏信息...',
-                        style: valueStyle.copyWith(fontSize: 12),
-                      ),
-                    ],
-                  )
-                else
-                  RichText(
-                    text: TextSpan(
-                      style: valueStyle.copyWith(fontSize: 12),
-                      children: [
-                        TextSpan(
-                          text: '我的Bangumi评分: ',
-                          style: TextStyle(
-                              color: AppAccentColors.current,
-                              fontWeight: FontWeight.bold),
-                        ),
-                        if (_bangumiUserRating > 0) ...[
-                          TextSpan(
-                            text: '$_bangumiUserRating 分',
-                            style: TextStyle(
-                              color: AppAccentColors.current,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 14,
-                            ),
-                          ),
-                          TextSpan(
-                            text: _ratingEvaluationMap[_bangumiUserRating] !=
-                                    null
-                                ? ' (${_ratingEvaluationMap[_bangumiUserRating]})'
-                                : '',
-                            style: TextStyle(
-                              color: AppAccentColors.current.withOpacity(0.75),
-                              fontSize: 12,
-                            ),
-                          ),
-                        ] else
-                          TextSpan(
-                            text: '未评分',
-                            style: TextStyle(color: secondaryTextColor),
-                          ),
-                      ],
-                    ),
-                  ),
-                SizedBox(width: 12),
-                Builder(
-                  builder: (context) {
-                    final bool isBangumiActionEnabled =
-                        !_isLoadingBangumiCollection &&
-                            !_isSavingBangumiCollection;
-                    final bool enableBangumiHover =
-                        isBangumiActionEnabled && !globals.isTouch;
-                    final bool isBangumiHovered =
-                        enableBangumiHover && _isBangumiRatingButtonHovered;
-                    final Color bangumiActionColor = isBangumiActionEnabled
-                        ? (isBangumiHovered
-                            ? AppAccentColors.current
-                            : textColor.withOpacity(0.9))
-                        : textColor.withOpacity(0.45);
-
-                    final button = MouseRegion(
-                      cursor: enableBangumiHover
-                          ? SystemMouseCursors.click
-                          : SystemMouseCursors.basic,
-                      onEnter: enableBangumiHover
-                          ? (_) => setState(
-                              () => _isBangumiRatingButtonHovered = true)
-                          : null,
-                      onExit: enableBangumiHover
-                          ? (_) => setState(
-                              () => _isBangumiRatingButtonHovered = false)
-                          : null,
-                      child: GestureDetector(
-                        onTap:
-                            isBangumiActionEnabled ? _showRatingDialog : null,
-                        behavior: HitTestBehavior.opaque,
-                        child: AnimatedScale(
-                          scale: isBangumiHovered ? 1.1 : 1.0,
-                          duration: const Duration(milliseconds: 180),
-                          curve: Curves.easeOutCubic,
-                          child: AnimatedDefaultTextStyle(
-                            duration: const Duration(milliseconds: 180),
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: bangumiActionColor,
-                            ),
-                            child: IconTheme(
-                              data: IconThemeData(
-                                color: bangumiActionColor,
-                                size: 16,
-                              ),
-                              child: Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 6,
-                                  vertical: 4,
-                                ),
-                                child: Row(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    if (_isSavingBangumiCollection)
-                                      SizedBox(
-                                        width: 14,
-                                        height: 14,
-                                        child: CircularProgressIndicator(
-                                          strokeWidth: 1.5,
-                                          valueColor:
-                                              AlwaysStoppedAnimation<Color>(
-                                                  bangumiActionColor),
-                                        ),
-                                      )
-                                    else
-                                      Icon(Icons.edit),
-                                    SizedBox(width: 4),
-                                    const Text('编辑Bangumi评分'),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    );
-                    return _wrapLargeScreenFocusable(
-                      child: button,
-                      onActivate:
-                          isBangumiActionEnabled ? _showRatingDialog : null,
-                      borderRadius: BorderRadius.circular(6),
-                    );
-                  },
-                ),
-              ],
-            ),
-            SizedBox(height: 6),
-            if (!_isLoadingBangumiCollection && _hasBangumiCollection) ...[
-              Wrap(
-                spacing: 12,
-                runSpacing: 4,
+          // 详情 / 评论 切换导航栏
+          AnimatedBuilder(
+            animation: _detailTabController!,
+            builder: (context, _) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    '收藏状态: ${_collectionTypeLabel(_bangumiCollectionType)}',
-                    style: valueStyle.copyWith(fontSize: 12),
+                  TabBar(
+                    controller: _detailTabController,
+                    labelColor: AppAccentColors.current,
+                    unselectedLabelColor: secondaryTextColor,
+                    indicatorColor: AppAccentColors.current,
+                    labelStyle: const TextStyle(
+                        fontWeight: FontWeight.w600, fontSize: 14),
+                    unselectedLabelStyle: const TextStyle(fontSize: 14),
+                    tabAlignment: TabAlignment.start,
+                    isScrollable: true,
+                    dividerHeight: 0,
+                    tabs: const [
+                      Tab(text: '详情'),
+                      Tab(text: '评论'),
+                    ],
                   ),
-                  Text(
-                    '观看进度: ${_bangumiEpisodeStatus}/${_formatEpisodeTotal(anime)}',
-                    style: valueStyle.copyWith(fontSize: 12),
-                  ),
-                ],
-              ),
-              SizedBox(height: 6),
-            ] else if (!_isLoadingBangumiCollection) ...[
-              Text(
-                '尚未在Bangumi收藏此番剧',
-                style: valueStyle.copyWith(
-                    fontSize: 12, color: secondaryTextColor),
-              ),
-              SizedBox(height: 6),
-            ],
-            if (!_isLoadingBangumiCollection)
-              Builder(builder: (context) {
-                if (_bangumiComment != null && _bangumiComment!.isNotEmpty) {
-                  return Container(
-                    width: double.infinity,
-                    margin: const EdgeInsets.only(bottom: 6.0),
-                    padding: const EdgeInsets.all(8.0),
-                    decoration: BoxDecoration(
-                      color: textColor.withOpacity(0.08),
-                      borderRadius: BorderRadius.circular(6),
-                      border: Border.all(
-                        color: textColor.withOpacity(0.15),
-                        width: 0.8,
-                      ),
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          '我的Bangumi短评',
-                          style: boldWhiteKeyStyle.copyWith(
-                              fontSize: 12, fontWeight: FontWeight.w600),
-                        ),
-                        SizedBox(height: 4),
-                        Text(
-                          _bangumiComment!,
-                          style: valueStyle.copyWith(fontSize: 12, height: 1.4),
-                        ),
-                      ],
-                    ),
-                  );
-                }
-                if (_hasBangumiCollection) {
-                  return Text(
-                    '暂无Bangumi短评',
-                    style: valueStyle.copyWith(
-                        fontSize: 12, color: secondaryTextColor),
-                  );
-                }
-                return const SizedBox.shrink();
-              }),
-          ],
-          if (anime.ratingDetails != null &&
-              anime.ratingDetails!.entries.any((entry) =>
-                  entry.key != 'Bangumi评分' &&
-                  entry.value is num &&
-                  (entry.value as num) > 0))
-            Padding(
-                padding: const EdgeInsets.only(bottom: 4.0, top: 2.0),
-                child: Wrap(
-                    spacing: 12.0,
-                    runSpacing: 4.0,
-                    children: anime.ratingDetails!.entries
-                        .where((entry) =>
-                            entry.key != 'Bangumi评分' &&
-                            entry.value is num &&
-                            (entry.value as num) > 0)
-                        .map((entry) {
-                      String siteName = entry.key;
-                      if (siteName.endsWith('评分')) {
-                        siteName = siteName.substring(0, siteName.length - 2);
+                  const SizedBox(height: 12),
+                  if (_detailTabController!.index == 0)
+                    _buildDetailContent(
+                        anime,
+                        valueStyle,
+                        boldWhiteKeyStyle,
+                        sectionTitleStyle,
+                        textColor,
+                        secondaryTextColor,
+                        bangumiRatingValue,
+                        bangumiEvaluationText,
+                        metadataWidgets,
+                        titlesWidgets)
+                  else
+                    Builder(builder: (context) {
+                      debugPrint('[AnimeDetail] 评论tab: _bangumiSubjectId=$_bangumiSubjectId, anime.id=${anime.id}');
+                      final userInfo = BangumiApiService.userInfo;
+                      final int currentUserId = userInfo != null
+                          ? (userInfo['id'] as int? ?? 0)
+                          : 0;
+                      String userAvatar = '';
+                      if (userInfo != null) {
+                        final raw = userInfo['avatar'];
+                        if (raw is String) {
+                          userAvatar = raw;
+                        } else if (raw is Map<String, dynamic>) {
+                          userAvatar = (raw['large'] as String?) ??
+                              (raw['medium'] as String?) ??
+                              '';
+                        }
                       }
-                      final score = entry.value as num;
-                      return RichText(
-                          text: TextSpan(
-                              style: valueStyle.copyWith(fontSize: 12),
-                              children: [
-                            TextSpan(
-                                text: '$siteName: ',
-                                style: boldWhiteKeyStyle.copyWith(
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.normal)),
-                            TextSpan(
-                                text: score.toStringAsFixed(1),
-                                locale: const Locale("zh-Hans", "zh"),
-                                style: TextStyle(
-                                    color: textColor.withOpacity(0.95)))
-                          ]));
-                    }).toList())),
-          RichText(
-            text: TextSpan(
-              style: valueStyle,
-              children: [
-                TextSpan(text: '开播: ', style: boldWhiteKeyStyle),
-                TextSpan(
-                    text: (anime.airDate ?? '未知').split('T').first,
-                    style: valueStyle),
-              ],
-            ),
+                      final String userNickname = userInfo != null
+                          ? ((userInfo['nickname'] as String?) ??
+                              (userInfo['username'] as String?) ??
+                              '')
+                          : '';
+                      final BangumiMyCommentData? myComment =
+                          BangumiApiService.isLoggedIn
+                              ? BangumiMyCommentData(
+                                  nickname: userNickname,
+                                  avatarUrl: userAvatar,
+                                  rate: _bangumiUserRating,
+                                  comment: _bangumiComment ?? '',
+                                  updatedAt: _myCommentTimestamp > 0
+                                      ? _myCommentTimestamp
+                                      : DateTime.now().millisecondsSinceEpoch ~/
+                                          1000,
+                                )
+                              : null;
+                      return BangumiCommentsWidget(
+                        key: _commentsWidgetKey,
+                        subjectId: _bangumiSubjectId,
+                        onEditRating: BangumiApiService.isLoggedIn
+                            ? _showCommentDialog
+                            : null,
+                        myComment: myComment,
+                        currentUserId: currentUserId,
+                        commentsVersion: _commentsVersion,
+                        onMyCommentTimestamp: (timestamp) {
+                          if (mounted && timestamp != _myCommentTimestamp) {
+                            setState(() {
+                              _myCommentTimestamp = timestamp;
+                            });
+                          }
+                        },
+                      );
+                    }),
+                ],
+              );
+            },
           ),
-          if (anime.typeDescription != null)
-            Padding(
-              padding: const EdgeInsets.only(top: 4.0),
-              child: RichText(
-                text: TextSpan(
-                  style: valueStyle,
-                  children: [
-                    TextSpan(text: '类型: ', style: boldWhiteKeyStyle),
-                    TextSpan(text: anime.typeDescription!),
-                  ],
-                ),
-              ),
-            ),
-          if (anime.totalEpisodes != null)
-            Padding(
-              padding: const EdgeInsets.only(top: 4.0),
-              child: RichText(
-                text: TextSpan(
-                  style: valueStyle,
-                  children: [
-                    TextSpan(text: '话数: ', style: boldWhiteKeyStyle),
-                    TextSpan(text: '${anime.totalEpisodes}'),
-                  ],
-                ),
-              ),
-            ),
-          if (anime.isOnAir != null)
-            Padding(
-              padding: const EdgeInsets.only(top: 4.0),
-              child: RichText(
-                text: TextSpan(
-                  style: valueStyle,
-                  children: [
-                    TextSpan(text: '状态: ', style: boldWhiteKeyStyle),
-                    TextSpan(text: anime.isOnAir! ? '正连载' : '已完结'),
-                  ],
-                ),
-              ),
-            ),
-
-          if (anime.isNSFW == true)
-            Padding(
-              padding: const EdgeInsets.only(top: 4.0),
-              child: RichText(
-                  text: TextSpan(style: valueStyle, children: [
-                TextSpan(
-                    text: '限制内容: ',
-                    style: boldWhiteKeyStyle.copyWith(color: Colors.redAccent)),
-                TextSpan(
-                    text: '是',
-                    style: TextStyle(color: Colors.redAccent.withOpacity(0.85)))
-              ])),
-            ),
-          ...metadataWidgets,
-          ...titlesWidgets,
-          if (anime.tags != null && anime.tags!.isNotEmpty) ...[
-            SizedBox(height: 16),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text('标签:', style: sectionTitleStyle),
-                _wrapLargeScreenFocusable(
-                  onActivate: _openTagSearch,
-                  borderRadius: BorderRadius.circular(6),
-                  child: IconButton(
-                    onPressed: _isLargeScreenModeActive ? null : _openTagSearch,
-                    icon: Icon(
-                      Ionicons.search,
-                      color: secondaryTextColor,
-                    ),
-                    padding: const EdgeInsets.all(4),
-                    constraints: const BoxConstraints(),
-                  ),
-                ),
-              ],
-            ),
-            SizedBox(height: 8),
-            Wrap(
-                spacing: 8.0,
-                runSpacing: 4.0,
-                children: anime.tags!
-                    .map((tag) => _HoverableTag(
-                          tag: tag,
-                          onTap: () => _searchByTag(tag),
-                          isLargeScreenMode: _isLargeScreenModeActive,
-                        ))
-                    .toList())
-          ],
           SizedBox(height: 20),
         ],
       ),
+      ),
+    );
+  }
+
+  Widget _buildDetailContent(
+    BangumiAnime anime,
+    TextStyle valueStyle,
+    TextStyle boldWhiteKeyStyle,
+    TextStyle? sectionTitleStyle,
+    Color textColor,
+    Color secondaryTextColor,
+    dynamic bangumiRatingValue,
+    String bangumiEvaluationText,
+    List<Widget> metadataWidgets,
+    List<Widget> titlesWidgets,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (bangumiRatingValue is num && bangumiRatingValue > 0) ...[
+          RichText(
+              text: TextSpan(
+                  style: valueStyle,
+                  children: [
+                TextSpan(text: 'Bangumi评分: ', style: boldWhiteKeyStyle),
+                WidgetSpan(
+                    child: _buildRatingStars(bangumiRatingValue.toDouble())),
+                TextSpan(
+                    text: ' ${bangumiRatingValue.toStringAsFixed(1)} ',
+                    locale: const Locale("zh-Hans", "zh"),
+                    style: TextStyle(
+                        color: AppAccentColors.current,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14)),
+                TextSpan(
+                    text: bangumiEvaluationText,
+                    locale: const Locale("zh-Hans", "zh"),
+                    style: TextStyle(color: secondaryTextColor, fontSize: 12))
+              ])),
+          SizedBox(height: 6),
+        ],
+
+        // Bangumi云端收藏信息
+        if (BangumiApiService.isLoggedIn) ...[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              if (_isLoadingBangumiCollection)
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 1.5,
+                        valueColor:
+                            AlwaysStoppedAnimation<Color>(secondaryTextColor),
+                      ),
+                    ),
+                    SizedBox(width: 8),
+                    Text(
+                      '正在加载Bangumi收藏信息...',
+                      style: valueStyle.copyWith(fontSize: 12),
+                    ),
+                  ],
+                )
+              else
+                RichText(
+                  text: TextSpan(
+                    style: valueStyle.copyWith(fontSize: 12),
+                    children: [
+                      TextSpan(
+                        text: '我的Bangumi评分: ',
+                        style: TextStyle(
+                            color: AppAccentColors.current,
+                            fontWeight: FontWeight.bold),
+                      ),
+                      if (_bangumiUserRating > 0) ...[
+                        TextSpan(
+                          text: '$_bangumiUserRating 分',
+                          style: TextStyle(
+                            color: AppAccentColors.current,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14,
+                          ),
+                        ),
+                        TextSpan(
+                          text: _ratingEvaluationMap[_bangumiUserRating] !=
+                                  null
+                              ? ' (${_ratingEvaluationMap[_bangumiUserRating]})'
+                              : '',
+                          style: TextStyle(
+                            color: AppAccentColors.current.withOpacity(0.75),
+                            fontSize: 12,
+                          ),
+                        ),
+                      ] else
+                        TextSpan(
+                          text: '未评分',
+                          style: TextStyle(color: secondaryTextColor),
+                        ),
+                    ],
+                  ),
+                ),
+              SizedBox(width: 12),
+              Builder(
+                builder: (context) {
+                  final bool isBangumiActionEnabled =
+                      !_isLoadingBangumiCollection &&
+                          !_isSavingBangumiCollection;
+                  final bool enableBangumiHover =
+                      isBangumiActionEnabled && !globals.isTouch;
+                  final bool isBangumiHovered =
+                      enableBangumiHover && _isBangumiRatingButtonHovered;
+                  final Color bangumiActionColor = isBangumiActionEnabled
+                      ? (isBangumiHovered
+                          ? AppAccentColors.current
+                          : textColor.withOpacity(0.9))
+                      : textColor.withOpacity(0.45);
+
+                  final button = MouseRegion(
+                    cursor: enableBangumiHover
+                        ? SystemMouseCursors.click
+                        : SystemMouseCursors.basic,
+                    onEnter: enableBangumiHover
+                        ? (_) => setState(
+                            () => _isBangumiRatingButtonHovered = true)
+                        : null,
+                    onExit: enableBangumiHover
+                        ? (_) => setState(
+                            () => _isBangumiRatingButtonHovered = false)
+                        : null,
+                    child: GestureDetector(
+                      onTap:
+                          isBangumiActionEnabled ? _showRatingDialog : null,
+                      behavior: HitTestBehavior.opaque,
+                      child: AnimatedScale(
+                        scale: isBangumiHovered ? 1.1 : 1.0,
+                        duration: const Duration(milliseconds: 180),
+                        curve: Curves.easeOutCubic,
+                        child: AnimatedDefaultTextStyle(
+                          duration: const Duration(milliseconds: 180),
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: bangumiActionColor,
+                          ),
+                          child: IconTheme(
+                            data: IconThemeData(
+                              color: bangumiActionColor,
+                              size: 16,
+                            ),
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 6,
+                                vertical: 4,
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  if (_isSavingBangumiCollection)
+                                    SizedBox(
+                                      width: 14,
+                                      height: 14,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 1.5,
+                                        valueColor:
+                                            AlwaysStoppedAnimation<Color>(
+                                                bangumiActionColor),
+                                      ),
+                                    )
+                                  else
+                                    Icon(Icons.edit),
+                                  SizedBox(width: 4),
+                                  const Text('编辑Bangumi评分'),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  );
+                  return _wrapLargeScreenFocusable(
+                    child: button,
+                    onActivate:
+                        isBangumiActionEnabled ? _showRatingDialog : null,
+                    borderRadius: BorderRadius.circular(6),
+                  );
+                },
+              ),
+            ],
+          ),
+          SizedBox(height: 6),
+          if (!_isLoadingBangumiCollection && _hasBangumiCollection) ...[
+            Wrap(
+              spacing: 12,
+              runSpacing: 4,
+              children: [
+                Text(
+                  '收藏状态: ${_collectionTypeLabel(_bangumiCollectionType)}',
+                  style: valueStyle.copyWith(fontSize: 12),
+                ),
+                Text(
+                  '观看进度: ${_bangumiEpisodeStatus}/${_formatEpisodeTotal(anime)}',
+                  style: valueStyle.copyWith(fontSize: 12),
+                ),
+              ],
+            ),
+            SizedBox(height: 6),
+          ] else if (!_isLoadingBangumiCollection) ...[
+            Text(
+              '尚未在Bangumi收藏此番剧',
+              style: valueStyle.copyWith(
+                  fontSize: 12, color: secondaryTextColor),
+            ),
+            SizedBox(height: 6),
+          ],
+          if (!_isLoadingBangumiCollection)
+            Builder(builder: (context) {
+              if (_bangumiComment != null && _bangumiComment!.isNotEmpty) {
+                return Container(
+                  width: double.infinity,
+                  margin: const EdgeInsets.only(bottom: 6.0),
+                  padding: const EdgeInsets.all(8.0),
+                  decoration: BoxDecoration(
+                    color: textColor.withOpacity(0.08),
+                    borderRadius: BorderRadius.circular(6),
+                    border: Border.all(
+                      color: textColor.withOpacity(0.15),
+                      width: 0.8,
+                    ),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '我的Bangumi短评',
+                        style: boldWhiteKeyStyle.copyWith(
+                            fontSize: 12, fontWeight: FontWeight.w600),
+                      ),
+                      SizedBox(height: 4),
+                      Text(
+                        _bangumiComment!,
+                        style: valueStyle.copyWith(fontSize: 12, height: 1.4),
+                      ),
+                    ],
+                  ),
+                );
+              }
+              if (_hasBangumiCollection) {
+                return Text(
+                  '暂无Bangumi短评',
+                  style: valueStyle.copyWith(
+                      fontSize: 12, color: secondaryTextColor),
+                );
+              }
+              return const SizedBox.shrink();
+            }),
+        ],
+        if (anime.ratingDetails != null &&
+            anime.ratingDetails!.entries.any((entry) =>
+                entry.key != 'Bangumi评分' &&
+                entry.value is num &&
+                (entry.value as num) > 0))
+          Padding(
+              padding: const EdgeInsets.only(bottom: 4.0, top: 2.0),
+              child: Wrap(
+                  spacing: 12.0,
+                  runSpacing: 4.0,
+                  children: anime.ratingDetails!.entries
+                      .where((entry) =>
+                          entry.key != 'Bangumi评分' &&
+                          entry.value is num &&
+                          (entry.value as num) > 0)
+                      .map((entry) {
+                    String siteName = entry.key;
+                    if (siteName.endsWith('评分')) {
+                      siteName = siteName.substring(0, siteName.length - 2);
+                    }
+                    final score = entry.value as num;
+                    return RichText(
+                        text: TextSpan(
+                            style: valueStyle.copyWith(fontSize: 12),
+                            children: [
+                          TextSpan(
+                              text: '$siteName: ',
+                              style: boldWhiteKeyStyle.copyWith(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.normal)),
+                          TextSpan(
+                              text: score.toStringAsFixed(1),
+                              locale: const Locale("zh-Hans", "zh"),
+                              style: TextStyle(
+                                  color: textColor.withOpacity(0.95)))
+                        ]));
+                  }).toList())),
+        RichText(
+          text: TextSpan(
+            style: valueStyle,
+            children: [
+              TextSpan(text: '开播: ', style: boldWhiteKeyStyle),
+              TextSpan(
+                  text: (anime.airDate ?? '未知').split('T').first,
+                  style: valueStyle),
+            ],
+          ),
+        ),
+        if (anime.typeDescription != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 4.0),
+            child: RichText(
+              text: TextSpan(
+                style: valueStyle,
+                children: [
+                  TextSpan(text: '类型: ', style: boldWhiteKeyStyle),
+                  TextSpan(text: anime.typeDescription!),
+                ],
+              ),
+            ),
+          ),
+        if (anime.totalEpisodes != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 4.0),
+            child: RichText(
+              text: TextSpan(
+                style: valueStyle,
+                children: [
+                  TextSpan(text: '话数: ', style: boldWhiteKeyStyle),
+                  TextSpan(text: '${anime.totalEpisodes}'),
+                ],
+              ),
+            ),
+          ),
+        if (anime.isOnAir != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 4.0),
+            child: RichText(
+              text: TextSpan(
+                style: valueStyle,
+                children: [
+                  TextSpan(text: '状态: ', style: boldWhiteKeyStyle),
+                  TextSpan(text: anime.isOnAir! ? '正连载' : '已完结'),
+                ],
+              ),
+            ),
+          ),
+
+        if (anime.isNSFW == true)
+          Padding(
+            padding: const EdgeInsets.only(top: 4.0),
+            child: RichText(
+                text: TextSpan(style: valueStyle, children: [
+              TextSpan(
+                  text: '限制内容: ',
+                  style: boldWhiteKeyStyle.copyWith(color: Colors.redAccent)),
+              TextSpan(
+                  text: '是',
+                  style: TextStyle(color: Colors.redAccent.withOpacity(0.85)))
+            ])),
+          ),
+        ...metadataWidgets,
+        ...titlesWidgets,
+        if (anime.tags != null && anime.tags!.isNotEmpty) ...[
+          SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('标签:', style: sectionTitleStyle),
+              _wrapLargeScreenFocusable(
+                onActivate: _openTagSearch,
+                borderRadius: BorderRadius.circular(6),
+                child: IconButton(
+                  onPressed: _isLargeScreenModeActive ? null : _openTagSearch,
+                  icon: Icon(
+                    Ionicons.search,
+                    color: secondaryTextColor,
+                  ),
+                  padding: const EdgeInsets.all(4),
+                  constraints: const BoxConstraints(),
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: 8),
+          Wrap(
+              spacing: 8.0,
+              runSpacing: 4.0,
+              children: anime.tags!
+                  .map((tag) => _HoverableTag(
+                        tag: tag,
+                        onTap: () => _searchByTag(tag),
+                        isLargeScreenMode: _isLargeScreenModeActive,
+                      ))
+                  .toList())
+        ],
+      ],
     );
   }
 
@@ -2452,6 +2604,23 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
     }
   }
 
+  // 显示轻量版短评对话框
+  void _showCommentDialog() {
+    if (_detailedAnime == null || !BangumiApiService.isLoggedIn) return;
+
+    final int effectiveCollectionType =
+        _bangumiCollectionType != 0 ? _bangumiCollectionType : 3;
+
+    BangumiCommentDialog.show(
+      context: context,
+      animeTitle: _detailedAnime!.nameCn,
+      initialRating: _bangumiUserRating > 0 ? _bangumiUserRating : _userRating,
+      initialComment: _bangumiComment,
+      collectionType: effectiveCollectionType,
+      onSubmit: _handleBangumiCollectionSubmitted,
+    );
+  }
+
   Future<void> _handleBangumiCollectionSubmitted(
     BangumiCollectionSubmitResult result,
   ) async {
@@ -2512,6 +2681,9 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
     if (mounted) {
       setState(() {
         _isSavingBangumiCollection = false;
+        if (bangumiSuccess) {
+          _commentsVersion++;
+        }
       });
 
       if (bangumiSuccess && dandanSuccess) {

--- a/lib/services/bangumi_api_service.dart
+++ b/lib/services/bangumi_api_service.dart
@@ -741,4 +741,48 @@ class BangumiApiService {
 
     return result;
   }
+
+  /// 获取条目的短评列表（公开接口，无需登录）
+  static Future<Map<String, dynamic>> getSubjectComments(
+    int subjectId, {
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    try {
+      final targetUri = Uri.parse(
+              'https://next.bgm.tv/p1/subjects/$subjectId/comments')
+          .replace(queryParameters: {
+        'limit': limit.toString(),
+        'offset': offset.toString(),
+      });
+      debugPrint('[Bangumi Comments] 原始URI: $targetUri');
+      final uri = WebRemoteAccessService.proxyUri(targetUri);
+      debugPrint('[Bangumi Comments] 代理后URI: $uri');
+
+      final response = await http.get(uri, headers: {
+        'User-Agent': _userAgent,
+        'Accept': 'application/json',
+      });
+      debugPrint('[Bangumi Comments] 状态码: ${response.statusCode}');
+      debugPrint('[Bangumi Comments] 响应体前200字符: ${response.body.length > 200 ? response.body.substring(0, 200) : response.body}');
+
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        final data = json.decode(response.body);
+        debugPrint('[Bangumi Comments] 解析成功, data类型: ${data.runtimeType}');
+        if (data is Map && data['data'] is List) {
+          debugPrint('[Bangumi Comments] data.data 列表长度: ${(data['data'] as List).length}, total: ${data['total']}');
+        }
+        return {'success': true, 'data': data};
+      } else {
+        debugPrint('[Bangumi Comments] 请求失败: ${response.statusCode} - ${response.body}');
+        return {
+          'success': false,
+          'message': '获取评论失败: ${response.statusCode}',
+        };
+      }
+    } catch (e) {
+      debugPrint('[Bangumi Comments] 获取评论异常: $e');
+      return {'success': false, 'message': '网络错误: $e'};
+    }
+  }
 }

--- a/lib/themes/nipaplay/widgets/bangumi_comment_dialog.dart
+++ b/lib/themes/nipaplay/widgets/bangumi_comment_dialog.dart
@@ -1,0 +1,474 @@
+import 'package:flutter/material.dart';
+import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/providers/appearance_settings_provider.dart';
+import 'package:nipaplay/models/bangumi_collection_submit_result.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
+import 'package:nipaplay/utils/globals.dart' as globals;
+import 'package:provider/provider.dart';
+import 'package:nipaplay/utils/app_accent_color.dart';
+
+class BangumiCommentDialog extends StatefulWidget {
+  final String animeTitle;
+  final int initialRating;
+  final String? initialComment;
+  final int collectionType;
+  final Future<void> Function(BangumiCollectionSubmitResult result) onSubmit;
+
+  const BangumiCommentDialog({
+    super.key,
+    required this.animeTitle,
+    required this.initialRating,
+    this.initialComment,
+    required this.collectionType,
+    required this.onSubmit,
+  });
+
+  static Future<void> show({
+    required BuildContext context,
+    required String animeTitle,
+    required int initialRating,
+    String? initialComment,
+    required int collectionType,
+    required Future<void> Function(BangumiCollectionSubmitResult result)
+        onSubmit,
+  }) {
+    final enableAnimation = Provider.of<AppearanceSettingsProvider>(
+      context,
+      listen: false,
+    ).enablePageAnimation;
+
+    return NipaplayWindow.show(
+      context: context,
+      enableAnimation: enableAnimation,
+      barrierDismissible: true,
+      child: BangumiCommentDialog(
+        animeTitle: animeTitle,
+        initialRating: initialRating,
+        initialComment: initialComment,
+        collectionType: collectionType,
+        onSubmit: onSubmit,
+      ),
+    );
+  }
+
+  @override
+  State<BangumiCommentDialog> createState() => _BangumiCommentDialogState();
+}
+
+class _BangumiCommentDialogState extends State<BangumiCommentDialog> {
+  static Color get _accentColor => AppAccentColors.current;
+  static const Map<int, String> _ratingEvaluationMap = {
+    1: '不忍直视',
+    2: '很差',
+    3: '差',
+    4: '较差',
+    5: '不过不失',
+    6: '还行',
+    7: '推荐',
+    8: '力荐',
+    9: '神作',
+    10: '超神作',
+  };
+
+  late int _selectedRating;
+  late TextEditingController _commentController;
+  bool _isSubmitting = false;
+
+  bool get _isDarkMode => Theme.of(context).brightness == Brightness.dark;
+  Color get _textColor => Theme.of(context).colorScheme.onSurface;
+  Color get _subTextColor => _textColor.withOpacity(0.7);
+  Color get _mutedTextColor => _textColor.withOpacity(0.5);
+  Color get _borderColor => _textColor.withOpacity(_isDarkMode ? 0.12 : 0.2);
+  Color get _surfaceColor =>
+      _isDarkMode ? const Color(0xFF1E1E1E) : const Color(0xFFF2F2F2);
+  Color get _panelAltColor =>
+      _isDarkMode ? const Color(0xFF2B2B2B) : const Color(0xFFF7F7F7);
+
+  TextSelectionThemeData get _selectionTheme => TextSelectionThemeData(
+        cursorColor: _accentColor,
+        selectionColor: _accentColor.withOpacity(0.3),
+        selectionHandleColor: _accentColor,
+      );
+
+  ButtonStyle _textButtonStyle({Color? baseColor}) {
+    final resolvedBase = baseColor ?? _textColor;
+    return ButtonStyle(
+      foregroundColor: MaterialStateProperty.resolveWith((states) {
+        if (states.contains(MaterialState.disabled)) {
+          return _mutedTextColor;
+        }
+        if (states.contains(MaterialState.hovered)) {
+          return _accentColor;
+        }
+        return resolvedBase;
+      }),
+      overlayColor: MaterialStateProperty.all(Colors.transparent),
+      splashFactory: NoSplash.splashFactory,
+      padding: MaterialStateProperty.all(
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      ),
+    );
+  }
+
+  ButtonStyle _primaryButtonStyle() {
+    return ButtonStyle(
+      backgroundColor: MaterialStateProperty.resolveWith((states) {
+        if (states.contains(MaterialState.disabled)) {
+          return _accentColor.withOpacity(0.5);
+        }
+        return _accentColor;
+      }),
+      foregroundColor: MaterialStateProperty.all(Colors.white),
+      overlayColor: MaterialStateProperty.all(Colors.transparent),
+      splashFactory: NoSplash.splashFactory,
+      padding: MaterialStateProperty.all(
+        const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      ),
+      minimumSize: MaterialStateProperty.all(const Size(96, 44)),
+      elevation: MaterialStateProperty.all(0),
+      shadowColor: MaterialStateProperty.all(Colors.transparent),
+      shape: MaterialStateProperty.all(
+        RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+      ),
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedRating = widget.initialRating.clamp(0, 10);
+    _commentController =
+        TextEditingController(text: widget.initialComment ?? '');
+  }
+
+  @override
+  void dispose() {
+    _commentController.dispose();
+    super.dispose();
+  }
+
+  void _dismissKeyboard() {
+    final focusScope = FocusScope.of(context);
+    if (!focusScope.hasPrimaryFocus) {
+      focusScope.unfocus();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.of(context).size;
+    final dialogWidth = screenSize.width >= 760
+        ? 480.0
+        : globals.DialogSizes.getDialogWidth(screenSize.width);
+    final maxHeightFactor =
+        (globals.isPhone && screenSize.shortestSide < 600) ? 0.85 : 0.8;
+    final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+
+    return TextSelectionTheme(
+      data: _selectionTheme,
+      child: NipaplayWindowScaffold(
+        maxWidth: dialogWidth,
+        maxHeightFactor: maxHeightFactor,
+        onClose: () => Navigator.of(context).maybePop(),
+        backgroundColor: _surfaceColor,
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: _dismissKeyboard,
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(24, 16, 24, 24 + keyboardHeight),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _buildHeader(),
+                SizedBox(height: 16),
+                Flexible(
+                  child: SingleChildScrollView(
+                    keyboardDismissBehavior:
+                        ScrollViewKeyboardDismissBehavior.onDrag,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _buildRatingSection(),
+                        SizedBox(height: 18),
+                        _buildCommentInput(),
+                      ],
+                    ),
+                  ),
+                ),
+                SizedBox(height: 16),
+                _buildActionButtons(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Row(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: _accentColor.withOpacity(0.18),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Icon(
+            Ionicons.chatbubble_ellipses_outline,
+            color: _accentColor,
+            size: 20,
+          ),
+        ),
+        SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '编辑短评',
+                style: TextStyle(
+                  color: _textColor,
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              SizedBox(height: 4),
+              Text(
+                widget.animeTitle,
+                style: TextStyle(
+                  color: _subTextColor,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildRatingSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '评分',
+          style: TextStyle(
+            color: _textColor,
+            fontWeight: FontWeight.w600,
+            fontSize: 14,
+          ),
+        ),
+        SizedBox(height: 8),
+        Center(
+          child: Column(
+            children: [
+              Text(
+                _selectedRating > 0 ? '$_selectedRating 分' : '未评分',
+                style: TextStyle(
+                  color: _textColor,
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              if (_selectedRating > 0) ...[
+                SizedBox(height: 4),
+                Text(
+                  _ratingEvaluationMap[_selectedRating] ?? '',
+                  style: TextStyle(
+                    color: _accentColor,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+        SizedBox(height: 16),
+        Center(
+          child: Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: List.generate(10, (index) {
+              final rating = index + 1;
+              final isActive = rating <= _selectedRating;
+              return GestureDetector(
+                onTap: () => setState(() => _selectedRating = rating),
+                child: Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: isActive
+                        ? _accentColor.withOpacity(_isDarkMode ? 0.2 : 0.12)
+                        : _panelAltColor,
+                    border: Border.all(
+                      color: isActive ? _accentColor : _borderColor,
+                      width: 1,
+                    ),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Icon(
+                    isActive ? Ionicons.star : Ionicons.star_outline,
+                    color: isActive ? _accentColor : _mutedTextColor,
+                    size: 18,
+                  ),
+                ),
+              );
+            }),
+          ),
+        ),
+        SizedBox(height: 16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: List.generate(10, (index) {
+            final rating = index + 1;
+            final isSelected = rating == _selectedRating;
+            return GestureDetector(
+              onTap: () => setState(() => _selectedRating = rating),
+              child: Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  color: isSelected
+                      ? _accentColor.withOpacity(_isDarkMode ? 0.2 : 0.12)
+                      : _panelAltColor,
+                  border: Border.all(
+                    color: isSelected ? _accentColor : _borderColor,
+                    width: 1,
+                  ),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Center(
+                  child: Text(
+                    '$rating',
+                    style: TextStyle(
+                      color: isSelected ? _accentColor : _textColor,
+                      fontSize: 12,
+                      fontWeight:
+                          isSelected ? FontWeight.bold : FontWeight.normal,
+                    ),
+                  ),
+                ),
+              ),
+            );
+          }),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCommentInput() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '短评',
+          style: TextStyle(
+            color: _textColor,
+            fontWeight: FontWeight.w600,
+            fontSize: 14,
+          ),
+        ),
+        SizedBox(height: 8),
+        TextField(
+          controller: _commentController,
+          minLines: 3,
+          maxLines: 4,
+          maxLength: 200,
+          onTapOutside: (_) => _dismissKeyboard(),
+          style: TextStyle(color: _textColor, fontSize: 13, height: 1.4),
+          cursorColor: _accentColor,
+          decoration: InputDecoration(
+            counterStyle: TextStyle(color: _mutedTextColor, fontSize: 11),
+            hintText: '写下你的短评（可选）',
+            hintStyle: TextStyle(color: _mutedTextColor, fontSize: 13),
+            filled: true,
+            fillColor: _panelAltColor,
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: _borderColor, width: 1),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: _accentColor, width: 1.2),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildActionButtons() {
+    return Row(
+      children: [
+        if (_selectedRating > 0)
+          TextButton(
+            onPressed: _isSubmitting
+                ? null
+                : () => setState(() => _selectedRating = 0),
+            style: _textButtonStyle(baseColor: _accentColor),
+            child: const Text('清除评分'),
+          ),
+        const Spacer(),
+        TextButton(
+          onPressed: _isSubmitting ? null : () => Navigator.of(context).pop(),
+          style: _textButtonStyle(),
+          child: const Text('取消'),
+        ),
+        SizedBox(width: 8),
+        ElevatedButton(
+          onPressed:
+              _isSubmitting || _selectedRating == 0 ? null : _handleSubmit,
+          style: _primaryButtonStyle(),
+          child: _isSubmitting
+              ? SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  ),
+                )
+              : const Text(
+                  '确定',
+                  style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+                ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _handleSubmit() async {
+    if (_isSubmitting) return;
+
+    setState(() {
+      _isSubmitting = true;
+    });
+
+    final result = BangumiCollectionSubmitResult(
+      rating: _selectedRating,
+      collectionType: widget.collectionType,
+      comment: _commentController.text,
+      episodeStatus: 0,
+    );
+
+    try {
+      await widget.onSubmit(result);
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          _isSubmitting = false;
+        });
+      }
+    }
+  }
+}

--- a/lib/themes/nipaplay/widgets/bangumi_comments_widget.dart
+++ b/lib/themes/nipaplay/widgets/bangumi_comments_widget.dart
@@ -1,0 +1,479 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/models/bangumi_comment_model.dart';
+import 'package:nipaplay/services/bangumi_api_service.dart';
+import 'package:nipaplay/utils/app_accent_color.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:nipaplay/services/web_remote_access_service.dart';
+
+class BangumiMyCommentData {
+  final String nickname;
+  final String avatarUrl;
+  final int rate;
+  final String comment;
+  final int updatedAt;
+
+  const BangumiMyCommentData({
+    required this.nickname,
+    required this.avatarUrl,
+    this.rate = 0,
+    this.comment = '',
+    required this.updatedAt,
+  });
+}
+
+class BangumiCommentsWidget extends StatefulWidget {
+  final int? subjectId;
+  final VoidCallback? onEditRating;
+  final BangumiMyCommentData? myComment;
+  final int currentUserId;
+  final int commentsVersion;
+  final ValueChanged<int>? onMyCommentTimestamp;
+
+  const BangumiCommentsWidget({
+    super.key,
+    required this.subjectId,
+    this.onEditRating,
+    this.myComment,
+    this.currentUserId = 0,
+    this.commentsVersion = 0,
+    this.onMyCommentTimestamp,
+  });
+
+  @override
+  State<BangumiCommentsWidget> createState() => _BangumiCommentsWidgetState();
+}
+
+class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
+  final List<BangumiComment> _comments = [];
+  bool _isLoading = false;
+  bool _hasMore = true;
+  int _currentOffset = 0;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.subjectId != null) {
+      _loadComments();
+    }
+  }
+
+  @override
+  void didUpdateWidget(BangumiCommentsWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.subjectId != widget.subjectId ||
+        oldWidget.commentsVersion != widget.commentsVersion) {
+      _comments.clear();
+      _currentOffset = 0;
+      _hasMore = true;
+      _error = null;
+      if (widget.subjectId != null) {
+        _loadComments();
+      }
+    }
+  }
+
+  Future<void> _loadComments() async {
+    if (_isLoading) return;
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    try {
+      if (widget.subjectId == null) {
+        debugPrint('[Bangumi Comments Widget] subjectId为null，跳过加载');
+        return;
+      }
+      debugPrint('[Bangumi Comments Widget] 开始加载 subjectId=${widget.subjectId}, offset=$_currentOffset');
+      final result = await BangumiApiService.getSubjectComments(
+        widget.subjectId!,
+        offset: _currentOffset,
+      );
+      debugPrint('[Bangumi Comments Widget] API返回 success=${result['success']}, message=${result['message']}');
+
+      if (!mounted) return;
+
+      if (result['success'] == true) {
+        final data = result['data'];
+        debugPrint('[Bangumi Comments Widget] data类型: ${data.runtimeType}');
+        final list = (data['data'] as List?) ?? (data['list'] as List?) ?? [];
+        final total = data['total'] as int? ?? 0;
+        debugPrint('[Bangumi Comments Widget] 解析到 ${list.length} 条, total=$total');
+        var newComments =
+            list.map((e) => BangumiComment.fromJson(e)).toList();
+        if (widget.currentUserId > 0) {
+          final myComment = newComments.cast<BangumiComment?>().firstWhere(
+                (c) => c!.userId == widget.currentUserId,
+                orElse: () => null,
+              );
+          if (myComment != null && myComment.updatedAt > 0) {
+            widget.onMyCommentTimestamp?.call(myComment.updatedAt);
+          }
+          newComments = newComments
+              .where((c) => c.userId != widget.currentUserId)
+              .toList();
+        }
+        debugPrint('[Bangumi Comments Widget] 转换后 ${newComments.length} 条 BangumiComment');
+
+        setState(() {
+          _comments.addAll(newComments);
+          _currentOffset += newComments.length;
+          _hasMore = _currentOffset < total;
+          _isLoading = false;
+        });
+      } else {
+        setState(() {
+          _error = result['message'] as String? ?? '加载失败';
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = '加载失败: $e';
+        _isLoading = false;
+      });
+    }
+  }
+
+  void loadMore() {
+    _loadComments();
+  }
+
+  String _formatRelativeTime(int timestamp) {
+    final now = DateTime.now();
+    final time = DateTime.fromMillisecondsSinceEpoch(timestamp * 1000);
+    final diff = now.difference(time);
+    if (diff.inSeconds <= 60) return '刚刚';
+    if (diff.inMinutes <= 60) return '${diff.inMinutes}分钟前';
+    if (diff.inHours <= 12) return '${diff.inHours}小时前';
+    if (diff.inDays <= 30) return '${diff.inDays}天前';
+    if (diff.inDays <= 365) return '${diff.inDays ~/ 30}个月前';
+    return '${diff.inDays ~/ 365}年前';
+  }
+
+  String _proxiedImageUrl(String url) {
+    if (url.isEmpty) return url;
+    if (kIsWeb) {
+      return WebRemoteAccessService.imageProxyUrl(url) ?? url;
+    }
+    return url;
+  }
+
+  Widget _buildMiniStars(int rate, Color accentColor, Color mutedColor) {
+    if (rate <= 0) return const SizedBox.shrink();
+    final double starRating = rate / 2;
+    final int fullStars = starRating.floor();
+    final bool hasHalf = (starRating - fullStars) >= 0.5;
+    final List<Widget> stars = [];
+    for (int i = 0; i < 5; i++) {
+      if (i < fullStars) {
+        stars.add(Icon(Ionicons.star, size: 14, color: accentColor));
+      } else if (i == fullStars && hasHalf) {
+        stars.add(Icon(Ionicons.star_half, size: 14, color: accentColor));
+      } else {
+        stars.add(Icon(Ionicons.star_outline, size: 14, color: mutedColor));
+      }
+      if (i < 4) stars.add(const SizedBox(width: 1));
+    }
+    return Row(mainAxisSize: MainAxisSize.min, children: stars);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.subjectId == null) {
+      final bool isDark = Theme.of(context).brightness == Brightness.dark;
+      final Color secondaryTextColor =
+          isDark ? Colors.white70 : Colors.black54;
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 32),
+        child: Center(
+          child: Text('当前番剧未关联Bangumi条目，无法加载评论',
+              style: TextStyle(color: secondaryTextColor, fontSize: 13)),
+        ),
+      );
+    }
+
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final Color textColor = isDark ? Colors.white : Colors.black87;
+    final Color secondaryTextColor =
+        isDark ? Colors.white70 : Colors.black54;
+    final Color accentColor = AppAccentColors.current;
+    final Color mutedColor = accentColor.withOpacity(isDark ? 0.4 : 0.3);
+
+    final bool hasMyComment = widget.myComment != null &&
+        (widget.myComment!.rate > 0 ||
+            widget.myComment!.comment.trim().isNotEmpty);
+
+    // Initial loading
+    if (_comments.isEmpty && _isLoading) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 32),
+        child: Center(
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            valueColor: AlwaysStoppedAnimation<Color>(accentColor),
+          ),
+        ),
+      );
+    }
+
+    // Error on first load
+    if (_comments.isEmpty && _error != null) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 32),
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Ionicons.alert_circle_outline,
+                  color: secondaryTextColor, size: 32),
+              const SizedBox(height: 8),
+              Text(_error!,
+                  style: TextStyle(color: secondaryTextColor, fontSize: 13)),
+              const SizedBox(height: 12),
+              TextButton(
+                onPressed: _loadComments,
+                child: Text('重试', style: TextStyle(color: accentColor)),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Empty (no comments from API and no personal comment)
+    if (_comments.isEmpty && !hasMyComment) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 32),
+        child: Center(
+          child: Text('暂无短评',
+              style: TextStyle(color: secondaryTextColor, fontSize: 13)),
+        ),
+      );
+    }
+
+    final valueStyle = TextStyle(
+        color: textColor.withOpacity(0.85), fontSize: 13, height: 1.5);
+
+    final int totalItemCount =
+        _comments.length + (hasMyComment ? 1 : 0);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text('全部短评',
+                style: TextStyle(
+                    color: textColor,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 14,
+                    height: 1.5)),
+            if (widget.onEditRating != null)
+              GestureDetector(
+                onTap: widget.onEditRating,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Ionicons.create_outline,
+                        size: 15, color: accentColor),
+                    const SizedBox(width: 4),
+                    Text('编辑评分',
+                        style: TextStyle(
+                            color: accentColor,
+                            fontSize: 13,
+                            fontWeight: FontWeight.w500)),
+                  ],
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        ListView.separated(
+          key: ValueKey('${widget.subjectId}_${widget.commentsVersion}'),
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: totalItemCount,
+          separatorBuilder: (_, __) => const SizedBox(height: 8),
+          itemBuilder: (context, index) {
+            // "我的评论" as first item
+            if (hasMyComment && index == 0) {
+              final my = widget.myComment!;
+              return Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: accentColor.withOpacity(0.08),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                      color: accentColor.withOpacity(0.25), width: 0.8),
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    CircleAvatar(
+                      radius: 18,
+                      backgroundColor: textColor.withOpacity(0.1),
+                      backgroundImage: my.avatarUrl.isNotEmpty
+                          ? NetworkImage(
+                              _proxiedImageUrl(my.avatarUrl))
+                          : null,
+                      child: my.avatarUrl.isEmpty
+                          ? Icon(Ionicons.person,
+                              size: 18, color: secondaryTextColor)
+                          : null,
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Flexible(
+                                child: Text(
+                                  my.nickname.isNotEmpty
+                                      ? my.nickname
+                                      : '我',
+                                  style: TextStyle(
+                                    color: textColor,
+                                    fontWeight: FontWeight.w500,
+                                    fontSize: 13,
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                              Text(
+                                _formatRelativeTime(my.updatedAt),
+                                style: TextStyle(
+                                    color: secondaryTextColor, fontSize: 11),
+                              ),
+                            ],
+                          ),
+                          if (my.rate > 0) ...[
+                            const SizedBox(height: 3),
+                            _buildMiniStars(
+                                my.rate, accentColor, mutedColor),
+                          ],
+                          if (my.comment.isNotEmpty) ...[
+                            const SizedBox(height: 4),
+                            Text(my.comment, style: valueStyle),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }
+
+            final int commentIndex =
+                hasMyComment ? index - 1 : index;
+            final comment = _comments[commentIndex];
+
+            final card = Container(
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: textColor.withOpacity(0.06),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                    color: textColor.withOpacity(0.12), width: 0.8),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  CircleAvatar(
+                    radius: 18,
+                    backgroundColor: textColor.withOpacity(0.1),
+                    backgroundImage: comment.avatarUrl.isNotEmpty
+                        ? NetworkImage(
+                            _proxiedImageUrl(comment.avatarUrl))
+                        : null,
+                    child: comment.avatarUrl.isEmpty
+                        ? Icon(Ionicons.person,
+                            size: 18, color: secondaryTextColor)
+                        : null,
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Flexible(
+                              child: Text(
+                                comment.nickname.isNotEmpty
+                                    ? comment.nickname
+                                    : comment.username,
+                                style: TextStyle(
+                                  color: textColor,
+                                  fontWeight: FontWeight.w500,
+                                  fontSize: 13,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            Text(
+                              _formatRelativeTime(comment.updatedAt),
+                              style: TextStyle(
+                                  color: secondaryTextColor, fontSize: 11),
+                            ),
+                          ],
+                        ),
+                        if (comment.rate > 0) ...[
+                          const SizedBox(height: 3),
+                          _buildMiniStars(
+                              comment.rate, accentColor, mutedColor),
+                        ],
+                        if (comment.comment.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(comment.comment, style: valueStyle),
+                        ],
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            );
+
+            return card;
+          },
+        ),
+        // Loading more indicator
+        if (_isLoading && _comments.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            child: Center(
+              child: SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation<Color>(accentColor),
+                ),
+              ),
+            ),
+          ),
+        // Error loading more
+        if (_error != null && _comments.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Center(
+              child: TextButton(
+                onPressed: _loadComments,
+                child: Text('加载失败，点击重试',
+                    style: TextStyle(color: accentColor, fontSize: 12)),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/themes/nipaplay/widgets/bangumi_comments_widget.dart
+++ b/lib/themes/nipaplay/widgets/bangumi_comments_widget.dart
@@ -65,6 +65,7 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.subjectId != widget.subjectId ||
         oldWidget.commentsVersion != widget.commentsVersion) {
+      _isLoading = false;
       _comments.clear();
       _currentOffset = 0;
       _hasMore = true;
@@ -87,14 +88,16 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
         debugPrint('[Bangumi Comments Widget] subjectId为null，跳过加载');
         return;
       }
-      debugPrint('[Bangumi Comments Widget] 开始加载 subjectId=${widget.subjectId}, offset=$_currentOffset');
+      final int requestedSubjectId = widget.subjectId!;
+      debugPrint('[Bangumi Comments Widget] 开始加载 subjectId=$requestedSubjectId, offset=$_currentOffset');
       final result = await BangumiApiService.getSubjectComments(
-        widget.subjectId!,
+        requestedSubjectId,
         offset: _currentOffset,
       );
       debugPrint('[Bangumi Comments Widget] API返回 success=${result['success']}, message=${result['message']}');
 
       if (!mounted) return;
+      if (widget.subjectId != requestedSubjectId) return;
 
       if (result['success'] == true) {
         final data = result['data'];
@@ -120,7 +123,7 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
 
         setState(() {
           _comments.addAll(newComments);
-          _currentOffset += newComments.length;
+          _currentOffset += list.length;
           _hasMore = _currentOffset < total;
           _isLoading = false;
         });
@@ -140,6 +143,7 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
   }
 
   void loadMore() {
+    if (!_hasMore || _isLoading) return;
     _loadComments();
   }
 

--- a/macos/Runner/Configs/Debug.xcconfig
+++ b/macos/Runner/Configs/Debug.xcconfig
@@ -1,4 +1,5 @@
 #include "../../Flutter/Flutter-Debug.xcconfig"
+#include "../../Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Warnings.xcconfig"
 
 ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES

--- a/macos/Runner/Configs/Release.xcconfig
+++ b/macos/Runner/Configs/Release.xcconfig
@@ -1,4 +1,5 @@
 #include "../../Flutter/Flutter-Release.xcconfig"
+#include "../../Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Warnings.xcconfig"
 
 ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES


### PR DESCRIPTION
## Summary

### 为NipaUI新增了番剧详情页：
1. 默认优先显示用户评论（如果有评论）
2. 一次请求20条评论，划到底部之后会加载接下来的评论
3. 登录状态下显示“编辑评论”按钮，点击后显示轻量化的评分弹窗，可设置评分和短评内容

## Related Issue

无

## What Changed

新建文件

  lib/models/bangumi_comment_model.dart — Bangumi 评论数据模型，解析 API 返回的
  user.id、user.nickname、user.avatar、rate、comment、updatedAt 字段。
  
  lib/themes/nipaplay/widgets/bangumi_comments_widget.dart —
  评论列表组件，包含：
  - BangumiMyCommentData 数据类（我的评论展示用）
  - 首次加载、错误重试、空状态处理
  - "我的评论"置顶显示（仅当有评分或评论时）
  - 根据 currentUserId 过滤掉自己的评论避免重复
  - 滚动到底部通过 loadMore() 公开方法触发分页
  - "编辑评分"按钮（仅登录时显示）
  - 底部加载转圈动画
  - 评论 API 加载到用户评论时通过 onMyCommentTimestamp 回调传回真实时间戳
  
  lib/themes/nipaplay/widgets/bangumi_comment_dialog.dart —
  轻量版短评对话框，只保留星级评分和短评文本框，去掉收藏状态和观看进度。复用
  BangumiCollectionSubmitResult 提交。
  
  修改文件
  
  lib/services/bangumi_api_service.dart — 新增 getSubjectComments() 方法，调用
  next.bgm.tv/p1/subjects/{id}/comments 公开接口，limit=20，支持分页。
  
  lib/pages/anime_detail_page.dart — 主要改动：
  - 引入 TickerProviderStateMixin，新增 TabController 实现"详情"/"评论"切换
  - _buildSummaryView 中插入 TabBar，评论 tab 渲染 BangumiCommentsWidget
  - 外层 SingleChildScrollView 包裹 NotificationListener 检测滚动到底
  - 新增 _commentsVersion（提交评分后 +1
  触发刷新）、_myCommentTimestamp（我的评论时间戳）
  - 新增 _showCommentDialog() 打开轻量对话框，_commentsWidgetKey 通过 key 调用
  loadMore()
  - _loadBangumiUserData 提取 subject ID
  改到登录检查之前，非登录用户也能加载评论

