### PR TITLE
feat(macos): 迁移菜单栏到 PlatformMenuBar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,6 +42,7 @@ import 'package:nipaplay/services/auto_sync_service.dart';
 import 'package:nipaplay/providers/developer_options_provider.dart';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'package:nipaplay/providers/downloader_settings_provider.dart';
+import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
 import 'package:nipaplay/providers/home_sections_settings_provider.dart';
 import 'package:nipaplay/providers/shared_remote_library_provider.dart';
 import 'package:nipaplay/providers/ui_theme_provider.dart';
@@ -759,23 +760,56 @@ class _NipaPlayAppState extends State<NipaPlayApp> with WidgetsBindingObserver {
   @override
   Widget build(BuildContext context) {
     return MacosPlatformMenu(
+      navigationItemsBuilder: (ctx) {
+        final webdav = ctx.read<WebDAVQuickAccessProvider>();
+        final downloader = ctx.read<DownloaderSettingsProvider>();
+        final showWebDAV = webdav.showWebDAVTab;
+        final showDownloader = globals.isDownloaderSupportedPlatform &&
+            downloader.enabled;
+        // 实际 Tab 顺序：主页(0), 视频(1), [WebDAV(2)], 媒体库, [下载器], 账户
+        final mediaLibIdx = showWebDAV ? 3 : 2;
+        final downloaderIdx = showWebDAV ? 4 : 3;
+        final accountIdx = showWebDAV
+            ? 5
+            : showDownloader
+                ? 4
+                : 3;
+        final items = <NavigationItem>[
+          NavigationItem(
+            label: AppLocalizations.of(ctx)!.tabHome,
+            onSelected: () => _navigateToPage(ctx, 0),
+          ),
+          NavigationItem(
+            label: AppLocalizations.of(ctx)!.tabVideoPlay,
+            onSelected: () => _navigateToPage(ctx, 1),
+          ),
+        ];
+        if (showWebDAV) {
+          items.add(NavigationItem(
+            label: 'WebDAV',
+            onSelected: () => _navigateToPage(ctx, 2),
+          ));
+        }
+        items.add(NavigationItem(
+          label: AppLocalizations.of(ctx)!.tabMediaLibrary,
+          onSelected: () => _navigateToPage(ctx, mediaLibIdx),
+        ));
+        if (showDownloader) {
+          items.add(NavigationItem(
+            label: AppLocalizations.of(ctx)!.tabTorrentDownload,
+            onSelected: () => _navigateToPage(ctx, downloaderIdx),
+          ));
+        }
+        items.add(NavigationItem(
+          label: AppLocalizations.of(ctx)!.tabAccount,
+          onSelected: () => _navigateToPage(ctx, accountIdx),
+        ));
+        return items;
+      },
       onUploadVideo: () {
         final ctx = navigatorKey.currentState?.overlay?.context;
         if (ctx != null) _showGlobalUploadDialog(ctx);
       },
-      onOpenHome: () {
-        final ctx = navigatorKey.currentState?.overlay?.context;
-        if (ctx != null) _navigateToPage(ctx, 0);
-      },
-      onOpenVideoPlayback: () {
-        final ctx = navigatorKey.currentState?.overlay?.context;
-        if (ctx != null) _navigateToPage(ctx, 1);
-      },
-      onOpenMediaLibrary: () {
-        final ctx = navigatorKey.currentState?.overlay?.context;
-        if (ctx != null) _navigateToPage(ctx, 2);
-      },
-
       onOpenSettings: () {
         final ctx = navigatorKey.currentState?.overlay?.context;
         if (ctx == null) return;
@@ -810,10 +844,7 @@ class _NipaPlayAppState extends State<NipaPlayApp> with WidgetsBindingObserver {
                 '• Cmd+W - 关闭窗口\n'
                 '• Cmd+Q - 退出应用\n'
                 '• Cmd+, - 偏好设置\n'
-                '• Cmd+1 - 主页\n'
-                '• Cmd+2 - 视频播放\n'
-                '• Cmd+3 - 媒体库\n'
-
+                '• Cmd+1~N - 切换标签页（根据当前显示的标签动态分配）\n\n'
                 '支持的视频格式：\n'
                 'MP4, MKV, AVI, MOV, WebM, WMV, M4V, 3GP, FLV, TS, M2TS',
               ),
@@ -1972,10 +2003,7 @@ Future<void> _showGlobalUploadDialog(BuildContext context) async {
 // 导航到特定页面逻辑
 void _navigateToPage(BuildContext context, int pageIndex) {
   MainPageState? mainPageState = MainPageState.of(context);
-  final resolvedPageIndex = _resolveRequestedPageIndex(
-    requestedIndex: pageIndex,
-    tabLength: mainPageState?.globalTabController?.length,
-  );
+  final resolvedPageIndex = pageIndex;
   print('[Dart] 准备导航到页面索引: $resolvedPageIndex');
 
   // 尝试获取MainPageState

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,6 +57,8 @@ import 'services/file_picker_service.dart';
 import 'services/security_bookmark_service.dart';
 import 'themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/providers/theme_background_reveal_provider.dart';
+import 'package:nipaplay/platform_menu/macos_platform_menu.dart';
+import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
 import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/utils/storage_service.dart';
@@ -99,8 +101,6 @@ import 'package:nipaplay/services/desktop_exit_handler_stub.dart'
     if (dart.library.io) 'package:nipaplay/services/desktop_exit_handler.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = globals.navigatorKey;
-// 将通道定义为全局变量
-const MethodChannel menuChannel = MethodChannel('custom_menu_channel');
 
 final GlobalKey<State<DefaultTabController>> tabControllerKey =
     GlobalKey<State<DefaultTabController>>();
@@ -375,132 +375,7 @@ void main(List<String> args) async {
     final manageStatus = await Permission.manageExternalStorage.status;
     debugPrint("最终存储权限状态: $finalStatus, 管理存储权限状态: $manageStatus");
   }
-  // 设置方法通道处理器
-  menuChannel.setMethodCallHandler((call) async {
-    print('[Dart] 收到方法调用: ${call.method}');
-
-    if (call.method == 'uploadVideo') {
-      try {
-        // 获取UI上下文
-        final context = navigatorKey.currentState?.overlay?.context;
-        if (context == null) {
-          print('[Dart] 错误: 无法获取UI上下文');
-          return '错误: 无法获取UI上下文';
-        }
-
-        // 延迟确保UI准备好
-        Future.microtask(() {
-          print('[Dart] 启动文件选择器');
-          _showGlobalUploadDialog(context);
-        });
-
-        return '正在显示文件选择器';
-      } catch (e) {
-        print('[Dart] 错误: $e');
-        return '错误: $e';
-      }
-    } else if (call.method == 'openVideoPlayback') {
-      try {
-        final context = navigatorKey.currentState?.overlay?.context;
-        if (context == null) {
-          print('[Dart] 错误: 无法获取UI上下文');
-          return '错误: 无法获取UI上下文';
-        }
-
-        Future.microtask(() {
-          _navigateToPage(context, 1); // 切换到视频播放页面（索引1）
-        });
-
-        return '正在切换到视频播放页面';
-      } catch (e) {
-        print('[Dart] 错误: $e');
-        return '错误: $e';
-      }
-    } else if (call.method == 'openHome') {
-      try {
-        final context = navigatorKey.currentState?.overlay?.context;
-        if (context == null) {
-          print('[Dart] 错误: 无法获取UI上下文');
-          return '错误: 无法获取UI上下文';
-        }
-
-        Future.microtask(() {
-          _navigateToPage(context, 0); // 切换到主页（索引0）
-        });
-
-        return '正在切换到主页';
-      } catch (e) {
-        print('[Dart] 错误: $e');
-        return '错误: $e';
-      }
-    } else if (call.method == 'openMediaLibrary') {
-      try {
-        final context = navigatorKey.currentState?.overlay?.context;
-        if (context == null) {
-          print('[Dart] 错误: 无法获取UI上下文');
-          return '错误: 无法获取UI上下文';
-        }
-
-        Future.microtask(() {
-          _navigateToPage(context, 2); // 切换到媒体库页面（索引2）
-        });
-
-        return '正在切换到媒体库页面';
-      } catch (e) {
-        print('[Dart] 错误: $e');
-        return '错误: $e';
-      }
-    } else if (call.method == 'openNewSeries') {
-      try {
-        // iOS平台不支持新番更新页面，直接返回错误信息
-        if (Platform.isIOS) {
-          print('[Dart] iOS平台不支持新番更新功能');
-          return 'iOS平台不支持新番更新功能';
-        }
-
-        final context = navigatorKey.currentState?.overlay?.context;
-        if (context == null) {
-          print('[Dart] 错误: 无法获取UI上下文');
-          return '错误: 无法获取UI上下文';
-        }
-
-        Future.microtask(() {
-          _navigateToPage(context, 3); // 切换到新番更新页面（索引3）
-        });
-
-        return '正在切换到新番更新页面';
-      } catch (e) {
-        print('[Dart] 错误: $e');
-        return '错误: $e';
-      }
-    } else if (call.method == 'openSettings') {
-      try {
-        final context = navigatorKey.currentState?.overlay?.context;
-        if (context == null) {
-          print('[Dart] 错误: 无法获取UI上下文');
-          return '错误: 无法获取UI上下文';
-        }
-
-        Future.microtask(() {
-          final uiThemeProvider =
-              Provider.of<UIThemeProvider>(context, listen: false);
-          if (uiThemeProvider.isCupertinoTheme) {
-            _navigateToPage(context, 3); // Cupertino 主题保留底部设置页
-          } else {
-            SettingsPage.showWindow(context); // Nipaplay 主题使用弹窗设置页
-          }
-        });
-
-        return '正在打开设置';
-      } catch (e) {
-        print('[Dart] 错误: $e');
-        return '错误: $e';
-      }
-    }
-
-    // 默认返回空字符串
-    return '';
-  });
+  // (Menu actions are now handled by PlatformMenuBar in lib/platform_menu/)
 
   // 创建应用所需的目录结构
   await _initializeAppDirectories();
@@ -883,7 +758,94 @@ class _NipaPlayAppState extends State<NipaPlayApp> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
-    return DropTarget(
+    return MacosPlatformMenu(
+      onUploadVideo: () {
+        final ctx = navigatorKey.currentState?.overlay?.context;
+        if (ctx != null) _showGlobalUploadDialog(ctx);
+      },
+      onOpenHome: () {
+        final ctx = navigatorKey.currentState?.overlay?.context;
+        if (ctx != null) _navigateToPage(ctx, 0);
+      },
+      onOpenVideoPlayback: () {
+        final ctx = navigatorKey.currentState?.overlay?.context;
+        if (ctx != null) _navigateToPage(ctx, 1);
+      },
+      onOpenMediaLibrary: () {
+        final ctx = navigatorKey.currentState?.overlay?.context;
+        if (ctx != null) _navigateToPage(ctx, 2);
+      },
+      onOpenNewSeries: () {
+        final ctx = navigatorKey.currentState?.overlay?.context;
+        if (ctx != null) _navigateToPage(ctx, 3);
+      },
+      onOpenSettings: () {
+        final ctx = navigatorKey.currentState?.overlay?.context;
+        if (ctx == null) return;
+        final uiThemeProvider =
+            Provider.of<UIThemeProvider>(ctx, listen: false);
+        if (uiThemeProvider.isCupertinoTheme) {
+          _navigateToPage(ctx, 3);
+        } else {
+          SettingsPage.showWindow(ctx);
+        }
+      },
+      onShowAbout: () {
+        final ctx = navigatorKey.currentState?.overlay?.context;
+        if (ctx != null) {
+          showAboutDialog(
+            context: ctx,
+            applicationName: 'NipaPlay',
+            applicationLegalese: '© AimesSoft',
+          );
+        }
+      },
+      onShowHelp: () {
+        final ctx = navigatorKey.currentState?.overlay?.context;
+        if (ctx != null) {
+          showDialog(
+            context: ctx,
+            builder: (dialogContext) => AlertDialog(
+              title: const Text('NipaPlay 帮助'),
+              content: const Text(
+                '快捷键：\n'
+                '• Cmd+U - 上传视频\n'
+                '• Cmd+W - 关闭窗口\n'
+                '• Cmd+Q - 退出应用\n'
+                '• Cmd+, - 偏好设置\n'
+                '• Cmd+1 - 主页\n'
+                '• Cmd+2 - 视频播放\n'
+                '• Cmd+3 - 媒体库\n'
+                '• Cmd+4 - 新番更新\n\n'
+                '支持的视频格式：\n'
+                'MP4, MKV, AVI, MOV, WebM, WMV, M4V, 3GP, FLV, TS, M2TS',
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(),
+                  child: const Text('确定'),
+                ),
+              ],
+            ),
+          );
+        }
+      },
+      onOpenGitHub: () {
+        url_launcher.launchUrl(
+          Uri.parse('https://github.com/AimesSoft/NipaPlay-Reload'),
+        );
+      },
+      onOpenWebsite: () {
+        url_launcher.launchUrl(
+          Uri.parse('https://nipaplay.aimes-soft.com/'),
+        );
+      },
+      onCloseWindow: () {
+        if (!kIsWeb && Platform.isMacOS) {
+          windowManager.close();
+        }
+      },
+      child: DropTarget(
       onDragEntered: (details) {
         setState(() {
           _isDragging = true;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -775,10 +775,7 @@ class _NipaPlayAppState extends State<NipaPlayApp> with WidgetsBindingObserver {
         final ctx = navigatorKey.currentState?.overlay?.context;
         if (ctx != null) _navigateToPage(ctx, 2);
       },
-      onOpenNewSeries: () {
-        final ctx = navigatorKey.currentState?.overlay?.context;
-        if (ctx != null) _navigateToPage(ctx, 3);
-      },
+
       onOpenSettings: () {
         final ctx = navigatorKey.currentState?.overlay?.context;
         if (ctx == null) return;
@@ -816,7 +813,7 @@ class _NipaPlayAppState extends State<NipaPlayApp> with WidgetsBindingObserver {
                 '• Cmd+1 - 主页\n'
                 '• Cmd+2 - 视频播放\n'
                 '• Cmd+3 - 媒体库\n'
-                '• Cmd+4 - 新番更新\n\n'
+
                 '支持的视频格式：\n'
                 'MP4, MKV, AVI, MOV, WebM, WMV, M4V, 3GP, FLV, TS, M2TS',
               ),

--- a/lib/platform_menu/macos_platform_menu.dart
+++ b/lib/platform_menu/macos_platform_menu.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -55,6 +57,11 @@ class MacosPlatformMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // PlatformMenuBar 的 PlatformProvidedMenuItem 仅在 macOS 上支持，
+    // 其他平台直接返回子组件。
+    if (kIsWeb || !Platform.isMacOS) {
+      return child;
+    }
     return PlatformMenuBar(
       menus: _buildMenus(),
       child: child,

--- a/lib/platform_menu/macos_platform_menu.dart
+++ b/lib/platform_menu/macos_platform_menu.dart
@@ -13,7 +13,6 @@ class MacosPlatformMenu extends StatelessWidget {
     this.onOpenHome,
     this.onOpenVideoPlayback,
     this.onOpenMediaLibrary,
-    this.onOpenNewSeries,
     this.onOpenSettings,
     this.onShowAbout,
     this.onShowHelp,
@@ -35,9 +34,6 @@ class MacosPlatformMenu extends StatelessWidget {
 
   /// 媒体库 (Cmd+3)
   final VoidCallback? onOpenMediaLibrary;
-
-  /// 新番更新 (Cmd+4)
-  final VoidCallback? onOpenNewSeries;
 
   /// 偏好设置 (Cmd+,)
   final VoidCallback? onOpenSettings;
@@ -198,15 +194,6 @@ class MacosPlatformMenu extends StatelessWidget {
                   meta: true,
                 ),
                 onSelected: onOpenMediaLibrary,
-              ),
-            if (onOpenNewSeries != null)
-              PlatformMenuItem(
-                label: '新番更新',
-                shortcut: const SingleActivator(
-                  LogicalKeyboardKey.digit4,
-                  meta: true,
-                ),
-                onSelected: onOpenNewSeries,
               ),
           ],
         ),

--- a/lib/platform_menu/macos_platform_menu.dart
+++ b/lib/platform_menu/macos_platform_menu.dart
@@ -1,0 +1,278 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// macOS PlatformMenuBar wrapper for NipaPlay.
+///
+/// Replaces the native XIB-based menu bar with Flutter's PlatformMenuBar API,
+/// allowing menu structure and callbacks to be defined entirely in Dart.
+class MacosPlatformMenu extends StatelessWidget {
+  const MacosPlatformMenu({
+    super.key,
+    required this.child,
+    this.onUploadVideo,
+    this.onOpenHome,
+    this.onOpenVideoPlayback,
+    this.onOpenMediaLibrary,
+    this.onOpenNewSeries,
+    this.onOpenSettings,
+    this.onShowAbout,
+    this.onShowHelp,
+    this.onOpenGitHub,
+    this.onOpenWebsite,
+    this.onCloseWindow,
+  });
+
+  final Widget child;
+
+  /// 上传视频 (Cmd+U)
+  final VoidCallback? onUploadVideo;
+
+  /// 主页 (Cmd+1)
+  final VoidCallback? onOpenHome;
+
+  /// 视频播放 (Cmd+2)
+  final VoidCallback? onOpenVideoPlayback;
+
+  /// 媒体库 (Cmd+3)
+  final VoidCallback? onOpenMediaLibrary;
+
+  /// 新番更新 (Cmd+4)
+  final VoidCallback? onOpenNewSeries;
+
+  /// 偏好设置 (Cmd+,)
+  final VoidCallback? onOpenSettings;
+
+  /// 关于 NipaPlay
+  final VoidCallback? onShowAbout;
+
+  /// NipaPlay 帮助 (Cmd+?)
+  final VoidCallback? onShowHelp;
+
+  /// 打开 GitHub 页面
+  final VoidCallback? onOpenGitHub;
+
+  /// 打开网站
+  final VoidCallback? onOpenWebsite;
+
+  /// 关闭窗口 (Cmd+W)
+  final VoidCallback? onCloseWindow;
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformMenuBar(
+      menus: _buildMenus(),
+      child: child,
+    );
+  }
+
+  List<PlatformMenuItem> _buildMenus() {
+    return <PlatformMenuItem>[
+      _buildAppMenu(),
+      _buildFileMenu(),
+      _buildNavigationMenu(),
+      _buildWindowMenu(),
+      _buildHelpMenu(),
+    ];
+  }
+
+  /// 应用菜单 (NipaPlay)
+  PlatformMenu _buildAppMenu() {
+    return PlatformMenu(
+      label: 'NipaPlay',
+      menus: <PlatformMenuItem>[
+        // 关于 NipaPlay
+        if (onShowAbout != null)
+          PlatformMenuItem(
+            label: '关于 NipaPlay',
+            onSelected: onShowAbout,
+          ),
+        // 偏好设置 (Cmd+,)
+        if (onOpenSettings != null)
+          PlatformMenuItem(
+            label: '偏好设置...',
+            shortcut: const SingleActivator(
+              LogicalKeyboardKey.comma,
+              meta: true,
+            ),
+            onSelected: onOpenSettings,
+          ),
+        // Services 子菜单 (系统提供)
+        const PlatformMenuItemGroup(
+          members: <PlatformMenuItem>[
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.servicesSubmenu,
+            ),
+          ],
+        ),
+        // 隐藏 / 隐藏其他 / 显示全部 (系统提供)
+        const PlatformMenuItemGroup(
+          members: <PlatformMenuItem>[
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.hide,
+            ),
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.hideOtherApplications,
+            ),
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.showAllApplications,
+            ),
+          ],
+        ),
+        // 退出 (系统提供)
+        const PlatformMenuItemGroup(
+          members: <PlatformMenuItem>[
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.quit,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  /// 文件菜单
+  PlatformMenu _buildFileMenu() {
+    return PlatformMenu(
+      label: '文件',
+      menus: <PlatformMenuItem>[
+        PlatformMenuItemGroup(
+          members: <PlatformMenuItem>[
+            if (onUploadVideo != null)
+              PlatformMenuItem(
+                label: '上传视频',
+                shortcut: const SingleActivator(
+                  LogicalKeyboardKey.keyU,
+                  meta: true,
+                ),
+                onSelected: onUploadVideo,
+              ),
+          ],
+        ),
+        PlatformMenuItemGroup(
+          members: <PlatformMenuItem>[
+            if (onCloseWindow != null)
+              PlatformMenuItem(
+                label: '关闭窗口',
+                shortcut: const SingleActivator(
+                  LogicalKeyboardKey.keyW,
+                  meta: true,
+                ),
+                onSelected: onCloseWindow,
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  /// 导航菜单
+  PlatformMenu _buildNavigationMenu() {
+    return PlatformMenu(
+      label: '导航',
+      menus: <PlatformMenuItem>[
+        PlatformMenuItemGroup(
+          members: <PlatformMenuItem>[
+            if (onOpenHome != null)
+              PlatformMenuItem(
+                label: '主页',
+                shortcut: const SingleActivator(
+                  LogicalKeyboardKey.digit1,
+                  meta: true,
+                ),
+                onSelected: onOpenHome,
+              ),
+            if (onOpenVideoPlayback != null)
+              PlatformMenuItem(
+                label: '视频播放',
+                shortcut: const SingleActivator(
+                  LogicalKeyboardKey.digit2,
+                  meta: true,
+                ),
+                onSelected: onOpenVideoPlayback,
+              ),
+            if (onOpenMediaLibrary != null)
+              PlatformMenuItem(
+                label: '媒体库',
+                shortcut: const SingleActivator(
+                  LogicalKeyboardKey.digit3,
+                  meta: true,
+                ),
+                onSelected: onOpenMediaLibrary,
+              ),
+            if (onOpenNewSeries != null)
+              PlatformMenuItem(
+                label: '新番更新',
+                shortcut: const SingleActivator(
+                  LogicalKeyboardKey.digit4,
+                  meta: true,
+                ),
+                onSelected: onOpenNewSeries,
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  /// 窗口菜单 (系统提供)
+  PlatformMenu _buildWindowMenu() {
+    return const PlatformMenu(
+      label: '窗口',
+      menus: <PlatformMenuItem>[
+        PlatformMenuItemGroup(
+          members: <PlatformMenuItem>[
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.minimizeWindow,
+            ),
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.zoomWindow,
+            ),
+          ],
+        ),
+        PlatformMenuItemGroup(
+          members: <PlatformMenuItem>[
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.arrangeWindowsInFront,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  /// 帮助菜单
+  PlatformMenu _buildHelpMenu() {
+    return PlatformMenu(
+      label: '帮助',
+      menus: <PlatformMenuItem>[
+        PlatformMenuItemGroup(
+          members: <PlatformMenuItem>[
+            if (onShowHelp != null)
+              PlatformMenuItem(
+                label: 'NipaPlay 帮助',
+                shortcut: const SingleActivator(
+                  LogicalKeyboardKey.question,
+                  meta: true,
+                ),
+                onSelected: onShowHelp,
+              ),
+          ],
+        ),
+        PlatformMenuItemGroup(
+          members: <PlatformMenuItem>[
+            if (onOpenGitHub != null)
+              PlatformMenuItem(
+                label: 'GitHub',
+                onSelected: onOpenGitHub,
+              ),
+            if (onOpenWebsite != null)
+              PlatformMenuItem(
+                label: '网站',
+                onSelected: onOpenWebsite,
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/platform_menu/macos_platform_menu.dart
+++ b/lib/platform_menu/macos_platform_menu.dart
@@ -3,39 +3,49 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+/// 单个导航菜单项
+class NavigationItem {
+  const NavigationItem({required this.label, required this.onSelected});
+
+  final String label;
+  final VoidCallback onSelected;
+}
+
 /// macOS PlatformMenuBar wrapper for NipaPlay.
 ///
-/// Replaces the native XIB-based menu bar with Flutter's PlatformMenuBar API,
-/// allowing menu structure and callbacks to be defined entirely in Dart.
+/// [navigationItems] 动态传入当前可见的导航页面，
+/// 菜单会自动分配 Cmd+1, Cmd+2, ... 快捷键。
+///
+/// 或使用 [navigationItemsBuilder] 从 context 动态构建导航项。
 class MacosPlatformMenu extends StatelessWidget {
   const MacosPlatformMenu({
     super.key,
     required this.child,
+    this.navigationItems,
+    this.navigationItemsBuilder,
     this.onUploadVideo,
-    this.onOpenHome,
-    this.onOpenVideoPlayback,
-    this.onOpenMediaLibrary,
     this.onOpenSettings,
     this.onShowAbout,
     this.onShowHelp,
     this.onOpenGitHub,
     this.onOpenWebsite,
     this.onCloseWindow,
-  });
+  }) : assert(
+          navigationItems != null || navigationItemsBuilder != null,
+          'Either navigationItems or navigationItemsBuilder must be provided',
+        );
 
   final Widget child;
 
+  /// 当前可见的导航页面列表（静态传入）
+  final List<NavigationItem>? navigationItems;
+
+  /// 从 context 动态构建导航项（优先于 navigationItems）
+  final List<NavigationItem> Function(BuildContext context)?
+      navigationItemsBuilder;
+
   /// 上传视频 (Cmd+U)
   final VoidCallback? onUploadVideo;
-
-  /// 主页 (Cmd+1)
-  final VoidCallback? onOpenHome;
-
-  /// 视频播放 (Cmd+2)
-  final VoidCallback? onOpenVideoPlayback;
-
-  /// 媒体库 (Cmd+3)
-  final VoidCallback? onOpenMediaLibrary;
 
   /// 偏好设置 (Cmd+,)
   final VoidCallback? onOpenSettings;
@@ -55,6 +65,13 @@ class MacosPlatformMenu extends StatelessWidget {
   /// 关闭窗口 (Cmd+W)
   final VoidCallback? onCloseWindow;
 
+  List<NavigationItem> _resolveNavigationItems(BuildContext context) {
+    if (navigationItemsBuilder != null) {
+      return navigationItemsBuilder!(context);
+    }
+    return navigationItems ?? const [];
+  }
+
   @override
   Widget build(BuildContext context) {
     // PlatformMenuBar 的 PlatformProvidedMenuItem 仅在 macOS 上支持，
@@ -63,16 +80,16 @@ class MacosPlatformMenu extends StatelessWidget {
       return child;
     }
     return PlatformMenuBar(
-      menus: _buildMenus(),
+      menus: _buildMenus(context),
       child: child,
     );
   }
 
-  List<PlatformMenuItem> _buildMenus() {
+  List<PlatformMenuItem> _buildMenus(BuildContext context) {
     return <PlatformMenuItem>[
       _buildAppMenu(),
       _buildFileMenu(),
-      _buildNavigationMenu(),
+      _buildNavigationMenu(context),
       _buildWindowMenu(),
       _buildHelpMenu(),
     ];
@@ -83,13 +100,11 @@ class MacosPlatformMenu extends StatelessWidget {
     return PlatformMenu(
       label: 'NipaPlay',
       menus: <PlatformMenuItem>[
-        // 关于 NipaPlay
         if (onShowAbout != null)
           PlatformMenuItem(
             label: '关于 NipaPlay',
             onSelected: onShowAbout,
           ),
-        // 偏好设置 (Cmd+,)
         if (onOpenSettings != null)
           PlatformMenuItem(
             label: '偏好设置...',
@@ -99,7 +114,6 @@ class MacosPlatformMenu extends StatelessWidget {
             ),
             onSelected: onOpenSettings,
           ),
-        // Services 子菜单 (系统提供)
         const PlatformMenuItemGroup(
           members: <PlatformMenuItem>[
             PlatformProvidedMenuItem(
@@ -107,7 +121,6 @@ class MacosPlatformMenu extends StatelessWidget {
             ),
           ],
         ),
-        // 隐藏 / 隐藏其他 / 显示全部 (系统提供)
         const PlatformMenuItemGroup(
           members: <PlatformMenuItem>[
             PlatformProvidedMenuItem(
@@ -121,7 +134,6 @@ class MacosPlatformMenu extends StatelessWidget {
             ),
           ],
         ),
-        // 退出 (系统提供)
         const PlatformMenuItemGroup(
           members: <PlatformMenuItem>[
             PlatformProvidedMenuItem(
@@ -168,42 +180,36 @@ class MacosPlatformMenu extends StatelessWidget {
     );
   }
 
-  /// 导航菜单
-  PlatformMenu _buildNavigationMenu() {
+  /// 导航菜单 — 根据当前可见的 Tab 动态生成快捷键
+  PlatformMenu _buildNavigationMenu(BuildContext context) {
+    const digitKeys = [
+      LogicalKeyboardKey.digit1,
+      LogicalKeyboardKey.digit2,
+      LogicalKeyboardKey.digit3,
+      LogicalKeyboardKey.digit4,
+      LogicalKeyboardKey.digit5,
+      LogicalKeyboardKey.digit6,
+      LogicalKeyboardKey.digit7,
+      LogicalKeyboardKey.digit8,
+      LogicalKeyboardKey.digit9,
+    ];
+
+    final navItems = _resolveNavigationItems(context);
+    final items = <PlatformMenuItem>[];
+    for (var i = 0; i < navItems.length && i < digitKeys.length; i++) {
+      items.add(
+        PlatformMenuItem(
+          label: navItems[i].label,
+          shortcut: SingleActivator(digitKeys[i], meta: true),
+          onSelected: navItems[i].onSelected,
+        ),
+      );
+    }
+
     return PlatformMenu(
       label: '导航',
       menus: <PlatformMenuItem>[
-        PlatformMenuItemGroup(
-          members: <PlatformMenuItem>[
-            if (onOpenHome != null)
-              PlatformMenuItem(
-                label: '主页',
-                shortcut: const SingleActivator(
-                  LogicalKeyboardKey.digit1,
-                  meta: true,
-                ),
-                onSelected: onOpenHome,
-              ),
-            if (onOpenVideoPlayback != null)
-              PlatformMenuItem(
-                label: '视频播放',
-                shortcut: const SingleActivator(
-                  LogicalKeyboardKey.digit2,
-                  meta: true,
-                ),
-                onSelected: onOpenVideoPlayback,
-              ),
-            if (onOpenMediaLibrary != null)
-              PlatformMenuItem(
-                label: '媒体库',
-                shortcut: const SingleActivator(
-                  LogicalKeyboardKey.digit3,
-                  meta: true,
-                ),
-                onSelected: onOpenMediaLibrary,
-              ),
-          ],
-        ),
+        PlatformMenuItemGroup(members: items),
       ],
     );
   }

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -6,15 +6,9 @@ import UniformTypeIdentifiers
 @main
 @objcMembers
 class AppDelegate: FlutterAppDelegate {
-  // 直接创建全局引用
-  var uploadMenuItem: NSMenuItem?
-  var videoPlaybackMenuItem: NSMenuItem?
-  var mediaLibraryMenuItem: NSMenuItem?
-  var newSeriesMenuItem: NSMenuItem?
-  var settingsMenuItem: NSMenuItem?
-  
-  // 连接到xib中定义的导航菜单 - 使用不同名称避免与基类冲突
-  @IBOutlet weak var playerMenu: NSMenu!
+  // Keep IBOutlet connected from MainMenu.xib to avoid runtime crash,
+  // but no longer used — Flutter's PlatformMenuBar handles the menu bar.
+  @IBOutlet weak var playerMenu: NSMenu?
 
   private var didConfigureBundledMoltenVK = false
 
@@ -25,11 +19,6 @@ class AppDelegate: FlutterAppDelegate {
   @objc override func applicationDidFinishLaunching(_ notification: Notification) {
     configureBundledMoltenVKIfAvailable()
     print("[AppDelegate] 应用启动")
-    
-    // 延迟更新菜单项，确保应用完全初始化
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-      self.updateMenuItems()
-    }
   }
 
   private func configureBundledMoltenVKIfAvailable() {
@@ -88,314 +77,10 @@ class AppDelegate: FlutterAppDelegate {
     }
   }
   
-  // 更新菜单项
-  private func updateMenuItems() {
-    print("[AppDelegate] 开始更新菜单项")
-    
-    // 直接使用已连接的playerMenu
-    guard let menu = playerMenu else {
-      print("[AppDelegate] 错误: playerMenu未连接")
-      return
-    }
-    
-    // 查找已有的上传视频菜单项
-    var uploadItemExists = false
-    for item in menu.items {
-      if item.title == "上传视频" {
-        uploadItemExists = true
-        item.action = #selector(uploadVideo(_:))
-        item.target = self
-        uploadMenuItem = item
-        break
-      }
-    }
-    
-    // 如果不存在，则添加上传视频菜单项
-    if !uploadItemExists {
-      let uploadItem = NSMenuItem(title: "上传视频", action: #selector(uploadVideo(_:)), keyEquivalent: "u")
-      uploadItem.keyEquivalentModifierMask = [.command]
-      uploadItem.target = self
-      menu.addItem(uploadItem)
-      uploadMenuItem = uploadItem
-    }
-    
-    // 添加分隔线（如果不存在）
-    var hasSeparator = false
-    for (index, item) in menu.items.enumerated() {
-      if item.isSeparatorItem && index > 0 {
-        hasSeparator = true
-        break
-      }
-    }
-    
-    if !hasSeparator {
-      menu.addItem(NSMenuItem.separator())
-    }
-    
-    // 添加或更新媒体库菜单项
-    var hasMediaLibraryItem = false
-    for item in menu.items {
-      if item.title == "媒体库" {
-        hasMediaLibraryItem = true
-        item.action = #selector(openMediaLibrary(_:))
-        item.target = self
-        mediaLibraryMenuItem = item
-        break
-      }
-    }
-    
-    if !hasMediaLibraryItem {
-      let mediaLibraryItem = NSMenuItem(title: "媒体库", action: #selector(openMediaLibrary(_:)), keyEquivalent: "1")
-      mediaLibraryItem.keyEquivalentModifierMask = [.command]
-      mediaLibraryItem.target = self
-      menu.addItem(mediaLibraryItem)
-      mediaLibraryMenuItem = mediaLibraryItem
-    }
-    
-    // 添加或更新新番更新菜单项
-    var hasNewSeriesItem = false
-    for item in menu.items {
-      if item.title == "新番更新" {
-        hasNewSeriesItem = true
-        item.action = #selector(openNewSeries(_:))
-        item.target = self
-        newSeriesMenuItem = item
-        break
-      }
-    }
-    
-    if !hasNewSeriesItem {
-      let newSeriesItem = NSMenuItem(title: "新番更新", action: #selector(openNewSeries(_:)), keyEquivalent: "2")
-      newSeriesItem.keyEquivalentModifierMask = [.command]
-      newSeriesItem.target = self
-      menu.addItem(newSeriesItem)
-      newSeriesMenuItem = newSeriesItem
-    }
-    
-    // 添加或更新设置菜单项
-    var hasSettingsItem = false
-    for item in menu.items {
-      if item.title == "设置" {
-        hasSettingsItem = true
-        item.action = #selector(openSettings(_:))
-        item.target = self
-        settingsMenuItem = item
-        break
-      }
-    }
-    
-    if !hasSettingsItem {
-      let settingsItem = NSMenuItem(title: "设置", action: #selector(openSettings(_:)), keyEquivalent: "3")
-      settingsItem.keyEquivalentModifierMask = [.command]
-      settingsItem.target = self
-      menu.addItem(settingsItem)
-      settingsMenuItem = settingsItem
-    }
-    
-    print("[AppDelegate] 菜单已更新: \(menu.items.count) 个项目")
-  }
-  
-  // 处理菜单点击，直接获取FlutterViewController并创建通道
-  @objc func uploadVideo(_ sender: Any?) {
-    print("[AppDelegate] 菜单点击: 上传视频")
-    invokeFlutterMethod("uploadVideo")
-  }
+  // MARK: - Window lifecycle
 
-  // 打开视频播放
-  @objc func openVideoPlayback(_ sender: Any?) {
-      print("[AppDelegate] 菜单点击: 视频播放")
-      invokeFlutterMethod("openVideoPlayback")
-  }
-  
-  // 打开主页
-  @objc func openHome(_ sender: Any?) {
-    print("[AppDelegate] 菜单点击: 主页")
-    invokeFlutterMethod("openHome")
-  }
-  
-  // 打开媒体库
-  @objc func openMediaLibrary(_ sender: Any?) {
-    print("[AppDelegate] 菜单点击: 媒体库")
-    invokeFlutterMethod("openMediaLibrary")
-  }
-  
-  // 打开新番更新
-  @objc func openNewSeries(_ sender: Any?) {
-    print("[AppDelegate] 菜单点击: 新番更新")
-    invokeFlutterMethod("openNewSeries")
-  }
-  
-  // 打开设置
-  @objc func openSettings(_ sender: Any?) {
-    print("[AppDelegate] 菜单点击: 设置")
-    invokeFlutterMethod("openSettings")
-  }
-  
-  // 显示关于页面
-  @objc func showAbout(_ sender: Any?) {
-    print("[AppDelegate] 菜单点击: 关于")
-    showAboutDialog()
-  }
-  
-  // 显示帮助
-  @objc func showHelp(_ sender: Any?) {
-    print("[AppDelegate] 菜单点击: 帮助")
-    showHelpDialog()
-  }
-  
-  // 打开 GitHub 页面
-  @objc func openGitHub(_ sender: Any?) {
-    if let url = URL(string: "https://github.com/AimesSoft/NipaPlay-Reload") {
-      NSWorkspace.shared.open(url)
-    }
-  }
-  
-  // 打开网站
-  @objc func openWebsite(_ sender: Any?) {
-    if let url = URL(string: "https://nipaplay.aimes-soft.com/") {
-      NSWorkspace.shared.open(url)
-    }
-  }
-  
-  // 显示关于对话框
-  private func showAboutDialog() {
-    DispatchQueue.main.async {
-      let alert = NSAlert()
-      alert.messageText = "关于 NipaPlay"
-      
-      // 自动获取版本号
-      let version = self.getAppVersion()
-      
-      alert.informativeText = "NipaPlay - 跨平台弹幕视频播放器\n\n版本：\(version)\n\n一个支持多种视频格式和弹幕功能的现代化播放器。"
-      alert.alertStyle = .informational
-      alert.addButton(withTitle: "确定")
-      
-      if let window = NSApp.mainWindow {
-        alert.beginSheetModal(for: window, completionHandler: nil)
-      } else {
-        alert.runModal()
-      }
-    }
-  }
-  
-  // 获取应用版本号
-  private func getAppVersion() -> String {
-    if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
-      return version
-    }
-    return "1.0.0" // 默认版本号
-  }
-  
-  // 显示帮助对话框
-  private func showHelpDialog() {
-    DispatchQueue.main.async {
-      let alert = NSAlert()
-      alert.messageText = "NipaPlay 帮助"
-      alert.informativeText = """
-      快捷键：
-      • Cmd+U - 上传视频
-      • Cmd+W - 关闭窗口
-      • Cmd+Q - 退出应用
-      • Cmd+, - 偏好设置
-      • Cmd+1 - 主页
-      • Cmd+2 - 视频播放
-      • Cmd+3 - 媒体库
-      • Cmd+4 - 新番更新
-      
-      支持的视频格式：
-      MP4, MKV, AVI, MOV, WebM, WMV, M4V, 3GP, FLV, TS, M2TS
-      
-      更多信息请访问项目主页：
-      https://github.com/AimesSoft/NipaPlay-Reload
-      https://nipaplay.aimes-soft.com/
-      """
-      alert.alertStyle = .informational
-      alert.addButton(withTitle: "访问 GitHub")
-      alert.addButton(withTitle: "访问网站")
-      alert.addButton(withTitle: "确定")
-      
-      if let window = NSApp.mainWindow {
-        alert.beginSheetModal(for: window) { response in
-          switch response {
-          case .alertFirstButtonReturn: // 访问 GitHub
-            self.openGitHub(nil)
-          case .alertSecondButtonReturn: // 访问网站
-            self.openWebsite(nil)
-          default:
-            break
-          }
-        }
-      } else {
-        let response = alert.runModal()
-        switch response {
-        case .alertFirstButtonReturn:
-          self.openGitHub(nil)
-        case .alertSecondButtonReturn:
-          self.openWebsite(nil)
-        default:
-          break
-        }
-      }
-    }
-  }
-  
-  // 封装调用Flutter方法的逻辑
-  private func invokeFlutterMethod(_ method: String, arguments: Any? = nil) {
-    // 获取控制器和创建通道
-    guard let controller = self.mainFlutterWindow?.nipaplayFlutterViewController else {
-      print("[AppDelegate] 错误: 无法获取Flutter控制器")
-      showSimpleAlert(message: "应用尚未准备好，请稍后再试")
-      return
-    }
-    
-    // 立即创建通道
-    let channel = FlutterMethodChannel(name: "custom_menu_channel", binaryMessenger: controller.engine.binaryMessenger)
-    
-    // 定义一个操作映射
-    let methodActions: [String: () -> Void] = [
-        "uploadVideo": { channel.invokeMethod("uploadVideo", arguments: arguments, result: self.handleFlutterResult) },
-        "openVideoPlayback": { channel.invokeMethod("openVideoPlayback", arguments: arguments, result: self.handleFlutterResult) },
-        "openHome": { channel.invokeMethod("openHome", arguments: arguments, result: self.handleFlutterResult) },
-        "openMediaLibrary": { channel.invokeMethod("openMediaLibrary", arguments: arguments, result: self.handleFlutterResult) },
-        "openNewSeries": { channel.invokeMethod("openNewSeries", arguments: arguments, result: self.handleFlutterResult) },
-        "openSettings": { channel.invokeMethod("openSettings", arguments: arguments, result: self.handleFlutterResult) }
-    ]
-
-    if let action = methodActions[method] {
-        print("[AppDelegate] 调用\(method)方法")
-        action()
-    } else {
-        print("[AppDelegate] 未知的Flutter方法: \(method)")
-        showSimpleAlert(message: "未知的操作")
-    }
-  }
-
-  // 统一处理Flutter调用结果
-  private func handleFlutterResult(result: Any?) {
-      if let error = result as? FlutterError {
-          print("[AppDelegate] 调用失败: \(error.message ?? "未知错误")")
-          self.showSimpleAlert(message: "操作失败: \(error.message ?? "未知错误")")
-      } else {
-          print("[AppDelegate] 调用成功")
-      }
-  }
-  
-  // 简化的警告显示
-  private func showSimpleAlert(message: String) {
-    DispatchQueue.main.async {
-      if let window = NSApp.mainWindow {
-        let alert = NSAlert()
-        alert.messageText = "提示"
-        alert.informativeText = message
-        alert.alertStyle = .informational
-        alert.addButton(withTitle: "确定")
-        alert.beginSheetModal(for: window, completionHandler: nil)
-      }
-    }
-  }
-  
   @objc override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-    // 需要支持“关闭窗口后仍驻留菜单栏(托盘)”的行为，因此不能在最后一个窗口关闭时退出进程。
+    // 需要支持"关闭窗口后仍驻留菜单栏(托盘)"的行为，因此不能在最后一个窗口关闭时退出进程。
     return false
   }
 
@@ -403,17 +88,16 @@ class AppDelegate: FlutterAppDelegate {
     return true
   }
   
-  // 处理单个文件拖拽到Dock图标
+  // MARK: - File handling (drag-drop to Dock icon)
+
   @objc override func application(_ sender: NSApplication, openFile filename: String) -> Bool {
     print("[AppDelegate] 收到文件拖拽: \(filename)")
     handleOpenFile(filename)
     return true
   }
   
-  // 处理多个文件拖拽到Dock图标
   @objc override func application(_ sender: NSApplication, openFiles filenames: [String]) {
     print("[AppDelegate] 收到多个文件拖拽: \(filenames)")
-    // 处理第一个支持的视频文件
     for filename in filenames {
       if isSupportedVideoFile(filename) {
         handleOpenFile(filename)
@@ -422,23 +106,18 @@ class AppDelegate: FlutterAppDelegate {
     }
   }
   
-  // 处理文件打开
   private func handleOpenFile(_ filename: String) {
     print("[AppDelegate] 处理文件: \(filename)")
     
-    // 检查文件是否为支持的视频格式
     guard isSupportedVideoFile(filename) else {
       print("[AppDelegate] 不支持的文件格式: \(filename)")
       showSimpleAlert(message: "不支持的文件格式")
       return
     }
     
-    // 如果应用未启动，保存文件路径供后续处理
     if !isFlutterReady() {
       print("[AppDelegate] Flutter未准备好，保存文件路径")
       pendingFilePath = filename
-      
-      // 延迟处理，等待Flutter初始化
       DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
         if let savedPath = self.pendingFilePath {
           self.sendFileToFlutter(savedPath)
@@ -450,14 +129,12 @@ class AppDelegate: FlutterAppDelegate {
     }
   }
   
-  // 检查是否为支持的视频文件
   private func isSupportedVideoFile(_ filename: String) -> Bool {
     let supportedExtensions = ["mp4", "mkv", "avi", "mov", "webm", "wmv", "m4v", "3gp", "flv", "ts", "m2ts"]
     let fileExtension = (filename as NSString).pathExtension.lowercased()
     return supportedExtensions.contains(fileExtension)
   }
   
-  // 检查Flutter是否准备好
   private func isFlutterReady() -> Bool {
     guard let _ = self.mainFlutterWindow?.nipaplayFlutterViewController else {
       return false
@@ -465,7 +142,6 @@ class AppDelegate: FlutterAppDelegate {
     return true
   }
   
-  // 发送文件路径到Flutter
   private func sendFileToFlutter(_ filename: String) {
     print("[AppDelegate] 发送文件到Flutter: \(filename)")
     
@@ -485,6 +161,20 @@ class AppDelegate: FlutterAppDelegate {
     }
   }
   
-  // 保存待处理的文件路径
   private var pendingFilePath: String?
+
+  // MARK: - Helpers
+
+  private func showSimpleAlert(message: String) {
+    DispatchQueue.main.async {
+      if let window = NSApp.mainWindow {
+        let alert = NSAlert()
+        alert.messageText = "提示"
+        alert.informativeText = message
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "确定")
+        alert.beginSheetModal(for: window, completionHandler: nil)
+      }
+    }
+  }
 }


### PR DESCRIPTION
## 概述
将 macOS 菜单栏从原生 Swift/XIB 控制迁移到 Flutter 的 PlatformMenuBar API，解决 #564。

## 改动内容
- **新增** `lib/platform_menu/macos_platform_menu.dart`：使用 PlatformMenuBar API 定义菜单结构（文件/导航/窗口/帮助）
- **修改** `lib/main.dart`：移除 FlutterMethodChannel 菜单桥接代码，用 MacosPlatformMenu 包裹应用
- **修改** `macos/Runner/AppDelegate.swift`：简化原生代码，移除菜单相关的 updateMenuItems/MethodChannel 处理

## 参考
- MisaRin 项目的 MacosMenuShell/MacosMenuBuilder 架构
- Flutter PlatformMenuBar 文档

Closes #564