### PR TITLE
Fix Linux Next2 crash and CJK font fallback gaps

### DIFF
--- a/lib/pages/anime_detail_page.dart
+++ b/lib/pages/anime_detail_page.dart
@@ -1114,13 +1114,11 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
     final Color textColor = isDark ? Colors.white : Colors.black87;
     final Color secondaryTextColor = isDark ? Colors.white70 : Colors.black54;
 
-    final valueStyle = TextStyle(
+    final baseTextStyle = DefaultTextStyle.of(context).style;
+    final valueStyle = baseTextStyle.copyWith(
         color: textColor.withOpacity(0.85), fontSize: 13, height: 1.5);
-    final boldWhiteKeyStyle = TextStyle(
-        color: textColor,
-        fontWeight: FontWeight.w600,
-        fontSize: 13,
-        height: 1.5);
+    final boldWhiteKeyStyle =
+        valueStyle.copyWith(color: textColor, fontWeight: FontWeight.w600);
     final sectionTitleStyle = Theme.of(context)
         .textTheme
         .titleMedium
@@ -1161,7 +1159,7 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
       titlesWidgets.add(Text('其他标题:', style: sectionTitleStyle));
       titlesWidgets.add(SizedBox(height: 4));
       TextStyle aliasTextStyle =
-          TextStyle(color: secondaryTextColor, fontSize: 12);
+          baseTextStyle.copyWith(color: secondaryTextColor, fontSize: 12);
       for (var titleEntry in anime.titles!) {
         String titleText = titleEntry['title'] ?? '未知标题';
         String languageText = '';

--- a/lib/pages/torrent_download_page.dart
+++ b/lib/pages/torrent_download_page.dart
@@ -635,6 +635,9 @@ class _TorrentHoverActionState extends State<_TorrentHoverAction> {
                     style: TextStyle(
                       color: activeColor,
                       fontSize: 14,
+                      fontFamilyFallback: AppTheme.platformFontFamilyFallback,
+                      decoration: TextDecoration.none,
+                      decorationColor: Colors.transparent,
                       fontWeight:
                           enabled && _isHovered ? FontWeight.w500 : null,
                     ),

--- a/lib/pages/torrent_download_page.dart
+++ b/lib/pages/torrent_download_page.dart
@@ -16,6 +16,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/library_management_layout.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
+import 'package:nipaplay/utils/app_theme.dart';
 import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 
@@ -951,20 +952,32 @@ class _MetricText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final themeTextStyle = Theme.of(context).textTheme.bodySmall;
+    final baseStyle = (themeTextStyle ?? const TextStyle()).copyWith(
+      fontSize: 12,
+      fontFamilyFallback: AppTheme.platformFontFamilyFallback,
+      decoration: TextDecoration.none,
+      decorationColor: Colors.transparent,
+    );
     return Text.rich(
       TextSpan(
+        style: baseStyle,
         children: [
           TextSpan(
             text: '$label ',
-            style: TextStyle(color: colorScheme.onSurface.withOpacity(0.50)),
+            style: baseStyle.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.50),
+            ),
           ),
           TextSpan(
             text: value,
-            style: TextStyle(color: colorScheme.onSurface.withOpacity(0.82)),
+            style: baseStyle.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.82),
+            ),
           ),
         ],
       ),
-      style: const TextStyle(fontSize: 12),
+      style: baseStyle,
     );
   }
 }

--- a/lib/themes/nipaplay/pages/account/material_account_page.dart
+++ b/lib/themes/nipaplay/pages/account/material_account_page.dart
@@ -10,6 +10,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/widgets/user_activity/material_user_activity.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
+import 'package:nipaplay/utils/app_theme.dart';
 
 enum _BangumiSyncHelpService { dandanplay, nipaplay }
 
