### PR TITLE
fix(linux): 将 rust_lib_nipaplay 恢复为 FFI plugin 修复 deb 依赖问题

### DIFF
--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -16,7 +16,6 @@
 #include <hotkey_manager_linux/hotkey_manager_linux_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <media_kit_video/media_kit_video_plugin.h>
-#include <rust_lib_nipaplay/rust_lib_nipaplay_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <tray_manager/tray_manager_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
@@ -54,9 +53,6 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) media_kit_video_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "MediaKitVideoPlugin");
   media_kit_video_plugin_register_with_registrar(media_kit_video_registrar);
-  g_autoptr(FlPluginRegistrar) rust_lib_nipaplay_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "RustLibNipaplayPlugin");
-  rust_lib_nipaplay_plugin_register_with_registrar(rust_lib_nipaplay_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -13,7 +13,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   hotkey_manager_linux
   media_kit_libs_linux
   media_kit_video
-  rust_lib_nipaplay
   screen_retriever_linux
   tray_manager
   url_launcher_linux
@@ -23,6 +22,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
   nipaplay_smb2
+  rust_lib_nipaplay
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)


### PR DESCRIPTION
## 问题描述

在 v1.10.5 到 v1.10.7 之间，Linux 构建中 `rust_lib_nipaplay` 从 FFI plugin 变更为 native plugin。这导致 deb 包出现缺失依赖 "lib nipaplay" 的问题。

## 修复方案

将 `rust_lib_nipaplay` 恢复为 FFI plugin：

1. **`linux/flutter/generated_plugins.cmake`**
   - 从 `FLUTTER_PLUGIN_LIST` 中移除 `rust_lib_nipaplay`
   - 将 `rust_lib_nipaplay` 添加回 `FLUTTER_FFI_PLUGIN_LIST`

2. **`linux/flutter/generated_plugin_registrant.cc`**
   - 移除 `#include <rust_lib_nipaplay/rust_lib_nipaplay_plugin.h>` 头文件引用
   - 移除 `RustLibNipaplayPlugin` 的 native plugin 注册代码（3行）

这样 deb 包就不会错误地依赖 "lib nipaplay" 系统库，而是像 v1.10.5 一样通过 FFI 方式加载 Rust 库。