### PR TITLE
Add Nipaplay UI preview and reusable control guidance

### DIFF
--- a/lib/pages/anime_detail_page.dart
+++ b/lib/pages/anime_detail_page.dart
@@ -42,6 +42,8 @@ import 'package:nipaplay/themes/nipaplay/widgets/large_screen_window_page.dart';
 import 'package:nipaplay/services/web_remote_access_service.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/bangumi_comments_widget.dart';
+import 'package:nipaplay/pages/tab_labels.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_main_tab_bar.dart';
 
 enum _EpisodeCleanupAction {
   clearScanResults,
@@ -142,12 +144,9 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
   // 添加外观设置
   AppearanceSettingsProvider? _appearanceSettings;
   bool _isEpisodeListReversed = false;
-  bool _isSortButtonHovered = false;
-  bool _isCleanupButtonHovered = false;
   bool _isCleaningEpisodeHistory = false;
   int? _hoveredEpisodeTileId;
   int? _hoveredWatchToggleEpisodeId;
-  bool _isBangumiRatingButtonHovered = false;
   final FocusNode _largeScreenDetailsFocusNode = FocusNode(
     debugLabel: 'large_screen_anime_detail_content_focus',
   );
@@ -538,7 +537,8 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
   Future<void> _loadBangumiUserData(BangumiAnime anime) async {
     // 先提取Bangumi subject ID（评论功能不需要登录）
     final subjectId = _extractBangumiSubjectId(anime);
-    debugPrint('[番剧详情] Bangumi subjectId=$subjectId, bangumiUrl=${anime.bangumiUrl}');
+    debugPrint(
+        '[番剧详情] Bangumi subjectId=$subjectId, bangumiUrl=${anime.bangumiUrl}');
 
     if (subjectId == null) {
       if (mounted) {
@@ -666,8 +666,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
           _isLoadingBangumiCollection = false;
           if (_myCommentTimestamp == 0 &&
               (userRating > 0 || (comment != null && comment.isNotEmpty))) {
-            _myCommentTimestamp =
-                DateTime.now().millisecondsSinceEpoch ~/ 1000;
+            _myCommentTimestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
           }
         });
       } else {
@@ -852,8 +851,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
             if (ratingPayload != null) {
               _bangumiUserRating = ratingPayload;
             }
-            _myCommentTimestamp =
-                DateTime.now().millisecondsSinceEpoch ~/ 1000;
+            _myCommentTimestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
           });
         }
         if (episodeStatus != null) {
@@ -1167,140 +1165,148 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
         return false;
       },
       child: SingleChildScrollView(
-      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          if (anime.name != anime.nameCn)
-            Padding(
-                padding: const EdgeInsets.only(bottom: 8.0),
-                child: Text(anime.name,
-                    style: valueStyle.copyWith(
-                        fontSize: 14, fontStyle: FontStyle.italic))),
-          Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
-            if (anime.imageUrl.isNotEmpty)
+        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            if (anime.name != anime.nameCn)
               Padding(
-                  padding: const EdgeInsets.only(right: 16.0, bottom: 8.0),
-                  child: ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: CachedNetworkImageWidget(
-                          imageUrl: coverImageUrl, // 使用处理后的URL
-                          width: 130,
-                          height: 195,
-                          fit: BoxFit.cover,
-                          loadMode: CachedImageLoadMode
-                              .legacy))), // 番剧详情页面统一使用legacy模式，避免海报突然切换
-            Expanded(
-              child: SizedBox(
-                height: 195,
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.only(right: 8.0),
-                  child: Text(summaryText, style: valueStyle),
+                  padding: const EdgeInsets.only(bottom: 8.0),
+                  child: Text(anime.name,
+                      style: valueStyle.copyWith(
+                          fontSize: 14, fontStyle: FontStyle.italic))),
+            Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
+              if (anime.imageUrl.isNotEmpty)
+                Padding(
+                    padding: const EdgeInsets.only(right: 16.0, bottom: 8.0),
+                    child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: CachedNetworkImageWidget(
+                            imageUrl: coverImageUrl, // 使用处理后的URL
+                            width: 130,
+                            height: 195,
+                            fit: BoxFit.cover,
+                            loadMode: CachedImageLoadMode
+                                .legacy))), // 番剧详情页面统一使用legacy模式，避免海报突然切换
+              Expanded(
+                child: SizedBox(
+                  height: 195,
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.only(right: 8.0),
+                    child: Text(summaryText, style: valueStyle),
+                  ),
                 ),
               ),
-            ),
-          ]),
-          SizedBox(height: 16),
-          Divider(color: textColor.withOpacity(0.15)),
-          SizedBox(height: 8),
+            ]),
+            SizedBox(height: 16),
+            Divider(color: textColor.withOpacity(0.15)),
+            SizedBox(height: 8),
 
-          // 详情 / 评论 切换导航栏
-          AnimatedBuilder(
-            animation: _detailTabController!,
-            builder: (context, _) {
-              return Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  TabBar(
-                    controller: _detailTabController,
-                    labelColor: AppAccentColors.current,
-                    unselectedLabelColor: secondaryTextColor,
-                    indicatorColor: AppAccentColors.current,
-                    labelStyle: const TextStyle(
-                        fontWeight: FontWeight.w600, fontSize: 14),
-                    unselectedLabelStyle: const TextStyle(fontSize: 14),
-                    tabAlignment: TabAlignment.start,
-                    isScrollable: true,
-                    dividerHeight: 0,
-                    tabs: const [
-                      Tab(text: '详情'),
-                      Tab(text: '评论'),
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-                  if (_detailTabController!.index == 0)
-                    _buildDetailContent(
-                        anime,
-                        valueStyle,
-                        boldWhiteKeyStyle,
-                        sectionTitleStyle,
-                        textColor,
-                        secondaryTextColor,
-                        bangumiRatingValue,
-                        bangumiEvaluationText,
-                        metadataWidgets,
-                        titlesWidgets)
-                  else
-                    Builder(builder: (context) {
-                      debugPrint('[AnimeDetail] 评论tab: _bangumiSubjectId=$_bangumiSubjectId, anime.id=${anime.id}');
-                      final userInfo = BangumiApiService.userInfo;
-                      final int currentUserId = userInfo != null
-                          ? (userInfo['id'] as int? ?? 0)
-                          : 0;
-                      String userAvatar = '';
-                      if (userInfo != null) {
-                        final raw = userInfo['avatar'];
-                        if (raw is String) {
-                          userAvatar = raw;
-                        } else if (raw is Map<String, dynamic>) {
-                          userAvatar = (raw['large'] as String?) ??
-                              (raw['medium'] as String?) ??
-                              '';
-                        }
-                      }
-                      final String userNickname = userInfo != null
-                          ? ((userInfo['nickname'] as String?) ??
-                              (userInfo['username'] as String?) ??
-                              '')
-                          : '';
-                      final BangumiMyCommentData? myComment =
-                          BangumiApiService.isLoggedIn
-                              ? BangumiMyCommentData(
-                                  nickname: userNickname,
-                                  avatarUrl: userAvatar,
-                                  rate: _bangumiUserRating,
-                                  comment: _bangumiComment ?? '',
-                                  updatedAt: _myCommentTimestamp > 0
-                                      ? _myCommentTimestamp
-                                      : DateTime.now().millisecondsSinceEpoch ~/
-                                          1000,
-                                )
-                              : null;
-                      return BangumiCommentsWidget(
-                        key: _commentsWidgetKey,
-                        subjectId: _bangumiSubjectId,
-                        onEditRating: BangumiApiService.isLoggedIn
-                            ? _showCommentDialog
-                            : null,
-                        myComment: myComment,
-                        currentUserId: currentUserId,
-                        commentsVersion: _commentsVersion,
-                        onMyCommentTimestamp: (timestamp) {
-                          if (mounted && timestamp != _myCommentTimestamp) {
-                            setState(() {
-                              _myCommentTimestamp = timestamp;
-                            });
+            // 详情 / 评论 切换导航栏
+            AnimatedBuilder(
+              animation: _detailTabController!,
+              builder: (context, _) {
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    NipaplayMainTabBar(
+                      controller: _detailTabController!,
+                      showLeadingLogoOnMobile: false,
+                      preferredHeight: 34,
+                      labelPadding: const EdgeInsets.only(
+                        left: 2,
+                        right: 14,
+                        bottom: 7,
+                      ),
+                      tabs: const [
+                        HoverZoomTab(
+                          text: '详情',
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        HoverZoomTab(
+                          text: '评论',
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    if (_detailTabController!.index == 0)
+                      _buildDetailContent(
+                          anime,
+                          valueStyle,
+                          boldWhiteKeyStyle,
+                          sectionTitleStyle,
+                          textColor,
+                          secondaryTextColor,
+                          bangumiRatingValue,
+                          bangumiEvaluationText,
+                          metadataWidgets,
+                          titlesWidgets)
+                    else
+                      Builder(builder: (context) {
+                        debugPrint(
+                            '[AnimeDetail] 评论tab: _bangumiSubjectId=$_bangumiSubjectId, anime.id=${anime.id}');
+                        final userInfo = BangumiApiService.userInfo;
+                        final int currentUserId = userInfo != null
+                            ? (userInfo['id'] as int? ?? 0)
+                            : 0;
+                        String userAvatar = '';
+                        if (userInfo != null) {
+                          final raw = userInfo['avatar'];
+                          if (raw is String) {
+                            userAvatar = raw;
+                          } else if (raw is Map<String, dynamic>) {
+                            userAvatar = (raw['large'] as String?) ??
+                                (raw['medium'] as String?) ??
+                                '';
                           }
-                        },
-                      );
-                    }),
-                ],
-              );
-            },
-          ),
-          SizedBox(height: 20),
-        ],
-      ),
+                        }
+                        final String userNickname = userInfo != null
+                            ? ((userInfo['nickname'] as String?) ??
+                                (userInfo['username'] as String?) ??
+                                '')
+                            : '';
+                        final BangumiMyCommentData? myComment =
+                            BangumiApiService.isLoggedIn
+                                ? BangumiMyCommentData(
+                                    nickname: userNickname,
+                                    avatarUrl: userAvatar,
+                                    rate: _bangumiUserRating,
+                                    comment: _bangumiComment ?? '',
+                                    updatedAt: _myCommentTimestamp > 0
+                                        ? _myCommentTimestamp
+                                        : DateTime.now()
+                                                .millisecondsSinceEpoch ~/
+                                            1000,
+                                  )
+                                : null;
+                        return BangumiCommentsWidget(
+                          key: _commentsWidgetKey,
+                          subjectId: _bangumiSubjectId,
+                          onEditRating: BangumiApiService.isLoggedIn
+                              ? _showCommentDialog
+                              : null,
+                          myComment: myComment,
+                          currentUserId: currentUserId,
+                          commentsVersion: _commentsVersion,
+                          onMyCommentTimestamp: (timestamp) {
+                            if (mounted && timestamp != _myCommentTimestamp) {
+                              setState(() {
+                                _myCommentTimestamp = timestamp;
+                              });
+                            }
+                          },
+                        );
+                      }),
+                  ],
+                );
+              },
+            ),
+            SizedBox(height: 20),
+          ],
+        ),
       ),
     );
   }
