### PR TITLE
Fix Next2 custom font import

### DIFF
--- a/lib/danmaku_next/next2_layout_bridge.dart
+++ b/lib/danmaku_next/next2_layout_bridge.dart
@@ -12,6 +12,8 @@ class Next2LayoutBridge {
   double _lastDisplayArea = -1;
   bool _lastAllowStacking = false;
   bool _lastMergeDanmaku = false;
+  String _lastCustomFontFamily = '';
+  String _lastCustomFontFilePath = '';
 
   Future<void> configure({
     required List<Map<String, dynamic>> danmakuList,
@@ -22,6 +24,8 @@ class Next2LayoutBridge {
     required double scrollDurationSeconds,
     required bool allowStacking,
     required bool mergeDanmaku,
+    required String customFontFamily,
+    required String customFontFilePath,
   }) async {
     final listIdentity = identityHashCode(danmakuList);
     final changed = listIdentity != _sourceListIdentity ||
@@ -31,6 +35,8 @@ class Next2LayoutBridge {
         (_lastDisplayArea - displayArea).abs() > 0.0001 ||
         _lastAllowStacking != allowStacking ||
         _lastMergeDanmaku != mergeDanmaku ||
+        _lastCustomFontFamily != customFontFamily ||
+        _lastCustomFontFilePath != customFontFilePath ||
         !_sameLayoutConfig(
           _prepared!,
           size: size,
@@ -74,6 +80,8 @@ class Next2LayoutBridge {
         scrollDurationSeconds: scrollDurationSeconds,
         allowStacking: allowStacking,
         mergeDanmaku: mergeDanmaku,
+        customFontFamily: customFontFamily,
+        customFontFilePath: customFontFilePath,
       ),
     );
     _sourceListIdentity = listIdentity;
@@ -82,6 +90,8 @@ class Next2LayoutBridge {
     _lastDisplayArea = displayArea;
     _lastAllowStacking = allowStacking;
     _lastMergeDanmaku = mergeDanmaku;
+    _lastCustomFontFamily = customFontFamily;
+    _lastCustomFontFilePath = customFontFilePath;
   }
 
   Future<List<PositionedDanmakuItem>> layout(double currentTimeSeconds) async {

--- a/lib/danmaku_next/next2_texture_bridge.dart
+++ b/lib/danmaku_next/next2_texture_bridge.dart
@@ -64,7 +64,10 @@ class Next2TextureBridge {
     final outHeight = (raw['height'] as num?)?.toInt() ?? height;
     final isNewEngine = raw['isNewEngine'] == true;
 
-    if (textureId == null || textureId < 0 || engineHandle == null || engineHandle <= 0) {
+    if (textureId == null ||
+        textureId < 0 ||
+        engineHandle == null ||
+        engineHandle <= 0) {
       return null;
     }
 
@@ -85,6 +88,8 @@ class Next2TextureBridge {
     required double outlineWidth,
     required DanmakuShadowStyle shadowStyle,
     required double opacity,
+    String customFontFamily = '',
+    String customFontFilePath = '',
     double scaleX = 1.0,
     double scaleY = 1.0,
     double fontScale = 1.0,
@@ -121,6 +126,8 @@ class Next2TextureBridge {
         'outlineWidth': outlineWidth,
         'shadowStyle': _shadowStyleCode(shadowStyle),
         'opacity': opacity,
+        'customFontFamily': customFontFamily,
+        'customFontFilePath': customFontFilePath,
       },
     );
 

--- a/lib/danmaku_next/nipaplay_next2_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next2_overlay.dart
@@ -23,6 +23,7 @@ class NipaPlayNext2Overlay extends StatefulWidget {
     required this.allowStacking,
     required this.mergeDanmaku,
     required this.customFontFamily,
+    required this.customFontFilePath,
     required this.outlineWidth,
     required this.shadowStyle,
     this.onLayoutCalculated,
@@ -41,6 +42,7 @@ class NipaPlayNext2Overlay extends StatefulWidget {
   final bool allowStacking;
   final bool mergeDanmaku;
   final String customFontFamily;
+  final String customFontFilePath;
   final double outlineWidth;
   final DanmakuShadowStyle shadowStyle;
   final ValueChanged<List<PositionedDanmakuItem>>? onLayoutCalculated;
@@ -88,6 +90,7 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
         oldWidget.displayArea != widget.displayArea ||
         oldWidget.scrollDurationSeconds != widget.scrollDurationSeconds ||
         oldWidget.customFontFamily != widget.customFontFamily ||
+        oldWidget.customFontFilePath != widget.customFontFilePath ||
         oldWidget.outlineWidth != widget.outlineWidth ||
         oldWidget.shadowStyle != widget.shadowStyle ||
         oldWidget.opacity != widget.opacity ||
@@ -180,6 +183,8 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
           scrollDurationSeconds: widget.scrollDurationSeconds,
           allowStacking: widget.allowStacking,
           mergeDanmaku: widget.mergeDanmaku,
+          customFontFamily: widget.customFontFamily,
+          customFontFilePath: widget.customFontFilePath,
         );
 
         final frame = await _bridge.layout(
@@ -267,6 +272,8 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
       // Overall opacity is applied by the outer Flutter Opacity widget.
       // Keep Rust-side glyph compositing at full alpha to avoid edge fringe.
       opacity: 1.0,
+      customFontFamily: widget.customFontFamily,
+      customFontFilePath: widget.customFontFilePath,
       scaleX: widthScale,
       scaleY: heightScale,
       fontScale: fontScale,

--- a/lib/src/rust/api/next2.dart
+++ b/lib/src/rust/api/next2.dart
@@ -156,6 +156,8 @@ class RustNext2PrepareRequest {
   final double scrollDurationSeconds;
   final bool allowStacking;
   final bool mergeDanmaku;
+  final String customFontFamily;
+  final String customFontFilePath;
 
   const RustNext2PrepareRequest({
     required this.items,
@@ -166,6 +168,8 @@ class RustNext2PrepareRequest {
     required this.scrollDurationSeconds,
     required this.allowStacking,
     required this.mergeDanmaku,
+    required this.customFontFamily,
+    required this.customFontFilePath,
   });
 
   @override
@@ -177,7 +181,9 @@ class RustNext2PrepareRequest {
       displayArea.hashCode ^
       scrollDurationSeconds.hashCode ^
       allowStacking.hashCode ^
-      mergeDanmaku.hashCode;
+      mergeDanmaku.hashCode ^
+      customFontFamily.hashCode ^
+      customFontFilePath.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -191,7 +197,9 @@ class RustNext2PrepareRequest {
           displayArea == other.displayArea &&
           scrollDurationSeconds == other.scrollDurationSeconds &&
           allowStacking == other.allowStacking &&
-          mergeDanmaku == other.mergeDanmaku;
+          mergeDanmaku == other.mergeDanmaku &&
+          customFontFamily == other.customFontFamily &&
+          customFontFilePath == other.customFontFilePath;
 }
 
 class RustNext2PreparedItem {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -10,1258 +10,1737 @@ import 'api/torrent.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart' if (dart.library.js_interop) 'frb_generated.web.dart';
+import 'frb_generated.io.dart'
+    if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
+/// Main entrypoint of the Rust API
+class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
+  @internal
+  static final instance = RustLib._();
+
+  RustLib._();
+
+  /// Initialize flutter_rust_bridge
+  static Future<void> init({
+    RustLibApi? api,
+    BaseHandler? handler,
+    ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
+  }) async {
+    await instance.initImpl(
+      api: api,
+      handler: handler,
+      externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
+    );
+  }
 
-                /// Main entrypoint of the Rust API
-                class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
-                  @internal
-                  static final instance = RustLib._();
+  /// Initialize flutter_rust_bridge in mock mode.
+  /// No libraries for FFI are loaded.
+  static void initMock({
+    required RustLibApi api,
+  }) {
+    instance.initMockImpl(
+      api: api,
+    );
+  }
 
-                  RustLib._();
-
-                  /// Initialize flutter_rust_bridge
-                  static Future<void> init({
-                    RustLibApi? api,
-                    BaseHandler? handler,
-                    ExternalLibrary? externalLibrary,
-                    bool forceSameCodegenVersion = true,
-                  }) async {
-                    await instance.initImpl(
-                      api: api,
-                      handler: handler,
-                      externalLibrary: externalLibrary,
-                      forceSameCodegenVersion: forceSameCodegenVersion,
-                    );
-                  }
-
-                  /// Initialize flutter_rust_bridge in mock mode.
-                  /// No libraries for FFI are loaded.
-                  static void initMock({
-                    required RustLibApi api,
-                  }) {
-                    instance.initMockImpl(
-                      api: api,
-                    );
-                  }
-
-                  /// Dispose flutter_rust_bridge
-                  ///
-                  /// The call to this function is optional, since flutter_rust_bridge (and everything else)
-                  /// is automatically disposed when the app stops.
-                  static void dispose() => instance.disposeImpl();
-
-                  @override
-                  ApiImplConstructor<RustLibApiImpl, RustLibWire> get apiImplConstructor => RustLibApiImpl.new;
-
-                  @override
-                  WireConstructor<RustLibWire> get wireConstructor => RustLibWire.fromExternalLibrary;
-
-                  @override
-                  Future<void> executeRustInitializers() async {
-                    await api.crateApiSimpleInitApp();
-
-                  }
-
-                  @override
-                  ExternalLibraryLoaderConfig get defaultExternalLibraryLoaderConfig => kDefaultExternalLibraryLoaderConfig;
-
-                  @override
-                  String get codegenVersion => '2.12.0';
-
-                  @override
-                  int get rustContentHash => 8444697;
-
-                  static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
-                    stem: 'rust_lib_nipaplay',
-                    ioDirectory: 'rust/target/release/',
-                    webPrefix: 'pkg/',
-                    wasmBindgenName: 'wasm_bindgen',
-                  );
-                }
-                
-
-                abstract class RustLibApi extends BaseApi {
-                  Future<RustFileScanDiff> crateApiFileScanDiffVideoFiles({required String folderPath , required List<RustFileHashEntry> cachedHashes });
-
-Future<void> crateApiSimpleInitApp();
-
-bool crateApiPerformanceIsPerformanceProbeAvailable();
-
-bool crateApiTorrentIsTorrentEngineAvailable();
-
-Future<RustNext2FrameLayout> crateApiNext2Next2LayoutFrame({required RustNext2FrameRequest request });
-
-Future<RustNext2PreparedLayout> crateApiNext2Next2PrepareLayout({required RustNext2PrepareRequest request });
-
-Future<RustCpuSample> crateApiPerformanceSampleCpuCounters();
-
-Future<RustGpuSample> crateApiPerformanceSampleGpuPercent();
-
-Future<double> crateApiPerformanceSampleMemoryRssMb();
-
-Future<RustPerformanceSample> crateApiPerformanceSamplePerformance();
-
-Future<RustFileScanSnapshot> crateApiFileScanScanVideoFiles({required String folderPath });
-
-Future<String> crateApiTorrentTorrentAddFile({required String torrentFilePath , required String downloadDir , required bool createFolderForTask });
-
-Future<String> crateApiTorrentTorrentAddMagnet({required String magnetUri , required String downloadDir , required bool createFolderForTask });
-
-Future<void> crateApiTorrentTorrentDelete({required int id });
-
-Future<String> crateApiTorrentTorrentDetails({required int id });
-
-Future<void> crateApiTorrentTorrentForget({required int id });
-
-Future<void> crateApiTorrentTorrentInitSession({required String downloadDir });
-
-Future<String> crateApiTorrentTorrentList({required String downloadDir });
-
-Future<void> crateApiTorrentTorrentPause({required int id });
-
-Future<void> crateApiTorrentTorrentResume({required int id });
-
-Future<String> crateApiTorrentTorrentStreamUrl({required int id , required int fileId , required String filename });
-
-
-                }
-                
-
-                class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
-                  RustLibApiImpl({
-                    required super.handler,
-                    required super.wire,
-                    required super.generalizedFrbRustBinding,
-                    required super.portManager,
-                  });
-
-                  @override Future<RustFileScanDiff> crateApiFileScanDiffVideoFiles({required String folderPath , required List<RustFileHashEntry> cachedHashes })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_String(folderPath, serializer);
-sse_encode_list_rust_file_hash_entry(cachedHashes, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_rust_file_scan_diff,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiFileScanDiffVideoFilesConstMeta,
-            argValues: [folderPath, cachedHashes],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiFileScanDiffVideoFilesConstMeta => const TaskConstMeta(
-            debugName: "diff_video_files",
-            argNames: ["folderPath", "cachedHashes"],
-        );
-        
-
-@override Future<void> crateApiSimpleInitApp()  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: null,
-        )
-        ,
-            constMeta: kCrateApiSimpleInitAppConstMeta,
-            argValues: [],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiSimpleInitAppConstMeta => const TaskConstMeta(
-            debugName: "init_app",
-            argNames: [],
-        );
-        
-
-@override bool crateApiPerformanceIsPerformanceProbeAvailable()  { return handler.executeSync(SyncTask(
-            callFfi: () {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 3)!;
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_bool,
-          decodeErrorData: null,
-        )
-        ,
-            constMeta: kCrateApiPerformanceIsPerformanceProbeAvailableConstMeta,
-            argValues: [],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiPerformanceIsPerformanceProbeAvailableConstMeta => const TaskConstMeta(
-            debugName: "is_performance_probe_available",
-            argNames: [],
-        );
-        
-
-@override bool crateApiTorrentIsTorrentEngineAvailable()  { return handler.executeSync(SyncTask(
-            callFfi: () {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_bool,
-          decodeErrorData: null,
-        )
-        ,
-            constMeta: kCrateApiTorrentIsTorrentEngineAvailableConstMeta,
-            argValues: [],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiTorrentIsTorrentEngineAvailableConstMeta => const TaskConstMeta(
-            debugName: "is_torrent_engine_available",
-            argNames: [],
-        );
-        
-
-@override Future<RustNext2FrameLayout> crateApiNext2Next2LayoutFrame({required RustNext2FrameRequest request })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_box_autoadd_rust_next_2_frame_request(request, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_rust_next_2_frame_layout,
-          decodeErrorData: null,
-        )
-        ,
-            constMeta: kCrateApiNext2Next2LayoutFrameConstMeta,
-            argValues: [request],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiNext2Next2LayoutFrameConstMeta => const TaskConstMeta(
-            debugName: "next2_layout_frame",
-            argNames: ["request"],
-        );
-        
-
-@override Future<RustNext2PreparedLayout> crateApiNext2Next2PrepareLayout({required RustNext2PrepareRequest request })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_box_autoadd_rust_next_2_prepare_request(request, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_rust_next_2_prepared_layout,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiNext2Next2PrepareLayoutConstMeta,
-            argValues: [request],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiNext2Next2PrepareLayoutConstMeta => const TaskConstMeta(
-            debugName: "next2_prepare_layout",
-            argNames: ["request"],
-        );
-        
-
-@override Future<RustCpuSample> crateApiPerformanceSampleCpuCounters()  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_rust_cpu_sample,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiPerformanceSampleCpuCountersConstMeta,
-            argValues: [],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiPerformanceSampleCpuCountersConstMeta => const TaskConstMeta(
-            debugName: "sample_cpu_counters",
-            argNames: [],
-        );
-        
-
-@override Future<RustGpuSample> crateApiPerformanceSampleGpuPercent()  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_rust_gpu_sample,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiPerformanceSampleGpuPercentConstMeta,
-            argValues: [],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiPerformanceSampleGpuPercentConstMeta => const TaskConstMeta(
-            debugName: "sample_gpu_percent",
-            argNames: [],
-        );
-        
-
-@override Future<double> crateApiPerformanceSampleMemoryRssMb()  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_f_64,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiPerformanceSampleMemoryRssMbConstMeta,
-            argValues: [],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiPerformanceSampleMemoryRssMbConstMeta => const TaskConstMeta(
-            debugName: "sample_memory_rss_mb",
-            argNames: [],
-        );
-        
-
-@override Future<RustPerformanceSample> crateApiPerformanceSamplePerformance()  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_rust_performance_sample,
-          decodeErrorData: null,
-        )
-        ,
-            constMeta: kCrateApiPerformanceSamplePerformanceConstMeta,
-            argValues: [],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiPerformanceSamplePerformanceConstMeta => const TaskConstMeta(
-            debugName: "sample_performance",
-            argNames: [],
-        );
-        
-
-@override Future<RustFileScanSnapshot> crateApiFileScanScanVideoFiles({required String folderPath })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_String(folderPath, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_rust_file_scan_snapshot,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiFileScanScanVideoFilesConstMeta,
-            argValues: [folderPath],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiFileScanScanVideoFilesConstMeta => const TaskConstMeta(
-            debugName: "scan_video_files",
-            argNames: ["folderPath"],
-        );
-        
-
-@override Future<String> crateApiTorrentTorrentAddFile({required String torrentFilePath , required String downloadDir , required bool createFolderForTask })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_String(torrentFilePath, serializer);
-sse_encode_String(downloadDir, serializer);
-sse_encode_bool(createFolderForTask, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_String,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiTorrentTorrentAddFileConstMeta,
-            argValues: [torrentFilePath, downloadDir, createFolderForTask],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiTorrentTorrentAddFileConstMeta => const TaskConstMeta(
-            debugName: "torrent_add_file",
-            argNames: ["torrentFilePath", "downloadDir", "createFolderForTask"],
-        );
-        
-
-@override Future<String> crateApiTorrentTorrentAddMagnet({required String magnetUri , required String downloadDir , required bool createFolderForTask })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_String(magnetUri, serializer);
-sse_encode_String(downloadDir, serializer);
-sse_encode_bool(createFolderForTask, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_String,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiTorrentTorrentAddMagnetConstMeta,
-            argValues: [magnetUri, downloadDir, createFolderForTask],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiTorrentTorrentAddMagnetConstMeta => const TaskConstMeta(
-            debugName: "torrent_add_magnet",
-            argNames: ["magnetUri", "downloadDir", "createFolderForTask"],
-        );
-        
-
-@override Future<void> crateApiTorrentTorrentDelete({required int id })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_i_32(id, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiTorrentTorrentDeleteConstMeta,
-            argValues: [id],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiTorrentTorrentDeleteConstMeta => const TaskConstMeta(
-            debugName: "torrent_delete",
-            argNames: ["id"],
-        );
-        
-
-@override Future<String> crateApiTorrentTorrentDetails({required int id })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_i_32(id, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_String,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiTorrentTorrentDetailsConstMeta,
-            argValues: [id],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiTorrentTorrentDetailsConstMeta => const TaskConstMeta(
-            debugName: "torrent_details",
-            argNames: ["id"],
-        );
-        
-
-@override Future<void> crateApiTorrentTorrentForget({required int id })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_i_32(id, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiTorrentTorrentForgetConstMeta,
-            argValues: [id],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiTorrentTorrentForgetConstMeta => const TaskConstMeta(
-            debugName: "torrent_forget",
-            argNames: ["id"],
-        );
-        
-
-@override Future<void> crateApiTorrentTorrentInitSession({required String downloadDir })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_String(downloadDir, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiTorrentTorrentInitSessionConstMeta,
-            argValues: [downloadDir],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiTorrentTorrentInitSessionConstMeta => const TaskConstMeta(
-            debugName: "torrent_init_session",
-            argNames: ["downloadDir"],
-        );
-        
-
-@override Future<String> crateApiTorrentTorrentList({required String downloadDir })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_String(downloadDir, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_String,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiTorrentTorrentListConstMeta,
-            argValues: [downloadDir],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiTorrentTorrentListConstMeta => const TaskConstMeta(
-            debugName: "torrent_list",
-            argNames: ["downloadDir"],
-        );
-        
-
-@override Future<void> crateApiTorrentTorrentPause({required int id })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_i_32(id, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiTorrentTorrentPauseConstMeta,
-            argValues: [id],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiTorrentTorrentPauseConstMeta => const TaskConstMeta(
-            debugName: "torrent_pause",
-            argNames: ["id"],
-        );
-        
-
-@override Future<void> crateApiTorrentTorrentResume({required int id })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_i_32(id, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiTorrentTorrentResumeConstMeta,
-            argValues: [id],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiTorrentTorrentResumeConstMeta => const TaskConstMeta(
-            debugName: "torrent_resume",
-            argNames: ["id"],
-        );
-        
-
-@override Future<String> crateApiTorrentTorrentStreamUrl({required int id , required int fileId , required String filename })  { return handler.executeNormal(NormalTask(
-            callFfi: (port_) {
-              
-            final serializer = SseSerializer(generalizedFrbRustBinding);sse_encode_i_32(id, serializer);
-sse_encode_i_32(fileId, serializer);
-sse_encode_String(filename, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21, port: port_);
-            
-            },
-            codec: 
-        SseCodec(
-          decodeSuccessData: sse_decode_String,
-          decodeErrorData: sse_decode_String,
-        )
-        ,
-            constMeta: kCrateApiTorrentTorrentStreamUrlConstMeta,
-            argValues: [id, fileId, filename],
-            apiImpl: this,
-        )); }
-
-
-        TaskConstMeta get kCrateApiTorrentTorrentStreamUrlConstMeta => const TaskConstMeta(
-            debugName: "torrent_stream_url",
-            argNames: ["id", "fileId", "filename"],
-        );
-        
-
-
-
-                  @protected String dco_decode_String(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as String; }
-
-@protected bool dco_decode_bool(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as bool; }
-
-@protected double dco_decode_box_autoadd_f_64(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as double; }
-
-@protected RustNext2FrameRequest dco_decode_box_autoadd_rust_next_2_frame_request(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return dco_decode_rust_next_2_frame_request(raw); }
-
-@protected RustNext2PrepareRequest dco_decode_box_autoadd_rust_next_2_prepare_request(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return dco_decode_rust_next_2_prepare_request(raw); }
-
-@protected double dco_decode_f_64(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as double; }
-
-@protected int dco_decode_i_32(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as int; }
-
-@protected PlatformInt64 dco_decode_i_64(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return dcoDecodeI64(raw); }
-
-@protected List<String> dco_decode_list_String(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return (raw as List<dynamic>).map(dco_decode_String).toList(); }
-
-@protected Float64List dco_decode_list_prim_f_64_strict(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as Float64List; }
-
-@protected Uint8List dco_decode_list_prim_u_8_strict(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as Uint8List; }
-
-@protected List<RustFileHashEntry> dco_decode_list_rust_file_hash_entry(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return (raw as List<dynamic>).map(dco_decode_rust_file_hash_entry).toList(); }
-
-@protected List<RustFileScanEntry> dco_decode_list_rust_file_scan_entry(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return (raw as List<dynamic>).map(dco_decode_rust_file_scan_entry).toList(); }
-
-@protected List<RustNext2DanmakuItem> dco_decode_list_rust_next_2_danmaku_item(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return (raw as List<dynamic>).map(dco_decode_rust_next_2_danmaku_item).toList(); }
-
-@protected List<RustNext2FrameItem> dco_decode_list_rust_next_2_frame_item(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return (raw as List<dynamic>).map(dco_decode_rust_next_2_frame_item).toList(); }
-
-@protected List<RustNext2PreparedItem> dco_decode_list_rust_next_2_prepared_item(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return (raw as List<dynamic>).map(dco_decode_rust_next_2_prepared_item).toList(); }
-
-@protected String? dco_decode_opt_String(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw == null ? null : dco_decode_String(raw); }
-
-@protected double? dco_decode_opt_box_autoadd_f_64(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw == null ? null : dco_decode_box_autoadd_f_64(raw); }
-
-@protected RustCpuSample dco_decode_rust_cpu_sample(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
-                return RustCpuSample(processCpuMicros: dco_decode_i_64(arr[0]),
-timestampMs: dco_decode_i_64(arr[1]),
-logicalCpus: dco_decode_i_32(arr[2]),); }
-
-@protected RustFileHashEntry dco_decode_rust_file_hash_entry(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-                return RustFileHashEntry(relativePath: dco_decode_String(arr[0]),
-hash: dco_decode_String(arr[1]),); }
-
-@protected RustFileScanDiff dco_decode_rust_file_scan_diff(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 7) throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
-                return RustFileScanDiff(currentCount: dco_decode_i_32(arr[0]),
-cachedCount: dco_decode_i_32(arr[1]),
-currentFiles: dco_decode_list_String(arr[2]),
-newFiles: dco_decode_list_String(arr[3]),
-modifiedFiles: dco_decode_list_String(arr[4]),
-deletedFiles: dco_decode_list_String(arr[5]),
-currentHashes: dco_decode_list_rust_file_hash_entry(arr[6]),); }
-
-@protected RustFileScanEntry dco_decode_rust_file_scan_entry(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 5) throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
-                return RustFileScanEntry(relativePath: dco_decode_String(arr[0]),
-absolutePath: dco_decode_String(arr[1]),
-size: dco_decode_i_64(arr[2]),
-modifiedMillis: dco_decode_i_64(arr[3]),
-fileHash: dco_decode_String(arr[4]),); }
-
-@protected RustFileScanSnapshot dco_decode_rust_file_scan_snapshot(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-                return RustFileScanSnapshot(files: dco_decode_list_rust_file_scan_entry(arr[0]),); }
-
-@protected RustGpuSample dco_decode_rust_gpu_sample(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-                return RustGpuSample(gpuPercent: dco_decode_f_64(arr[0]),
-source: dco_decode_String(arr[1]),); }
-
-@protected RustNext2DanmakuItem dco_decode_rust_next_2_danmaku_item(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 5) throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
-                return RustNext2DanmakuItem(timeSeconds: dco_decode_f_64(arr[0]),
-text: dco_decode_String(arr[1]),
-typeCode: dco_decode_i_32(arr[2]),
-colorArgb: dco_decode_i_32(arr[3]),
-isMe: dco_decode_bool(arr[4]),); }
-
-@protected RustNext2FrameItem dco_decode_rust_next_2_frame_item(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
-                return RustNext2FrameItem(timeSeconds: dco_decode_f_64(arr[0]),
-text: dco_decode_String(arr[1]),
-typeCode: dco_decode_i_32(arr[2]),
-colorArgb: dco_decode_i_32(arr[3]),
-isMe: dco_decode_bool(arr[4]),
-fontSizeMultiplier: dco_decode_f_64(arr[5]),
-countText: dco_decode_opt_String(arr[6]),
-x: dco_decode_f_64(arr[7]),
-y: dco_decode_f_64(arr[8]),
-offstageX: dco_decode_f_64(arr[9]),); }
-
-@protected RustNext2FrameLayout dco_decode_rust_next_2_frame_layout(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-                return RustNext2FrameLayout(items: dco_decode_list_rust_next_2_frame_item(arr[0]),); }
-
-@protected RustNext2FrameRequest dco_decode_rust_next_2_frame_request(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-                return RustNext2FrameRequest(layout: dco_decode_rust_next_2_prepared_layout(arr[0]),
-currentTimeSeconds: dco_decode_f_64(arr[1]),); }
-
-@protected RustNext2PrepareRequest dco_decode_rust_next_2_prepare_request(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 8) throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
-                return RustNext2PrepareRequest(items: dco_decode_list_rust_next_2_danmaku_item(arr[0]),
-width: dco_decode_f_64(arr[1]),
-height: dco_decode_f_64(arr[2]),
-fontSize: dco_decode_f_64(arr[3]),
-displayArea: dco_decode_f_64(arr[4]),
-scrollDurationSeconds: dco_decode_f_64(arr[5]),
-allowStacking: dco_decode_bool(arr[6]),
-mergeDanmaku: dco_decode_bool(arr[7]),); }
-
-@protected RustNext2PreparedItem dco_decode_rust_next_2_prepared_item(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 11) throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
-                return RustNext2PreparedItem(timeSeconds: dco_decode_f_64(arr[0]),
-text: dco_decode_String(arr[1]),
-typeCode: dco_decode_i_32(arr[2]),
-colorArgb: dco_decode_i_32(arr[3]),
-isMe: dco_decode_bool(arr[4]),
-fontSizeMultiplier: dco_decode_f_64(arr[5]),
-countText: dco_decode_opt_String(arr[6]),
-trackIndex: dco_decode_i_32(arr[7]),
-yPosition: dco_decode_f_64(arr[8]),
-width: dco_decode_f_64(arr[9]),
-scrollSpeed: dco_decode_f_64(arr[10]),); }
-
-@protected RustNext2PreparedLayout dco_decode_rust_next_2_prepared_layout(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 7) throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
-                return RustNext2PreparedLayout(width: dco_decode_f_64(arr[0]),
-height: dco_decode_f_64(arr[1]),
-scrollDurationSeconds: dco_decode_f_64(arr[2]),
-staticDurationSeconds: dco_decode_f_64(arr[3]),
-items: dco_decode_list_rust_next_2_prepared_item(arr[4]),
-itemTimes: dco_decode_list_prim_f_64_strict(arr[5]),
-trackCount: dco_decode_i_32(arr[6]),); }
-
-@protected RustPerformanceSample dco_decode_rust_performance_sample(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-final arr = raw as List<dynamic>;
-                if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
-                return RustPerformanceSample(cpuProcessPercent: dco_decode_opt_box_autoadd_f_64(arr[0]),
-memoryRssMb: dco_decode_opt_box_autoadd_f_64(arr[1]),
-gpuPercent: dco_decode_opt_box_autoadd_f_64(arr[2]),
-source: dco_decode_String(arr[3]),
-timestampMs: dco_decode_i_64(arr[4]),
-note: dco_decode_opt_String(arr[5]),); }
-
-@protected int dco_decode_u_8(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return raw as int; }
-
-@protected void dco_decode_unit(dynamic raw){ // Codec=Dco (DartCObject based), see doc to use other codecs
-return; }
-
-@protected String sse_decode_String(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var inner = sse_decode_list_prim_u_8_strict(deserializer);
-        return utf8.decoder.convert(inner); }
-
-@protected bool sse_decode_bool(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return deserializer.buffer.getUint8() != 0; }
-
-@protected double sse_decode_box_autoadd_f_64(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return (sse_decode_f_64(deserializer)); }
-
-@protected RustNext2FrameRequest sse_decode_box_autoadd_rust_next_2_frame_request(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return (sse_decode_rust_next_2_frame_request(deserializer)); }
-
-@protected RustNext2PrepareRequest sse_decode_box_autoadd_rust_next_2_prepare_request(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return (sse_decode_rust_next_2_prepare_request(deserializer)); }
-
-@protected double sse_decode_f_64(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return deserializer.buffer.getFloat64(); }
-
-@protected int sse_decode_i_32(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return deserializer.buffer.getInt32(); }
-
-@protected PlatformInt64 sse_decode_i_64(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return deserializer.buffer.getPlatformInt64(); }
-
-@protected List<String> sse_decode_list_String(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-
-        var len_ = sse_decode_i_32(deserializer);
-        var ans_ = <String>[];
-        for (var idx_ = 0; idx_ < len_; ++idx_) { ans_.add(sse_decode_String(deserializer)); }
-        return ans_;
-         }
-
-@protected Float64List sse_decode_list_prim_f_64_strict(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var len_ = sse_decode_i_32(deserializer);
-                return deserializer.buffer.getFloat64List(len_); }
-
-@protected Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var len_ = sse_decode_i_32(deserializer);
-                return deserializer.buffer.getUint8List(len_); }
-
-@protected List<RustFileHashEntry> sse_decode_list_rust_file_hash_entry(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-
-        var len_ = sse_decode_i_32(deserializer);
-        var ans_ = <RustFileHashEntry>[];
-        for (var idx_ = 0; idx_ < len_; ++idx_) { ans_.add(sse_decode_rust_file_hash_entry(deserializer)); }
-        return ans_;
-         }
-
-@protected List<RustFileScanEntry> sse_decode_list_rust_file_scan_entry(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-
-        var len_ = sse_decode_i_32(deserializer);
-        var ans_ = <RustFileScanEntry>[];
-        for (var idx_ = 0; idx_ < len_; ++idx_) { ans_.add(sse_decode_rust_file_scan_entry(deserializer)); }
-        return ans_;
-         }
-
-@protected List<RustNext2DanmakuItem> sse_decode_list_rust_next_2_danmaku_item(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-
-        var len_ = sse_decode_i_32(deserializer);
-        var ans_ = <RustNext2DanmakuItem>[];
-        for (var idx_ = 0; idx_ < len_; ++idx_) { ans_.add(sse_decode_rust_next_2_danmaku_item(deserializer)); }
-        return ans_;
-         }
-
-@protected List<RustNext2FrameItem> sse_decode_list_rust_next_2_frame_item(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-
-        var len_ = sse_decode_i_32(deserializer);
-        var ans_ = <RustNext2FrameItem>[];
-        for (var idx_ = 0; idx_ < len_; ++idx_) { ans_.add(sse_decode_rust_next_2_frame_item(deserializer)); }
-        return ans_;
-         }
-
-@protected List<RustNext2PreparedItem> sse_decode_list_rust_next_2_prepared_item(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-
-        var len_ = sse_decode_i_32(deserializer);
-        var ans_ = <RustNext2PreparedItem>[];
-        for (var idx_ = 0; idx_ < len_; ++idx_) { ans_.add(sse_decode_rust_next_2_prepared_item(deserializer)); }
-        return ans_;
-         }
-
-@protected String? sse_decode_opt_String(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-
-            if (sse_decode_bool(deserializer)) {
-                return (sse_decode_String(deserializer));
-            } else {
-                return null;
-            }
-             }
-
-@protected double? sse_decode_opt_box_autoadd_f_64(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-
-            if (sse_decode_bool(deserializer)) {
-                return (sse_decode_box_autoadd_f_64(deserializer));
-            } else {
-                return null;
-            }
-             }
-
-@protected RustCpuSample sse_decode_rust_cpu_sample(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_processCpuMicros = sse_decode_i_64(deserializer);
-var var_timestampMs = sse_decode_i_64(deserializer);
-var var_logicalCpus = sse_decode_i_32(deserializer);
-return RustCpuSample(processCpuMicros: var_processCpuMicros, timestampMs: var_timestampMs, logicalCpus: var_logicalCpus); }
-
-@protected RustFileHashEntry sse_decode_rust_file_hash_entry(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_relativePath = sse_decode_String(deserializer);
-var var_hash = sse_decode_String(deserializer);
-return RustFileHashEntry(relativePath: var_relativePath, hash: var_hash); }
-
-@protected RustFileScanDiff sse_decode_rust_file_scan_diff(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_currentCount = sse_decode_i_32(deserializer);
-var var_cachedCount = sse_decode_i_32(deserializer);
-var var_currentFiles = sse_decode_list_String(deserializer);
-var var_newFiles = sse_decode_list_String(deserializer);
-var var_modifiedFiles = sse_decode_list_String(deserializer);
-var var_deletedFiles = sse_decode_list_String(deserializer);
-var var_currentHashes = sse_decode_list_rust_file_hash_entry(deserializer);
-return RustFileScanDiff(currentCount: var_currentCount, cachedCount: var_cachedCount, currentFiles: var_currentFiles, newFiles: var_newFiles, modifiedFiles: var_modifiedFiles, deletedFiles: var_deletedFiles, currentHashes: var_currentHashes); }
-
-@protected RustFileScanEntry sse_decode_rust_file_scan_entry(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_relativePath = sse_decode_String(deserializer);
-var var_absolutePath = sse_decode_String(deserializer);
-var var_size = sse_decode_i_64(deserializer);
-var var_modifiedMillis = sse_decode_i_64(deserializer);
-var var_fileHash = sse_decode_String(deserializer);
-return RustFileScanEntry(relativePath: var_relativePath, absolutePath: var_absolutePath, size: var_size, modifiedMillis: var_modifiedMillis, fileHash: var_fileHash); }
-
-@protected RustFileScanSnapshot sse_decode_rust_file_scan_snapshot(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_files = sse_decode_list_rust_file_scan_entry(deserializer);
-return RustFileScanSnapshot(files: var_files); }
-
-@protected RustGpuSample sse_decode_rust_gpu_sample(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_gpuPercent = sse_decode_f_64(deserializer);
-var var_source = sse_decode_String(deserializer);
-return RustGpuSample(gpuPercent: var_gpuPercent, source: var_source); }
-
-@protected RustNext2DanmakuItem sse_decode_rust_next_2_danmaku_item(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_timeSeconds = sse_decode_f_64(deserializer);
-var var_text = sse_decode_String(deserializer);
-var var_typeCode = sse_decode_i_32(deserializer);
-var var_colorArgb = sse_decode_i_32(deserializer);
-var var_isMe = sse_decode_bool(deserializer);
-return RustNext2DanmakuItem(timeSeconds: var_timeSeconds, text: var_text, typeCode: var_typeCode, colorArgb: var_colorArgb, isMe: var_isMe); }
-
-@protected RustNext2FrameItem sse_decode_rust_next_2_frame_item(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_timeSeconds = sse_decode_f_64(deserializer);
-var var_text = sse_decode_String(deserializer);
-var var_typeCode = sse_decode_i_32(deserializer);
-var var_colorArgb = sse_decode_i_32(deserializer);
-var var_isMe = sse_decode_bool(deserializer);
-var var_fontSizeMultiplier = sse_decode_f_64(deserializer);
-var var_countText = sse_decode_opt_String(deserializer);
-var var_x = sse_decode_f_64(deserializer);
-var var_y = sse_decode_f_64(deserializer);
-var var_offstageX = sse_decode_f_64(deserializer);
-return RustNext2FrameItem(timeSeconds: var_timeSeconds, text: var_text, typeCode: var_typeCode, colorArgb: var_colorArgb, isMe: var_isMe, fontSizeMultiplier: var_fontSizeMultiplier, countText: var_countText, x: var_x, y: var_y, offstageX: var_offstageX); }
-
-@protected RustNext2FrameLayout sse_decode_rust_next_2_frame_layout(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_items = sse_decode_list_rust_next_2_frame_item(deserializer);
-return RustNext2FrameLayout(items: var_items); }
-
-@protected RustNext2FrameRequest sse_decode_rust_next_2_frame_request(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_layout = sse_decode_rust_next_2_prepared_layout(deserializer);
-var var_currentTimeSeconds = sse_decode_f_64(deserializer);
-return RustNext2FrameRequest(layout: var_layout, currentTimeSeconds: var_currentTimeSeconds); }
-
-@protected RustNext2PrepareRequest sse_decode_rust_next_2_prepare_request(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_items = sse_decode_list_rust_next_2_danmaku_item(deserializer);
-var var_width = sse_decode_f_64(deserializer);
-var var_height = sse_decode_f_64(deserializer);
-var var_fontSize = sse_decode_f_64(deserializer);
-var var_displayArea = sse_decode_f_64(deserializer);
-var var_scrollDurationSeconds = sse_decode_f_64(deserializer);
-var var_allowStacking = sse_decode_bool(deserializer);
-var var_mergeDanmaku = sse_decode_bool(deserializer);
-return RustNext2PrepareRequest(items: var_items, width: var_width, height: var_height, fontSize: var_fontSize, displayArea: var_displayArea, scrollDurationSeconds: var_scrollDurationSeconds, allowStacking: var_allowStacking, mergeDanmaku: var_mergeDanmaku); }
-
-@protected RustNext2PreparedItem sse_decode_rust_next_2_prepared_item(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_timeSeconds = sse_decode_f_64(deserializer);
-var var_text = sse_decode_String(deserializer);
-var var_typeCode = sse_decode_i_32(deserializer);
-var var_colorArgb = sse_decode_i_32(deserializer);
-var var_isMe = sse_decode_bool(deserializer);
-var var_fontSizeMultiplier = sse_decode_f_64(deserializer);
-var var_countText = sse_decode_opt_String(deserializer);
-var var_trackIndex = sse_decode_i_32(deserializer);
-var var_yPosition = sse_decode_f_64(deserializer);
-var var_width = sse_decode_f_64(deserializer);
-var var_scrollSpeed = sse_decode_f_64(deserializer);
-return RustNext2PreparedItem(timeSeconds: var_timeSeconds, text: var_text, typeCode: var_typeCode, colorArgb: var_colorArgb, isMe: var_isMe, fontSizeMultiplier: var_fontSizeMultiplier, countText: var_countText, trackIndex: var_trackIndex, yPosition: var_yPosition, width: var_width, scrollSpeed: var_scrollSpeed); }
-
-@protected RustNext2PreparedLayout sse_decode_rust_next_2_prepared_layout(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_width = sse_decode_f_64(deserializer);
-var var_height = sse_decode_f_64(deserializer);
-var var_scrollDurationSeconds = sse_decode_f_64(deserializer);
-var var_staticDurationSeconds = sse_decode_f_64(deserializer);
-var var_items = sse_decode_list_rust_next_2_prepared_item(deserializer);
-var var_itemTimes = sse_decode_list_prim_f_64_strict(deserializer);
-var var_trackCount = sse_decode_i_32(deserializer);
-return RustNext2PreparedLayout(width: var_width, height: var_height, scrollDurationSeconds: var_scrollDurationSeconds, staticDurationSeconds: var_staticDurationSeconds, items: var_items, itemTimes: var_itemTimes, trackCount: var_trackCount); }
-
-@protected RustPerformanceSample sse_decode_rust_performance_sample(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-var var_cpuProcessPercent = sse_decode_opt_box_autoadd_f_64(deserializer);
-var var_memoryRssMb = sse_decode_opt_box_autoadd_f_64(deserializer);
-var var_gpuPercent = sse_decode_opt_box_autoadd_f_64(deserializer);
-var var_source = sse_decode_String(deserializer);
-var var_timestampMs = sse_decode_i_64(deserializer);
-var var_note = sse_decode_opt_String(deserializer);
-return RustPerformanceSample(cpuProcessPercent: var_cpuProcessPercent, memoryRssMb: var_memoryRssMb, gpuPercent: var_gpuPercent, source: var_source, timestampMs: var_timestampMs, note: var_note); }
-
-@protected int sse_decode_u_8(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-return deserializer.buffer.getUint8(); }
-
-@protected void sse_decode_unit(SseDeserializer deserializer){ // Codec=Sse (Serialization based), see doc to use other codecs
- }
-
-@protected void sse_encode_String(String self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer); }
-
-@protected void sse_encode_bool(bool self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-serializer.buffer.putUint8(self ? 1 : 0); }
-
-@protected void sse_encode_box_autoadd_f_64(double self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_f_64(self, serializer); }
-
-@protected void sse_encode_box_autoadd_rust_next_2_frame_request(RustNext2FrameRequest self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_rust_next_2_frame_request(self, serializer); }
-
-@protected void sse_encode_box_autoadd_rust_next_2_prepare_request(RustNext2PrepareRequest self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_rust_next_2_prepare_request(self, serializer); }
-
-@protected void sse_encode_f_64(double self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-serializer.buffer.putFloat64(self); }
-
-@protected void sse_encode_i_32(int self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-serializer.buffer.putInt32(self); }
-
-@protected void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-serializer.buffer.putPlatformInt64(self); }
-
-@protected void sse_encode_list_String(List<String> self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.length, serializer);
-        for (final item in self) { sse_encode_String(item, serializer); } }
-
-@protected void sse_encode_list_prim_f_64_strict(Float64List self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.length, serializer);
-                    serializer.buffer.putFloat64List(self); }
-
-@protected void sse_encode_list_prim_u_8_strict(Uint8List self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.length, serializer);
-                    serializer.buffer.putUint8List(self); }
-
-@protected void sse_encode_list_rust_file_hash_entry(List<RustFileHashEntry> self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.length, serializer);
-        for (final item in self) { sse_encode_rust_file_hash_entry(item, serializer); } }
-
-@protected void sse_encode_list_rust_file_scan_entry(List<RustFileScanEntry> self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.length, serializer);
-        for (final item in self) { sse_encode_rust_file_scan_entry(item, serializer); } }
-
-@protected void sse_encode_list_rust_next_2_danmaku_item(List<RustNext2DanmakuItem> self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.length, serializer);
-        for (final item in self) { sse_encode_rust_next_2_danmaku_item(item, serializer); } }
-
-@protected void sse_encode_list_rust_next_2_frame_item(List<RustNext2FrameItem> self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.length, serializer);
-        for (final item in self) { sse_encode_rust_next_2_frame_item(item, serializer); } }
-
-@protected void sse_encode_list_rust_next_2_prepared_item(List<RustNext2PreparedItem> self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.length, serializer);
-        for (final item in self) { sse_encode_rust_next_2_prepared_item(item, serializer); } }
-
-@protected void sse_encode_opt_String(String? self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-
-                sse_encode_bool(self != null, serializer);
-                if (self != null) {
-                    sse_encode_String(self, serializer);
-                }
-                 }
-
-@protected void sse_encode_opt_box_autoadd_f_64(double? self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-
-                sse_encode_bool(self != null, serializer);
-                if (self != null) {
-                    sse_encode_box_autoadd_f_64(self, serializer);
-                }
-                 }
-
-@protected void sse_encode_rust_cpu_sample(RustCpuSample self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_64(self.processCpuMicros, serializer);
-sse_encode_i_64(self.timestampMs, serializer);
-sse_encode_i_32(self.logicalCpus, serializer);
- }
-
-@protected void sse_encode_rust_file_hash_entry(RustFileHashEntry self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_String(self.relativePath, serializer);
-sse_encode_String(self.hash, serializer);
- }
-
-@protected void sse_encode_rust_file_scan_diff(RustFileScanDiff self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_i_32(self.currentCount, serializer);
-sse_encode_i_32(self.cachedCount, serializer);
-sse_encode_list_String(self.currentFiles, serializer);
-sse_encode_list_String(self.newFiles, serializer);
-sse_encode_list_String(self.modifiedFiles, serializer);
-sse_encode_list_String(self.deletedFiles, serializer);
-sse_encode_list_rust_file_hash_entry(self.currentHashes, serializer);
- }
-
-@protected void sse_encode_rust_file_scan_entry(RustFileScanEntry self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_String(self.relativePath, serializer);
-sse_encode_String(self.absolutePath, serializer);
-sse_encode_i_64(self.size, serializer);
-sse_encode_i_64(self.modifiedMillis, serializer);
-sse_encode_String(self.fileHash, serializer);
- }
-
-@protected void sse_encode_rust_file_scan_snapshot(RustFileScanSnapshot self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_list_rust_file_scan_entry(self.files, serializer);
- }
-
-@protected void sse_encode_rust_gpu_sample(RustGpuSample self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_f_64(self.gpuPercent, serializer);
-sse_encode_String(self.source, serializer);
- }
-
-@protected void sse_encode_rust_next_2_danmaku_item(RustNext2DanmakuItem self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_f_64(self.timeSeconds, serializer);
-sse_encode_String(self.text, serializer);
-sse_encode_i_32(self.typeCode, serializer);
-sse_encode_i_32(self.colorArgb, serializer);
-sse_encode_bool(self.isMe, serializer);
- }
-
-@protected void sse_encode_rust_next_2_frame_item(RustNext2FrameItem self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_f_64(self.timeSeconds, serializer);
-sse_encode_String(self.text, serializer);
-sse_encode_i_32(self.typeCode, serializer);
-sse_encode_i_32(self.colorArgb, serializer);
-sse_encode_bool(self.isMe, serializer);
-sse_encode_f_64(self.fontSizeMultiplier, serializer);
-sse_encode_opt_String(self.countText, serializer);
-sse_encode_f_64(self.x, serializer);
-sse_encode_f_64(self.y, serializer);
-sse_encode_f_64(self.offstageX, serializer);
- }
-
-@protected void sse_encode_rust_next_2_frame_layout(RustNext2FrameLayout self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_list_rust_next_2_frame_item(self.items, serializer);
- }
-
-@protected void sse_encode_rust_next_2_frame_request(RustNext2FrameRequest self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_rust_next_2_prepared_layout(self.layout, serializer);
-sse_encode_f_64(self.currentTimeSeconds, serializer);
- }
-
-@protected void sse_encode_rust_next_2_prepare_request(RustNext2PrepareRequest self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_list_rust_next_2_danmaku_item(self.items, serializer);
-sse_encode_f_64(self.width, serializer);
-sse_encode_f_64(self.height, serializer);
-sse_encode_f_64(self.fontSize, serializer);
-sse_encode_f_64(self.displayArea, serializer);
-sse_encode_f_64(self.scrollDurationSeconds, serializer);
-sse_encode_bool(self.allowStacking, serializer);
-sse_encode_bool(self.mergeDanmaku, serializer);
- }
-
-@protected void sse_encode_rust_next_2_prepared_item(RustNext2PreparedItem self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_f_64(self.timeSeconds, serializer);
-sse_encode_String(self.text, serializer);
-sse_encode_i_32(self.typeCode, serializer);
-sse_encode_i_32(self.colorArgb, serializer);
-sse_encode_bool(self.isMe, serializer);
-sse_encode_f_64(self.fontSizeMultiplier, serializer);
-sse_encode_opt_String(self.countText, serializer);
-sse_encode_i_32(self.trackIndex, serializer);
-sse_encode_f_64(self.yPosition, serializer);
-sse_encode_f_64(self.width, serializer);
-sse_encode_f_64(self.scrollSpeed, serializer);
- }
-
-@protected void sse_encode_rust_next_2_prepared_layout(RustNext2PreparedLayout self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_f_64(self.width, serializer);
-sse_encode_f_64(self.height, serializer);
-sse_encode_f_64(self.scrollDurationSeconds, serializer);
-sse_encode_f_64(self.staticDurationSeconds, serializer);
-sse_encode_list_rust_next_2_prepared_item(self.items, serializer);
-sse_encode_list_prim_f_64_strict(self.itemTimes, serializer);
-sse_encode_i_32(self.trackCount, serializer);
- }
-
-@protected void sse_encode_rust_performance_sample(RustPerformanceSample self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-sse_encode_opt_box_autoadd_f_64(self.cpuProcessPercent, serializer);
-sse_encode_opt_box_autoadd_f_64(self.memoryRssMb, serializer);
-sse_encode_opt_box_autoadd_f_64(self.gpuPercent, serializer);
-sse_encode_String(self.source, serializer);
-sse_encode_i_64(self.timestampMs, serializer);
-sse_encode_opt_String(self.note, serializer);
- }
-
-@protected void sse_encode_u_8(int self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
-serializer.buffer.putUint8(self); }
-
-@protected void sse_encode_unit(void self, SseSerializer serializer){ // Codec=Sse (Serialization based), see doc to use other codecs
- }
-                }
-                
+  /// Dispose flutter_rust_bridge
+  ///
+  /// The call to this function is optional, since flutter_rust_bridge (and everything else)
+  /// is automatically disposed when the app stops.
+  static void dispose() => instance.disposeImpl();
+
+  @override
+  ApiImplConstructor<RustLibApiImpl, RustLibWire> get apiImplConstructor =>
+      RustLibApiImpl.new;
+
+  @override
+  WireConstructor<RustLibWire> get wireConstructor =>
+      RustLibWire.fromExternalLibrary;
+
+  @override
+  Future<void> executeRustInitializers() async {
+    await api.crateApiSimpleInitApp();
+  }
+
+  @override
+  ExternalLibraryLoaderConfig get defaultExternalLibraryLoaderConfig =>
+      kDefaultExternalLibraryLoaderConfig;
+
+  @override
+  String get codegenVersion => '2.12.0';
+
+  @override
+  int get rustContentHash => 8444697;
+
+  static const kDefaultExternalLibraryLoaderConfig =
+      ExternalLibraryLoaderConfig(
+    stem: 'rust_lib_nipaplay',
+    ioDirectory: 'rust/target/release/',
+    webPrefix: 'pkg/',
+    wasmBindgenName: 'wasm_bindgen',
+  );
+}
+
+abstract class RustLibApi extends BaseApi {
+  Future<RustFileScanDiff> crateApiFileScanDiffVideoFiles(
+      {required String folderPath,
+      required List<RustFileHashEntry> cachedHashes});
+
+  Future<void> crateApiSimpleInitApp();
+
+  bool crateApiPerformanceIsPerformanceProbeAvailable();
+
+  bool crateApiTorrentIsTorrentEngineAvailable();
+
+  Future<RustNext2FrameLayout> crateApiNext2Next2LayoutFrame(
+      {required RustNext2FrameRequest request});
+
+  Future<RustNext2PreparedLayout> crateApiNext2Next2PrepareLayout(
+      {required RustNext2PrepareRequest request});
+
+  Future<RustCpuSample> crateApiPerformanceSampleCpuCounters();
+
+  Future<RustGpuSample> crateApiPerformanceSampleGpuPercent();
+
+  Future<double> crateApiPerformanceSampleMemoryRssMb();
+
+  Future<RustPerformanceSample> crateApiPerformanceSamplePerformance();
+
+  Future<RustFileScanSnapshot> crateApiFileScanScanVideoFiles(
+      {required String folderPath});
+
+  Future<String> crateApiTorrentTorrentAddFile(
+      {required String torrentFilePath,
+      required String downloadDir,
+      required bool createFolderForTask});
+
+  Future<String> crateApiTorrentTorrentAddMagnet(
+      {required String magnetUri,
+      required String downloadDir,
+      required bool createFolderForTask});
+
+  Future<void> crateApiTorrentTorrentDelete({required int id});
+
+  Future<String> crateApiTorrentTorrentDetails({required int id});
+
+  Future<void> crateApiTorrentTorrentForget({required int id});
+
+  Future<void> crateApiTorrentTorrentInitSession({required String downloadDir});
+
+  Future<String> crateApiTorrentTorrentList({required String downloadDir});
+
+  Future<void> crateApiTorrentTorrentPause({required int id});
+
+  Future<void> crateApiTorrentTorrentResume({required int id});
+
+  Future<String> crateApiTorrentTorrentStreamUrl(
+      {required int id, required int fileId, required String filename});
+}
+
+class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
+  RustLibApiImpl({
+    required super.handler,
+    required super.wire,
+    required super.generalizedFrbRustBinding,
+    required super.portManager,
+  });
+
+  @override
+  Future<RustFileScanDiff> crateApiFileScanDiffVideoFiles(
+      {required String folderPath,
+      required List<RustFileHashEntry> cachedHashes}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(folderPath, serializer);
+        sse_encode_list_rust_file_hash_entry(cachedHashes, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_rust_file_scan_diff,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiFileScanDiffVideoFilesConstMeta,
+      argValues: [folderPath, cachedHashes],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiFileScanDiffVideoFilesConstMeta =>
+      const TaskConstMeta(
+        debugName: "diff_video_files",
+        argNames: ["folderPath", "cachedHashes"],
+      );
+
+  @override
+  Future<void> crateApiSimpleInitApp() {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 2, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiSimpleInitAppConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiSimpleInitAppConstMeta => const TaskConstMeta(
+        debugName: "init_app",
+        argNames: [],
+      );
+
+  @override
+  bool crateApiPerformanceIsPerformanceProbeAvailable() {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 3)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_bool,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiPerformanceIsPerformanceProbeAvailableConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiPerformanceIsPerformanceProbeAvailableConstMeta =>
+      const TaskConstMeta(
+        debugName: "is_performance_probe_available",
+        argNames: [],
+      );
+
+  @override
+  bool crateApiTorrentIsTorrentEngineAvailable() {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_bool,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiTorrentIsTorrentEngineAvailableConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentIsTorrentEngineAvailableConstMeta =>
+      const TaskConstMeta(
+        debugName: "is_torrent_engine_available",
+        argNames: [],
+      );
+
+  @override
+  Future<RustNext2FrameLayout> crateApiNext2Next2LayoutFrame(
+      {required RustNext2FrameRequest request}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_rust_next_2_frame_request(request, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 5, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_rust_next_2_frame_layout,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiNext2Next2LayoutFrameConstMeta,
+      argValues: [request],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiNext2Next2LayoutFrameConstMeta =>
+      const TaskConstMeta(
+        debugName: "next2_layout_frame",
+        argNames: ["request"],
+      );
+
+  @override
+  Future<RustNext2PreparedLayout> crateApiNext2Next2PrepareLayout(
+      {required RustNext2PrepareRequest request}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_rust_next_2_prepare_request(request, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 6, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_rust_next_2_prepared_layout,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiNext2Next2PrepareLayoutConstMeta,
+      argValues: [request],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiNext2Next2PrepareLayoutConstMeta =>
+      const TaskConstMeta(
+        debugName: "next2_prepare_layout",
+        argNames: ["request"],
+      );
+
+  @override
+  Future<RustCpuSample> crateApiPerformanceSampleCpuCounters() {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 7, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_rust_cpu_sample,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiPerformanceSampleCpuCountersConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiPerformanceSampleCpuCountersConstMeta =>
+      const TaskConstMeta(
+        debugName: "sample_cpu_counters",
+        argNames: [],
+      );
+
+  @override
+  Future<RustGpuSample> crateApiPerformanceSampleGpuPercent() {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 8, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_rust_gpu_sample,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiPerformanceSampleGpuPercentConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiPerformanceSampleGpuPercentConstMeta =>
+      const TaskConstMeta(
+        debugName: "sample_gpu_percent",
+        argNames: [],
+      );
+
+  @override
+  Future<double> crateApiPerformanceSampleMemoryRssMb() {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 9, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_f_64,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiPerformanceSampleMemoryRssMbConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiPerformanceSampleMemoryRssMbConstMeta =>
+      const TaskConstMeta(
+        debugName: "sample_memory_rss_mb",
+        argNames: [],
+      );
+
+  @override
+  Future<RustPerformanceSample> crateApiPerformanceSamplePerformance() {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 10, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_rust_performance_sample,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiPerformanceSamplePerformanceConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiPerformanceSamplePerformanceConstMeta =>
+      const TaskConstMeta(
+        debugName: "sample_performance",
+        argNames: [],
+      );
+
+  @override
+  Future<RustFileScanSnapshot> crateApiFileScanScanVideoFiles(
+      {required String folderPath}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(folderPath, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 11, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_rust_file_scan_snapshot,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiFileScanScanVideoFilesConstMeta,
+      argValues: [folderPath],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiFileScanScanVideoFilesConstMeta =>
+      const TaskConstMeta(
+        debugName: "scan_video_files",
+        argNames: ["folderPath"],
+      );
+
+  @override
+  Future<String> crateApiTorrentTorrentAddFile(
+      {required String torrentFilePath,
+      required String downloadDir,
+      required bool createFolderForTask}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(torrentFilePath, serializer);
+        sse_encode_String(downloadDir, serializer);
+        sse_encode_bool(createFolderForTask, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 12, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentAddFileConstMeta,
+      argValues: [torrentFilePath, downloadDir, createFolderForTask],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentAddFileConstMeta =>
+      const TaskConstMeta(
+        debugName: "torrent_add_file",
+        argNames: ["torrentFilePath", "downloadDir", "createFolderForTask"],
+      );
+
+  @override
+  Future<String> crateApiTorrentTorrentAddMagnet(
+      {required String magnetUri,
+      required String downloadDir,
+      required bool createFolderForTask}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(magnetUri, serializer);
+        sse_encode_String(downloadDir, serializer);
+        sse_encode_bool(createFolderForTask, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 13, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentAddMagnetConstMeta,
+      argValues: [magnetUri, downloadDir, createFolderForTask],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentAddMagnetConstMeta =>
+      const TaskConstMeta(
+        debugName: "torrent_add_magnet",
+        argNames: ["magnetUri", "downloadDir", "createFolderForTask"],
+      );
+
+  @override
+  Future<void> crateApiTorrentTorrentDelete({required int id}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_i_32(id, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 14, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentDeleteConstMeta,
+      argValues: [id],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentDeleteConstMeta =>
+      const TaskConstMeta(
+        debugName: "torrent_delete",
+        argNames: ["id"],
+      );
+
+  @override
+  Future<String> crateApiTorrentTorrentDetails({required int id}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_i_32(id, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 15, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentDetailsConstMeta,
+      argValues: [id],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentDetailsConstMeta =>
+      const TaskConstMeta(
+        debugName: "torrent_details",
+        argNames: ["id"],
+      );
+
+  @override
+  Future<void> crateApiTorrentTorrentForget({required int id}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_i_32(id, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 16, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentForgetConstMeta,
+      argValues: [id],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentForgetConstMeta =>
+      const TaskConstMeta(
+        debugName: "torrent_forget",
+        argNames: ["id"],
+      );
+
+  @override
+  Future<void> crateApiTorrentTorrentInitSession(
+      {required String downloadDir}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(downloadDir, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 17, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentInitSessionConstMeta,
+      argValues: [downloadDir],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentInitSessionConstMeta =>
+      const TaskConstMeta(
+        debugName: "torrent_init_session",
+        argNames: ["downloadDir"],
+      );
+
+  @override
+  Future<String> crateApiTorrentTorrentList({required String downloadDir}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(downloadDir, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 18, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentListConstMeta,
+      argValues: [downloadDir],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentListConstMeta => const TaskConstMeta(
+        debugName: "torrent_list",
+        argNames: ["downloadDir"],
+      );
+
+  @override
+  Future<void> crateApiTorrentTorrentPause({required int id}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_i_32(id, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 19, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentPauseConstMeta,
+      argValues: [id],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentPauseConstMeta =>
+      const TaskConstMeta(
+        debugName: "torrent_pause",
+        argNames: ["id"],
+      );
+
+  @override
+  Future<void> crateApiTorrentTorrentResume({required int id}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_i_32(id, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 20, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentResumeConstMeta,
+      argValues: [id],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentResumeConstMeta =>
+      const TaskConstMeta(
+        debugName: "torrent_resume",
+        argNames: ["id"],
+      );
+
+  @override
+  Future<String> crateApiTorrentTorrentStreamUrl(
+      {required int id, required int fileId, required String filename}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_i_32(id, serializer);
+        sse_encode_i_32(fileId, serializer);
+        sse_encode_String(filename, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 21, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentStreamUrlConstMeta,
+      argValues: [id, fileId, filename],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentStreamUrlConstMeta =>
+      const TaskConstMeta(
+        debugName: "torrent_stream_url",
+        argNames: ["id", "fileId", "filename"],
+      );
+
+  @protected
+  String dco_decode_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as String;
+  }
+
+  @protected
+  bool dco_decode_bool(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as bool;
+  }
+
+  @protected
+  double dco_decode_box_autoadd_f_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as double;
+  }
+
+  @protected
+  RustNext2FrameRequest dco_decode_box_autoadd_rust_next_2_frame_request(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_rust_next_2_frame_request(raw);
+  }
+
+  @protected
+  RustNext2PrepareRequest dco_decode_box_autoadd_rust_next_2_prepare_request(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_rust_next_2_prepare_request(raw);
+  }
+
+  @protected
+  double dco_decode_f_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as double;
+  }
+
+  @protected
+  int dco_decode_i_32(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as int;
+  }
+
+  @protected
+  PlatformInt64 dco_decode_i_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dcoDecodeI64(raw);
+  }
+
+  @protected
+  List<String> dco_decode_list_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_String).toList();
+  }
+
+  @protected
+  Float64List dco_decode_list_prim_f_64_strict(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as Float64List;
+  }
+
+  @protected
+  Uint8List dco_decode_list_prim_u_8_strict(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as Uint8List;
+  }
+
+  @protected
+  List<RustFileHashEntry> dco_decode_list_rust_file_hash_entry(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_rust_file_hash_entry).toList();
+  }
+
+  @protected
+  List<RustFileScanEntry> dco_decode_list_rust_file_scan_entry(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_rust_file_scan_entry).toList();
+  }
+
+  @protected
+  List<RustNext2DanmakuItem> dco_decode_list_rust_next_2_danmaku_item(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_rust_next_2_danmaku_item)
+        .toList();
+  }
+
+  @protected
+  List<RustNext2FrameItem> dco_decode_list_rust_next_2_frame_item(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_rust_next_2_frame_item)
+        .toList();
+  }
+
+  @protected
+  List<RustNext2PreparedItem> dco_decode_list_rust_next_2_prepared_item(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_rust_next_2_prepared_item)
+        .toList();
+  }
+
+  @protected
+  String? dco_decode_opt_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_String(raw);
+  }
+
+  @protected
+  double? dco_decode_opt_box_autoadd_f_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_f_64(raw);
+  }
+
+  @protected
+  RustCpuSample dco_decode_rust_cpu_sample(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return RustCpuSample(
+      processCpuMicros: dco_decode_i_64(arr[0]),
+      timestampMs: dco_decode_i_64(arr[1]),
+      logicalCpus: dco_decode_i_32(arr[2]),
+    );
+  }
+
+  @protected
+  RustFileHashEntry dco_decode_rust_file_hash_entry(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return RustFileHashEntry(
+      relativePath: dco_decode_String(arr[0]),
+      hash: dco_decode_String(arr[1]),
+    );
+  }
+
+  @protected
+  RustFileScanDiff dco_decode_rust_file_scan_diff(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    return RustFileScanDiff(
+      currentCount: dco_decode_i_32(arr[0]),
+      cachedCount: dco_decode_i_32(arr[1]),
+      currentFiles: dco_decode_list_String(arr[2]),
+      newFiles: dco_decode_list_String(arr[3]),
+      modifiedFiles: dco_decode_list_String(arr[4]),
+      deletedFiles: dco_decode_list_String(arr[5]),
+      currentHashes: dco_decode_list_rust_file_hash_entry(arr[6]),
+    );
+  }
+
+  @protected
+  RustFileScanEntry dco_decode_rust_file_scan_entry(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    return RustFileScanEntry(
+      relativePath: dco_decode_String(arr[0]),
+      absolutePath: dco_decode_String(arr[1]),
+      size: dco_decode_i_64(arr[2]),
+      modifiedMillis: dco_decode_i_64(arr[3]),
+      fileHash: dco_decode_String(arr[4]),
+    );
+  }
+
+  @protected
+  RustFileScanSnapshot dco_decode_rust_file_scan_snapshot(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return RustFileScanSnapshot(
+      files: dco_decode_list_rust_file_scan_entry(arr[0]),
+    );
+  }
+
+  @protected
+  RustGpuSample dco_decode_rust_gpu_sample(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return RustGpuSample(
+      gpuPercent: dco_decode_f_64(arr[0]),
+      source: dco_decode_String(arr[1]),
+    );
+  }
+
+  @protected
+  RustNext2DanmakuItem dco_decode_rust_next_2_danmaku_item(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    return RustNext2DanmakuItem(
+      timeSeconds: dco_decode_f_64(arr[0]),
+      text: dco_decode_String(arr[1]),
+      typeCode: dco_decode_i_32(arr[2]),
+      colorArgb: dco_decode_i_32(arr[3]),
+      isMe: dco_decode_bool(arr[4]),
+    );
+  }
+
+  @protected
+  RustNext2FrameItem dco_decode_rust_next_2_frame_item(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 10)
+      throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+    return RustNext2FrameItem(
+      timeSeconds: dco_decode_f_64(arr[0]),
+      text: dco_decode_String(arr[1]),
+      typeCode: dco_decode_i_32(arr[2]),
+      colorArgb: dco_decode_i_32(arr[3]),
+      isMe: dco_decode_bool(arr[4]),
+      fontSizeMultiplier: dco_decode_f_64(arr[5]),
+      countText: dco_decode_opt_String(arr[6]),
+      x: dco_decode_f_64(arr[7]),
+      y: dco_decode_f_64(arr[8]),
+      offstageX: dco_decode_f_64(arr[9]),
+    );
+  }
+
+  @protected
+  RustNext2FrameLayout dco_decode_rust_next_2_frame_layout(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return RustNext2FrameLayout(
+      items: dco_decode_list_rust_next_2_frame_item(arr[0]),
+    );
+  }
+
+  @protected
+  RustNext2FrameRequest dco_decode_rust_next_2_frame_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return RustNext2FrameRequest(
+      layout: dco_decode_rust_next_2_prepared_layout(arr[0]),
+      currentTimeSeconds: dco_decode_f_64(arr[1]),
+    );
+  }
+
+  @protected
+  RustNext2PrepareRequest dco_decode_rust_next_2_prepare_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 10)
+      throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+    return RustNext2PrepareRequest(
+      items: dco_decode_list_rust_next_2_danmaku_item(arr[0]),
+      width: dco_decode_f_64(arr[1]),
+      height: dco_decode_f_64(arr[2]),
+      fontSize: dco_decode_f_64(arr[3]),
+      displayArea: dco_decode_f_64(arr[4]),
+      scrollDurationSeconds: dco_decode_f_64(arr[5]),
+      allowStacking: dco_decode_bool(arr[6]),
+      mergeDanmaku: dco_decode_bool(arr[7]),
+      customFontFamily: dco_decode_String(arr[8]),
+      customFontFilePath: dco_decode_String(arr[9]),
+    );
+  }
+
+  @protected
+  RustNext2PreparedItem dco_decode_rust_next_2_prepared_item(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 11)
+      throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
+    return RustNext2PreparedItem(
+      timeSeconds: dco_decode_f_64(arr[0]),
+      text: dco_decode_String(arr[1]),
+      typeCode: dco_decode_i_32(arr[2]),
+      colorArgb: dco_decode_i_32(arr[3]),
+      isMe: dco_decode_bool(arr[4]),
+      fontSizeMultiplier: dco_decode_f_64(arr[5]),
+      countText: dco_decode_opt_String(arr[6]),
+      trackIndex: dco_decode_i_32(arr[7]),
+      yPosition: dco_decode_f_64(arr[8]),
+      width: dco_decode_f_64(arr[9]),
+      scrollSpeed: dco_decode_f_64(arr[10]),
+    );
+  }
+
+  @protected
+  RustNext2PreparedLayout dco_decode_rust_next_2_prepared_layout(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    return RustNext2PreparedLayout(
+      width: dco_decode_f_64(arr[0]),
+      height: dco_decode_f_64(arr[1]),
+      scrollDurationSeconds: dco_decode_f_64(arr[2]),
+      staticDurationSeconds: dco_decode_f_64(arr[3]),
+      items: dco_decode_list_rust_next_2_prepared_item(arr[4]),
+      itemTimes: dco_decode_list_prim_f_64_strict(arr[5]),
+      trackCount: dco_decode_i_32(arr[6]),
+    );
+  }
+
+  @protected
+  RustPerformanceSample dco_decode_rust_performance_sample(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 6)
+      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    return RustPerformanceSample(
+      cpuProcessPercent: dco_decode_opt_box_autoadd_f_64(arr[0]),
+      memoryRssMb: dco_decode_opt_box_autoadd_f_64(arr[1]),
+      gpuPercent: dco_decode_opt_box_autoadd_f_64(arr[2]),
+      source: dco_decode_String(arr[3]),
+      timestampMs: dco_decode_i_64(arr[4]),
+      note: dco_decode_opt_String(arr[5]),
+    );
+  }
+
+  @protected
+  int dco_decode_u_8(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as int;
+  }
+
+  @protected
+  void dco_decode_unit(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return;
+  }
+
+  @protected
+  String sse_decode_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_list_prim_u_8_strict(deserializer);
+    return utf8.decoder.convert(inner);
+  }
+
+  @protected
+  bool sse_decode_bool(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getUint8() != 0;
+  }
+
+  @protected
+  double sse_decode_box_autoadd_f_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_f_64(deserializer));
+  }
+
+  @protected
+  RustNext2FrameRequest sse_decode_box_autoadd_rust_next_2_frame_request(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_rust_next_2_frame_request(deserializer));
+  }
+
+  @protected
+  RustNext2PrepareRequest sse_decode_box_autoadd_rust_next_2_prepare_request(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_rust_next_2_prepare_request(deserializer));
+  }
+
+  @protected
+  double sse_decode_f_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getFloat64();
+  }
+
+  @protected
+  int sse_decode_i_32(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getInt32();
+  }
+
+  @protected
+  PlatformInt64 sse_decode_i_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getPlatformInt64();
+  }
+
+  @protected
+  List<String> sse_decode_list_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <String>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_String(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  Float64List sse_decode_list_prim_f_64_strict(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var len_ = sse_decode_i_32(deserializer);
+    return deserializer.buffer.getFloat64List(len_);
+  }
+
+  @protected
+  Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var len_ = sse_decode_i_32(deserializer);
+    return deserializer.buffer.getUint8List(len_);
+  }
+
+  @protected
+  List<RustFileHashEntry> sse_decode_list_rust_file_hash_entry(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <RustFileHashEntry>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_rust_file_hash_entry(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<RustFileScanEntry> sse_decode_list_rust_file_scan_entry(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <RustFileScanEntry>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_rust_file_scan_entry(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<RustNext2DanmakuItem> sse_decode_list_rust_next_2_danmaku_item(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <RustNext2DanmakuItem>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_rust_next_2_danmaku_item(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<RustNext2FrameItem> sse_decode_list_rust_next_2_frame_item(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <RustNext2FrameItem>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_rust_next_2_frame_item(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<RustNext2PreparedItem> sse_decode_list_rust_next_2_prepared_item(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <RustNext2PreparedItem>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_rust_next_2_prepared_item(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_String(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  double? sse_decode_opt_box_autoadd_f_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_f_64(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  RustCpuSample sse_decode_rust_cpu_sample(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_processCpuMicros = sse_decode_i_64(deserializer);
+    var var_timestampMs = sse_decode_i_64(deserializer);
+    var var_logicalCpus = sse_decode_i_32(deserializer);
+    return RustCpuSample(
+        processCpuMicros: var_processCpuMicros,
+        timestampMs: var_timestampMs,
+        logicalCpus: var_logicalCpus);
+  }
+
+  @protected
+  RustFileHashEntry sse_decode_rust_file_hash_entry(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_relativePath = sse_decode_String(deserializer);
+    var var_hash = sse_decode_String(deserializer);
+    return RustFileHashEntry(relativePath: var_relativePath, hash: var_hash);
+  }
+
+  @protected
+  RustFileScanDiff sse_decode_rust_file_scan_diff(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_currentCount = sse_decode_i_32(deserializer);
+    var var_cachedCount = sse_decode_i_32(deserializer);
+    var var_currentFiles = sse_decode_list_String(deserializer);
+    var var_newFiles = sse_decode_list_String(deserializer);
+    var var_modifiedFiles = sse_decode_list_String(deserializer);
+    var var_deletedFiles = sse_decode_list_String(deserializer);
+    var var_currentHashes = sse_decode_list_rust_file_hash_entry(deserializer);
+    return RustFileScanDiff(
+        currentCount: var_currentCount,
+        cachedCount: var_cachedCount,
+        currentFiles: var_currentFiles,
+        newFiles: var_newFiles,
+        modifiedFiles: var_modifiedFiles,
+        deletedFiles: var_deletedFiles,
+        currentHashes: var_currentHashes);
+  }
+
+  @protected
+  RustFileScanEntry sse_decode_rust_file_scan_entry(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_relativePath = sse_decode_String(deserializer);
+    var var_absolutePath = sse_decode_String(deserializer);
+    var var_size = sse_decode_i_64(deserializer);
+    var var_modifiedMillis = sse_decode_i_64(deserializer);
+    var var_fileHash = sse_decode_String(deserializer);
+    return RustFileScanEntry(
+        relativePath: var_relativePath,
+        absolutePath: var_absolutePath,
+        size: var_size,
+        modifiedMillis: var_modifiedMillis,
+        fileHash: var_fileHash);
+  }
+
+  @protected
+  RustFileScanSnapshot sse_decode_rust_file_scan_snapshot(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_files = sse_decode_list_rust_file_scan_entry(deserializer);
+    return RustFileScanSnapshot(files: var_files);
+  }
+
+  @protected
+  RustGpuSample sse_decode_rust_gpu_sample(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_gpuPercent = sse_decode_f_64(deserializer);
+    var var_source = sse_decode_String(deserializer);
+    return RustGpuSample(gpuPercent: var_gpuPercent, source: var_source);
+  }
+
+  @protected
+  RustNext2DanmakuItem sse_decode_rust_next_2_danmaku_item(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_timeSeconds = sse_decode_f_64(deserializer);
+    var var_text = sse_decode_String(deserializer);
+    var var_typeCode = sse_decode_i_32(deserializer);
+    var var_colorArgb = sse_decode_i_32(deserializer);
+    var var_isMe = sse_decode_bool(deserializer);
+    return RustNext2DanmakuItem(
+        timeSeconds: var_timeSeconds,
+        text: var_text,
+        typeCode: var_typeCode,
+        colorArgb: var_colorArgb,
+        isMe: var_isMe);
+  }
+
+  @protected
+  RustNext2FrameItem sse_decode_rust_next_2_frame_item(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_timeSeconds = sse_decode_f_64(deserializer);
+    var var_text = sse_decode_String(deserializer);
+    var var_typeCode = sse_decode_i_32(deserializer);
+    var var_colorArgb = sse_decode_i_32(deserializer);
+    var var_isMe = sse_decode_bool(deserializer);
+    var var_fontSizeMultiplier = sse_decode_f_64(deserializer);
+    var var_countText = sse_decode_opt_String(deserializer);
+    var var_x = sse_decode_f_64(deserializer);
+    var var_y = sse_decode_f_64(deserializer);
+    var var_offstageX = sse_decode_f_64(deserializer);
+    return RustNext2FrameItem(
+        timeSeconds: var_timeSeconds,
+        text: var_text,
+        typeCode: var_typeCode,
+        colorArgb: var_colorArgb,
+        isMe: var_isMe,
+        fontSizeMultiplier: var_fontSizeMultiplier,
+        countText: var_countText,
+        x: var_x,
+        y: var_y,
+        offstageX: var_offstageX);
+  }
+
+  @protected
+  RustNext2FrameLayout sse_decode_rust_next_2_frame_layout(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_items = sse_decode_list_rust_next_2_frame_item(deserializer);
+    return RustNext2FrameLayout(items: var_items);
+  }
+
+  @protected
+  RustNext2FrameRequest sse_decode_rust_next_2_frame_request(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_layout = sse_decode_rust_next_2_prepared_layout(deserializer);
+    var var_currentTimeSeconds = sse_decode_f_64(deserializer);
+    return RustNext2FrameRequest(
+        layout: var_layout, currentTimeSeconds: var_currentTimeSeconds);
+  }
+
+  @protected
+  RustNext2PrepareRequest sse_decode_rust_next_2_prepare_request(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_items = sse_decode_list_rust_next_2_danmaku_item(deserializer);
+    var var_width = sse_decode_f_64(deserializer);
+    var var_height = sse_decode_f_64(deserializer);
+    var var_fontSize = sse_decode_f_64(deserializer);
+    var var_displayArea = sse_decode_f_64(deserializer);
+    var var_scrollDurationSeconds = sse_decode_f_64(deserializer);
+    var var_allowStacking = sse_decode_bool(deserializer);
+    var var_mergeDanmaku = sse_decode_bool(deserializer);
+    var var_customFontFamily = sse_decode_String(deserializer);
+    var var_customFontFilePath = sse_decode_String(deserializer);
+    return RustNext2PrepareRequest(
+        items: var_items,
+        width: var_width,
+        height: var_height,
+        fontSize: var_fontSize,
+        displayArea: var_displayArea,
+        scrollDurationSeconds: var_scrollDurationSeconds,
+        allowStacking: var_allowStacking,
+        mergeDanmaku: var_mergeDanmaku,
+        customFontFamily: var_customFontFamily,
+        customFontFilePath: var_customFontFilePath);
+  }
+
+  @protected
+  RustNext2PreparedItem sse_decode_rust_next_2_prepared_item(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_timeSeconds = sse_decode_f_64(deserializer);
+    var var_text = sse_decode_String(deserializer);
+    var var_typeCode = sse_decode_i_32(deserializer);
+    var var_colorArgb = sse_decode_i_32(deserializer);
+    var var_isMe = sse_decode_bool(deserializer);
+    var var_fontSizeMultiplier = sse_decode_f_64(deserializer);
+    var var_countText = sse_decode_opt_String(deserializer);
+    var var_trackIndex = sse_decode_i_32(deserializer);
+    var var_yPosition = sse_decode_f_64(deserializer);
+    var var_width = sse_decode_f_64(deserializer);
+    var var_scrollSpeed = sse_decode_f_64(deserializer);
+    return RustNext2PreparedItem(
+        timeSeconds: var_timeSeconds,
+        text: var_text,
+        typeCode: var_typeCode,
+        colorArgb: var_colorArgb,
+        isMe: var_isMe,
+        fontSizeMultiplier: var_fontSizeMultiplier,
+        countText: var_countText,
+        trackIndex: var_trackIndex,
+        yPosition: var_yPosition,
+        width: var_width,
+        scrollSpeed: var_scrollSpeed);
+  }
+
+  @protected
+  RustNext2PreparedLayout sse_decode_rust_next_2_prepared_layout(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_width = sse_decode_f_64(deserializer);
+    var var_height = sse_decode_f_64(deserializer);
+    var var_scrollDurationSeconds = sse_decode_f_64(deserializer);
+    var var_staticDurationSeconds = sse_decode_f_64(deserializer);
+    var var_items = sse_decode_list_rust_next_2_prepared_item(deserializer);
+    var var_itemTimes = sse_decode_list_prim_f_64_strict(deserializer);
+    var var_trackCount = sse_decode_i_32(deserializer);
+    return RustNext2PreparedLayout(
+        width: var_width,
+        height: var_height,
+        scrollDurationSeconds: var_scrollDurationSeconds,
+        staticDurationSeconds: var_staticDurationSeconds,
+        items: var_items,
+        itemTimes: var_itemTimes,
+        trackCount: var_trackCount);
+  }
+
+  @protected
+  RustPerformanceSample sse_decode_rust_performance_sample(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_cpuProcessPercent = sse_decode_opt_box_autoadd_f_64(deserializer);
+    var var_memoryRssMb = sse_decode_opt_box_autoadd_f_64(deserializer);
+    var var_gpuPercent = sse_decode_opt_box_autoadd_f_64(deserializer);
+    var var_source = sse_decode_String(deserializer);
+    var var_timestampMs = sse_decode_i_64(deserializer);
+    var var_note = sse_decode_opt_String(deserializer);
+    return RustPerformanceSample(
+        cpuProcessPercent: var_cpuProcessPercent,
+        memoryRssMb: var_memoryRssMb,
+        gpuPercent: var_gpuPercent,
+        source: var_source,
+        timestampMs: var_timestampMs,
+        note: var_note);
+  }
+
+  @protected
+  int sse_decode_u_8(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getUint8();
+  }
+
+  @protected
+  void sse_decode_unit(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+  }
+
+  @protected
+  void sse_encode_String(String self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer);
+  }
+
+  @protected
+  void sse_encode_bool(bool self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putUint8(self ? 1 : 0);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_f_64(double self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_f_64(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_rust_next_2_frame_request(
+      RustNext2FrameRequest self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_rust_next_2_frame_request(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_rust_next_2_prepare_request(
+      RustNext2PrepareRequest self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_rust_next_2_prepare_request(self, serializer);
+  }
+
+  @protected
+  void sse_encode_f_64(double self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putFloat64(self);
+  }
+
+  @protected
+  void sse_encode_i_32(int self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putInt32(self);
+  }
+
+  @protected
+  void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putPlatformInt64(self);
+  }
+
+  @protected
+  void sse_encode_list_String(List<String> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_String(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_prim_f_64_strict(
+      Float64List self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    serializer.buffer.putFloat64List(self);
+  }
+
+  @protected
+  void sse_encode_list_prim_u_8_strict(
+      Uint8List self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    serializer.buffer.putUint8List(self);
+  }
+
+  @protected
+  void sse_encode_list_rust_file_hash_entry(
+      List<RustFileHashEntry> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_rust_file_hash_entry(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_rust_file_scan_entry(
+      List<RustFileScanEntry> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_rust_file_scan_entry(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_rust_next_2_danmaku_item(
+      List<RustNext2DanmakuItem> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_rust_next_2_danmaku_item(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_rust_next_2_frame_item(
+      List<RustNext2FrameItem> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_rust_next_2_frame_item(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_rust_next_2_prepared_item(
+      List<RustNext2PreparedItem> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_rust_next_2_prepared_item(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_String(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_f_64(double? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_f_64(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_rust_cpu_sample(
+      RustCpuSample self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_64(self.processCpuMicros, serializer);
+    sse_encode_i_64(self.timestampMs, serializer);
+    sse_encode_i_32(self.logicalCpus, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_file_hash_entry(
+      RustFileHashEntry self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.relativePath, serializer);
+    sse_encode_String(self.hash, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_file_scan_diff(
+      RustFileScanDiff self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.currentCount, serializer);
+    sse_encode_i_32(self.cachedCount, serializer);
+    sse_encode_list_String(self.currentFiles, serializer);
+    sse_encode_list_String(self.newFiles, serializer);
+    sse_encode_list_String(self.modifiedFiles, serializer);
+    sse_encode_list_String(self.deletedFiles, serializer);
+    sse_encode_list_rust_file_hash_entry(self.currentHashes, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_file_scan_entry(
+      RustFileScanEntry self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.relativePath, serializer);
+    sse_encode_String(self.absolutePath, serializer);
+    sse_encode_i_64(self.size, serializer);
+    sse_encode_i_64(self.modifiedMillis, serializer);
+    sse_encode_String(self.fileHash, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_file_scan_snapshot(
+      RustFileScanSnapshot self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_rust_file_scan_entry(self.files, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_gpu_sample(
+      RustGpuSample self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_f_64(self.gpuPercent, serializer);
+    sse_encode_String(self.source, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_next_2_danmaku_item(
+      RustNext2DanmakuItem self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_f_64(self.timeSeconds, serializer);
+    sse_encode_String(self.text, serializer);
+    sse_encode_i_32(self.typeCode, serializer);
+    sse_encode_i_32(self.colorArgb, serializer);
+    sse_encode_bool(self.isMe, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_next_2_frame_item(
+      RustNext2FrameItem self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_f_64(self.timeSeconds, serializer);
+    sse_encode_String(self.text, serializer);
+    sse_encode_i_32(self.typeCode, serializer);
+    sse_encode_i_32(self.colorArgb, serializer);
+    sse_encode_bool(self.isMe, serializer);
+    sse_encode_f_64(self.fontSizeMultiplier, serializer);
+    sse_encode_opt_String(self.countText, serializer);
+    sse_encode_f_64(self.x, serializer);
+    sse_encode_f_64(self.y, serializer);
+    sse_encode_f_64(self.offstageX, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_next_2_frame_layout(
+      RustNext2FrameLayout self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_rust_next_2_frame_item(self.items, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_next_2_frame_request(
+      RustNext2FrameRequest self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_rust_next_2_prepared_layout(self.layout, serializer);
+    sse_encode_f_64(self.currentTimeSeconds, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_next_2_prepare_request(
+      RustNext2PrepareRequest self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_rust_next_2_danmaku_item(self.items, serializer);
+    sse_encode_f_64(self.width, serializer);
+    sse_encode_f_64(self.height, serializer);
+    sse_encode_f_64(self.fontSize, serializer);
+    sse_encode_f_64(self.displayArea, serializer);
+    sse_encode_f_64(self.scrollDurationSeconds, serializer);
+    sse_encode_bool(self.allowStacking, serializer);
+    sse_encode_bool(self.mergeDanmaku, serializer);
+    sse_encode_String(self.customFontFamily, serializer);
+    sse_encode_String(self.customFontFilePath, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_next_2_prepared_item(
+      RustNext2PreparedItem self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_f_64(self.timeSeconds, serializer);
+    sse_encode_String(self.text, serializer);
+    sse_encode_i_32(self.typeCode, serializer);
+    sse_encode_i_32(self.colorArgb, serializer);
+    sse_encode_bool(self.isMe, serializer);
+    sse_encode_f_64(self.fontSizeMultiplier, serializer);
+    sse_encode_opt_String(self.countText, serializer);
+    sse_encode_i_32(self.trackIndex, serializer);
+    sse_encode_f_64(self.yPosition, serializer);
+    sse_encode_f_64(self.width, serializer);
+    sse_encode_f_64(self.scrollSpeed, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_next_2_prepared_layout(
+      RustNext2PreparedLayout self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_f_64(self.width, serializer);
+    sse_encode_f_64(self.height, serializer);
+    sse_encode_f_64(self.scrollDurationSeconds, serializer);
+    sse_encode_f_64(self.staticDurationSeconds, serializer);
+    sse_encode_list_rust_next_2_prepared_item(self.items, serializer);
+    sse_encode_list_prim_f_64_strict(self.itemTimes, serializer);
+    sse_encode_i_32(self.trackCount, serializer);
+  }
+
+  @protected
+  void sse_encode_rust_performance_sample(
+      RustPerformanceSample self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_opt_box_autoadd_f_64(self.cpuProcessPercent, serializer);
+    sse_encode_opt_box_autoadd_f_64(self.memoryRssMb, serializer);
+    sse_encode_opt_box_autoadd_f_64(self.gpuPercent, serializer);
+    sse_encode_String(self.source, serializer);
+    sse_encode_i_64(self.timestampMs, serializer);
+    sse_encode_opt_String(self.note, serializer);
+  }
+
+  @protected
+  void sse_encode_u_8(int self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putUint8(self);
+  }
+
+  @protected
+  void sse_encode_unit(void self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+  }
+}

--- a/lib/widgets/danmaku_overlay.dart
+++ b/lib/widgets/danmaku_overlay.dart
@@ -156,6 +156,7 @@ class _DanmakuOverlayState extends State<DanmakuOverlay> {
             allowStacking: videoState.danmakuStacking,
             mergeDanmaku: widget.isVisible && videoState.mergeDanmaku,
             customFontFamily: videoState.danmakuFontFamily,
+            customFontFilePath: videoState.danmakuFontFilePath,
             outlineWidth: videoState.next2DanmakuOutlineWidth,
             shadowStyle: videoState.danmakuShadowStyle,
           );

--- a/rust/src/api/next2.rs
+++ b/rust/src/api/next2.rs
@@ -25,6 +25,8 @@ pub struct RustNext2PrepareRequest {
     pub scroll_duration_seconds: f64,
     pub allow_stacking: bool,
     pub merge_danmaku: bool,
+    pub custom_font_family: String,
+    pub custom_font_file_path: String,
 }
 
 pub struct RustNext2PreparedLayout {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -1087,6 +1087,8 @@ impl SseDecode for crate::api::next2::RustNext2PrepareRequest {
         let mut var_scrollDurationSeconds = <f64>::sse_decode(deserializer);
         let mut var_allowStacking = <bool>::sse_decode(deserializer);
         let mut var_mergeDanmaku = <bool>::sse_decode(deserializer);
+        let mut var_customFontFamily = <String>::sse_decode(deserializer);
+        let mut var_customFontFilePath = <String>::sse_decode(deserializer);
         return crate::api::next2::RustNext2PrepareRequest {
             items: var_items,
             width: var_width,
@@ -1096,6 +1098,8 @@ impl SseDecode for crate::api::next2::RustNext2PrepareRequest {
             scroll_duration_seconds: var_scrollDurationSeconds,
             allow_stacking: var_allowStacking,
             merge_danmaku: var_mergeDanmaku,
+            custom_font_family: var_customFontFamily,
+            custom_font_file_path: var_customFontFilePath,
         };
     }
 }
@@ -1839,6 +1843,8 @@ impl SseEncode for crate::api::next2::RustNext2PrepareRequest {
         <f64>::sse_encode(self.scroll_duration_seconds, serializer);
         <bool>::sse_encode(self.allow_stacking, serializer);
         <bool>::sse_encode(self.merge_danmaku, serializer);
+        <String>::sse_encode(self.custom_font_family, serializer);
+        <String>::sse_encode(self.custom_font_file_path, serializer);
     }
 }
 

--- a/rust/src/next2_android_jni.rs
+++ b/rust/src/next2_android_jni.rs
@@ -114,6 +114,8 @@ pub extern "system" fn Java_com_flutter_1rust_1bridge_rust_1lib_1nipaplay_RustLi
             outline_width,
             shadow_style as u8,
             opacity,
+            std::ptr::null(),
+            std::ptr::null(),
         ) as jint;
         release_string_utf_chars(env, frame_json, c_str_ptr);
         ok

--- a/rust/src/next2_engine/engine/renderer_core.rs
+++ b/rust/src/next2_engine/engine/renderer_core.rs
@@ -100,8 +100,13 @@ impl Next2Renderer {
         })
     }
 
-    fn new(ctx: Arc<EngineDeviceContext>, width: u32, height: u32) -> Result<Self, String> {
-        let atlas = Next2GlyphAtlas::new(ctx.device.as_ref())?;
+    fn new(
+        ctx: Arc<EngineDeviceContext>,
+        width: u32,
+        height: u32,
+        custom_font: Option<FontSource>,
+    ) -> Result<Self, String> {
+        let atlas = Next2GlyphAtlas::new(ctx.device.as_ref(), custom_font)?;
 
         let atlas_bind_group_layout =
             ctx.device
@@ -359,11 +364,20 @@ impl Next2Renderer {
         self.emoji_atlas.clear();
     }
 
-    fn update_frame(&mut self, input: RenderFrameInput) -> bool {
+    fn update_frame(&mut self, input: RenderFrameInput, custom_font: Option<FontSource>) -> bool {
         let parsed = match serde_json::from_str::<FramePayload>(&input.frame_json) {
             Ok(parsed) => parsed,
             Err(_) => return false,
         };
+
+        let font_key = custom_font_key(custom_font.as_ref());
+        if self.atlas.font_key != font_key {
+            let Ok(atlas) = Next2GlyphAtlas::new(self.ctx.device.as_ref(), custom_font) else {
+                return false;
+            };
+            self.atlas = atlas;
+            self.rebuild_atlas_bind_group();
+        }
 
         let emoji_rasters = decode_emoji_rasters(parsed.emoji_glyphs.as_deref().unwrap_or(&[]));
         if !emoji_rasters.is_empty() {
@@ -399,6 +413,42 @@ impl Next2Renderer {
         }
 
         true
+    }
+
+    fn rebuild_atlas_bind_group(&mut self) {
+        self.atlas_bind_group = self
+            .ctx
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("next2 atlas bg"),
+                layout: &self.atlas_bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&self.atlas.texture_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&self.atlas.sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::TextureView(
+                            &self.emoji_atlas.color_texture_view,
+                        ),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 3,
+                        resource: wgpu::BindingResource::TextureView(
+                            &self.emoji_atlas.mask_texture_view,
+                        ),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 4,
+                        resource: wgpu::BindingResource::Sampler(&self.emoji_atlas.sampler),
+                    },
+                ],
+            });
     }
 
     fn draw_to_present(&mut self, present: &mut PresentTarget) {

--- a/rust/src/next2_engine/engine/rendering.rs
+++ b/rust/src/next2_engine/engine/rendering.rs
@@ -344,6 +344,7 @@ impl Next2EmojiAtlas {
 }
 
 struct Next2GlyphAtlas {
+    font_key: String,
     fonts: Vec<FontFaceHandle>,
     texture: wgpu::Texture,
     texture_view: wgpu::TextureView,
@@ -358,8 +359,9 @@ struct Next2GlyphAtlas {
 }
 
 impl Next2GlyphAtlas {
-    fn new(device: &wgpu::Device) -> Result<Self, String> {
-        let fonts = load_font_chain()?;
+    fn new(device: &wgpu::Device, custom_font: Option<FontSource>) -> Result<Self, String> {
+        let font_key = custom_font_key(custom_font.as_ref());
+        let fonts = load_font_chain(custom_font)?;
 
         let texture = device.create_texture(&wgpu::TextureDescriptor {
             label: Some("next2 msdf atlas"),
@@ -388,6 +390,7 @@ impl Next2GlyphAtlas {
         });
 
         Ok(Self {
+            font_key,
             fonts,
             texture,
             texture_view,
@@ -407,6 +410,7 @@ impl Next2GlyphAtlas {
         self.cursor_y = 0;
         self.row_height = 0;
         self.entries.clear();
+        self.line_ascent_cache.clear();
     }
 
     fn line_ascent(&mut self, quantized_size: u32) -> f32 {
@@ -604,9 +608,14 @@ fn hash_font_bytes(bytes: &[u8], collection_index: u32) -> u64 {
     hasher.finish()
 }
 
-fn load_font_chain() -> Result<Vec<FontFaceHandle>, String> {
+fn load_font_chain(custom_font: Option<FontSource>) -> Result<Vec<FontFaceHandle>, String> {
     let mut fonts = Vec::new();
     let mut seen = HashSet::new();
+
+    if let Some(custom_font) = custom_font {
+        let boxed = custom_font.bytes;
+        let _ = load_faces_from_owned_bytes(boxed, &mut seen, &mut fonts)?;
+    }
 
     let primary_bytes = FONT_DATA.to_vec().into_boxed_slice();
     load_faces_from_owned_bytes(primary_bytes, &mut seen, &mut fonts)?;
@@ -620,6 +629,18 @@ fn load_font_chain() -> Result<Vec<FontFaceHandle>, String> {
         return Err("next2: no usable font faces loaded".to_string());
     }
     Ok(fonts)
+}
+
+fn custom_font_key(custom_font: Option<&FontSource>) -> String {
+    match custom_font {
+        Some(font) => {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            font.family.hash(&mut hasher);
+            font.bytes.hash(&mut hasher);
+            format!("{}:{:x}", font.family, hasher.finish())
+        }
+        None => String::new(),
+    }
 }
 
 fn load_faces_from_owned_bytes(
@@ -773,4 +794,3 @@ struct Next2Renderer {
     #[cfg(target_os = "android")]
     surface_screen_pipeline: Option<wgpu::RenderPipeline>,
 }
-

--- a/rust/src/next2_engine/engine/runtime.rs
+++ b/rust/src/next2_engine/engine/runtime.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
+use std::fs;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex, OnceLock};
@@ -66,6 +67,8 @@ pub struct RenderFrameInput {
     pub outline_width: f32,
     pub shadow_style: u8,
     pub opacity: f32,
+    pub custom_font_family: String,
+    pub custom_font_file_path: String,
 }
 
 pub struct Next2ReadbackFrame {
@@ -101,6 +104,12 @@ pub struct EngineEntry {
     pub cmd_tx: mpsc::Sender<EngineCommand>,
     pub frame_ready: Arc<AtomicBool>,
     pub mtl_device_ptr: usize,
+}
+
+#[derive(Clone)]
+pub struct FontSource {
+    pub family: String,
+    pub bytes: Box<[u8]>,
 }
 
 struct EngineRegistry {
@@ -331,7 +340,7 @@ fn run_engine_loop(
     frame_ready: Arc<AtomicBool>,
     cmd_rx: mpsc::Receiver<EngineCommand>,
 ) {
-    let mut renderer = match Next2Renderer::new(Arc::clone(&ctx), width, height) {
+    let mut renderer = match Next2Renderer::new(Arc::clone(&ctx), width, height, None) {
         Ok(renderer) => renderer,
         Err(_) => return,
     };
@@ -432,7 +441,13 @@ fn run_engine_loop(
                     has_pending_frame = true;
                 }
                 EngineCommand::SetFrame { input, reply } => {
-                    let ok = renderer.update_frame(input);
+                    let font_source = load_custom_font_source(
+                        input.custom_font_family.as_str(),
+                        input.custom_font_file_path.as_str(),
+                    )
+                    .ok()
+                    .flatten();
+                    let ok = renderer.update_frame(input, font_source);
                     let _ = reply.send(ok);
                     if ok {
                         has_pending_frame = true;
@@ -462,4 +477,23 @@ fn run_engine_loop(
             has_pending_frame = false;
         }
     }
+}
+
+fn load_custom_font_source(family: &str, file_path: &str) -> Result<Option<FontSource>, String> {
+    let family = family.trim();
+    let file_path = file_path.trim();
+    if family.is_empty() || file_path.is_empty() {
+        return Ok(None);
+    }
+
+    let bytes = fs::read(file_path)
+        .map_err(|err| format!("next2: failed to read custom font '{file_path}': {err}"))?;
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(FontSource {
+        family: family.to_string(),
+        bytes: bytes.into_boxed_slice(),
+    }))
 }

--- a/rust/src/next2_engine/ffi.rs
+++ b/rust/src/next2_engine/ffi.rs
@@ -115,6 +115,8 @@ pub extern "C" fn next2_engine_set_frame(
     outline_width: f32,
     shadow_style: u8,
     opacity: f32,
+    custom_font_family: *const c_char,
+    custom_font_file_path: *const c_char,
 ) -> u8 {
     let Some(entry) = lookup_engine(handle) else {
         return 0;
@@ -122,6 +124,9 @@ pub extern "C" fn next2_engine_set_frame(
     let Some(json) = parse_c_string(frame_json) else {
         return 0;
     };
+
+    let custom_font_family = parse_c_string(custom_font_family).unwrap_or_default();
+    let custom_font_file_path = parse_c_string(custom_font_file_path).unwrap_or_default();
 
     let (reply_tx, reply_rx) = mpsc::channel();
     if entry
@@ -133,6 +138,8 @@ pub extern "C" fn next2_engine_set_frame(
                 outline_width,
                 shadow_style,
                 opacity,
+                custom_font_family,
+                custom_font_file_path,
             },
             reply: reply_tx,
         })

--- a/rust_builder/ios/Classes/RustLibNipaplayPlugin.swift
+++ b/rust_builder/ios/Classes/RustLibNipaplayPlugin.swift
@@ -33,7 +33,9 @@ private func next2_engine_set_frame(
   _ fontSize: Float,
   _ outlineWidth: Float,
   _ shadowStyle: UInt8,
-  _ opacity: Float
+  _ opacity: Float,
+  _ customFontFamily: UnsafePointer<CChar>?,
+  _ customFontFilePath: UnsafePointer<CChar>?
 ) -> UInt8
 
 @_silgen_name("next2_engine_resize")
@@ -457,9 +459,15 @@ private final class Next2SurfaceState {
     let outlineWidth = (dict["outlineWidth"] as? NSNumber)?.floatValue ?? 1.0
     let shadowStyle = (dict["shadowStyle"] as? NSNumber)?.uint8Value ?? 1
     let opacity = (dict["opacity"] as? NSNumber)?.floatValue ?? 1.0
+    let customFontFamily = (dict["customFontFamily"] as? String) ?? ""
+    let customFontFilePath = (dict["customFontFilePath"] as? String) ?? ""
 
     let ok = frameJson.withCString { ptr in
-      next2_engine_set_frame(handle, ptr, fontSize, outlineWidth, shadowStyle, opacity) != 0
+      customFontFamily.withCString { familyPtr in
+        customFontFilePath.withCString { filePtr in
+          next2_engine_set_frame(handle, ptr, fontSize, outlineWidth, shadowStyle, opacity, familyPtr, filePtr) != 0
+        }
+      }
     }
     result(ok)
   }

--- a/rust_builder/linux/rust_lib_nipaplay_plugin.cc
+++ b/rust_builder/linux/rust_lib_nipaplay_plugin.cc
@@ -20,7 +20,9 @@ uint8_t next2_engine_set_frame(uint64_t handle,
                                float font_size,
                                float outline_width,
                                uint8_t shadow_style,
-                               float opacity);
+                               float opacity,
+                               const char* custom_font_family,
+                               const char* custom_font_file_path);
 uint8_t next2_engine_reset_scene(uint64_t handle);
 uint8_t next2_engine_copy_bgra_frame(uint64_t handle,
                                      uint8_t* out_pixels,
@@ -360,8 +362,19 @@ static void handle_method_call(RustLibNipaplayPlugin* self,
     const float outline_width = ReadFloat(args, "outlineWidth", 1.0f);
     const uint8_t shadow_style = ReadU8(args, "shadowStyle", 1);
     const float opacity = ReadFloat(args, "opacity", 1.0f);
+    FlValue* custom_font_family_v = fl_value_lookup_string(args, "customFontFamily");
+    FlValue* custom_font_file_path_v = fl_value_lookup_string(args, "customFontFilePath");
+    const char* custom_font_family =
+        custom_font_family_v != nullptr && fl_value_get_type(custom_font_family_v) == FL_VALUE_TYPE_STRING
+            ? fl_value_get_string(custom_font_family_v)
+            : "";
+    const char* custom_font_file_path =
+        custom_font_file_path_v != nullptr && fl_value_get_type(custom_font_file_path_v) == FL_VALUE_TYPE_STRING
+            ? fl_value_get_string(custom_font_file_path_v)
+            : "";
     const uint8_t ok = next2_engine_set_frame(handle, frame_json, font_size,
-                                              outline_width, shadow_style, opacity);
+                                              outline_width, shadow_style, opacity,
+                                              custom_font_family, custom_font_file_path);
     g_autoptr(FlMethodResponse) response = FL_METHOD_RESPONSE(
         fl_method_success_response_new(fl_value_new_bool(ok != 0)));
     fl_method_call_respond(method_call, response, nullptr);

--- a/rust_builder/macos/Classes/RustLibNipaplayPlugin.swift
+++ b/rust_builder/macos/Classes/RustLibNipaplayPlugin.swift
@@ -32,7 +32,9 @@ private func next2_engine_set_frame(
   _ fontSize: Float,
   _ outlineWidth: Float,
   _ shadowStyle: UInt8,
-  _ opacity: Float
+  _ opacity: Float,
+  _ customFontFamily: UnsafePointer<CChar>?,
+  _ customFontFilePath: UnsafePointer<CChar>?
 ) -> UInt8
 
 @_silgen_name("next2_engine_resize")
@@ -476,9 +478,15 @@ public final class RustLibNipaplayPlugin: NSObject, FlutterPlugin {
     let outlineWidth = (dict["outlineWidth"] as? NSNumber)?.floatValue ?? 1.0
     let shadowStyle = (dict["shadowStyle"] as? NSNumber)?.uint8Value ?? 1
     let opacity = (dict["opacity"] as? NSNumber)?.floatValue ?? 1.0
+    let customFontFamily = (dict["customFontFamily"] as? String) ?? ""
+    let customFontFilePath = (dict["customFontFilePath"] as? String) ?? ""
 
     let ok = frameJson.withCString { ptr in
-      next2_engine_set_frame(handle, ptr, fontSize, outlineWidth, shadowStyle, opacity) != 0
+      customFontFamily.withCString { familyPtr in
+        customFontFilePath.withCString { filePtr in
+          next2_engine_set_frame(handle, ptr, fontSize, outlineWidth, shadowStyle, opacity, familyPtr, filePtr) != 0
+        }
+      }
     }
     result(ok)
   }

--- a/rust_builder/windows/rust_lib_nipaplay_plugin.cpp
+++ b/rust_builder/windows/rust_lib_nipaplay_plugin.cpp
@@ -18,7 +18,9 @@ uint8_t next2_engine_set_frame(uint64_t handle,
                                float font_size,
                                float outline_width,
                                uint8_t shadow_style,
-                               float opacity);
+                               float opacity,
+                               const char* custom_font_family,
+                               const char* custom_font_file_path);
 uint8_t next2_engine_reset_scene(uint64_t handle);
 uint8_t next2_engine_copy_bgra_frame(uint64_t handle,
                                      uint8_t* out_pixels,
@@ -337,9 +339,13 @@ void RustLibNipaplayPlugin::HandleMethodCall(
     const float outline_width = ReadFloat(*args, "outlineWidth", 1.0f);
     const uint8_t shadow_style = ReadU8(*args, "shadowStyle", 1);
     const float opacity = ReadFloat(*args, "opacity", 1.0f);
+    const std::string custom_font_family = ReadString(*args, "customFontFamily");
+    const std::string custom_font_file_path = ReadString(*args, "customFontFilePath");
     const uint8_t ok = next2_engine_set_frame(handle, frame_json->c_str(),
                                               font_size, outline_width,
-                                              shadow_style, opacity);
+                                              shadow_style, opacity,
+                                              custom_font_family.c_str(),
+                                              custom_font_file_path.c_str());
     result->Success(flutter::EncodableValue(ok != 0));
     return;
   }


### PR DESCRIPTION
This fixes Next2 custom font import not taking effect.

Changes:
- pass imported font file path through the Flutter Next2 overlay and bridges
- extend FRB/Dart and Rust request structs to carry custom font metadata
- load the imported font into the Next2 glyph atlas on the Rust side before fallback fonts
- update macOS/iOS/Linux/Windows plugin bindings to forward the new arguments

Validation:
- fixed the generated Dart String codec name mismatch
- ran dart format on touched Dart files
- flutter analyze is noisy in this repo because of unrelated third-party/build issues