@@ -43,8 +44,44 @@ class _MaterialAccountPageState extends State<MaterialAccountPage>
     return fluent.FluentThemeData(
       brightness: brightness,
       accentColor: fluent.AccentColor.swatch({'normal': _accentColor}),
+      typography: _buildFluentTypography(context),
       micaBackgroundColor: Colors.transparent,
       scaffoldBackgroundColor: Colors.transparent,
+    );
+  }
+
+  fluent.Typography _buildFluentTypography(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final resources = brightness == Brightness.light
+        ? const fluent.ResourceDictionary.light()
+        : const fluent.ResourceDictionary.dark();
+    return _withCjkFallback(
+      fluent.Typography.fromBrightness(
+        brightness: brightness,
+        color: resources.textFillColorPrimary,
+      ),
+    );
+  }
+
+  fluent.Typography _withCjkFallback(fluent.Typography typography) {
+    return fluent.Typography.raw(
+      display: _textStyleWithCjkFallback(typography.display),
+      titleLarge: _textStyleWithCjkFallback(typography.titleLarge),
+      title: _textStyleWithCjkFallback(typography.title),
+      subtitle: _textStyleWithCjkFallback(typography.subtitle),
+      bodyLarge: _textStyleWithCjkFallback(typography.bodyLarge),
+      bodyStrong: _textStyleWithCjkFallback(typography.bodyStrong),
+      body: _textStyleWithCjkFallback(typography.body),
+      caption: _textStyleWithCjkFallback(typography.caption),
+    );
+  }
+
+  TextStyle? _textStyleWithCjkFallback(TextStyle? style) {
+    if (style == null) return null;
+    return style.copyWith(
+      fontFamilyFallback: AppTheme.platformFontFamilyFallback,
+      decoration: TextDecoration.none,
+      decorationColor: Colors.transparent,
     );
   }
 

--- a/lib/themes/nipaplay/widgets/system_resource_display.dart
+++ b/lib/themes/nipaplay/widgets/system_resource_display.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:nipaplay/providers/developer_options_provider.dart';
+import 'package:nipaplay/utils/app_theme.dart';
 import 'package:nipaplay/utils/system_resource_monitor.dart';
 import 'package:provider/provider.dart';
 
@@ -102,13 +103,14 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
   }
 
   TextStyle _outlinedTextStyle({
+    required TextStyle baseStyle,
     required Color color,
     required double fontSize,
     FontWeight weight = FontWeight.w900,
     double strokeWidth = 2.4,
-    double letterSpacing = 0.2,
+    double letterSpacing = 0,
   }) {
-    return TextStyle(
+    return baseStyle.copyWith(
       fontSize: fontSize,
       height: 1.0,
       fontWeight: weight,
@@ -143,6 +145,7 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
     required String value,
     required Color labelColor,
     required Color valueColor,
+    required TextStyle baseStyle,
     bool compact = false,
   }) {
     return RichText(
@@ -153,21 +156,21 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
           TextSpan(
             text: '$label ',
             style: _outlinedTextStyle(
+              baseStyle: baseStyle,
               color: labelColor,
               fontSize: compact ? 12 : 13,
               weight: FontWeight.w800,
               strokeWidth: 1.9,
-              letterSpacing: 0.35,
             ),
           ),
           TextSpan(
             text: value,
             style: _outlinedTextStyle(
+              baseStyle: baseStyle,
               color: valueColor,
               fontSize: compact ? 13 : 14,
               weight: FontWeight.w900,
               strokeWidth: 2.6,
-              letterSpacing: 0.1,
             ),
           ),
         ],
@@ -228,6 +231,12 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
         final narrowScreen = screenWidth < 720;
         final showDetail = screenWidth >= 1160;
         final compact = screenWidth < 900;
+        final themeTextStyle = Theme.of(context).textTheme.bodyMedium;
+        final baseTextStyle = (themeTextStyle ?? const TextStyle()).copyWith(
+          fontFamilyFallback: AppTheme.platformFontFamilyFallback,
+          decoration: TextDecoration.none,
+          decorationColor: Colors.transparent,
+        );
 
         final items = <Widget>[
           _segment(
@@ -235,6 +244,7 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
             value: cpuText,
             labelColor: cpuBase,
             valueColor: cpuColor,
+            baseStyle: baseTextStyle,
             compact: compact,
           ),
           _segment(
@@ -242,6 +252,7 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
             value: memText,
             labelColor: memBase,
             valueColor: memColor,
+            baseStyle: baseTextStyle,
             compact: compact,
           ),
           _segment(
@@ -249,6 +260,7 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
             value: gpuText,
             labelColor: gpuBase,
             valueColor: gpuColor,
+            baseStyle: baseTextStyle,
             compact: compact,
           ),
           _segment(
@@ -256,6 +268,7 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
             value: fpsText,
             labelColor: fpsBase,
             valueColor: fpsColor,
+            baseStyle: baseTextStyle,
             compact: compact,
           ),
           if (showDetail)
@@ -264,6 +277,7 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
               value: _activeDecoder,
               labelColor: _shade(decBase, 0.28),
               valueColor: _shade(decBase, 0.06),
+              baseStyle: baseTextStyle,
               compact: true,
             ),
           if (showDetail)
@@ -272,6 +286,7 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
               value: _playerKernelType,
               labelColor: _shade(playerBase, 0.28),
               valueColor: _shade(playerBase, 0.06),
+              baseStyle: baseTextStyle,
               compact: true,
             ),
           if (showDetail)
@@ -280,6 +295,7 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
               value: _danmakuKernelType,
               labelColor: _shade(danmakuBase, 0.28),
               valueColor: _shade(danmakuBase, 0.06),
+              baseStyle: baseTextStyle,
               compact: true,
             ),
         ];