@@ -1322,24 +1328,21 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
       children: [
         if (bangumiRatingValue is num && bangumiRatingValue > 0) ...[
           RichText(
-              text: TextSpan(
-                  style: valueStyle,
-                  children: [
-                TextSpan(text: 'Bangumi评分: ', style: boldWhiteKeyStyle),
-                WidgetSpan(
-                    child: _buildRatingStars(bangumiRatingValue.toDouble())),
-                TextSpan(
-                    text: ' ${bangumiRatingValue.toStringAsFixed(1)} ',
-                    locale: const Locale("zh-Hans", "zh"),
-                    style: TextStyle(
-                        color: AppAccentColors.current,
-                        fontWeight: FontWeight.bold,
-                        fontSize: 14)),
-                TextSpan(
-                    text: bangumiEvaluationText,
-                    locale: const Locale("zh-Hans", "zh"),
-                    style: TextStyle(color: secondaryTextColor, fontSize: 12))
-              ])),
+              text: TextSpan(style: valueStyle, children: [
+            TextSpan(text: 'Bangumi评分: ', style: boldWhiteKeyStyle),
+            WidgetSpan(child: _buildRatingStars(bangumiRatingValue.toDouble())),
+            TextSpan(
+                text: ' ${bangumiRatingValue.toStringAsFixed(1)} ',
+                locale: const Locale("zh-Hans", "zh"),
+                style: TextStyle(
+                    color: AppAccentColors.current,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14)),
+            TextSpan(
+                text: bangumiEvaluationText,
+                locale: const Locale("zh-Hans", "zh"),
+                style: TextStyle(color: secondaryTextColor, fontSize: 12))
+          ])),
           SizedBox(height: 6),
         ],
 
@@ -1389,8 +1392,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                           ),
                         ),
                         TextSpan(
-                          text: _ratingEvaluationMap[_bangumiUserRating] !=
-                                  null
+                          text: _ratingEvaluationMap[_bangumiUserRating] != null
                               ? ' (${_ratingEvaluationMap[_bangumiUserRating]})'
                               : '',
                           style: TextStyle(
@@ -1412,76 +1414,42 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                   final bool isBangumiActionEnabled =
                       !_isLoadingBangumiCollection &&
                           !_isSavingBangumiCollection;
-                  final bool enableBangumiHover =
-                      isBangumiActionEnabled && !globals.isTouch;
-                  final bool isBangumiHovered =
-                      enableBangumiHover && _isBangumiRatingButtonHovered;
-                  final Color bangumiActionColor = isBangumiActionEnabled
-                      ? (isBangumiHovered
-                          ? AppAccentColors.current
-                          : textColor.withOpacity(0.9))
+                  final Color idleColor = isBangumiActionEnabled
+                      ? textColor.withOpacity(0.9)
                       : textColor.withOpacity(0.45);
 
-                  final button = MouseRegion(
-                    cursor: enableBangumiHover
-                        ? SystemMouseCursors.click
-                        : SystemMouseCursors.basic,
-                    onEnter: enableBangumiHover
-                        ? (_) => setState(
-                            () => _isBangumiRatingButtonHovered = true)
-                        : null,
-                    onExit: enableBangumiHover
-                        ? (_) => setState(
-                            () => _isBangumiRatingButtonHovered = false)
-                        : null,
-                    child: GestureDetector(
-                      onTap:
-                          isBangumiActionEnabled ? _showRatingDialog : null,
-                      behavior: HitTestBehavior.opaque,
-                      child: AnimatedScale(
-                        scale: isBangumiHovered ? 1.1 : 1.0,
-                        duration: const Duration(milliseconds: 180),
-                        curve: Curves.easeOutCubic,
-                        child: AnimatedDefaultTextStyle(
-                          duration: const Duration(milliseconds: 180),
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: bangumiActionColor,
-                          ),
-                          child: IconTheme(
-                            data: IconThemeData(
-                              color: bangumiActionColor,
-                              size: 16,
-                            ),
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 6,
-                                vertical: 4,
-                              ),
-                              child: Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  if (_isSavingBangumiCollection)
-                                    SizedBox(
-                                      width: 14,
-                                      height: 14,
-                                      child: CircularProgressIndicator(
-                                        strokeWidth: 1.5,
-                                        valueColor:
-                                            AlwaysStoppedAnimation<Color>(
-                                                bangumiActionColor),
-                                      ),
-                                    )
-                                  else
-                                    Icon(Icons.edit),
-                                  SizedBox(width: 4),
-                                  const Text('编辑Bangumi评分'),
-                                ],
+                  final button = HoverScaleTextButton(
+                    onPressed:
+                        isBangumiActionEnabled ? _showRatingDialog : null,
+                    idleColor: idleColor,
+                    hoverColor: AppAccentColors.current,
+                    hoverScale: 1.1,
+                    duration: const Duration(milliseconds: 180),
+                    curve: Curves.easeOutCubic,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 6,
+                      vertical: 4,
+                    ),
+                    textStyle: const TextStyle(fontSize: 12),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (_isSavingBangumiCollection)
+                          SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 1.5,
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                idleColor,
                               ),
                             ),
-                          ),
-                        ),
-                      ),
+                          )
+                        else
+                          const Icon(Icons.edit, size: 16),
+                        const SizedBox(width: 4),
+                        const Text('编辑Bangumi评分'),
+                      ],
                     ),
                   );
                   return _wrapLargeScreenFocusable(
@@ -1514,8 +1482,8 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
           ] else if (!_isLoadingBangumiCollection) ...[
             Text(
               '尚未在Bangumi收藏此番剧',
-              style: valueStyle.copyWith(
-                  fontSize: 12, color: secondaryTextColor),
+              style:
+                  valueStyle.copyWith(fontSize: 12, color: secondaryTextColor),
             ),
             SizedBox(height: 6),
           ],
