### PR TITLE
fix: tighten anime info title layout

### DIFF
--- a/lib/themes/nipaplay/widgets/anime_info_widget.dart
+++ b/lib/themes/nipaplay/widgets/anime_info_widget.dart
@@ -3,6 +3,7 @@ import 'package:nipaplay/utils/video_player_state.dart';
 import 'package:path/path.dart' as p;
 import 'control_shadow.dart';
 import 'dart:math' as math;
+import 'package:characters/characters.dart';
 // import 'package:nipaplay/utils/globals.dart' as globals; // globals is not used in this snippet
 
 class AnimeInfoWidget extends StatefulWidget {
@@ -20,6 +21,8 @@ class AnimeInfoWidget extends StatefulWidget {
 }
 
 class _AnimeInfoWidgetState extends State<AnimeInfoWidget> {
+  static const String _ellipsis = '...';
+
   String? _resolveTitle(String? value) {
     final trimmed = value?.trim() ?? '';
     return trimmed.isEmpty ? null : trimmed;
@@ -29,6 +32,57 @@ class _AnimeInfoWidgetState extends State<AnimeInfoWidget> {
     final trimmed = path?.trim() ?? '';
     if (trimmed.isEmpty) return null;
     return _resolveTitle(p.basenameWithoutExtension(trimmed));
+  }
+
+  double _measureTextWidth({
+    required BuildContext context,
+    required String text,
+    required TextStyle style,
+  }) {
+    if (text.isEmpty) return 0;
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: Directionality.of(context),
+      maxLines: 1,
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout(minWidth: 0, maxWidth: double.infinity);
+    return painter.width;
+  }
+
+  String _fitTextToWidth({
+    required BuildContext context,
+    required String text,
+    required TextStyle style,
+    required double maxWidth,
+  }) {
+    if (text.isEmpty || maxWidth <= 0) return '';
+    if (_measureTextWidth(context: context, text: text, style: style) <=
+        maxWidth) {
+      return text;
+    }
+
+    final ellipsisWidth =
+        _measureTextWidth(context: context, text: _ellipsis, style: style);
+    if (ellipsisWidth > maxWidth) {
+      return '';
+    }
+
+    final clusters = text.characters.toList(growable: false);
+    int left = 0;
+    int right = clusters.length;
+    while (left < right) {
+      final mid = (left + right + 1) >> 1;
+      final candidate = '${clusters.take(mid).join()}$_ellipsis';
+      if (_measureTextWidth(context: context, text: candidate, style: style) <=
+          maxWidth) {
+        left = mid;
+      } else {
+        right = mid - 1;
+      }
+    }
+
+    if (left <= 0) return _ellipsis;
+    return '${clusters.take(left).join()}$_ellipsis';
   }
 
   @override
@@ -51,6 +105,62 @@ class _AnimeInfoWidgetState extends State<AnimeInfoWidget> {
       return const SizedBox.shrink();
     }
 
+    const titleStyle = TextStyle(
+      color: Colors.white,
+      fontSize: 16,
+      fontWeight: FontWeight.bold,
+    );
+    const episodeStyle = TextStyle(
+      color: Colors.white,
+      fontSize: 14,
+    );
+
+    const titleGap = 8.0;
+    final hasEpisode = episodeTitle != null && episodeTitle != displayTitle;
+    String? episodeText;
+    double episodeWidth = 0;
+    const titleWidthCapFactor = 0.62;
+    const episodeWidthCapFactor = 0.34;
+    final hasEpisodeSpace = hasEpisode;
+
+    if (hasEpisodeSpace) {
+      final fittedEpisodeText = _fitTextToWidth(
+        context: context,
+        text: episodeTitle!,
+        style: episodeStyle,
+        maxWidth: maxInfoWidth * episodeWidthCapFactor,
+      );
+      if (fittedEpisodeText.isNotEmpty) {
+        episodeText = fittedEpisodeText;
+        episodeWidth = _measureTextWidth(
+          context: context,
+          text: fittedEpisodeText,
+          style: episodeStyle,
+        );
+      }
+    }
+
+    final titleMaxWidth = hasEpisodeSpace
+        ? math.max(
+            24.0,
+            math.min(
+              maxInfoWidth * titleWidthCapFactor,
+              maxInfoWidth - episodeWidth - titleGap,
+            ),
+          )
+        : maxInfoWidth;
+    final fittedTitleText = _fitTextToWidth(
+      context: context,
+      text: displayTitle,
+      style: titleStyle,
+      maxWidth: titleMaxWidth,
+    );
+    final titleWidth = _measureTextWidth(
+      context: context,
+      text: fittedTitleText,
+      style: titleStyle,
+    );
+
     return AnimatedSlide(
       duration: const Duration(milliseconds: 150),
       offset: Offset(widget.videoState.showControls ? 0 : -0.1, 0),
@@ -69,36 +179,37 @@ class _AnimeInfoWidgetState extends State<AnimeInfoWidget> {
               mainAxisSize: MainAxisSize.min,
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
-                Flexible(
-                  child: ControlTextShadow(
-                    child: Text(
-                      displayTitle,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontWeight: FontWeight.bold,
+                SizedBox(
+                  width: titleWidth,
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: ControlTextShadow(
+                      child: Text(
+                        fittedTitleText,
+                        style: titleStyle,
+                        maxLines: 1,
+                        softWrap: false,
+                        overflow: TextOverflow.visible,
                       ),
-                      maxLines: 1,
-                      softWrap: false,
-                      overflow: TextOverflow.ellipsis,
                     ),
                   ),
                 ),
-                if (episodeTitle != null && episodeTitle != displayTitle) ...[
-                  const SizedBox(width: 8),
-                  Flexible(
-                    child: AnimatedDefaultTextStyle(
-                      duration: const Duration(milliseconds: 200),
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 14,
-                      ),
-                      child: ControlTextShadow(
-                        child: Text(
-                          episodeTitle,
-                          maxLines: 1,
-                          softWrap: false,
-                          overflow: TextOverflow.ellipsis,
+                if (episodeText != null && episodeText.isNotEmpty) ...[
+                  const SizedBox(width: titleGap),
+                  SizedBox(
+                    width: episodeWidth,
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: AnimatedDefaultTextStyle(
+                        duration: const Duration(milliseconds: 200),
+                        style: episodeStyle,
+                        child: ControlTextShadow(
+                          child: Text(
+                            episodeText,
+                            maxLines: 1,
+                            softWrap: false,
+                            overflow: TextOverflow.visible,
+                          ),
                         ),
                       ),
                     ),

--- a/lib/themes/nipaplay/widgets/video_progress_bar.dart
+++ b/lib/themes/nipaplay/widgets/video_progress_bar.dart
@@ -68,8 +68,6 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
     final hasPreview = thumbnailPath != null &&
         thumbnailPath.isNotEmpty &&
         _isPreviewReady(thumbnailPath);
-    debugPrint(
-        'timeline preview overlay -> hasPreview=$hasPreview, thumb=$thumbnailPath');
     final previewWidth = globals.isPhone ? 140.0 : 200.0;
     final previewHeight = previewWidth * 9 / 16;
     final text =

--- a/test/anime_info_widget_test.dart
+++ b/test/anime_info_widget_test.dart
@@ -43,8 +43,8 @@ void main() {
       final videoState = _FakeVideoPlayerState(
         hasVideoValue: true,
         showControlsValue: true,
-        animeTitleValue: 'Sousou no Frieren',
-        episodeTitleValue: 'TV Special',
+        animeTitleValue: '关于邻家的天使大人不知不觉把我惯成了废人这档子事 第二季',
+        episodeTitleValue: '第4话',
       );
 
       await tester.pumpWidget(
@@ -62,8 +62,8 @@ void main() {
         ),
       );
 
-      expect(find.text('Sousou no Frieren'), findsOneWidget);
-      expect(find.text('TV Special'), findsOneWidget);
+      expect(find.textContaining('...'), findsOneWidget);
+      expect(find.text('第4话'), findsOneWidget);
       expect(find.byType(AnimatedSlide), findsOneWidget);
       expect(
         find.descendant(
@@ -73,6 +73,10 @@ void main() {
         findsNothing,
       );
       expect(find.byType(ControlTextShadow), findsNWidgets(2));
+
+      final titleRect = tester.getRect(find.textContaining('...'));
+      final episodeRect = tester.getRect(find.text('第4话'));
+      expect(episodeRect.left, greaterThan(titleRect.right));
     },
   );
 }


### PR DESCRIPTION
## Summary
- implement virtual truncation for anime info title text to preserve shadow rendering
- keep episode label positioned directly to the right of title with deterministic spacing
- add widget test coverage for truncation and title/episode ordering

## Testing
- flutter test test/anime_info_widget_test.dart