### PR TITLE
feat:api usability check

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -466,9 +466,6 @@ void main(List<String> args) async {
 
     // SMB 本地代理（用于 SMB 文件按 HTTP/Range 播放与匹配）
     if (!kIsWeb) SMBProxyService.instance.initialize() else Future.value(),
-
-    // 服务器连接状态检测
-    ServerConnectivityService.instance.initialize(),
   ]).then((results) async {
     // BangumiService初始化完成后，检查并刷新缺少标签的缓存
     Future.microtask(() async {
@@ -478,6 +475,9 @@ void main(List<String> args) async {
         debugPrint('检查缓存标签失败: $e');
       }
     });
+
+    // 服务器连接状态检测（后台执行，不阻塞启动）
+    ServerConnectivityService.instance.checkConnectivity();
 
     // 处理主题模式设置
     final settingsMap = results[2] as Map<String, dynamic>;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -88,6 +88,7 @@ import 'package:nipaplay/providers/app_language_provider.dart';
 import 'package:nipaplay/models/watch_history_database.dart';
 import 'package:nipaplay/services/http_client_initializer.dart';
 import 'package:nipaplay/services/smb_proxy_service.dart';
+import 'package:nipaplay/services/server_connectivity_service.dart';
 import 'package:nipaplay/providers/bottom_bar_provider.dart';
 import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
 import 'pages/webdav_browser_page.dart';
@@ -465,6 +466,9 @@ void main(List<String> args) async {
 
     // SMB 本地代理（用于 SMB 文件按 HTTP/Range 播放与匹配）
     if (!kIsWeb) SMBProxyService.instance.initialize() else Future.value(),
+
+    // 服务器连接状态检测
+    ServerConnectivityService.instance.initialize(),
   ]).then((results) async {
     // BangumiService初始化完成后，检查并刷新缺少标签的缓存
     Future.microtask(() async {

--- a/lib/services/bangumi_api_service.dart
+++ b/lib/services/bangumi_api_service.dart
@@ -801,6 +801,7 @@ class BangumiApiService {
   static Future<Map<String, dynamic>> getSubjectCommentsFallback(
     int bangumiId, {
     int page = 1,
+    Duration timeout = const Duration(seconds: 8),
   }) async {
     try {
       final targetUri = Uri.parse(
@@ -828,7 +829,7 @@ class BangumiApiService {
         'X-Timestamp': '$timestamp',
       };
 
-      final response = await http.get(uri, headers: headers);
+      final response = await http.get(uri, headers: headers).timeout(timeout);
       debugPrint('[Dandanplay Comments] 状态码: ${response.statusCode}');
       final dandanPreview = response.body.length > 300
           ? response.body.substring(0, 300)

--- a/lib/services/server_connectivity_service.dart
+++ b/lib/services/server_connectivity_service.dart
@@ -5,7 +5,6 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:nipaplay/services/dandanplay_service.dart';
-import 'package:nipaplay/utils/network_settings.dart';
 
 class ServerConnectivityService {
   static final ServerConnectivityService instance =
@@ -38,19 +37,22 @@ class ServerConnectivityService {
     dandanplayNotifier.value = null;
     bangumiNotifier.value = null;
 
-    final dandanplayServer = await NetworkSettings.getDandanplayServer();
+    try {
+      final dandanplayServer = await DandanplayService.getApiBaseUrl();
 
-    final results = await Future.wait([
-      _checkDandanplay(dandanplayServer),
-      _checkBangumi(),
-    ]);
+      final results = await Future.wait([
+        _checkDandanplay(dandanplayServer),
+        _checkBangumi(),
+      ]);
 
-    _dandanplayAvailable = results[0];
-    _bangumiAvailable = results[1];
-    _isChecking = false;
-    dandanplayNotifier.value = results[0];
-    bangumiNotifier.value = results[1];
-    checkingNotifier.value = false;
+      _dandanplayAvailable = results[0];
+      _bangumiAvailable = results[1];
+      dandanplayNotifier.value = results[0];
+      bangumiNotifier.value = results[1];
+    } finally {
+      _isChecking = false;
+      checkingNotifier.value = false;
+    }
   }
 
   static String _generateSignature(

--- a/lib/services/server_connectivity_service.dart
+++ b/lib/services/server_connectivity_service.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:nipaplay/services/dandanplay_service.dart';
+import 'package:nipaplay/utils/network_settings.dart';
+
+class ServerConnectivityService {
+  static final ServerConnectivityService instance =
+      ServerConnectivityService._internal();
+
+  ServerConnectivityService._internal();
+
+  bool? _dandanplayAvailable;
+  bool? _bangumiAvailable;
+  bool _isChecking = false;
+
+  bool? get dandanplayAvailable => _dandanplayAvailable;
+  bool? get bangumiAvailable => _bangumiAvailable;
+  bool get isChecking => _isChecking;
+
+  final ValueNotifier<bool?> dandanplayNotifier = ValueNotifier(null);
+  final ValueNotifier<bool?> bangumiNotifier = ValueNotifier(null);
+  final ValueNotifier<bool> checkingNotifier = ValueNotifier(false);
+
+  Future<void> initialize() async {
+    await checkConnectivity();
+  }
+
+  Future<void> checkConnectivity() async {
+    if (_isChecking) return;
+    _isChecking = true;
+    checkingNotifier.value = true;
+    _dandanplayAvailable = null;
+    _bangumiAvailable = null;
+    dandanplayNotifier.value = null;
+    bangumiNotifier.value = null;
+
+    final dandanplayServer = await NetworkSettings.getDandanplayServer();
+
+    final results = await Future.wait([
+      _checkDandanplay(dandanplayServer),
+      _checkBangumi(),
+    ]);
+
+    _dandanplayAvailable = results[0];
+    _bangumiAvailable = results[1];
+    _isChecking = false;
+    dandanplayNotifier.value = results[0];
+    bangumiNotifier.value = results[1];
+    checkingNotifier.value = false;
+  }
+
+  static String _generateSignature(
+    String appId,
+    int timestamp,
+    String apiPath,
+    String appSecret,
+  ) {
+    final signatureString = '$appId$timestamp$apiPath$appSecret';
+    final hash = sha256.convert(utf8.encode(signatureString));
+    return base64.encode(hash.bytes);
+  }
+
+  Future<bool> _checkDandanplay(String serverUrl) async {
+    const apiPath = '/api/v2/bangumi/1';
+    final uri = Uri.parse('$serverUrl$apiPath');
+    try {
+      final appSecret = await DandanplayService.getAppSecret();
+      final timestamp =
+          (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
+      final headers = {
+        'Accept': 'application/json',
+        'User-Agent': DandanplayService.userAgent,
+        'X-AppId': DandanplayService.appId,
+        'X-Signature': _generateSignature(
+          DandanplayService.appId,
+          timestamp,
+          apiPath,
+          appSecret,
+        ),
+        'X-Timestamp': '$timestamp',
+      };
+      final response =
+          await http.get(uri, headers: headers).timeout(const Duration(seconds: 8));
+      return response.statusCode == 200;
+    } on TimeoutException {
+      return false;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  Future<bool> _checkBangumi() async {
+    final uri = Uri.parse('https://api.bgm.tv/v0/subjects/1');
+    const headers = {'User-Agent': 'NipaPlay/1.0'};
+    try {
+      final response =
+          await http.get(uri, headers: headers).timeout(const Duration(seconds: 8));
+      return response.statusCode == 200;
+    } on TimeoutException {
+      return false;
+    } catch (e) {
+      return false;
+    }
+  }
+}

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_network_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_network_settings_page.dart
@@ -2,6 +2,7 @@ import 'package:nipaplay/themes/cupertino/cupertino_adaptive_platform_ui.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
 import 'package:nipaplay/l10n/l10n.dart';
 
+import 'package:nipaplay/services/server_connectivity_service.dart';
 import 'package:nipaplay/utils/network_settings.dart';
 import 'package:nipaplay/utils/cupertino_settings_colors.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_group_card.dart';
@@ -23,17 +24,29 @@ class _CupertinoNetworkSettingsPageState
   bool _isSavingCustom = false;
   late final TextEditingController _customServerController;
 
+  final _connectivity = ServerConnectivityService.instance;
+
   @override
   void initState() {
     super.initState();
     _customServerController = TextEditingController();
     _loadCurrentServer();
+    _connectivity.dandanplayNotifier.addListener(_onConnectivityChanged);
+    _connectivity.bangumiNotifier.addListener(_onConnectivityChanged);
+    _connectivity.checkingNotifier.addListener(_onConnectivityChanged);
   }
 
   @override
   void dispose() {
+    _connectivity.dandanplayNotifier.removeListener(_onConnectivityChanged);
+    _connectivity.bangumiNotifier.removeListener(_onConnectivityChanged);
+    _connectivity.checkingNotifier.removeListener(_onConnectivityChanged);
     _customServerController.dispose();
     super.dispose();
+  }
+
+  void _onConnectivityChanged() {
+    if (mounted) setState(() {});
   }
 
   Future<void> _loadCurrentServer() async {
@@ -219,6 +232,8 @@ class _CupertinoNetworkSettingsPageState
                   ),
                   padding: EdgeInsets.fromLTRB(16, topPadding, 16, 32),
                   children: [
+                    _buildConnectivityCard(context),
+                    const SizedBox(height: 24),
                     _buildServerSelectorCard(context),
                     const SizedBox(height: 24),
                     _buildCustomServerCard(context),
@@ -228,6 +243,115 @@ class _CupertinoNetworkSettingsPageState
                 ),
         ),
       ),
+    );
+  }
+
+  Widget _buildConnectivityCard(BuildContext context) {
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color secondaryColor = resolveSettingsSecondaryTextColor(context);
+    final textTheme = CupertinoTheme.of(context).textTheme.textStyle;
+    final isChecking = _connectivity.isChecking;
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(CupertinoIcons.wifi, size: 18, color: iconColor),
+                  const SizedBox(width: 8),
+                  Text(
+                    '网络诊断',
+                    style: textTheme.copyWith(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const Spacer(),
+                  GestureDetector(
+                    onTap: isChecking ? null : _connectivity.checkConnectivity,
+                    child: isChecking
+                        ? const CupertinoActivityIndicator(radius: 10)
+                        : Icon(
+                            CupertinoIcons.refresh,
+                            color: iconColor,
+                            size: 20,
+                          ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              _buildCupertinoStatusRow(
+                '弹弹play 服务器',
+                _connectivity.dandanplayAvailable,
+                textTheme,
+                secondaryColor,
+              ),
+              const SizedBox(height: 10),
+              _buildCupertinoStatusRow(
+                'Bangumi 服务器',
+                _connectivity.bangumiAvailable,
+                textTheme,
+                secondaryColor,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCupertinoStatusRow(
+    String label,
+    bool? available,
+    TextStyle textTheme,
+    Color secondaryColor,
+  ) {
+    String statusText;
+    Color statusColor;
+    IconData statusIcon;
+
+    if (available == null) {
+      statusText = '检测中…';
+      statusColor = secondaryColor;
+      statusIcon = CupertinoIcons.hourglass;
+    } else if (available) {
+      statusText = '可用';
+      statusColor = CupertinoColors.activeGreen;
+      statusIcon = CupertinoIcons.checkmark_circle;
+    } else {
+      statusText = '不可用';
+      statusColor = CupertinoColors.systemRed;
+      statusIcon = CupertinoIcons.xmark_circle;
+    }
+
+    return Row(
+      children: [
+        Icon(statusIcon, color: statusColor, size: 18),
+        const SizedBox(width: 8),
+        Text(
+          label,
+          style: textTheme.copyWith(
+            fontSize: 14,
+            color: secondaryColor,
+          ),
+        ),
+        const Spacer(),
+        Text(
+          statusText,
+          style: textTheme.copyWith(
+            fontSize: 14,
+            color: statusColor,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/themes/cupertino/widgets/cupertino_bangumi_comments_widget.dart
+++ b/lib/themes/cupertino/widgets/cupertino_bangumi_comments_widget.dart
@@ -117,7 +117,7 @@ class CupertinoBangumiCommentsWidgetState
           }
         }
 
-        if (shouldFallback && widget.dandanplayId != 0) {
+        if (shouldFallback && widget.dandanplayId != 0 && dandanplayAvailable != false) {
           debugPrint(
               '[Cupertino Comments] $fallbackReason，回退到Dandanplay, dandanplayId=${widget.dandanplayId}');
           _usingFallback = true;
@@ -128,6 +128,9 @@ class CupertinoBangumiCommentsWidgetState
           );
           debugPrint(
               '[Cupertino Comments] Dandanplay回退结果: success=${result['success']}');
+        } else if (shouldFallback && widget.dandanplayId != 0 && dandanplayAvailable == false) {
+          debugPrint(
+              '[Cupertino Comments] $fallbackReason，且Dandanplay不可用，跳过回退');
         } else if (shouldFallback && widget.dandanplayId == 0) {
           debugPrint(
               '[Cupertino Comments] $fallbackReason，但无dandanplayId可用，无法回退');

--- a/lib/themes/cupertino/widgets/cupertino_bangumi_comments_widget.dart
+++ b/lib/themes/cupertino/widgets/cupertino_bangumi_comments_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
 import 'package:nipaplay/models/bangumi_comment_model.dart';
 import 'package:nipaplay/services/bangumi_api_service.dart';
+import 'package:nipaplay/services/server_connectivity_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/bangumi_comments_widget.dart'
     show BangumiMyCommentData;
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -85,7 +86,11 @@ class CupertinoBangumiCommentsWidgetState
       final int requestedSubjectId = widget.subjectId ?? 0;
       Map<String, dynamic> result;
 
-      if (!_usingFallback && requestedSubjectId != 0) {
+      final connectivity = ServerConnectivityService.instance;
+      final bangumiUnavailable = connectivity.bangumiAvailable == false;
+      final dandanplayAvailable = connectivity.dandanplayAvailable == true;
+
+      if (!_usingFallback && requestedSubjectId != 0 && !(bangumiUnavailable && dandanplayAvailable && widget.dandanplayId != 0)) {
         debugPrint(
             '[Cupertino Comments] 尝试Bangumi主接口, subjectId=$requestedSubjectId, offset=$_currentOffset');
         result = await BangumiApiService.getSubjectComments(
@@ -128,6 +133,10 @@ class CupertinoBangumiCommentsWidgetState
               '[Cupertino Comments] $fallbackReason，但无dandanplayId可用，无法回退');
         }
       } else if (widget.dandanplayId != 0) {
+        if (bangumiUnavailable && dandanplayAvailable) {
+          debugPrint('[Cupertino Comments] Bangumi不可用但Dandanplay可用，跳过Bangumi直接回退, dandanplayId=${widget.dandanplayId}');
+        }
+        _usingFallback = true;
         debugPrint(
             '[Cupertino Comments] 使用Dandanplay回退接口, dandanplayId=${widget.dandanplayId}, page=$_currentPage');
         result = await BangumiApiService.getSubjectCommentsFallback(

--- a/lib/themes/nipaplay/pages/settings/network_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/network_settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/l10n/l10n.dart';
 import 'package:nipaplay/utils/network_settings.dart';
+import 'package:nipaplay/services/server_connectivity_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_item.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
@@ -22,16 +23,28 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
   final TextEditingController _customServerController = TextEditingController();
   bool _isSavingCustom = false;
 
+  final _connectivity = ServerConnectivityService.instance;
+
   @override
   void initState() {
     super.initState();
     _loadCurrentServer();
+    _connectivity.dandanplayNotifier.addListener(_onConnectivityChanged);
+    _connectivity.bangumiNotifier.addListener(_onConnectivityChanged);
+    _connectivity.checkingNotifier.addListener(_onConnectivityChanged);
   }
 
   @override
   void dispose() {
+    _connectivity.dandanplayNotifier.removeListener(_onConnectivityChanged);
+    _connectivity.bangumiNotifier.removeListener(_onConnectivityChanged);
+    _connectivity.checkingNotifier.removeListener(_onConnectivityChanged);
     _customServerController.dispose();
     super.dispose();
+  }
+
+  void _onConnectivityChanged() {
+    if (mounted) setState(() {});
   }
 
   Future<void> _loadCurrentServer() async {
@@ -107,6 +120,49 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
     }
   }
 
+  Widget _buildStatusRow(String label, bool? available, ColorScheme colorScheme) {
+    String statusText;
+    Color statusColor;
+    IconData statusIcon;
+
+    if (available == null) {
+      statusText = '检测中…';
+      statusColor = colorScheme.onSurface.withOpacity(0.5);
+      statusIcon = Ionicons.hourglass_outline;
+    } else if (available) {
+      statusText = '可用';
+      statusColor = Colors.green;
+      statusIcon = Ionicons.checkmark_circle_outline;
+    } else {
+      statusText = '不可用';
+      statusColor = Colors.red;
+      statusIcon = Ionicons.close_circle_outline;
+    }
+
+    return Row(
+      children: [
+        Icon(statusIcon, color: statusColor, size: 16),
+        SizedBox(width: 8),
+        Text(
+          label,
+          style: TextStyle(
+            color: colorScheme.onSurface.withOpacity(0.8),
+            fontSize: 13,
+          ),
+        ),
+        Spacer(),
+        Text(
+          statusText,
+          style: TextStyle(
+            color: statusColor,
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+  }
+
   List<DropdownMenuItemData> _getServerDropdownItems(BuildContext context) {
     final items = [
       DropdownMenuItemData(
@@ -147,11 +203,77 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
     }
 
     final colorScheme = Theme.of(context).colorScheme;
+    final isChecking = _connectivity.isChecking;
+    final dandanplayAvailable = _connectivity.dandanplayAvailable;
+    final bangumiAvailable = _connectivity.bangumiAvailable;
 
     return Scaffold(
       backgroundColor: Colors.transparent,
       body: ListView(
         children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(
+                      Ionicons.wifi_outline,
+                      color: colorScheme.onSurface,
+                      size: 18,
+                    ),
+                    SizedBox(width: 8),
+                    Text(
+                      '网络诊断',
+                      style: TextStyle(
+                        color: colorScheme.onSurface,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    Spacer(),
+                    SizedBox(
+                      width: 32,
+                      height: 32,
+                      child: IconButton(
+                        onPressed: isChecking ? null : _connectivity.checkConnectivity,
+                        icon: isChecking
+                            ? SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: AppAccentColors.current,
+                                ),
+                              )
+                            : Icon(
+                                Ionicons.refresh_outline,
+                                color: colorScheme.onSurface,
+                                size: 18,
+                              ),
+                        padding: EdgeInsets.zero,
+                        constraints: BoxConstraints(),
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 12),
+                _buildStatusRow(
+                  '弹弹play 服务器',
+                  dandanplayAvailable,
+                  colorScheme,
+                ),
+                SizedBox(height: 8),
+                _buildStatusRow(
+                  'Bangumi 服务器',
+                  bangumiAvailable,
+                  colorScheme,
+                ),
+              ],
+            ),
+          ),
+          Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
           SettingsItem.dropdown(
             title: l10n.dandanplayServer,
             subtitle: l10n.networkServerSelectSubtitle,
@@ -230,7 +352,6 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
             ),
           ),
           Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-          // 显示当前服务器信息
           Padding(
             padding: const EdgeInsets.all(16.0),
             child: Column(
@@ -275,7 +396,6 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
               ],
             ),
           ),
-          // 服务器说明
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16.0),
             child: Column(

--- a/lib/themes/nipaplay/widgets/bangumi_comments_widget.dart
+++ b/lib/themes/nipaplay/widgets/bangumi_comments_widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/models/bangumi_comment_model.dart';
 import 'package:nipaplay/services/bangumi_api_service.dart';
+import 'package:nipaplay/services/server_connectivity_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -100,8 +101,12 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
       final int requestedSubjectId = widget.subjectId ?? 0;
       Map<String, dynamic> result;
 
+      final connectivity = ServerConnectivityService.instance;
+      final bangumiUnavailable = connectivity.bangumiAvailable == false;
+      final dandanplayAvailable = connectivity.dandanplayAvailable == true;
+
       // 主请求：Bangumi API (4s超时)
-      if (!_usingFallback && requestedSubjectId != 0) {
+      if (!_usingFallback && requestedSubjectId != 0 && !(bangumiUnavailable && dandanplayAvailable && widget.dandanplayId != 0)) {
         debugPrint(
             '[Bangumi Comments Widget] 尝试Bangumi主接口, subjectId=$requestedSubjectId, offset=$_currentOffset');
         result = await BangumiApiService.getSubjectComments(
@@ -144,7 +149,11 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
           debugPrint('[Bangumi Comments Widget] $fallbackReason，但无dandanplayId可用，无法回退');
         }
       } else if (widget.dandanplayId != 0) {
-        // 已经在使用回退，或没有 subjectId，直接用 Dandanplay
+        // 已经在使用回退，或没有 subjectId，或 Bangumi 不可用但 Dandanplay 可用，直接用 Dandanplay
+        if (bangumiUnavailable && dandanplayAvailable) {
+          debugPrint('[Bangumi Comments Widget] Bangumi不可用但Dandanplay可用，跳过Bangumi直接回退, dandanplayId=${widget.dandanplayId}');
+        }
+        _usingFallback = true;
         debugPrint(
             '[Bangumi Comments Widget] 回退请求 dandanplayId=${widget.dandanplayId}, page=$_currentPage');
         result = await BangumiApiService.getSubjectCommentsFallback(

--- a/lib/themes/nipaplay/widgets/bangumi_comments_widget.dart
+++ b/lib/themes/nipaplay/widgets/bangumi_comments_widget.dart
@@ -135,7 +135,7 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
           }
         }
 
-        if (shouldFallback && widget.dandanplayId != 0) {
+        if (shouldFallback && widget.dandanplayId != 0 && dandanplayAvailable != false) {
           debugPrint('[Bangumi Comments Widget] $fallbackReason，回退到Dandanplay, dandanplayId=${widget.dandanplayId}');
           _usingFallback = true;
           _currentPage = 0;
@@ -145,6 +145,8 @@ class _BangumiCommentsWidgetState extends State<BangumiCommentsWidget> {
           );
           debugPrint(
               '[Bangumi Comments Widget] Dandanplay回退结果: success=${result['success']}');
+        } else if (shouldFallback && widget.dandanplayId != 0 && dandanplayAvailable == false) {
+          debugPrint('[Bangumi Comments Widget] $fallbackReason，且Dandanplay不可用，跳过回退');
         } else if (shouldFallback && widget.dandanplayId == 0) {
           debugPrint('[Bangumi Comments Widget] $fallbackReason，但无dandanplayId可用，无法回退');
         }


### PR DESCRIPTION
## Summary

- 在 网络设置 中增加了“网络诊断”相关项，用于检查当前 弹弹play 和 bangumi API 的可用性，并将检查逻辑添加到应用启动流程中
- 评论回退逻辑新增：读取可用性检查结果，当仅弹弹play可用时直接回退，避免 4s 的 timeout 等待
- 该项自检同时可为以后的 API 回退逻辑提供辅助

## Screen Shot
<img width="1878" height="1350" alt="image" src="https://github.com/user-attachments/assets/a1b967df-215d-436a-a1af-48b498d82357" />

