### PR TITLE
fix:smb danmaku match support

### DIFF
--- a/cpp_native/scripts/build_macos.sh
+++ b/cpp_native/scripts/build_macos.sh
@@ -3,6 +3,10 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CPP_NATIVE_DIR="$(dirname "$SCRIPT_DIR")"
 
+# Xcode Run Script 阶段的 PATH 不会继承 shell 配置，显式补上 Homebrew 路径
+# 让 Apple Silicon (/opt/homebrew) 和 Intel (/usr/local) 都能找到 cmake 等工具
+export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
+
 # Map Xcode configuration to CMake build type
 if [ "${CONFIGURATION}" = "Debug" ]; then
     CMAKE_BUILD_TYPE="Debug"

--- a/lib/themes/nipaplay/widgets/batch_danmaku_dialog.dart
+++ b/lib/themes/nipaplay/widgets/batch_danmaku_dialog.dart
@@ -75,11 +75,25 @@ class _BatchDanmakuMatchDialogState extends State<BatchDanmakuMatchDialog>
   String get hotkeyDisableReason => 'batch_danmaku_dialog';
 
   /// 从路径或 URL 得到显示名：URL 取 pathSegments 最后一段，本地路径用 basename。
+  /// 特殊处理 SMB 代理 URL（形如 http://127.0.0.1:PORT/smb/stream?conn=...&path=/foo/bar.mkv），
+  /// 真实文件名在查询参数 path 里，pathSegments.last 只会得到 "stream"。
   static String _displayNameFromPath(String path) {
     if (path.contains('://')) {
-      final segments = Uri.tryParse(path)?.pathSegments;
-      if (segments != null && segments.isNotEmpty) {
-        return segments.last;
+      final uri = Uri.tryParse(path);
+      if (uri != null) {
+        // SMB 代理：从查询参数 path 取真实文件名
+        final smbPath = uri.queryParameters['path'];
+        if (smbPath != null && smbPath.isNotEmpty) {
+          final lastSlash = smbPath.lastIndexOf('/');
+          final tail = lastSlash >= 0 ? smbPath.substring(lastSlash + 1) : smbPath;
+          if (tail.isNotEmpty) return tail;
+        }
+        // 一般 HTTP URL：取 pathSegments 最后一段
+        final segments = uri.pathSegments;
+        if (segments.isNotEmpty) {
+          final last = segments.last;
+          if (last.isNotEmpty) return last;
+        }
       }
       return path;
     }

--- a/lib/themes/nipaplay/widgets/library_management_tab.dart
+++ b/lib/themes/nipaplay/widgets/library_management_tab.dart
@@ -2168,10 +2168,21 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
   }
 
   /// URL 或本地路径取“文件名”：URL 取 pathSegments 最后一段，否则 p.basename。
+  /// SMB 代理 URL（/smb/stream?path=...）真实文件名在查询参数里，需特殊处理。
   static String _basenameOrUrlLastSegment(String pathOrUrl) {
     if (pathOrUrl.contains('://')) {
-      final last = Uri.tryParse(pathOrUrl)?.pathSegments.lastOrNull;
-      if (last != null && last.isNotEmpty) return last;
+      final uri = Uri.tryParse(pathOrUrl);
+      if (uri != null) {
+        final smbPath = uri.queryParameters['path'];
+        if (smbPath != null && smbPath.isNotEmpty) {
+          final lastSlash = smbPath.lastIndexOf('/');
+          final tail =
+              lastSlash >= 0 ? smbPath.substring(lastSlash + 1) : smbPath;
+          if (tail.isNotEmpty) return tail;
+        }
+        final last = uri.pathSegments.lastOrNull;
+        if (last != null && last.isNotEmpty) return last;
+      }
       return pathOrUrl;
     }
     return p.basename(pathOrUrl);
@@ -2258,6 +2269,51 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
           // 处理返回结果
           print('Custom media info result for WebDAV: $result');
         }
+      },
+    );
+  }
+
+  Widget _buildBatchDanmakuMatchFolderActionForSMB(
+    SMBConnection connection,
+    String folderPath,
+    List<SMBFileEntry> videoFiles,
+    double indent, {
+    required bool isDark,
+    required Color titleColor,
+    required Color subtitleColor,
+    required Color iconColor,
+  }) {
+    // SMB 文件以代理流 URL 作为唯一标识（与 _playSMBFile 写入历史记录时一致），
+    // 这样后续手动/批量匹配写入的 WatchHistoryItem 才能被播放路径命中。
+    final fileUrls = videoFiles
+        .map((f) => SMBProxyService.instance.buildStreamUrl(connection, f.path))
+        .toList();
+    final folderDisplayName = (folderPath == '/' || folderPath.isEmpty)
+        ? connection.name
+        : p.basename(folderPath);
+    return ListTile(
+      dense: true,
+      contentPadding: EdgeInsets.fromLTRB(indent, 0, 8, 0),
+      leading: Icon(Icons.playlist_add_check, color: iconColor, size: 18),
+      title: Text(
+        '批量匹配弹幕（本文件夹）',
+        locale: const Locale('zh-Hans', 'zh'),
+        style: TextStyle(color: titleColor, fontSize: 13),
+      ),
+      subtitle: Text(
+        '对齐左侧文件顺序与右侧剧集顺序，一键匹配 ${videoFiles.length} 个文件',
+        locale: const Locale('zh-Hans', 'zh'),
+        style: TextStyle(color: subtitleColor, fontSize: 12),
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      onTap: () {
+        _showBatchDanmakuMatchDialog(
+          folderPath,
+          fileUrls,
+          initialSearchKeyword: folderDisplayName,
+          onSuccessRefresh: () => setState(() {}),
+        );
       },
     );
   }
@@ -3180,6 +3236,19 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
         .where((f) => !f.isDirectory && SMBService.instance.isVideoFile(f.name))
         .toList();
 
+    final batchActionWidget = videoFilesInFolder.length >= 2
+        ? _buildBatchDanmakuMatchFolderActionForSMB(
+            connection,
+            path,
+            videoFilesInFolder,
+            indent,
+            isDark: isDark,
+            titleColor: textColor,
+            subtitleColor: secondaryTextColor,
+            iconColor: iconColor,
+          )
+        : null;
+
     final customMediaInfoWidget = videoFilesInFolder.length >= 2
         ? _buildCustomMediaInfoActionForSMB(
             connection,
@@ -3193,6 +3262,9 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
         : null;
 
     final widgets = <Widget>[];
+    if (batchActionWidget != null) {
+      widgets.add(batchActionWidget);
+    }
     if (customMediaInfoWidget != null) {
       widgets.add(customMediaInfoWidget);
     }
@@ -3309,11 +3381,16 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
                             );
                           },
                         ),