@@ -1589,13 +1557,12 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                           TextSpan(
                               text: '$siteName: ',
                               style: boldWhiteKeyStyle.copyWith(
-                                  fontSize: 12,
-                                  fontWeight: FontWeight.normal)),
+                                  fontSize: 12, fontWeight: FontWeight.normal)),
                           TextSpan(
                               text: score.toStringAsFixed(1),
                               locale: const Locale("zh-Hans", "zh"),
-                              style: TextStyle(
-                                  color: textColor.withOpacity(0.95)))
+                              style:
+                                  TextStyle(color: textColor.withOpacity(0.95)))
                         ]));
                   }).toList())),
         RichText(
@@ -1773,12 +1740,6 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
     final episodes = anime.episodeList!;
     final displayEpisodes =
         _isEpisodeListReversed ? episodes.reversed.toList() : episodes;
-    final Color sortButtonColor =
-        _isSortButtonHovered ? accentColor : secondaryTextColor;
-    final Color cleanupButtonColor = _isCleaningEpisodeHistory
-        ? secondaryTextColor.withOpacity(0.35)
-        : (_isCleanupButtonHovered ? accentColor : secondaryTextColor);
-
     return Column(
       children: [
         Padding(
@@ -1828,58 +1789,33 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                     ? null
                     : () => _showEpisodeListCleanupDialog(anime),
                 borderRadius: BorderRadius.circular(6),
-                child: MouseRegion(
-                  cursor: _isCleaningEpisodeHistory
-                      ? SystemMouseCursors.basic
-                      : SystemMouseCursors.click,
-                  onEnter: _isCleaningEpisodeHistory
-                      ? null
-                      : (_) => setState(() => _isCleanupButtonHovered = true),
-                  onExit: _isCleaningEpisodeHistory
-                      ? null
-                      : (_) => setState(() => _isCleanupButtonHovered = false),
-                  child: GestureDetector(
-                    onTap: _isLargeScreenModeActive
-                        ? null
-                        : (_isCleaningEpisodeHistory
-                            ? null
-                            : () => _showEpisodeListCleanupDialog(anime)),
-                    behavior: HitTestBehavior.opaque,
-                    child: AnimatedScale(
-                      scale: _isCleanupButtonHovered ? 1.1 : 1.0,
-                      duration: const Duration(milliseconds: 180),
-                      curve: Curves.easeOutCubic,
-                      child: AnimatedDefaultTextStyle(
-                        duration: const Duration(milliseconds: 180),
-                        style: TextStyle(
-                          color: cleanupButtonColor,
-                          fontSize: 12,
-                        ),
-                        child: IconTheme(
-                          data: IconThemeData(
-                            color: cleanupButtonColor,
-                            size: 16,
-                          ),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 6,
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Icon(Ionicons.trash_outline),
-                                SizedBox(width: 4),
-                                Text(
-                                  _isCleaningEpisodeHistory ? '处理中' : '清理记录',
-                                  locale: const Locale('zh-Hans', 'zh'),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
+                child: HoverScaleTextButton(
+                  onPressed:
+                      _isLargeScreenModeActive || _isCleaningEpisodeHistory
+                          ? null
+                          : () => _showEpisodeListCleanupDialog(anime),
+                  idleColor: _isCleaningEpisodeHistory
+                      ? secondaryTextColor.withOpacity(0.35)
+                      : secondaryTextColor,
+                  hoverColor: accentColor,
+                  hoverScale: 1.1,
+                  duration: const Duration(milliseconds: 180),
+                  curve: Curves.easeOutCubic,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 6,
+                  ),
+                  textStyle: const TextStyle(fontSize: 12),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Ionicons.trash_outline, size: 16),
+                      const SizedBox(width: 4),
+                      Text(
+                        _isCleaningEpisodeHistory ? '处理中' : '清理记录',
+                        locale: const Locale('zh-Hans', 'zh'),
                       ),
-                    ),
+                    ],
                   ),
                 ),
               ),
@@ -1890,54 +1826,34 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                   });
                 },
                 borderRadius: BorderRadius.circular(6),
-                child: MouseRegion(
-                  cursor: SystemMouseCursors.click,
-                  onEnter: (_) => setState(() => _isSortButtonHovered = true),
-                  onExit: (_) => setState(() => _isSortButtonHovered = false),
-                  child: GestureDetector(
-                    onTap: _isLargeScreenModeActive
-                        ? null
-                        : () {
-                            setState(() {
-                              _isEpisodeListReversed = !_isEpisodeListReversed;
-                            });
-                          },
-                    behavior: HitTestBehavior.opaque,
-                    child: AnimatedScale(
-                      scale: _isSortButtonHovered ? 1.1 : 1.0,
-                      duration: const Duration(milliseconds: 180),
-                      curve: Curves.easeOutCubic,
-                      child: AnimatedDefaultTextStyle(
-                        duration: const Duration(milliseconds: 180),
-                        style: TextStyle(
-                          color: sortButtonColor,
-                          fontSize: 12,
-                        ),
-                        child: IconTheme(
-                          data: IconThemeData(
-                            color: sortButtonColor,
-                            size: 16,
-                          ),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 6,
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Icon(Ionicons.swap_vertical_outline),
-                                SizedBox(width: 4),
-                                Text(
-                                  _isEpisodeListReversed ? '倒序' : '正序',
-                                  locale: const Locale('zh-Hans', 'zh'),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
+                child: HoverScaleTextButton(
+                  onPressed: _isLargeScreenModeActive
+                      ? null
+                      : () {
+                          setState(() {
+                            _isEpisodeListReversed = !_isEpisodeListReversed;
+                          });
+                        },
+                  idleColor: secondaryTextColor,
+                  hoverColor: accentColor,
+                  hoverScale: 1.1,
+                  duration: const Duration(milliseconds: 180),
+                  curve: Curves.easeOutCubic,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 6,
+                  ),
+                  textStyle: const TextStyle(fontSize: 12),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Ionicons.swap_vertical_outline, size: 16),
+                      const SizedBox(width: 4),
+                      Text(
+                        _isEpisodeListReversed ? '倒序' : '正序',
+                        locale: const Locale('zh-Hans', 'zh'),
                       ),
-                    ),
+                    ],
                   ),
                 ),
               ),
@@ -2102,8 +2018,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
                                               watchedChipBase.withOpacity(0.9),
                                           size: 12,
                                         ),
