### PR TITLE
Optimize next2 shadow rendering

### DIFF
--- a/rust/src/next2_engine/engine/runtime.rs
+++ b/rust/src/next2_engine/engine/runtime.rs
@@ -48,7 +48,7 @@ const EMOJI_SIDE_BEARING_RATIO: f32 = 0.08;
 const GLYPH_MODE_TEXT: f32 = 0.0;
 const GLYPH_MODE_EMOJI: f32 = 1.0;
 const SHADOW_ALPHA_SCALE: f32 = 1.0;
-const SHADOW_RENDER_SCALE: u32 = 2;
+const SHADOW_RENDER_SCALE: u32 = 1;
 const MISSING_GLYPH_FALLBACK: char = '□';
 const FALLBACK_GLYPH_ADVANCE_RATIO: f32 = 0.58;
 
@@ -463,4 +463,3 @@ fn run_engine_loop(
         }
     }
 }
-

--- a/rust/src/next2_engine/engine/shaders.rs
+++ b/rust/src/next2_engine/engine/shaders.rs
@@ -40,7 +40,7 @@ struct VsOut {
 @group(0) @binding(0) var source_tex: texture_2d<f32>;
 @group(0) @binding(1) var source_sampler: sampler;
 
-const BLUR_SCALE: f32 = 2.4;
+const BLUR_SCALE: f32 = 1.6;
 
 @vertex
 fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VsOut {
@@ -64,15 +64,11 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VsOut {
 fn fs_main(v: VsOut) -> @location(0) vec4<f32> {
     let dims = vec2<f32>(textureDimensions(source_tex));
     let step = vec2<f32>(BLUR_SCALE / max(dims.x, 1.0), 0.0);
-    var color = textureSample(source_tex, source_sampler, v.uv) * 0.2270270270;
-    color += textureSample(source_tex, source_sampler, v.uv + step * 1.3846154) * 0.194594595;
-    color += textureSample(source_tex, source_sampler, v.uv - step * 1.3846154) * 0.194594595;
-    color += textureSample(source_tex, source_sampler, v.uv + step * 3.2307692) * 0.121621622;
-    color += textureSample(source_tex, source_sampler, v.uv - step * 3.2307692) * 0.121621622;
-    color += textureSample(source_tex, source_sampler, v.uv + step * 5.0769231) * 0.054054055;
-    color += textureSample(source_tex, source_sampler, v.uv - step * 5.0769231) * 0.054054055;
-    color += textureSample(source_tex, source_sampler, v.uv + step * 6.9230769) * 0.016216217;
-    color += textureSample(source_tex, source_sampler, v.uv - step * 6.9230769) * 0.016216217;
+    var color = textureSample(source_tex, source_sampler, v.uv) * 0.29411766;
+    color += textureSample(source_tex, source_sampler, v.uv + step * 1.0) * 0.23529412;
+    color += textureSample(source_tex, source_sampler, v.uv - step * 1.0) * 0.23529412;
+    color += textureSample(source_tex, source_sampler, v.uv + step * 2.0) * 0.11764706;
+    color += textureSample(source_tex, source_sampler, v.uv - step * 2.0) * 0.11764706;
     return color;
 }
 "#;
@@ -86,7 +82,7 @@ struct VsOut {
 @group(0) @binding(0) var source_tex: texture_2d<f32>;
 @group(0) @binding(1) var source_sampler: sampler;
 
-const BLUR_SCALE: f32 = 2.4;
+const BLUR_SCALE: f32 = 1.6;
 
 @vertex
 fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VsOut {
@@ -110,15 +106,11 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VsOut {
 fn fs_main(v: VsOut) -> @location(0) vec4<f32> {
     let dims = vec2<f32>(textureDimensions(source_tex));
     let step = vec2<f32>(0.0, BLUR_SCALE / max(dims.y, 1.0));
-    var color = textureSample(source_tex, source_sampler, v.uv) * 0.2270270270;
-    color += textureSample(source_tex, source_sampler, v.uv + step * 1.3846154) * 0.194594595;
-    color += textureSample(source_tex, source_sampler, v.uv - step * 1.3846154) * 0.194594595;
-    color += textureSample(source_tex, source_sampler, v.uv + step * 3.2307692) * 0.121621622;
-    color += textureSample(source_tex, source_sampler, v.uv - step * 3.2307692) * 0.121621622;
-    color += textureSample(source_tex, source_sampler, v.uv + step * 5.0769231) * 0.054054055;
-    color += textureSample(source_tex, source_sampler, v.uv - step * 5.0769231) * 0.054054055;
-    color += textureSample(source_tex, source_sampler, v.uv + step * 6.9230769) * 0.016216217;
-    color += textureSample(source_tex, source_sampler, v.uv - step * 6.9230769) * 0.016216217;
+    var color = textureSample(source_tex, source_sampler, v.uv) * 0.29411766;
+    color += textureSample(source_tex, source_sampler, v.uv + step * 1.0) * 0.23529412;
+    color += textureSample(source_tex, source_sampler, v.uv - step * 1.0) * 0.23529412;
+    color += textureSample(source_tex, source_sampler, v.uv + step * 2.0) * 0.11764706;
+    color += textureSample(source_tex, source_sampler, v.uv - step * 2.0) * 0.11764706;
     return color;
 }
 "#;


### PR DESCRIPTION
Reduce next2 shadow cost by shrinking the shadow render scale and cutting blur passes from 9-tap to 5-tap. This keeps the shadow feature intact while removing the first-use frame drop and startup lag.