--- a/lib/utils/system_resource_monitor.dart
+++ b/lib/utils/system_resource_monitor.dart
@@ -44,6 +44,8 @@ class SystemResourceMonitor {
 
   int _lastGpuSampleMillis = 0;
   static const int _gpuSampleIntervalMs = 1500;
+  bool _gpuSamplingSupported = true;
+  String? _lastGpuSamplingError;
 
   double get cpuUsage => _cpuUsage;
   double get memoryUsageMB => _memoryUsageMB;
@@ -238,20 +240,40 @@ class SystemResourceMonitor {
       debugPrint('读取内存采样失败: $e');
     }
 
-    try {
-      final nowMs = DateTime.now().millisecondsSinceEpoch;
-      if (_gpuUsage != null &&
-          nowMs - _lastGpuSampleMillis < _gpuSampleIntervalMs) {
-        return;
-      }
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    if (!_gpuSamplingSupported) {
+      _gpuUsage = null;
+      return;
+    }
 
+    if (_gpuUsage != null &&
+        nowMs - _lastGpuSampleMillis < _gpuSampleIntervalMs) {
+      return;
+    }
+
+    try {
       final gpuSample = await rust_perf.sampleGpuPercent();
       _gpuUsage = gpuSample.gpuPercent.clamp(0.0, 100.0);
       _lastGpuSampleMillis = nowMs;
+      _lastGpuSamplingError = null;
     } catch (e) {
-      debugPrint('读取 GPU 采样失败: $e');
+      final error = e.toString();
+      if (_isUnsupportedGpuSamplingError(error)) {
+        _gpuSamplingSupported = false;
+        _gpuUsage = null;
+        return;
+      }
+      if (_lastGpuSamplingError != error) {
+        debugPrint('读取 GPU 采样失败: $error');
+        _lastGpuSamplingError = error;
+      }
       _gpuUsage = null;
     }
+  }
+
+  bool _isUnsupportedGpuSamplingError(String error) {
+    return error.contains('gpu_sampling_not_implemented') ||
+        error.contains('unsupported_platform');
   }
 
   void _stopMonitoring() {

--- a/rust/src/next2_engine/ffi.rs
+++ b/rust/src/next2_engine/ffi.rs
@@ -199,7 +199,7 @@ pub extern "C" fn next2_engine_set_frame(
 pub extern "C" fn next2_engine_copy_bgra_frame(
     handle: u64,
     out_pixels: *mut u8,
-    out_pixels_len: usize,
+    out_pixels_len: u32,
     out_width: *mut u32,
     out_height: *mut u32,
 ) -> u8 {
@@ -207,6 +207,7 @@ pub extern "C" fn next2_engine_copy_bgra_frame(
         let Some(frame) = readback_frame_bgra(handle) else {
             return 0;
         };
+        let out_pixels_len = out_pixels_len as usize;
         if out_pixels.is_null() || out_pixels_len < frame.pixels.len() {
             return 0;
         }

--- a/rust_builder/linux/rust_lib_nipaplay_plugin.cc
+++ b/rust_builder/linux/rust_lib_nipaplay_plugin.cc
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -39,6 +40,10 @@ constexpr char kChannelName[] = "nipaplay/next2_texture";
 constexpr int kMaxDimension = 16384;
 constexpr int kFallbackSize = 512;
 
+struct SurfaceState;
+using SurfaceMap = std::unordered_map<std::string, std::unique_ptr<SurfaceState>>;
+using SurfaceMutex = std::mutex;
+
 struct SurfaceState {
   std::string surface_id;
   FlPixelBufferTexture* texture = nullptr;
@@ -72,8 +77,8 @@ struct _RustLibNipaplayPlugin {
   FlMethodChannel* channel;
   FlPluginRegistrar* registrar;
   FlTextureRegistrar* texture_registrar;
-  std::unordered_map<std::string, std::unique_ptr<SurfaceState>> surfaces;
-  std::mutex surfaces_lock;
+  SurfaceMap surfaces;
+  SurfaceMutex surfaces_lock;
   guint tick_source = 0;
 };
 
@@ -431,11 +436,21 @@ static void rust_lib_nipaplay_plugin_dispose(GObject* object) {
   G_OBJECT_CLASS(rust_lib_nipaplay_plugin_parent_class)->dispose(object);
 }
 
+static void rust_lib_nipaplay_plugin_finalize(GObject* object) {
+  RustLibNipaplayPlugin* self = RUST_LIB_NIPAPLAY_PLUGIN(object);
+  self->surfaces.~SurfaceMap();
+  self->surfaces_lock.~SurfaceMutex();
+  G_OBJECT_CLASS(rust_lib_nipaplay_plugin_parent_class)->finalize(object);
+}
+
 static void rust_lib_nipaplay_plugin_class_init(RustLibNipaplayPluginClass* klass) {
   G_OBJECT_CLASS(klass)->dispose = rust_lib_nipaplay_plugin_dispose;
+  G_OBJECT_CLASS(klass)->finalize = rust_lib_nipaplay_plugin_finalize;
 }
 
 static void rust_lib_nipaplay_plugin_init(RustLibNipaplayPlugin* self) {
+  new (&self->surfaces) SurfaceMap();
+  new (&self->surfaces_lock) SurfaceMutex();
   self->channel = nullptr;
   self->registrar = nullptr;
   self->texture_registrar = nullptr;


### PR DESCRIPTION
Summary:\n- Fix Linux Next2/DFM+ texture bridge crash by constructing native plugin state correctly and matching the BGRA copy length ABI.\n- Add Linux CJK font fallback coverage for anime details, performance HUD, downloader metrics, and account page Fluent typography.\n- Avoid inheriting text decorations when applying fallback fonts so debug/HUD text does not gain unwanted underlines.\n\nValidation:\n- flutter build linux --release\n- dart analyze lib/themes/nipaplay/widgets/system_resource_display.dart\n- dart analyze lib/pages/torrent_download_page.dart lib/themes/nipaplay/pages/account/material_account_page.dart (existing info-level lints only)\n- git diff --check