-                                      if (isEpisodeWatched)
-                                        SizedBox(width: 4),
+                                      if (isEpisodeWatched) SizedBox(width: 4),
                                       Text(
                                         isEpisodeWatched ? '已看' : '',
                                         locale: const Locale('zh-Hans', 'zh'),
@@ -2497,7 +2412,6 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
 
     setState(() {
       _isCleaningEpisodeHistory = true;
-      _isCleanupButtonHovered = false;
     });
 
     int affectedCount = 0;

--- a/lib/pages/tab_labels.dart
+++ b/lib/pages/tab_labels.dart
@@ -55,12 +55,18 @@ List<Widget> createTabLabels(BuildContext context,
 class HoverZoomTab extends StatefulWidget {
   final String text;
   final double fontSize;
+  final FontWeight fontWeight;
+  final double hoverScale;
+  final Duration hoverAnimationDuration;
   final Widget? icon;
   final Color? hoverColor;
   const HoverZoomTab({
     super.key,
     required this.text,
     this.fontSize = 20,
+    this.fontWeight = FontWeight.bold,
+    this.hoverScale = 1.1,
+    this.hoverAnimationDuration = const Duration(milliseconds: 200),
     this.icon,
     this.hoverColor,
   });
@@ -105,8 +111,8 @@ class _HoverZoomTabState extends State<HoverZoomTab> {
       onEnter: (_) => setState(() => _isHovered = true),
       onExit: (_) => setState(() => _isHovered = false),
       child: AnimatedScale(
-        scale: _isHovered ? 1.1 : 1.0,
-        duration: const Duration(milliseconds: 200),
+        scale: _isHovered ? widget.hoverScale : 1.0,
+        duration: widget.hoverAnimationDuration,
         curve: Curves.easeOut,
         child: Opacity(
           opacity: targetOpacity,
@@ -133,7 +139,7 @@ class _HoverZoomTabState extends State<HoverZoomTab> {
                 style: TextStyle(
                   color: solidColor,
                   fontSize: widget.fontSize,
-                  fontWeight: FontWeight.bold,
+                  fontWeight: widget.fontWeight,
                 ),
               ),
             ],

--- a/lib/themes/nipaplay/pages/settings/developer_options_page.dart
+++ b/lib/themes/nipaplay/pages/settings/developer_options_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:nipaplay/providers/developer_options_provider.dart';
 import 'package:nipaplay/themes/nipaplay/pages/settings/dependency_versions_window.dart';
 import 'package:nipaplay/themes/nipaplay/pages/settings/debug_log_viewer_page.dart';
+import 'package:nipaplay/themes/nipaplay/pages/settings/nipaplay_ui_preview_window.dart';
 import 'package:nipaplay/services/debug_log_service.dart';
 import 'package:nipaplay/services/file_log_service.dart';
 import 'package:nipaplay/utils/linux_storage_migration.dart';
@@ -55,9 +56,9 @@ class DeveloperOptionsPage extends StatelessWidget {
                 devOptions.setShowSystemResources(value);
               },
             ),
-            
+
             Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-            
+
             // 调试日志收集开关
             SettingsItem.toggle(
               title: '调试日志收集',
@@ -66,7 +67,7 @@ class DeveloperOptionsPage extends StatelessWidget {
               value: devOptions.enableDebugLogCollection,
               onChanged: (bool value) async {
                 await devOptions.setEnableDebugLogCollection(value);
-                
+
                 // 根据设置控制日志服务
                 final logService = DebugLogService();
                 if (value) {
@@ -76,7 +77,7 @@ class DeveloperOptionsPage extends StatelessWidget {
                 }
               },
             ),
-            
+
             Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
 
             // 日志写入文件开关
@@ -123,9 +124,8 @@ class DeveloperOptionsPage extends StatelessWidget {
                 final enabled = videoState.spoilerPreventionEnabled;
                 return SettingsItem.toggle(
                   title: '调试：打印 AI 返回内容',
-                  subtitle: enabled
-                      ? '开启后会在日志里打印 AI 返回的原始文本与命中弹幕'
-                      : '需先启用防剧透模式',
+                  subtitle:
+                      enabled ? '开启后会在日志里打印 AI 返回的原始文本与命中弹幕' : '需先启用防剧透模式',
                   icon: Ionicons.information_circle_outline,
                   enabled: enabled,
                   value: videoState.spoilerAiDebugPrintResponse,
@@ -141,7 +141,7 @@ class DeveloperOptionsPage extends StatelessWidget {
             ),
 
             Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-            
+
             // 终端输出查看器
             SettingsItem.button(
               title: '终端输出',
@@ -152,7 +152,7 @@ class DeveloperOptionsPage extends StatelessWidget {
                 _openDebugLogViewer(context);
               },
             ),
-            
+
             Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
 
             SettingsItem.button(
@@ -162,6 +162,18 @@ class DeveloperOptionsPage extends StatelessWidget {
               trailingIcon: Ionicons.chevron_forward_outline,
               onTap: () {
                 _openDependencyVersions(context);
+              },
+            ),
+
+            Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+
+            SettingsItem.button(
+              title: 'Nipaplay 设计 UI 预览',
+              subtitle: '在窗口中集中查看 Nipaplay UI 组件示例',
+              icon: Ionicons.color_palette_outline,
+              trailingIcon: Ionicons.chevron_forward_outline,
+              onTap: () {
+                _openNipaplayUiPreview(context);
               },
             ),
 
@@ -185,75 +197,94 @@ class DeveloperOptionsPage extends StatelessWidget {
               ListTile(
                 title: Text(
                   '检查Linux存储迁移状态',
-                  locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: colorScheme.onSurface, fontWeight: FontWeight.bold),
+                  locale: Locale("zh-Hans", "zh"),
+                  style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontWeight: FontWeight.bold),
                 ),
                 subtitle: Text(
                   '查看Linux平台数据目录迁移状态',
-                  locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
+                  locale: Locale("zh-Hans", "zh"),
+                  style:
+                      TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
                 ),
-                trailing: Icon(Ionicons.information_circle_outline, color: colorScheme.onSurface),
+                trailing: Icon(Ionicons.information_circle_outline,
+                    color: colorScheme.onSurface),
                 onTap: () => _checkLinuxMigrationStatus(context),
               ),
-              
-              Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-              
+
+              Divider(
+                  color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+
               // 手动触发迁移
               ListTile(
                 title: Text(
                   '手动触发存储迁移',
-                  locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: colorScheme.onSurface, fontWeight: FontWeight.bold),
+                  locale: Locale("zh-Hans", "zh"),
+                  style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontWeight: FontWeight.bold),
                 ),
                 subtitle: Text(
                   '强制重新执行数据目录迁移（仅用于测试）',
-                  locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
+                  locale: Locale("zh-Hans", "zh"),
+                  style:
+                      TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
                 ),
-                trailing: const Icon(Ionicons.refresh_outline, color: Colors.orange),
+                trailing:
+                    const Icon(Ionicons.refresh_outline, color: Colors.orange),
                 onTap: () => _manualTriggerMigration(context),
               ),
-              
-              Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-              
+
+              Divider(
+                  color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+
               // 紧急恢复个人文件
               ListTile(
                 title: const Text(
                   '🚨 紧急恢复个人文件',
-                  locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: Colors.red, fontWeight: FontWeight.bold),
+                  locale: Locale("zh-Hans", "zh"),
+                  style:
+                      TextStyle(color: Colors.red, fontWeight: FontWeight.bold),
                 ),
                 subtitle: Text(
                   '将误迁移的个人文件恢复到Documents目录',
-                  locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
+                  locale: Locale("zh-Hans", "zh"),
+                  style:
+                      TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
                 ),
-                trailing: const Icon(Ionicons.medical_outline, color: Colors.red),
+                trailing:
+                    const Icon(Ionicons.medical_outline, color: Colors.red),
                 onTap: () => _emergencyRestorePersonalFiles(context),
               ),
-              
-              Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-              
+
+              Divider(
+                  color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+
               // 显示存储目录信息
               ListTile(
                 title: Text(
                   '显示存储目录信息',
-                  locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: colorScheme.onSurface, fontWeight: FontWeight.bold),
+                  locale: Locale("zh-Hans", "zh"),
+                  style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontWeight: FontWeight.bold),
                 ),
                 subtitle: Text(
                   '查看当前使用的数据和缓存目录路径',
-                  locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
+                  locale: Locale("zh-Hans", "zh"),
+                  style:
+                      TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
                 ),
-                trailing: Icon(Ionicons.folder_outline, color: colorScheme.onSurface),
+                trailing:
+                    Icon(Ionicons.folder_outline, color: colorScheme.onSurface),
                 onTap: () => _showStorageDirectoryInfo(context),
               ),
-              
-              Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+
+              Divider(
+                  color: colorScheme.onSurface.withOpacity(0.12), height: 1),
             ],
-            
+
             // 这里可以添加更多开发者选项
           ],
         );
@@ -333,6 +364,21 @@ style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
       barrierDismissible: true,
       barrierColor: Colors.transparent,
       child: const DependencyVersionsWindow(),
+    );
+  }
+
+  void _openNipaplayUiPreview(BuildContext context) {
+    final enableAnimation = Provider.of<AppearanceSettingsProvider>(
+      context,
+      listen: false,
+    ).enablePageAnimation;
+
+    NipaplayWindow.show<void>(
+      context: context,
+      enableAnimation: enableAnimation,
+      barrierDismissible: true,
+      barrierColor: Colors.transparent,
+      child: const NipaplayUiPreviewWindow(),
     );
   }
 
@@ -461,14 +507,14 @@ style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
   // 检查Linux存储迁移状态
   Future<void> _checkLinuxMigrationStatus(BuildContext context) async {
     if (kIsWeb || !platform.Platform.isLinux) return;
-    
+
     try {
       final needsMigration = await LinuxStorageMigration.needsMigration();
       final dataDir = await LinuxStorageMigration.getXDGDataDirectory();
       final cacheDir = await LinuxStorageMigration.getXDGCacheDirectory();
-      
+
       if (!context.mounted) return;
-      
+
       BlurDialog.show<void>(
         context: context,
         title: "Linux存储迁移状态",
@@ -479,18 +525,20 @@ XDG数据目录: $dataDir
 XDG缓存目录: $cacheDir
 
 遵循XDG Base Directory规范，提供更好的Linux用户体验。
-        """.trim(),
+        """
+            .trim(),
         actions: <Widget>[
           HoverScaleTextButton(
-            child: const Text("知道了", locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: Colors.lightBlueAccent)),
+            child: const Text("知道了",
+                locale: Locale("zh-Hans", "zh"),
+                style: TextStyle(color: Colors.lightBlueAccent)),
             onPressed: () => Navigator.of(context).pop(),
           ),
         ],
       );
     } catch (e) {
       if (!context.mounted) return;
-      
+
       BlurSnackBar.show(context, '检查迁移状态失败: $e');
     }
   }
@@ -498,37 +546,39 @@ style: TextStyle(color: Colors.lightBlueAccent)),
   // 手动触发存储迁移
   Future<void> _manualTriggerMigration(BuildContext context) async {
     if (kIsWeb || !platform.Platform.isLinux) return;
-    
+
     final confirm = await BlurDialog.show<bool>(
       context: context,
       title: "确认迁移",
       content: "这将重新执行数据目录迁移过程。\n\n注意：这是一个测试功能，在正常情况下不应该使用。",
       actions: <Widget>[
         HoverScaleTextButton(
-          child: const Text("取消", locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: Colors.white70)),
+          child: const Text("取消",
+              locale: Locale("zh-Hans", "zh"),
+              style: TextStyle(color: Colors.white70)),
           onPressed: () => Navigator.of(context).pop(false),
         ),
         HoverScaleTextButton(
-          child: const Text("确认", locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: Colors.orange)),
+          child: const Text("确认",
+              locale: Locale("zh-Hans", "zh"),
+              style: TextStyle(color: Colors.orange)),
           onPressed: () => Navigator.of(context).pop(true),
         ),
       ],
     );