-                        // 播放按钮
+                        // 手动匹配弹幕按钮（替换原“播放”按钮；行点击仍可播放）
                         SearchBarActionButton(
-                          icon: Icons.play_circle_outline,
-                          tooltip: '播放',
-                          onPressed: () => _playSMBFile(connection, file),
+                          icon: Icons.subtitles,
+                          color: iconColor,
+                          tooltip: '手动匹配弹幕',
+                          onPressed: () => _showManualDanmakuMatchDialog(
+                            fileUrl!,
+                            file.name,
+                            snapshot.data,
+                          ),
                         ),
                       ],
                     )

--- a/lib/themes/nipaplay/widgets/library_management_tab.dart
+++ b/lib/themes/nipaplay/widgets/library_management_tab.dart
@@ -2361,8 +2361,12 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
   }
 
   // 显示手动匹配弹幕对话框
+  // [onSuccessRefresh] 在匹配并保存成功后调用，用于触发调用方所在视图的刷新。
+  // 远程库（WebDAV/SMB）必须传入此回调，否则下方的 _refreshExpandedFolderContents
+  // 只会在本地文件夹 map 上查找，对远程内容是 no-op，导致行内字幕保持旧状态。
   Future<void> _showManualDanmakuMatchDialog(
-      String filePath, String fileName, WatchHistoryItem? historyItem) async {
+      String filePath, String fileName, WatchHistoryItem? historyItem,
+      {void Function()? onSuccessRefresh}) async {
     try {
       // 使用文件名作为初始搜索关键词
       String initialSearchKeyword = fileName;
@@ -2432,7 +2436,11 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
               BlurSnackBar.show(context, '弹幕匹配成功：$animeTitle - $episodeTitle');
 
               // 刷新UI以显示新的动画信息
-              _refreshExpandedFolderContents(p.dirname(filePath));
+              if (onSuccessRefresh != null) {
+                onSuccessRefresh();
+              } else {
+                _refreshExpandedFolderContents(p.dirname(filePath));
+              }
             }
           } catch (e) {
             debugPrint('❌ 更新弹幕匹配信息失败：$e');
@@ -3183,6 +3191,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
                               fileUrl!,
                               file.name,
                               snapshot.data,
+                              onSuccessRefresh: () => setState(() {}),
                             ),
                           ),
                         ],
@@ -3390,6 +3399,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
                             fileUrl!,
                             file.name,
                             snapshot.data,
+                            onSuccessRefresh: () => setState(() {}),
                           ),
                         ),
                       ],


### PR DESCRIPTION
## Summary

- 修复了SMB库管理中缺少“批量弹幕匹配”和“手动匹配弹幕”按钮的问题

## Related Issue

- Closes #566 
