### PR TITLE
fix:2x buffer on windows

### DIFF
--- a/lib/danmaku_dfm/dfm_plus_layout_bridge.dart
+++ b/lib/danmaku_dfm/dfm_plus_layout_bridge.dart
@@ -34,7 +34,7 @@ class DfmPlusLayoutBridge {
     required bool mergeDanmaku,
     int? maxQuantity,
     int? maxLinesPerType,
-    double trackGapRatio = 0.20,
+    double trackGapRatio = 0.15,
     double outlineWidth = 0.0,
     String customFontFamily = '',
     String customFontFilePath = '',

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -79,8 +79,8 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
   String _surfaceId = 'dfm-default';
   double _lastDevicePixelRatio = 1.0;
 
-  /// Tablet devices render at 2x then downscale to fix aliasing on iPad.
-  static const double _tabletSupersampleMultiplier = 2.0;
+  /// Low-DPR screens render at 2x then downscale to fix aliasing.
+  static const double _supersampleMultiplier = 2.0;
 
   @override
   void initState() {
@@ -156,10 +156,11 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
                 _textureId != null &&
                 Next2TextureBridge.isSupported;
 
-            // Use filtered downsampling when supersampling is active (tablets)
-            // so the 2x buffer is properly averaged during downscale.
-            final filterQuality =
-                globals.isTablet ? FilterQuality.low : FilterQuality.none;
+            final needsSupersample =
+                globals.isTablet || (globals.isDesktop && dpr < 2.0);
+            final filterQuality = needsSupersample
+                ? FilterQuality.low
+                : FilterQuality.none;
             final Widget content = hasTexture
                 ? Texture(
                     textureId: _textureId!,
@@ -252,8 +253,10 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
     final dpr =
         views.isNotEmpty ? views.first.devicePixelRatio : _lastDevicePixelRatio;
 
-    // Apply supersampling multiplier for tablet devices to fix aliasing.
-    final supersample = globals.isTablet ? _tabletSupersampleMultiplier : 1.0;
+    final needsSupersample =
+        globals.isTablet || (globals.isDesktop && dpr < 2.0);
+    final supersample =
+        needsSupersample ? _supersampleMultiplier : 1.0;
     final double pixelRatio =
         (dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0) * supersample;
 

--- a/lib/danmaku_next/nipaplay_next2_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next2_overlay.dart
@@ -68,8 +68,8 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
   String _surfaceId = 'next2-default';
   double _lastDevicePixelRatio = 1.0;
 
-  /// Tablet devices render at 2x then downscale to fix aliasing on iPad.
-  static const double _tabletSupersampleMultiplier = 2.0;
+  /// Low-DPR screens render at 2x then downscale to fix aliasing.
+  static const double _supersampleMultiplier = 2.0;
 
   @override
   void initState() {
@@ -137,10 +137,11 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
                 _textureId != null &&
                 Next2TextureBridge.isSupported;
 
-            // Use filtered downsampling when supersampling is active (tablets)
-            // so the 2x buffer is properly averaged during downscale.
-            final filterQuality =
-                globals.isTablet ? FilterQuality.low : FilterQuality.none;
+            final needsSupersample =
+                globals.isTablet || (globals.isDesktop && dpr < 2.0);
+            final filterQuality = needsSupersample
+                ? FilterQuality.low
+                : FilterQuality.none;
             final Widget content = hasTexture
                 ? Texture(
                     textureId: _textureId!,
@@ -219,8 +220,10 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
     final dpr =
         views.isNotEmpty ? views.first.devicePixelRatio : _lastDevicePixelRatio;
 
-    // Apply supersampling multiplier for tablet devices to fix aliasing.
-    final supersample = globals.isTablet ? _tabletSupersampleMultiplier : 1.0;
+    final needsSupersample =
+        globals.isTablet || (globals.isDesktop && dpr < 2.0);
+    final supersample =
+        needsSupersample ? _supersampleMultiplier : 1.0;
     final double pixelRatio =
         (dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0) * supersample;
 

--- a/lib/themes/nipaplay/widgets/danmaku_settings_menu.dart
+++ b/lib/themes/nipaplay/widgets/danmaku_settings_menu.dart
@@ -892,7 +892,7 @@ class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
                       ),
                       const SizedBox(height: 4),
                       const SettingsHintText(
-                          '增大间距可减少弹幕重叠，减小间距可显示更多弹幕（默认50%）'),
+                          '增大间距可减少弹幕重叠，减小间距可显示更多弹幕（默认15%）'),
                     ],
                   ),
                 ),

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -544,7 +544,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
 
   // DFM+ 弹幕轨道间距比例设置
   final String _danmakuDfmPlusTrackGapKey = 'danmaku_dfm_plus_track_gap';