-    
+
     if (confirm == true && context.mounted) {
       BlurSnackBar.show(context, '开始执行迁移...');
-      
+
       try {
         // 重置迁移状态
         await LinuxStorageMigration.resetMigrationStatus();
-        
+
         // 执行迁移
         final result = await LinuxStorageMigration.performMigration();
-        
+
         if (!context.mounted) return;
-        
+
         if (result.success) {
           BlurDialog.show<void>(
             context: context,
@@ -540,11 +590,13 @@ ${result.message}
 - 总项目数: ${result.totalItems}
 - 成功项目: ${result.migratedItems}
 - 失败项目: ${result.failedItems}
-            """.trim(),
+            """
+                .trim(),
             actions: <Widget>[
               HoverScaleTextButton(
-                child: const Text("知道了", locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: Colors.lightBlueAccent)),
+                child: const Text("知道了",
+                    locale: Locale("zh-Hans", "zh"),
+                    style: TextStyle(color: Colors.lightBlueAccent)),
                 onPressed: () => Navigator.of(context).pop(),
               ),
             ],
@@ -558,11 +610,13 @@ ${result.message}
 
 错误信息:
 ${result.errors.join('\n')}
-            """.trim(),
+            """
+                .trim(),
             actions: <Widget>[
               HoverScaleTextButton(
-                child: const Text("知道了", locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: Colors.orange)),
+                child: const Text("知道了",
+                    locale: Locale("zh-Hans", "zh"),
+                    style: TextStyle(color: Colors.orange)),
                 onPressed: () => Navigator.of(context).pop(),
               ),
             ],
@@ -578,18 +632,20 @@ style: TextStyle(color: Colors.orange)),
   // 显示存储目录信息
   Future<void> _showStorageDirectoryInfo(BuildContext context) async {
     if (kIsWeb || !platform.Platform.isLinux) return;
-    
+
     try {
       final dataDir = await LinuxStorageMigration.getXDGDataDirectory();
       final cacheDir = await LinuxStorageMigration.getXDGCacheDirectory();
-      
+
       // 获取环境变量信息
-      final xdgDataHome = platform.Platform.environment['XDG_DATA_HOME'] ?? '未设置';
-      final xdgCacheHome = platform.Platform.environment['XDG_CACHE_HOME'] ?? '未设置';
+      final xdgDataHome =
+          platform.Platform.environment['XDG_DATA_HOME'] ?? '未设置';
+      final xdgCacheHome =
+          platform.Platform.environment['XDG_CACHE_HOME'] ?? '未设置';
       final homeDir = platform.Platform.environment['HOME'] ?? '未知';
-      
+
       if (!context.mounted) return;
-      
+
       BlurDialog.show<void>(
         context: context,
         title: "Linux存储目录信息",
@@ -608,11 +664,13 @@ XDG_CACHE_HOME: $xdgCacheHome
 • 缓存目录用于存储临时文件和缓存
 • 遵循XDG Base Directory规范
 • 提供与其他Linux应用一致的用户体验
-        """.trim(),
+        """
+            .trim(),
         actions: <Widget>[
           HoverScaleTextButton(
-            child: const Text("知道了", locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: Colors.lightBlueAccent)),
+            child: const Text("知道了",
+                locale: Locale("zh-Hans", "zh"),
+                style: TextStyle(color: Colors.lightBlueAccent)),
             onPressed: () => Navigator.of(context).pop(),
           ),
         ],
@@ -622,11 +680,11 @@ style: TextStyle(color: Colors.lightBlueAccent)),
       BlurSnackBar.show(context, '获取目录信息失败: $e');
     }
   }
-  
+
   // 紧急恢复个人文件
   Future<void> _emergencyRestorePersonalFiles(BuildContext context) async {
     if (kIsWeb || !platform.Platform.isLinux) return;
-    
+
     final confirm = await BlurDialog.show<bool>(
       context: context,
       title: "🚨 紧急恢复个人文件",
@@ -639,29 +697,33 @@ style: TextStyle(color: Colors.lightBlueAccent)),
 • 这是一个紧急修复功能
 
 是否继续？
-      """.trim(),
+      """
+          .trim(),
       actions: <Widget>[
         HoverScaleTextButton(
-          child: const Text("取消", locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: Colors.white70)),
+          child: const Text("取消",
+              locale: Locale("zh-Hans", "zh"),
+              style: TextStyle(color: Colors.white70)),
           onPressed: () => Navigator.of(context).pop(false),
         ),
         HoverScaleTextButton(
-          child: const Text("确认恢复", locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: Colors.red)),
+          child: const Text("确认恢复",
+              locale: Locale("zh-Hans", "zh"),
+              style: TextStyle(color: Colors.red)),
           onPressed: () => Navigator.of(context).pop(true),
         ),
       ],
     );
-    
+
     if (confirm == true && context.mounted) {
       BlurSnackBar.show(context, '开始恢复个人文件...');
-      
+
       try {
-        final result = await LinuxStorageMigration.emergencyRestorePersonalFiles();
-        
+        final result =
+            await LinuxStorageMigration.emergencyRestorePersonalFiles();
+
         if (!context.mounted) return;
-        
+
         if (result.success) {
           BlurDialog.show<void>(
             context: context,
@@ -675,11 +737,13 @@ ${result.message}
 - 失败项目: ${result.failedItems}
 
 您的个人文件已恢复到 ~/Documents 目录。
-            """.trim(),
+            """
+                .trim(),
             actions: <Widget>[
               HoverScaleTextButton(
-                child: const Text("知道了", locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: Colors.lightBlueAccent)),
+                child: const Text("知道了",
+                    locale: Locale("zh-Hans", "zh"),
+                    style: TextStyle(color: Colors.lightBlueAccent)),
                 onPressed: () => Navigator.of(context).pop(),
               ),
             ],
@@ -693,11 +757,13 @@ ${result.message}
 
 错误信息:
 ${result.errors.join('\n')}
-            """.trim(),
+            """
+                .trim(),
             actions: <Widget>[
               HoverScaleTextButton(
-                child: const Text("知道了", locale:Locale("zh-Hans","zh"),
-style: TextStyle(color: Colors.orange)),
+                child: const Text("知道了",
+                    locale: Locale("zh-Hans", "zh"),
+                    style: TextStyle(color: Colors.orange)),
                 onPressed: () => Navigator.of(context).pop(),
               ),
             ],
@@ -709,4 +775,4 @@ style: TextStyle(color: Colors.orange)),
       }
     }
   }
-} 
+}

