### PR TITLE
fix(ios): add MinimumOSVersion to App.framework Info.plist

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -12,6 +12,8 @@
   <string>6.0</string>
   <key>CFBundleName</key>
   <string>App</string>
+  <key>MinimumOSVersion</key>
+  <string>13.0</string>
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## Summary
- add MinimumOSVersion to ios/Flutter/AppFrameworkInfo.plist
- set the value to 13.0 to match the iOS deployment target

## Why
App Store Connect upload failed with validation errors:
- Invalid MinimumOSVersion
- Missing Info.plist value for key MinimumOSVersion in Runner.app/Frameworks/App.framework

This ensures the generated App.framework bundle contains a valid minimum OS version during IPA export.

## Validation
- rebuilt IPA with flutter build ipa
- verified Runner.app/Frameworks/App.framework/Info.plist contains MinimumOSVersion = 13.0
- confirmed upload succeeds via xcrun altool --upload-app