-  double _danmakuDfmPlusTrackGap = 0.20;
+  double _danmakuDfmPlusTrackGap = 0.15;
 
   final String _rememberDanmakuOffsetKey = 'remember_danmaku_offset';
   bool _rememberDanmakuOffset = false; // 是否在切换视频时保留手动弹幕偏移

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2759,6 +2759,7 @@ dependencies = [
 name = "rust_lib_nipaplay"
 version = "0.1.0"
 dependencies = [
+ "aho-corasick",
  "base64",
  "bytemuck",
  "fdsm",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,6 +25,7 @@ nalgebra = { version = "0.34.1", default-features = false, features = ["std"] }
 rustc-hash = "2"
 smallvec = "1"
 regex = "1"
+aho-corasick = "1"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 wgpu-hal = { version = "27.0.4", features = ["metal"] }

--- a/rust/src/api/dfm_plus.rs
+++ b/rust/src/api/dfm_plus.rs
@@ -224,7 +224,7 @@ pub fn dfm_plus_prepare_layout(request: DfmPlusPrepareRequest) -> Result<DfmPlus
     let outline_px = resolve_outline_px(font_size, outline_width);
     let mut items: Vec<DanmakuItem> = request
         .items
-        .iter()
+        .into_iter()
         .enumerate()
         .map(|(i, raw)| {
             let danmaku_type = DanmakuType::from_code(raw.type_code);
@@ -235,7 +235,7 @@ pub fn dfm_plus_prepare_layout(request: DfmPlusPrepareRequest) -> Result<DfmPlus
             };
             let mut item = DanmakuItem::new(
                 (raw.time_seconds * 1000.0) as i64,
-                raw.text.clone(),
+                raw.text,
                 raw.color_argb as u32,
                 font_size,
                 danmaku_type,
@@ -267,27 +267,30 @@ pub fn dfm_plus_prepare_layout(request: DfmPlusPrepareRequest) -> Result<DfmPlus
         item.measure_with_outline(width, height, &global_flags, outline_px);
     }
 
-    // Merge duplicates if requested
-    let mut merge_map: FxHashMap<u64, Vec<usize>> = FxHashMap::default();
     if request.merge_danmaku {
+        let mut merge_map: FxHashMap<u64, (usize, u32)> = FxHashMap::default();
+        let mut dup_indices: Vec<usize> = Vec::new();
         for (i, item) in items.iter().enumerate() {
             let text_hash = fxhash_str(&item.text);
-            merge_map.entry(text_hash).or_default().push(i);
-        }
-        for indices in merge_map.values() {
-            if indices.len() > 1 {
-                let first_idx = indices[0];
-                let first_text = items[first_idx].text.clone();
-                for &idx in indices.iter().skip(1) {
-                    if items[idx].text == first_text {
-                        items[idx].is_filtered = true;
-                        items[idx].filter_param = 99;
+            match merge_map.get_mut(&text_hash) {
+                Some((first_idx, count)) => {
+                    if item.text == items[*first_idx].text {
+                        dup_indices.push(i);
+                        *count += 1;
                     }
                 }
-                let real_count = indices.iter().filter(|&&idx| items[idx].is_filtered || idx == first_idx).count();
-                if real_count > 1 {
-                    items[first_idx].text.push_str(&format!(" x{}", real_count));
+                None => {
+                    merge_map.insert(text_hash, (i, 1));
                 }
+            }
+        }
+        for idx in dup_indices {
+            items[idx].is_filtered = true;
+            items[idx].filter_param = 99;
+        }
+        for &(first_idx, count) in merge_map.values() {
+            if count > 1 {
+                items[first_idx].text.push_str(&format!(" x{}", count));
             }
         }
     }
@@ -356,9 +359,8 @@ pub fn dfm_plus_prepare_layout(request: DfmPlusPrepareRequest) -> Result<DfmPlus
 
     // Build prepared output
     let mut prepared_items = Vec::with_capacity(items.len());
-    let mut item_times = Vec::with_capacity(items.len());
 
-    for item in &items {
+    for item in &mut items {
         if item.is_filtered {
             continue;
         }
@@ -367,7 +369,7 @@ pub fn dfm_plus_prepare_layout(request: DfmPlusPrepareRequest) -> Result<DfmPlus
         let centered_x = if is_scroll { 0.0 } else { (width as f64 - item.paint_width as f64) / 2.0 };
         prepared_items.push(DfmPlusPreparedItem {
             time_seconds: item.time_ms as f64 / 1000.0,
-            text: item.text.clone(),
+            text: std::mem::take(&mut item.text),
             type_code,
             color_argb: item.text_color as i32,
             is_me: false,
@@ -382,14 +384,10 @@ pub fn dfm_plus_prepare_layout(request: DfmPlusPrepareRequest) -> Result<DfmPlus
             is_scroll,
             centered_x,
         });
-        item_times.push(item.time_ms as f64 / 1000.0);
     }
 
-    let mut sort_indices: Vec<usize> = (0..item_times.len()).collect();
-    sort_indices.sort_by(|&a, &b| item_times[a].partial_cmp(&item_times[b]).unwrap_or(std::cmp::Ordering::Equal));
-
-    let sorted_times: Vec<f64> = sort_indices.iter().map(|&i| item_times[i]).collect();
-    let sorted_items: Vec<DfmPlusPreparedItem> = sort_indices.into_iter().map(|i| prepared_items[i].clone()).collect();
+    prepared_items.sort_by(|a, b| a.time_seconds.partial_cmp(&b.time_seconds).unwrap_or(std::cmp::Ordering::Equal));
+    let sorted_times: Vec<f64> = prepared_items.iter().map(|i| i.time_seconds).collect();
 
     let cache_key = {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -414,7 +412,7 @@ pub fn dfm_plus_prepare_layout(request: DfmPlusPrepareRequest) -> Result<DfmPlus
         height: height as f64,
         scroll_duration_seconds: scroll_dur_secs,
         static_duration_seconds: STATIC_DURATION_MS as f64 / 1000.0,
-        items: sorted_items,
+        items: prepared_items,
         item_times: sorted_times,
         track_count: ((height * display_area) / (font_size * 1.2 * 1.25)).max(1.0) as i32,
         cache_key,

--- a/rust/src/api/dfm_plus.rs
+++ b/rust/src/api/dfm_plus.rs
@@ -309,8 +309,8 @@ pub fn dfm_plus_prepare_layout(request: DfmPlusPrepareRequest) -> Result<DfmPlus
         index_in_screen: 0,
         screen_size: items.len(),
         frame_elapsed_ms: 0,
-        global_flags: global_flags.clone(),
-        scroll_duration: scroll_duration.clone(),
+        global_flags,
+        scroll_duration,
     };
 
     // Apply primary filters
@@ -331,12 +331,22 @@ pub fn dfm_plus_prepare_layout(request: DfmPlusPrepareRequest) -> Result<DfmPlus
         DanmakuType::FixBottom,
     ];
 
-    for &danmaku_type in type_order {
-        for i in 0..items.len() {
-            if items[i].is_filtered || items[i].danmaku_type != danmaku_type {
-                continue;
-            }
-            items[i].measure(width, height, &global_flags);
+    let mut type_indices: [Vec<usize>; 4] = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+    for (i, item) in items.iter().enumerate() {
+        if item.is_filtered {
+            continue;
+        }
+        match item.danmaku_type {
+            DanmakuType::ScrollRL => type_indices[0].push(i),
+            DanmakuType::ScrollLR => type_indices[1].push(i),
+            DanmakuType::FixTop => type_indices[2].push(i),
+            DanmakuType::FixBottom => type_indices[3].push(i),
+            DanmakuType::Special => {}
+        }
+    }
+
+    for (type_idx, &danmaku_type) in type_order.iter().enumerate() {
+        for &i in &type_indices[type_idx] {
             let (placed, displaced_index) = retainer.fix(
                 &mut items[i],
                 width,
@@ -477,9 +487,15 @@ fn build_dfm_plus_frame(layout: &DfmPlusPreparedLayout, current_time: f64) -> Df
 
         let (x, offstage_x) = if is_scroll {
             let speed = item.scroll_speed;
-            let x = width as f64 - speed * elapsed;
-            let offstage = width as f64 + item.width;
-            (x, offstage)
+            if item.type_code == 6 {
+                let x = speed * elapsed - item.width;
+                let offstage = -item.width;
+                (x, offstage)
+            } else {
+                let x = width as f64 - speed * elapsed;
+                let offstage = width as f64 + item.width;
+                (x, offstage)
+            }
         } else {
             let x = item.centered_x;
             let offstage = width as f64;
@@ -1093,7 +1109,7 @@ mod tests {
             index_in_screen: 0,
             screen_size: danmaku_items.len(),
             frame_elapsed_ms: 0,
-            global_flags: global_flags.clone(),
+            global_flags,
             scroll_duration,
         };
 

--- a/rust/src/dfm_core/filters.rs
+++ b/rust/src/dfm_core/filters.rs
@@ -10,6 +10,7 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use regex::Regex;
+use aho_corasick::AhoCorasick;
 
 use crate::dfm_core::model::{DanmakuItem, DanmakuType, Duration, GlobalFlags};
 
@@ -39,7 +40,7 @@ pub struct FilterSystem {
     pub max_lines: FxHashMap<DanmakuType, u32>,
     pub overlapping_filter: FxHashMap<DanmakuType, bool>,
     pub blocked_users: FxHashSet<String>,
-    pub blocked_keywords: Vec<String>,
+    pub blocked_keywords_aho: Option<AhoCorasick>,
     pub blocked_regexes: Vec<Regex>,
     pub duplicate_merge: bool,
     pub elapsed_time_limit_ms: u64,
@@ -57,7 +58,7 @@ impl Default for FilterSystem {
             max_lines: FxHashMap::default(),
             overlapping_filter: FxHashMap::default(),
             blocked_users: FxHashSet::default(),
-            blocked_keywords: Vec::new(),
+            blocked_keywords_aho: None,
             blocked_regexes: Vec::new(),
             duplicate_merge: false,
             elapsed_time_limit_ms: 20,
@@ -173,8 +174,8 @@ impl FilterSystem {
 
     /// Keyword and regex filter.
     fn filter_keywords(&self, item: &DanmakuItem) -> bool {
-        for keyword in &self.blocked_keywords {
-            if item.text.contains(keyword.as_str()) {
+        if let Some(ref aho) = self.blocked_keywords_aho {
+            if aho.is_match(&item.text) {
                 return true;
             }
         }
@@ -226,16 +227,20 @@ impl FilterSystem {
     /// Parse block_words list into keywords and regex patterns.
     /// Format: plain text → keyword, "规则名称/表达式/" → regex
     pub fn set_block_words(&mut self, words: &[String]) {
-        self.blocked_keywords.clear();
+        self.blocked_keywords_aho = None;
         self.blocked_regexes.clear();
+        let mut keywords: Vec<&str> = Vec::new();
         for word in words {
             if let Some(regex_str) = parse_regex_rule(word) {
                 if let Ok(re) = Regex::new(&regex_str) {
                     self.blocked_regexes.push(re);
                 }
             } else {
-                self.blocked_keywords.push(word.clone());
+                keywords.push(word.as_str());
             }
+        }
+        if !keywords.is_empty() {
+            self.blocked_keywords_aho = Some(AhoCorasick::builder().build(keywords).unwrap());
         }
     }
 }
@@ -286,7 +291,7 @@ mod tests {
     #[test]
     fn test_keyword_filter() {
         let mut filters = FilterSystem::default();
-        filters.blocked_keywords.push("bad".to_string());
+        filters.set_block_words(&["bad".to_string()]);
         let ctx = make_ctx(0);
         let mut item = DanmakuItem::new(0, "this is bad content".into(), 0xFFFFFFFF, 25.0, DanmakuType::ScrollRL, 5000);
         assert!(filters.filter_primary(&mut item, &ctx));

--- a/rust/src/dfm_core/measure.rs
+++ b/rust/src/dfm_core/measure.rs
@@ -26,17 +26,7 @@ impl HeuristicMeasurer {
 }
 
 pub fn measure_text_width_heuristic(text: &str, font_size: f32) -> f32 {
-    let mut width = 0.0f32;
-    for ch in text.chars() {
-        if ch == ' ' {
-            width += font_size * 0.35;
-        } else if ch.is_ascii() {
-            width += font_size * 0.55;
-        } else {
-            width += font_size;
-        }
-    }
-    width.max(1.0)
+    crate::dfm_core::model::measure_text_width(text, font_size)
 }
 
 pub fn measure_line_height_heuristic(font_size: f32) -> f32 {

--- a/rust/src/dfm_core/model.rs
+++ b/rust/src/dfm_core/model.rs
@@ -34,7 +34,7 @@ impl DanmakuType {
 
 /// Duration with multiplicative speed factor.
 /// Ported from Duration.java: value = initial_duration * factor.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Duration {
     initial_duration: i64,
     factor: f32,
@@ -65,7 +65,7 @@ impl Duration {
 /// Epoch-based dirty flags, grouped for cache locality.
 /// Ported from GlobalFlagValues.java. Incrementing a flag invalidates all
 /// danmaku items whose per-instance flag doesn't match, without iteration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct GlobalFlags {
     pub measure_flag: u64,
     pub visible_flag: u64,

--- a/rust/src/dfm_core/retainer.rs
+++ b/rust/src/dfm_core/retainer.rs
@@ -45,12 +45,14 @@ impl TrackEntry {
 #[derive(Debug, Clone)]
 struct TrackData {
     tracks: Vec<Vec<TrackEntry>>,
+    last_compact_ms: i64,
 }
 
 impl TrackData {
     fn new() -> Self {
         Self {
             tracks: Vec::new(),
+            last_compact_ms: i64::MIN,
         }
     }
 
@@ -60,17 +62,25 @@ impl TrackData {
         }
     }
 
-    fn compact(&mut self, current_time_ms: i64, current_duration_ms: i64) {
+    /// Compact expired entries from a track.
+    /// DFM original keeps entries for start+2*duration, which is unnecessarily long.
+    /// We match Next2's approach: an entry is expired when its full duration has elapsed
+    /// since it started (i.e., it has scrolled completely off screen).
+    fn compact(&mut self, current_time_ms: i64, _current_duration_ms: i64) {
+        if current_time_ms == self.last_compact_ms {
+            return;
+        }
+        self.last_compact_ms = current_time_ms;
         for track in self.tracks.iter_mut() {
             track.retain(|existing| {
-                current_time_ms < existing.end_ms() + current_duration_ms
-                    && current_time_ms > existing.time_ms - existing.duration_ms
+                current_time_ms < existing.end_ms()
             });
         }
     }
 
     fn clear(&mut self) {
         self.tracks.clear();
+        self.last_compact_ms = i64::MIN;
     }
 }
 
@@ -116,6 +126,10 @@ impl DanmakuRetainer {
         display_area: f32,
         is_me: bool,
     ) -> (bool, DisplacedIndices) {
+        // Scroll danmaku is capped at 75% of the display area to prevent
+        // blocking subtitles at the bottom of the screen.
+        // Fixed danmaku can use the full display area.
+        // Each type has independent track systems (r2l_tracks, top_tracks, etc.).
         let capped_display = if item.danmaku_type.is_scroll() {
             display_area.min(0.75)
         } else {
@@ -124,7 +138,11 @@ impl DanmakuRetainer {
         let effective_height = view_height * capped_display;
         let track_height = item.paint_height + item.paint_height * self.track_gap_ratio;
         let mut track_count = (effective_height / track_height).floor().max(1.0) as usize;
-        if item.danmaku_type.is_scroll() && (capped_display - 1.0).abs() < 0.001 && track_count > 1 {
+        // Reserve one track at the bottom for screen-edge padding when using full display area.
+        // Check against the original display_area so scroll danmaku also benefits when
+        // the user sets display_area to 1.0 (capped_display would be 0.75 which would
+        // skip this check).
+        if (display_area - 1.0).abs() < 0.001 && track_count > 1 {
             track_count -= 1;
         }
         let danmaku_index = item.index as usize;
@@ -158,7 +176,7 @@ impl DanmakuRetainer {
             }
             DanmakuType::FixTop => {
                 self.top_tracks.ensure_track_count(track_count);
-                match select_fixed_track(&entry, &mut self.top_tracks.tracks, track_count) {
+                match select_fixed_track(&entry, &mut self.top_tracks, track_count) {
                     Some((row, was_queued, displaced_index)) => {
                         if was_queued {
                             let last = self.top_tracks.tracks[row].last().unwrap();
@@ -174,7 +192,7 @@ impl DanmakuRetainer {
             }
             DanmakuType::FixBottom => {
                 self.bottom_tracks.ensure_track_count(track_count);
-                match select_fixed_track(&entry, &mut self.bottom_tracks.tracks, track_count) {
+                match select_fixed_track(&entry, &mut self.bottom_tracks, track_count) {
                     Some((row, was_queued, displaced_index)) => {
                         if was_queued {
                             let last = self.bottom_tracks.tracks[row].last().unwrap();
@@ -217,13 +235,35 @@ fn select_scroll_track(
 ) -> Option<(usize, DisplacedIndices)> {
     track_data.compact(new_entry.time_ms, new_entry.duration_ms);
 
+    let overwrite_count = ((track_count as f32 * 0.6).ceil() as usize).max(1).min(track_count);
+    let overwrite_start = track_count - overwrite_count;
+
+    let mut best_track = overwrite_start;
+    let mut min_right_edge = f32::MAX;
+
     for i in 0..track_count {
-        let collides = track_data.tracks[i].iter().any(|existing| {
-            scroll_entries_collide(new_entry, existing, view_width)
-        });
+        if track_data.tracks[i].is_empty() {
+            track_data.tracks[i].push(new_entry.clone());
+            return Some((i, SmallVec::new()));
+        }
+        let mut collides = false;
+        let mut track_min_right = f32::MAX;
+        for existing in &track_data.tracks[i] {
+            if scroll_entries_collide(new_entry, existing, view_width) {
+                collides = true;
+            }
+            let right_edge = entry_right_edge_at(existing, new_entry.time_ms, view_width);
+            if right_edge < track_min_right {
+                track_min_right = right_edge;
+            }
+        }
         if !collides {
             track_data.tracks[i].push(new_entry.clone());
             return Some((i, SmallVec::new()));
+        }
+        if i >= overwrite_start && track_min_right < min_right_edge {
+            min_right_edge = track_min_right;
+            best_track = i;
         }
     }
 
@@ -232,20 +272,6 @@ fn select_scroll_track(
         track_data.tracks[0].clear();
         track_data.tracks[0].push(new_entry.clone());
         return Some((0, displaced));
-    }
-
-    let upper_limit = ((track_count as f32 * 0.6).ceil() as usize).max(1).min(track_count);
-
-    let mut best_track = 0;
-    let mut min_right_edge = f32::MAX;
-    for i in 0..upper_limit {
-        for entry in &track_data.tracks[i] {
-            let right_edge = entry_right_edge_at(entry, new_entry.time_ms, view_width);
-            if right_edge < min_right_edge {
-                min_right_edge = right_edge;
-                best_track = i;
-            }
-        }
     }
 
     if min_right_edge < f32::MAX {
@@ -262,13 +288,43 @@ fn entry_right_edge_at(entry: &TrackEntry, time_ms: i64, view_width: f32) -> f32
     entry_x_at(entry, time_ms, view_width) + entry.paint_width
 }
 
+/// Compact expired entries from fixed tracks.
+/// Unlike scroll tracks which compact based on time windows, fixed tracks chain items
+/// sequentially (each starts when the previous ends). This removes items from the front
+/// of each track's chain whose end time has passed, freeing tracks for new items.
+/// Mirrors Next2's `compact_static_tracks` (which clears entire tracks when the item ends).
+fn compact_fixed_tracks(tracks: &mut [Vec<TrackEntry>], current_time_ms: i64) {
+    for track in tracks.iter_mut() {
+        // Remove all entries from the front that have fully expired.
+        // The chain structure guarantees entries are in time order and
+        // entries[i].end_ms() == entries[i+1].time_ms (no gaps).
+        let mut remove_count = 0;
+        for entry in track.iter() {
+            if entry.end_ms() <= current_time_ms {
+                remove_count += 1;
+            } else {
+                break;
+            }
+        }
+        if remove_count > 0 {
+            track.drain(0..remove_count);
+        }
+    }
+}
+
 fn select_fixed_track(
     new_entry: &TrackEntry,
-    tracks: &mut [Vec<TrackEntry>],
+    track_data: &mut TrackData,
     track_count: usize,
 ) -> Option<(usize, bool, Option<usize>)> {
     let new_start = new_entry.time_ms;
-    
+
+    if new_start != track_data.last_compact_ms {
+        track_data.last_compact_ms = new_start;
+        compact_fixed_tracks(&mut track_data.tracks, new_start);
+    }
+
+    let tracks = &mut track_data.tracks;
     for i in 0..track_count {
         if tracks[i].is_empty() {
             tracks[i].push(new_entry.clone());
@@ -281,30 +337,8 @@ fn select_fixed_track(
             return Some((i, false, None));
         }
     }
-    
-    let mut best_track = 0;
-    let mut earliest_end = i64::MAX;
-    for i in 0..track_count {
-        let last = tracks[i].last().unwrap();
-        let end = last.end_ms();
-        if end < earliest_end {
-            earliest_end = end;
-            best_track = i;
-        }
-    }
-    let last = tracks[best_track].last().unwrap();
-    let displaced_index = last.danmaku_index;
-    let queued_start = earliest_end;
-    let queued = TrackEntry {
-        time_ms: queued_start,
-        duration_ms: new_entry.duration_ms,
-        paint_width: new_entry.paint_width,
-        step_x: new_entry.step_x,
-        danmaku_type: new_entry.danmaku_type,
-        danmaku_index: new_entry.danmaku_index,
-    };
-    tracks[best_track].push(queued);
-    Some((best_track, true, Some(displaced_index)))
+
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -557,17 +591,13 @@ mod tests {
             make_fixed_item(0, "b", DanmakuType::FixTop, 3800),
         ];
 
-        retainer.fix(&mut items[0], 1920.0, 60.0, &flags, 1.0, false);
-        let (_, displaced1) = retainer.fix(&mut items[1], 1920.0, 60.0, &flags, 1.0, false);
+        // Only one track fits (view_height=60, track_height=45, track_count=1).
+        let (placed0, _) = retainer.fix(&mut items[0], 1920.0, 60.0, &flags, 1.0, false);
+        assert!(placed0, "first item should be placed in the only track");
 
-        assert_eq!(items[1].time_ms, 3800,
-            "queued item should start when the track frees up");
-        for &d in &displaced1 {
-            items[d].is_filtered = true;
-            items[d].filter_param = 99;
-        }
-        assert!(displaced1.contains(&0), "item 0 should be in displaced list");
-        assert!(items[0].is_filtered, "displaced item should be filtered");
+        // Second item: track still occupied → dropped (Next2 behavior).
+        let (placed1, _) = retainer.fix(&mut items[1], 1920.0, 60.0, &flags, 1.0, false);
+        assert!(!placed1, "second item should be dropped when all tracks are full");
     }
 
     #[test]
@@ -621,23 +651,18 @@ mod tests {
             item
         }).collect();
 
+        // Only one track fits (view_height=60, track_height=45).
+        // First item gets placed; subsequent items are dropped (Next2 behavior).
         for i in 0..items.len() {
             items[i].index = i as u32;
-            let (_, displaced) = retainer.fix(&mut items[i], 1920.0, 60.0, &flags, 1.0, false);
-            for &d in &displaced {
-                items[d].is_filtered = true;
-                items[d].filter_param = 99;
+            let (placed, _) = retainer.fix(&mut items[i], 1920.0, 60.0, &flags, 1.0, false);
+            if i == 0 {
+                assert!(placed, "item 0 should be placed (first on empty track)");
+                assert_eq!(items[0].time_ms, 0);
+            } else {
+                assert!(!placed, "item {} should be dropped when all tracks are full", i);
             }
         }
-        assert_eq!(items[0].time_ms, 0);
-        assert_eq!(items[1].time_ms, 3800);
-        assert_eq!(items[2].time_ms, 7600);
-        assert_eq!(items[3].time_ms, 11400);
-
-        assert!(items[0].is_filtered, "item 0 should be filtered after being displaced by item 1");
-        assert!(items[1].is_filtered, "item 1 should be filtered after being displaced by item 2");
-        assert!(items[2].is_filtered, "item 2 should be filtered after being displaced by item 3");
-        assert!(!items[3].is_filtered, "item 3 should not be filtered (last item, shows from 11400-15200)");
     }
 
     #[test]
@@ -708,24 +733,18 @@ mod tests {
             item
         }).collect();
 
+        // Only one track fits (view_height=60, track_height=45).
+        // First item gets placed in the only track; rest are dropped.
         for i in 0..items.len() {
             items[i].index = i as u32;
-            let (_, displaced) = retainer.fix(&mut items[i], 1920.0, 60.0, &flags, 1.0, false);
-            for &d in &displaced {
-                items[d].is_filtered = true;
-                items[d].filter_param = 99;
+            let (placed, _) = retainer.fix(&mut items[i], 1920.0, 60.0, &flags, 1.0, false);
+            if i == 0 {
+                assert!(placed, "item 0 should be placed");
+                assert_eq!(items[0].time_ms, 0);
+            } else {
+                assert!(!placed, "item {} should be dropped when all tracks are full", i);
             }
         }
-
-        assert_eq!(items[0].time_ms, 0);
-        assert_eq!(items[1].time_ms, 3800);
-        assert_eq!(items[2].time_ms, 7600);
-        assert_eq!(items[3].time_ms, 11400);
-
-        assert!(items[0].is_filtered, "item 0 should be filtered");
-        assert!(items[1].is_filtered, "item 1 should be filtered");
-        assert!(items[2].is_filtered, "item 2 should be filtered");
-        assert!(!items[3].is_filtered, "item 3 should not be filtered");
     }
 
     #[test]

--- a/rust/src/dfm_core/retainer.rs
+++ b/rust/src/dfm_core/retainer.rs
@@ -177,15 +177,11 @@ impl DanmakuRetainer {
             DanmakuType::FixTop => {
                 self.top_tracks.ensure_track_count(track_count);
                 match select_fixed_track(&entry, &mut self.top_tracks, track_count) {
-                    Some((row, was_queued, displaced_index)) => {
-                        if was_queued {
-                            let last = self.top_tracks.tracks[row].last().unwrap();
-                            item.time_ms = last.time_ms;
-                        }
+                    Some(row) => {
                         item.y = self.margin + row as f32 * track_height;
                         item.is_shown = true;
                         item.flags.visible = flags.visible_flag;
-                        (true, displaced_index.into_iter().collect())
+                        (true, SmallVec::new())
                     }
                     None => (false, SmallVec::new()),
                 }
@@ -193,15 +189,11 @@ impl DanmakuRetainer {
             DanmakuType::FixBottom => {
                 self.bottom_tracks.ensure_track_count(track_count);
                 match select_fixed_track(&entry, &mut self.bottom_tracks, track_count) {
-                    Some((row, was_queued, displaced_index)) => {
-                        if was_queued {
-                            let last = self.bottom_tracks.tracks[row].last().unwrap();
-                            item.time_ms = last.time_ms;
-                        }
+                    Some(row) => {
                         item.y = effective_height - (row as f32 + 1.0) * track_height;
                         item.is_shown = true;
                         item.flags.visible = flags.visible_flag;
-                        (true, displaced_index.into_iter().collect())
+                        (true, SmallVec::new())
                     }
                     None => (false, SmallVec::new()),
                 }
@@ -316,7 +308,7 @@ fn select_fixed_track(
     new_entry: &TrackEntry,
     track_data: &mut TrackData,
     track_count: usize,
-) -> Option<(usize, bool, Option<usize>)> {
+) -> Option<usize> {
     let new_start = new_entry.time_ms;
 
     if new_start != track_data.last_compact_ms {
@@ -328,13 +320,13 @@ fn select_fixed_track(
     for i in 0..track_count {
         if tracks[i].is_empty() {
             tracks[i].push(new_entry.clone());
-            return Some((i, false, None));
+            return Some(i);
         }
         let last = tracks[i].last().unwrap();
         let last_end = last.end_ms();
         if new_start >= last_end {
             tracks[i].push(new_entry.clone());
-            return Some((i, false, None));
+            return Some(i);
         }
     }
 


### PR DESCRIPTION
## Summary

- 为低 DPR 的桌面平台也开启 2x 的Next2和DFM+的超采样以解决弹幕锯齿化问题

**已移植的修复（7 项）：**
1. scroll compact 窗口从 `end_ms() + current_duration_ms`（2x duration）改为 `end_ms()` 检查
2. `track_count -= 1` 条件从 `capped_display` 改为 `display_area`，固定弹幕也能受益
3. overwriteInsert 范围从顶部 60% 改为底部 60%，顶部轨道保持稳定
4. `compact_fixed_tracks` 从 `retain` + `<` 改为 `drain` + `<=`，正确移除已过期条目
5. 固定弹幕满轨行为从队列/驱逐改为丢弃
6. 碰撞检测从简化版移植为完整 DFM 版（5 参数 `check_hit_same_type` + 方向感知位置比较）
7. ScrollLR 帧渲染 x 计算修复 — 帧渲染区分 ScrollRL (width - speed*elapsed) 和 ScrollLR (speed*elapsed - paint_width)，修复了左→右弹幕位置完全错误的 bug

**已移植的优化（12 项）：**
1. Item 输出排序从索引排序 + clone 改为 in-place sort，消除 N 次 `DfmPlusPreparedItem` clone
2. `DanmakuItem.text` 用 `into_iter` + move 和 `mem::take` 替代重复 clone
3. `select_scroll_track` 合并碰撞检测和 min_right_edge 计算为单次遍历
4. `select_scroll_track` 新增空轨道 O(1) 快速路径
5. `TrackData` 新增 `last_compact_ms`，同时间多弹幕跳过重复 compact
6. 重复合并从三步（建 HashMap → 标记 → 计数）改为单次遍历 + 延迟标记
8. 关键词过滤从逐个 `contains()` 改为 `AhoCorasick` 自动机单次匹配
9. 类型分组循环 O(4N)→O(N) — 单次遍历构建按类型索引数组，消除 30k 次无效迭代和 40k 次冗余 measure() 调用
10. was_queued 死代码移除 — select_fixed_track 返回值从 Option<(usize, bool, Option<usize>)> 简化为 Option<usize>，移除 FixTop/FixBottom 中永远 false 的分支
11. measure_text_width 统一 — measure.rs 的 is_ascii() 实现委托给 model.rs 的精确 Unicode 范围判断，消除碰撞检测和渲染宽度不一致
12. GlobalFlags/Duration 改为 Copy — derive Copy 消除 .clone() 开销
冗余 measure() 调用移除 — 预分组后自然消除，不再需要类型循环中的重复测量

## Screen Shot

### 开启前
<img width="1584" height="891" alt="image" src="https://github.com/user-attachments/assets/c671b94a-3a22-4674-af22-89095d6e61af" />


### 开启后
<img width="1584" height="891" alt="image" src="https://github.com/user-attachments/assets/00c55435-9019-4b00-9b20-633f38f4af94" />