--- a/lib/themes/nipaplay/pages/settings/nipaplay_ui_preview_window.dart
+++ b/lib/themes/nipaplay/pages/settings/nipaplay_ui_preview_window.dart
@@ -1,0 +1,274 @@
+import 'package:flutter/material.dart';
+import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/pages/tab_labels.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/fluent_settings_switch.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_demo_section.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_main_tab_bar.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/settings_card.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/settings_item.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/settings_no_ripple_theme.dart';
+import 'package:nipaplay/utils/app_accent_color.dart';
+
+class NipaplayUiPreviewWindow extends StatefulWidget {
+  const NipaplayUiPreviewWindow({super.key});
+
+  @override
+  State<NipaplayUiPreviewWindow> createState() =>
+      _NipaplayUiPreviewWindowState();
+}
+
+class _NipaplayUiPreviewWindowState extends State<NipaplayUiPreviewWindow>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+  final GlobalKey _dropdownKey = GlobalKey();
+  bool _switchValue = true;
+  String _dropdownValue = 'Fluent UI';
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 5, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return NipaplayWindowScaffold(
+      maxWidth: 1100,
+      maxHeightFactor: 0.9,
+      onClose: () => Navigator.of(context).maybePop(),
+      child: SettingsNoRippleTheme(
+        disableBlurEffect: false,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 12, 24, 12),
+              child: Row(
+                children: [
+                  Text(
+                    'Nipaplay 设计 UI 预览',
+                    style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const Spacer(),
+                  HoverScaleTextButton(
+                    text: '重置示例',
+                    onPressed: _resetDemoState,
+                    idleColor: colorScheme.onSurface.withValues(alpha: 0.7),
+                    hoverColor: AppAccentColors.current,
+                  ),
+                ],
+              ),
+            ),
+            Divider(
+              height: 1,
+              color: colorScheme.onSurface.withValues(alpha: 0.12),
+            ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  NipaplayDemoSection(
+                    title: '主 Tab',
+                    subtitle: '与主界面一致的 Tab 样式',
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        child: NipaplayMainTabBar(
+                          controller: _tabController,
+                          tabs: createTabLabels(context),
+                          showLeadingLogoOnMobile: false,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  NipaplayDemoSection(
+                    title: '基础控件',
+                    subtitle: '开关、下拉菜单、无背景按钮与设置项',
+                    children: [
+                      SettingsItem.toggle(
+                        title: 'Fluent 开关',
+                        subtitle: '使用项目统一的 Fluent 风格开关',
+                        icon: Ionicons.toggle_outline,
+                        value: _switchValue,
+                        onChanged: (value) {
+                          setState(() => _switchValue = value);
+                        },
+                      ),
+                      SettingsItem.dropdown(
+                        title: '项目下拉菜单',
+                        subtitle: '展示 BlurDropdown 的交互样式',
+                        icon: Ionicons.chevron_down_outline,
+                        dropdownKey: _dropdownKey,
+                        items: [
+                          DropdownMenuItemData<String>(
+                            title: 'Fluent UI',
+                            value: 'Fluent UI',
+                            isSelected: _dropdownValue == 'Fluent UI',
+                          ),
+                          DropdownMenuItemData<String>(
+                            title: 'Nipaplay',
+                            value: 'Nipaplay',
+                            isSelected: _dropdownValue == 'Nipaplay',
+                          ),
+                          DropdownMenuItemData<String>(
+                            title: 'Settings',
+                            value: 'Settings',
+                            isSelected: _dropdownValue == 'Settings',
+                          ),
+                        ],
+                        onChanged: (value) {
+                          setState(() => _dropdownValue = value as String);
+                        },
+                      ),
+                      SettingsItem.button(
+                        title: '悬浮放大变色按钮',
+                        subtitle: 'HoverScaleTextButton 的示例',
+                        icon: Ionicons.sparkles_outline,
+                        trailingIcon: Ionicons.chevron_forward_outline,
+                        onTap: () {},
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: HoverScaleTextButton(
+                            text: '无背景容器按钮',
+                            onPressed: () {},
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  NipaplayDemoSection(
+                    title: '设置卡片',
+                    subtitle: '承载设置内容的卡片与分割线容器',
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: SettingsCard(
+                          child: Column(
+                            children: [
+                              SettingsItem.toggle(
+                                title: '卡片内开关',
+                                subtitle: '示例卡片中的设置项',
+                                icon: Ionicons.options_outline,
+                                value: true,
+                                onChanged: (_) {},
+                              ),
+                              Divider(
+                                height: 1,
+                                color: colorScheme.onSurface
+                                    .withValues(alpha: 0.12),
+                              ),
+                              SettingsItem.button(
+                                title: '卡片内按钮',
+                                subtitle: '带分割线的设置内容承载方式',
+                                icon: Ionicons.folder_outline,
+                                trailingIcon: Ionicons.chevron_forward_outline,
+                                onTap: () {},
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  NipaplayDemoSection(
+                    title: '部分内容卡片',
+                    subtitle: '用于展示局部信息的卡片容器',
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: SettingsCard(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                '卡片标题',
+                                style: TextStyle(
+                                  color: colorScheme.onSurface,
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              const SizedBox(height: 8),
+                              Text(
+                                '这里适合承载说明、状态或局部动作，不需要像设置项那样强制分割。',
+                                style: TextStyle(
+                                  color: colorScheme.onSurface
+                                      .withValues(alpha: 0.7),
+                                  height: 1.45,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  NipaplayDemoSection(
+                    title: '状态展示',
+                    subtitle: '和项目配色一起观察当前控件状态',
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Row(
+                          children: [
+                            Icon(
+                              Ionicons.color_palette_outline,
+                              color: AppAccentColors.current,
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Text(
+                                '当前下拉选项: $_dropdownValue',
+                                style: TextStyle(
+                                  color: colorScheme.onSurface,
+                                ),
+                              ),
+                            ),
+                            FluentSettingsSwitch(
+                              value: _switchValue,
+                              onChanged: (value) =>
+                                  setState(() => _switchValue = value),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _resetDemoState() {
+    setState(() {
+      _switchValue = true;
+      _dropdownValue = 'Fluent UI';
+      _tabController.animateTo(0);
+    });
+  }
+}

--- a/lib/themes/nipaplay/widgets/bangumi_comments_widget.dart
+++ b/lib/themes/nipaplay/widgets/bangumi_comments_widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/models/bangumi_comment_model.dart';
 import 'package:nipaplay/services/bangumi_api_service.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:nipaplay/services/web_remote_access_service.dart';
@@ -89,12 +90,14 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
         return;
       }
       final int requestedSubjectId = widget.subjectId!;
-      debugPrint('[Bangumi Comments Widget] 开始加载 subjectId=$requestedSubjectId, offset=$_currentOffset');
+      debugPrint(
+          '[Bangumi Comments Widget] 开始加载 subjectId=$requestedSubjectId, offset=$_currentOffset');
       final result = await BangumiApiService.getSubjectComments(
         requestedSubjectId,
         offset: _currentOffset,
       );
-      debugPrint('[Bangumi Comments Widget] API返回 success=${result['success']}, message=${result['message']}');
+      debugPrint(
+          '[Bangumi Comments Widget] API返回 success=${result['success']}, message=${result['message']}');
 
       if (!mounted) return;
       if (widget.subjectId != requestedSubjectId) return;
@@ -104,9 +107,9 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
         debugPrint('[Bangumi Comments Widget] data类型: ${data.runtimeType}');
         final list = (data['data'] as List?) ?? (data['list'] as List?) ?? [];
         final total = data['total'] as int? ?? 0;
-        debugPrint('[Bangumi Comments Widget] 解析到 ${list.length} 条, total=$total');
-        var newComments =
-            list.map((e) => BangumiComment.fromJson(e)).toList();
+        debugPrint(
+            '[Bangumi Comments Widget] 解析到 ${list.length} 条, total=$total');
+        var newComments = list.map((e) => BangumiComment.fromJson(e)).toList();
         if (widget.currentUserId > 0) {
           final myComment = newComments.cast<BangumiComment?>().firstWhere(
                 (c) => c!.userId == widget.currentUserId,
@@ -119,7 +122,8 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
               .where((c) => c.userId != widget.currentUserId)
               .toList();
         }
-        debugPrint('[Bangumi Comments Widget] 转换后 ${newComments.length} 条 BangumiComment');
+        debugPrint(
+            '[Bangumi Comments Widget] 转换后 ${newComments.length} 条 BangumiComment');
 
         setState(() {
           _comments.addAll(newComments);
@@ -190,8 +194,7 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
   Widget build(BuildContext context) {
     if (widget.subjectId == null) {
       final bool isDark = Theme.of(context).brightness == Brightness.dark;
-      final Color secondaryTextColor =
-          isDark ? Colors.white70 : Colors.black54;
+      final Color secondaryTextColor = isDark ? Colors.white70 : Colors.black54;
       return Padding(
         padding: const EdgeInsets.symmetric(vertical: 32),
         child: Center(
@@ -203,8 +206,7 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
 
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
     final Color textColor = isDark ? Colors.white : Colors.black87;
-    final Color secondaryTextColor =
-        isDark ? Colors.white70 : Colors.black54;
+    final Color secondaryTextColor = isDark ? Colors.white70 : Colors.black54;
     final Color accentColor = AppAccentColors.current;
     final Color mutedColor = accentColor.withOpacity(isDark ? 0.4 : 0.3);
 
@@ -263,8 +265,7 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
     final valueStyle = TextStyle(
         color: textColor.withOpacity(0.85), fontSize: 13, height: 1.5);
 
-    final int totalItemCount =
-        _comments.length + (hasMyComment ? 1 : 0);
+    final int totalItemCount = _comments.length + (hasMyComment ? 1 : 0);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -279,19 +280,25 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
                     fontSize: 14,
                     height: 1.5)),
             if (widget.onEditRating != null)
-              GestureDetector(
-                onTap: widget.onEditRating,
+              HoverScaleTextButton(
+                onPressed: widget.onEditRating,
+                idleColor: textColor.withOpacity(0.72),
+                hoverColor: accentColor,
+                hoverScale: 1.08,
+                duration: const Duration(milliseconds: 180),
+                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Icon(Ionicons.create_outline,
-                        size: 15, color: accentColor),
+                    Icon(Ionicons.chatbubble_outline, size: 15),
                     const SizedBox(width: 4),
-                    Text('编辑评分',
-                        style: TextStyle(
-                            color: accentColor,
-                            fontSize: 13,
-                            fontWeight: FontWeight.w500)),
+                    const Text(
+                      '评论',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
                   ],
                 ),
               ),
@@ -323,8 +330,7 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
                       radius: 18,
                       backgroundColor: textColor.withOpacity(0.1),
                       backgroundImage: my.avatarUrl.isNotEmpty
-                          ? NetworkImage(
-                              _proxiedImageUrl(my.avatarUrl))
+                          ? NetworkImage(_proxiedImageUrl(my.avatarUrl))
                           : null,
                       child: my.avatarUrl.isEmpty
                           ? Icon(Ionicons.person,
@@ -341,9 +347,7 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
                             children: [
                               Flexible(
                                 child: Text(
-                                  my.nickname.isNotEmpty
-                                      ? my.nickname
-                                      : '我',
+                                  my.nickname.isNotEmpty ? my.nickname : '我',
                                   style: TextStyle(
                                     color: textColor,
                                     fontWeight: FontWeight.w500,
@@ -361,8 +365,7 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
                           ),
                           if (my.rate > 0) ...[
                             const SizedBox(height: 3),
-                            _buildMiniStars(
-                                my.rate, accentColor, mutedColor),
+                            _buildMiniStars(my.rate, accentColor, mutedColor),
                           ],
                           if (my.comment.isNotEmpty) ...[
                             const SizedBox(height: 4),
@@ -376,8 +379,7 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
               );
             }
 
-            final int commentIndex =
-                hasMyComment ? index - 1 : index;
+            final int commentIndex = hasMyComment ? index - 1 : index;
             final comment = _comments[commentIndex];
 
             final card = Container(
@@ -385,8 +387,8 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
               decoration: BoxDecoration(
                 color: textColor.withOpacity(0.06),
                 borderRadius: BorderRadius.circular(8),
-                border: Border.all(
-                    color: textColor.withOpacity(0.12), width: 0.8),
+                border:
+                    Border.all(color: textColor.withOpacity(0.12), width: 0.8),
               ),
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -395,8 +397,7 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
                     radius: 18,
                     backgroundColor: textColor.withOpacity(0.1),
                     backgroundImage: comment.avatarUrl.isNotEmpty
-                        ? NetworkImage(
-                            _proxiedImageUrl(comment.avatarUrl))
+                        ? NetworkImage(_proxiedImageUrl(comment.avatarUrl))
                         : null,
                     child: comment.avatarUrl.isEmpty
                         ? Icon(Ionicons.person,

--- a/lib/themes/nipaplay/widgets/custom_scaffold.dart
+++ b/lib/themes/nipaplay/widgets/custom_scaffold.dart
@@ -5,12 +5,12 @@ import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/background_with_blur.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_scaffold_layout.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_home_page.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_main_tab_bar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/switchable_view.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/platform_utils.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
 import 'package:provider/provider.dart';
-import 'package:nipaplay/utils/app_accent_color.dart';
 
 class CustomScaffold extends StatefulWidget {
   final List<Widget> pages;
@@ -206,28 +206,12 @@ class _CustomScaffoldState extends State<CustomScaffold> {
               surfaceTintColor: Colors.transparent,
               elevation: 0,
               systemOverlayStyle: appBarOverlayStyle,
-              bottom: _LogoTabBar(
-                tabBar: TabBar(
-                  controller: widget.tabController,
-                  isScrollable: true,
-                  tabs: widget.tabPage,
-                  labelColor: AppAccentColors.current,
-                  unselectedLabelColor:
-                      isDarkMode ? Colors.white60 : Colors.black54,
-                  labelPadding: const EdgeInsets.only(bottom: 15.0),
-                  tabAlignment: TabAlignment.start,
-                  splashFactory: NoSplash.splashFactory,
-                  overlayColor: WidgetStateProperty.all(Colors.transparent),
-                  dividerColor:
-                      showTabDivider ? tabDividerColor : Colors.transparent,
-                  dividerHeight: 3.0,
-                  indicator: _CustomTabIndicator(
-                    indicatorHeight: 3.0,
-                    indicatorColor: AppAccentColors.current,
-                    radius: 30.0,
-                  ),
-                  indicatorSize: TabBarIndicatorSize.label,
-                ),
+              bottom: NipaplayMainTabBar(
+                controller: widget.tabController!,
+                tabs: widget.tabPage,
+                showDivider: showTabDivider,
+                dividerColor: tabDividerColor,
+                showLeadingLogoOnMobile: true,
               ),
             )
           : null,
@@ -298,77 +282,5 @@ class TabControllerScope extends InheritedWidget {
   @override
   bool updateShouldNotify(TabControllerScope oldWidget) {
     return enabled != oldWidget.enabled || controller != oldWidget.controller;
-  }
-}
-
-class _CustomTabIndicator extends Decoration {
-  final double indicatorHeight;
-  final Color indicatorColor;
-  final double radius;
-
-  _CustomTabIndicator({
-    required this.indicatorHeight,
-    required this.indicatorColor,
-    required this.radius,
-  });
-
-  @override
-  BoxPainter createBoxPainter([VoidCallback? onChanged]) {
-    return _CustomPainter(this, onChanged);
-  }
-}
-
-class _CustomPainter extends BoxPainter {
-  final _CustomTabIndicator decoration;
-
-  _CustomPainter(this.decoration, VoidCallback? onChanged) : super(onChanged);
-
-  @override
-  void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {
-    assert(configuration.size != null);
-    final Rect rect = Offset(
-          offset.dx,
-          (configuration.size!.height - decoration.indicatorHeight),
-        ) &
-        Size(configuration.size!.width, decoration.indicatorHeight);
-    final Paint paint = Paint()
-      ..color = decoration.indicatorColor
-      ..style = PaintingStyle.fill;
-    canvas.drawRRect(
-      RRect.fromRectAndRadius(rect, Radius.circular(decoration.radius)),
-      paint,
-    );
-  }
-}
-
-class _LogoTabBar extends StatelessWidget implements PreferredSizeWidget {
-  final TabBar tabBar;
-
-  const _LogoTabBar({required this.tabBar});
-
-  @override
-  Size get preferredSize => tabBar.preferredSize;
-
-  @override
-  Widget build(BuildContext context) {
-    if (globals.isDesktopOrTablet) {
-      return tabBar;
-    }
-
-    return Row(
-      children: [
-        SizedBox(width: 16),
-        Padding(
-          padding: const EdgeInsets.only(bottom: 20.0),
-          child: Image.asset(
-            'assets/logo.png',
-            height: 40,
-            fit: BoxFit.contain,
-          ),
-        ),
-        SizedBox(width: 8),
-        Expanded(child: tabBar),
-      ],
-    );
   }
 }

--- a/lib/themes/nipaplay/widgets/hover_scale_text_button.dart
+++ b/lib/themes/nipaplay/widgets/hover_scale_text_button.dart
@@ -92,54 +92,66 @@ class _HoverScaleTextButtonState extends State<HoverScaleTextButton> {
       final TextStyle resolvedStyle = baseStyle.copyWith(color: textColor);
 
       if (textChild.data != null) {
-        return Text(
-          textChild.data!,
-          key: textChild.key,
-          style: resolvedStyle,
-          strutStyle: textChild.strutStyle,
-          textAlign: textChild.textAlign,
-          textDirection: textChild.textDirection,
-          locale: textChild.locale,
-          softWrap: textChild.softWrap,
-          overflow: textChild.overflow,
-          textScaleFactor: textChild.textScaleFactor,
-          maxLines: textChild.maxLines,
-          semanticsLabel: textChild.semanticsLabel,
-          textWidthBasis: textChild.textWidthBasis,
-          textHeightBehavior: textChild.textHeightBehavior,
+        return IconTheme(
+          data: IconThemeData(color: textColor),
+          child: Text(
+            textChild.data!,
+            key: textChild.key,
+            style: resolvedStyle,
+            strutStyle: textChild.strutStyle,
+            textAlign: textChild.textAlign,
+            textDirection: textChild.textDirection,
+            locale: textChild.locale,
+            softWrap: textChild.softWrap,
+            overflow: textChild.overflow,
+            textScaleFactor: textChild.textScaleFactor,
+            maxLines: textChild.maxLines,
+            semanticsLabel: textChild.semanticsLabel,
+            textWidthBasis: textChild.textWidthBasis,
+            textHeightBehavior: textChild.textHeightBehavior,
+          ),
         );
       }
 
       if (textChild.textSpan != null) {
-        return Text.rich(
-          textChild.textSpan!,
-          key: textChild.key,
-          style: resolvedStyle,
-          strutStyle: textChild.strutStyle,
-          textAlign: textChild.textAlign,
-          textDirection: textChild.textDirection,
-          locale: textChild.locale,
-          softWrap: textChild.softWrap,
-          overflow: textChild.overflow,
-          textScaleFactor: textChild.textScaleFactor,
-          maxLines: textChild.maxLines,
-          semanticsLabel: textChild.semanticsLabel,
-          textWidthBasis: textChild.textWidthBasis,
-          textHeightBehavior: textChild.textHeightBehavior,
+        return IconTheme(
+          data: IconThemeData(color: textColor),
+          child: Text.rich(
+            textChild.textSpan!,
+            key: textChild.key,
+            style: resolvedStyle,
+            strutStyle: textChild.strutStyle,
+            textAlign: textChild.textAlign,
+            textDirection: textChild.textDirection,
+            locale: textChild.locale,
+            softWrap: textChild.softWrap,
+            overflow: textChild.overflow,
+            textScaleFactor: textChild.textScaleFactor,
+            maxLines: textChild.maxLines,
+            semanticsLabel: textChild.semanticsLabel,
+            textWidthBasis: textChild.textWidthBasis,
+            textHeightBehavior: textChild.textHeightBehavior,
+          ),
         );
       }
     }
 
     if (widget.text != null) {
-      return Text(
-        widget.text!,
-        style: baseStyle.copyWith(color: textColor),
+      return IconTheme(
+        data: IconThemeData(color: textColor),
+        child: Text(
+          widget.text!,
+          style: baseStyle.copyWith(color: textColor),
+        ),
       );
     }
 
-    return DefaultTextStyle.merge(
-      style: baseStyle.copyWith(color: textColor),
-      child: widget.child!,
+    return IconTheme(
+      data: IconThemeData(color: textColor),
+      child: DefaultTextStyle.merge(
+        style: baseStyle.copyWith(color: textColor),
+        child: widget.child!,
+      ),
     );
   }
 }

--- a/lib/themes/nipaplay/widgets/nipaplay_demo_section.dart
+++ b/lib/themes/nipaplay/widgets/nipaplay_demo_section.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/settings_card.dart';
+
+class NipaplayDemoSection extends StatelessWidget {
+  const NipaplayDemoSection({
+    super.key,
+    required this.title,
+    this.subtitle,
+    required this.children,
+  });
+
+  final String title;
+  final String? subtitle;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return SettingsCard(
+      padding: EdgeInsets.zero,
+      backgroundOpacity: 0.22,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: colorScheme.onSurface,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                if (subtitle != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    subtitle!,
+                    style: TextStyle(
+                      color: colorScheme.onSurface.withValues(alpha: 0.65),
+                      fontSize: 12,
+                      height: 1.35,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          Divider(
+            height: 1,
+            color: colorScheme.onSurface.withValues(alpha: 0.12),
+          ),
+          Column(
+            children: children
+                .asMap()
+                .entries
+                .expand((entry) => [
+                      entry.value,
+                      if (entry.key != children.length - 1)
+                        Divider(
+                          height: 1,
+                          color: colorScheme.onSurface.withValues(alpha: 0.12),
+                        ),
+                    ])
+                .toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/themes/nipaplay/widgets/nipaplay_main_tab_bar.dart
+++ b/lib/themes/nipaplay/widgets/nipaplay_main_tab_bar.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:nipaplay/utils/app_accent_color.dart';
+import 'package:nipaplay/utils/globals.dart' as globals;
+
+/// 与主界面保持一致的 TabBar 样式。
+class NipaplayMainTabBar extends StatelessWidget
+    implements PreferredSizeWidget {
+  const NipaplayMainTabBar({
+    super.key,
+    required this.controller,
+    required this.tabs,
+    this.showDivider = false,
+    this.dividerColor,
+    this.showLeadingLogoOnMobile = true,
+    this.labelPadding = const EdgeInsets.only(bottom: 15.0),
+    this.preferredHeight = kTextTabBarHeight,
+  });
+
+  final TabController controller;
+  final List<Widget> tabs;
+  final bool showDivider;
+  final Color? dividerColor;
+  final bool showLeadingLogoOnMobile;
+  final EdgeInsetsGeometry labelPadding;
+  final double preferredHeight;
+
+  @override
+  Size get preferredSize => Size.fromHeight(preferredHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    final tabBar = _buildTabBar(context);
+    if (!showLeadingLogoOnMobile || globals.isDesktopOrTablet) {
+      return tabBar;
+    }
+
+    return Row(
+      children: [
+        const SizedBox(width: 16),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 20.0),
+          child: Image.asset(
+            'assets/logo.png',
+            height: 40,
+            fit: BoxFit.contain,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(child: tabBar),
+      ],
+    );
+  }
+
+  TabBar _buildTabBar(BuildContext context) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+    return TabBar(
+      controller: controller,
+      isScrollable: true,
+      tabs: tabs,
+      labelColor: AppAccentColors.current,
+      unselectedLabelColor: isDarkMode ? Colors.white60 : Colors.black54,
+      labelPadding: labelPadding,
+      tabAlignment: TabAlignment.start,
+      splashFactory: NoSplash.splashFactory,
+      overlayColor: WidgetStateProperty.all(Colors.transparent),
+      dividerColor: showDivider ? dividerColor : Colors.transparent,
+      dividerHeight: 3.0,
+      indicator: NipaplayMainTabIndicator(
+        indicatorHeight: 3.0,
+        indicatorColor: AppAccentColors.current,
+        radius: 30.0,
+      ),
+      indicatorSize: TabBarIndicatorSize.label,
+    );
+  }
+}
+
+/// 与主界面一致的底部指示器。
+class NipaplayMainTabIndicator extends Decoration {
+  const NipaplayMainTabIndicator({
+    required this.indicatorHeight,
+    required this.indicatorColor,
+    required this.radius,
+  });
+
+  final double indicatorHeight;
+  final Color indicatorColor;
+  final double radius;
+
+  @override
+  BoxPainter createBoxPainter([VoidCallback? onChanged]) {
+    return _NipaplayMainTabPainter(this, onChanged);
+  }
+}
+
+class _NipaplayMainTabPainter extends BoxPainter {
+  _NipaplayMainTabPainter(this.decoration, VoidCallback? onChanged)
+      : super(onChanged);
+
+  final NipaplayMainTabIndicator decoration;
+
+  @override
+  void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {
+    assert(configuration.size != null);
+    final rect = Offset(
+          offset.dx,
+          configuration.size!.height - decoration.indicatorHeight,
+        ) &
+        Size(configuration.size!.width, decoration.indicatorHeight);
+
+    final paint = Paint()
+      ..color = decoration.indicatorColor
+      ..style = PaintingStyle.fill;
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(rect, Radius.circular(decoration.radius)),
+      paint,
+    );
+  }
+}

--- a/skills/nipaplay-theme-ui/SKILL.md
+++ b/skills/nipaplay-theme-ui/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: nipaplay-theme-ui
+description: Use when creating, refactoring, or reviewing UI for the Nipaplay Flutter theme. Always inspect the developer-options Nipaplay UI preview and reuse controls from lib/themes/nipaplay/widgets before writing new UI.
+---
+
+# Nipaplay Theme UI
+
+Use this skill for any task that creates, changes, or reviews UI in the
+Nipaplay theme.
+
+## Required Workflow
+
+1. Inspect the UI reference page first:
+   - `lib/themes/nipaplay/pages/settings/nipaplay_ui_preview_window.dart`
+   - In the app, it is opened from Developer Options as `Nipaplay 设计 UI 预览`.
+2. Identify the UI pattern needed from the preview:
+   - Main tabs
+   - Fluent-style switches
+   - Project dropdowns
+   - Hover-scale text/icon buttons
+   - Settings rows
+   - Settings cards and divided containers
+   - Nipaplay windows/dialogs
+3. Find and reuse the matching widget under:
+   - `lib/themes/nipaplay/widgets/`
+4. Only create a new widget when no suitable widget exists.
+5. If a missing pattern is reusable, add it under `lib/themes/nipaplay/widgets/`
+   first, then use it from the page.
+
+## Reuse Rules
+
+- Do not hand-write a duplicate `MouseRegion + GestureDetector + AnimatedScale`
+  button in a page. Use `HoverScaleTextButton`.
+- Do not use Flutter default `TabBar` styling directly for Nipaplay UI. Use
+  `NipaplayMainTabBar` and `HoverZoomTab`.
+- Do not inline settings-row/card visuals in pages when `SettingsItem`,
+  `SettingsCard`, `NipaplayDemoSection`, or existing Nipaplay widgets cover the
+  pattern.
+- Do not keep one-off UI state in a page solely for hover color/scale if an
+  existing widget already handles it.
+- All Nipaplay-theme-specific reusable controls must live in
+  `lib/themes/nipaplay/widgets/`.
+
+## Common Widgets
+
+- Tabs: `NipaplayMainTabBar`, `HoverZoomTab`
+- Hover text/icon button: `HoverScaleTextButton`
+- Dropdown: `BlurDropdown`
+- Switch: `FluentSettingsSwitch`
+- Settings rows: `SettingsItem`
+- Settings cards/containers: `SettingsCard`, `NipaplayDemoSection`
+- Windows/dialog shells: `NipaplayWindow`, `NipaplayWindowScaffold`,
+  `BlurDialog`
+
+## Review Checklist
+
+- Did the implementation check the developer-options UI preview first?
+- Does the page import reusable widgets from `lib/themes/nipaplay/widgets/`?
+- Are there duplicated hover buttons, tabs, cards, switches, or dropdowns?
+- If a new widget was added, is it under `lib/themes/nipaplay/widgets/`?
+- Does the UI preview need to be updated to show the new reusable component?


### PR DESCRIPTION
## Summary
- add a Developer Options Nipaplay UI preview window for reusable theme controls
- extract and reuse the main Nipaplay tab bar, including detail-page tab usage
- replace duplicate hover text/icon button implementations with HoverScaleTextButton
- add a project skill documenting Nipaplay theme UI reuse workflow

## Validation
- ran targeted flutter analyze during implementation; remaining output is existing warnings/info in the touched large files