### PR TITLE
[Fix] Tablet danmaku 2x supersampling to fix iPad aliasing

### DIFF
--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -4,6 +4,7 @@ import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
 import 'package:nipaplay/danmaku_next/next2_emoji_pipeline.dart';
 import 'package:nipaplay/danmaku_next/next2_texture_bridge.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
+import 'package:nipaplay/utils/globals.dart' as globals;
 
 import 'dfm_plus_layout_bridge.dart';
 
@@ -77,6 +78,9 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
   bool _textureReady = false;
   String _surfaceId = 'dfm-default';
   double _lastDevicePixelRatio = 1.0;
+
+  /// Tablet devices render at 2x then downscale to fix aliasing on iPad.
+  static const double _tabletSupersampleMultiplier = 2.0;
 
   @override
   void initState() {
@@ -243,8 +247,12 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
     final views = WidgetsBinding.instance.platformDispatcher.views;
     final dpr =
         views.isNotEmpty ? views.first.devicePixelRatio : _lastDevicePixelRatio;
+
+    // Apply supersampling multiplier for tablet devices to fix aliasing.
+    final supersample = globals.isTablet ? _tabletSupersampleMultiplier : 1.0;
     final double pixelRatio =
-        dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0;
+        (dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0) * supersample;
+
     final int pixelWidth =
         (_layoutSize.width * pixelRatio).round().clamp(1, 16384).toInt();
     final int pixelHeight =

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -156,10 +156,14 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
                 _textureId != null &&
                 Next2TextureBridge.isSupported;
 
+            // Use filtered downsampling when supersampling is active (tablets)
+            // so the 2x buffer is properly averaged during downscale.
+            final filterQuality =
+                globals.isTablet ? FilterQuality.low : FilterQuality.none;
             final Widget content = hasTexture
                 ? Texture(
                     textureId: _textureId!,
-                    filterQuality: FilterQuality.none,
+                    filterQuality: filterQuality,
                   )
                 : const SizedBox.expand();
 

--- a/lib/danmaku_next/nipaplay_next2_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next2_overlay.dart
@@ -137,10 +137,14 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
                 _textureId != null &&
                 Next2TextureBridge.isSupported;
 
+            // Use filtered downsampling when supersampling is active (tablets)
+            // so the 2x buffer is properly averaged during downscale.
+            final filterQuality =
+                globals.isTablet ? FilterQuality.low : FilterQuality.none;
             final Widget content = hasTexture
                 ? Texture(
                     textureId: _textureId!,
-                    filterQuality: FilterQuality.none,
+                    filterQuality: filterQuality,
                   )
                 : const SizedBox.expand();
 

--- a/lib/danmaku_next/nipaplay_next2_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next2_overlay.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
+import 'package:nipaplay/utils/globals.dart' as globals;
 
 import 'next2_emoji_pipeline.dart';
 import 'next2_layout_bridge.dart';
@@ -66,6 +67,9 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
   bool _textureReady = false;
   String _surfaceId = 'next2-default';
   double _lastDevicePixelRatio = 1.0;
+
+  /// Tablet devices render at 2x then downscale to fix aliasing on iPad.
+  static const double _tabletSupersampleMultiplier = 2.0;
 
   @override
   void initState() {
@@ -210,8 +214,12 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
     final views = WidgetsBinding.instance.platformDispatcher.views;
     final dpr =
         views.isNotEmpty ? views.first.devicePixelRatio : _lastDevicePixelRatio;
+
+    // Apply supersampling multiplier for tablet devices to fix aliasing.
+    final supersample = globals.isTablet ? _tabletSupersampleMultiplier : 1.0;
     final double pixelRatio =
-        dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0;
+        (dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0) * supersample;
+
     final int pixelWidth =
         (_layoutSize.width * pixelRatio).round().clamp(1, 16384).toInt();
     final int pixelHeight =


### PR DESCRIPTION
## Summary

Fix jagged danmaku text on iPad by applying 2x supersampling for tablet devices.

### Problem

On iPad, the danmaku (bullet comments) text rendered by both next2 and dfm+ kernels has visible aliasing (jagged edges). This is because the texture resolution is not sufficient for the high-DPI display.

### Solution

Apply a 2x supersampling multiplier when the device is detected as a tablet (`globals.isTablet`). The texture is rendered at double the normal pixel density, then downscaled by Flutter's `Texture` widget, producing smoother text edges.

### Changes

- `lib/danmaku_next/nipaplay_next2_overlay.dart`: Added tablet supersampling logic in `_tryUpdateTexture()`
- `lib/danmaku_dfm/dfm_plus_overlay.dart`: Same change for dfm+ overlay

### How it works

1. Detect tablet device using existing `globals.isTablet` getter
2. Multiply `pixelRatio` by 2.0 for tablets
3. Create texture at 2x pixel dimensions (4x total pixels)
4. Flutter's `Texture` widget automatically downscales to display size
5. Result: smoother danmaku text with anti-aliased edges

### Notes

- Only affects tablet devices (iPad, Android tablets with shortest side >= 600dp)
- Phone and desktop devices are unaffected
- Performance impact: 4x texture memory for tablets (acceptable trade-off for quality)
- Uses existing `globals.isTablet` detection which is already well-tested
