### PR TITLE
feat/custom-bangumi-proxy-support

### DIFF
--- a/lib/pages/dashboard_home_page.dart
+++ b/lib/pages/dashboard_home_page.dart
@@ -17,6 +17,7 @@ import 'package:nipaplay/providers/emby_provider.dart';
 import 'package:nipaplay/services/jellyfin_service.dart';
 import 'package:nipaplay/services/emby_service.dart';
 import 'package:nipaplay/services/bangumi_service.dart';
+import 'package:nipaplay/utils/network_settings.dart';
 import 'package:nipaplay/services/dandanplay_service.dart';
 import 'package:nipaplay/services/search_service.dart';
 import 'package:nipaplay/services/scan_service.dart';

--- a/lib/services/bangumi_api_service.dart
+++ b/lib/services/bangumi_api_service.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nipaplay/services/web_remote_access_service.dart';
 import 'package:nipaplay/services/dandanplay_service.dart';
+import 'package:nipaplay/utils/network_settings.dart';
 
 /// Bangumi API服务
 ///
@@ -15,11 +16,24 @@ import 'package:nipaplay/services/dandanplay_service.dart';
 ///
 /// 遵循DandanplayService的设计模式，使用静态方法
 class BangumiApiService {
-  static const String _baseUrl = 'https://api.bgm.tv';
+  static const String _defaultBaseUrl = 'https://api.bgm.tv';
+  static const String _defaultNextBaseUrl = 'https://next.bgm.tv';
   static const String _userAgent = 'NipaPlay/1.0';
   static const String _tokenKey = 'bangumi_access_token';
   static const String _userInfoKey = 'bangumi_user_info';
   static const String _isLoggedInKey = 'bangumi_logged_in';
+
+  static Future<String> getBaseUrl() async {
+    return await NetworkSettings.getBangumiServer();
+  }
+
+  static Future<String> getNextBaseUrl() async {
+    final customServer = await NetworkSettings.getBangumiServer();
+    if (customServer != _defaultBaseUrl) {
+      return customServer;
+    }
+    return _defaultNextBaseUrl;
+  }
 
   static bool _initialized = false;
   static String? _accessToken;
@@ -173,8 +187,9 @@ class BangumiApiService {
     if (_accessToken == null) return false;
 
     try {
+      final baseUrl = await getBaseUrl();
       final response = await http.get(
-        WebRemoteAccessService.proxyUri(Uri.parse('$_baseUrl/v0/me')),
+        WebRemoteAccessService.proxyUri(Uri.parse('$baseUrl/v0/me')),
         headers: {
           'Authorization': 'Bearer $_accessToken',
           'User-Agent': _userAgent,
@@ -210,8 +225,9 @@ class BangumiApiService {
   static Future<Map<String, dynamic>> saveAccessToken(String token) async {
     try {
       // 验证Token有效性
+      final baseUrl = await getBaseUrl();
       final response = await http.get(
-        WebRemoteAccessService.proxyUri(Uri.parse('$_baseUrl/v0/me')),
+        WebRemoteAccessService.proxyUri(Uri.parse('$baseUrl/v0/me')),
         headers: {
           'Authorization': 'Bearer $token',
           'User-Agent': _userAgent,
@@ -315,7 +331,8 @@ class BangumiApiService {
     }
 
     try {
-      Uri targetUri = Uri.parse('$_baseUrl$path');
+      final baseUrl = await getBaseUrl();
+      Uri targetUri = Uri.parse('$baseUrl$path');
       if (queryParams != null && queryParams.isNotEmpty) {
         targetUri = targetUri.replace(queryParameters: queryParams);
       }
@@ -751,8 +768,9 @@ class BangumiApiService {
     Duration timeout = const Duration(seconds: 4),
   }) async {
     try {
+      final nextBaseUrl = await getNextBaseUrl();
       final targetUri = Uri.parse(
-              'https://next.bgm.tv/p1/subjects/$subjectId/comments')
+              '$nextBaseUrl/p1/subjects/$subjectId/comments')
           .replace(queryParameters: {
         'limit': limit.toString(),
         'offset': offset.toString(),

--- a/lib/services/server_connectivity_service.dart
+++ b/lib/services/server_connectivity_service.dart
@@ -5,6 +5,7 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:nipaplay/services/dandanplay_service.dart';
+import 'package:nipaplay/utils/network_settings.dart';
 
 class ServerConnectivityService {
   static final ServerConnectivityService instance =
@@ -39,10 +40,11 @@ class ServerConnectivityService {
 
     try {
       final dandanplayServer = await DandanplayService.getApiBaseUrl();
+      final bangumiServer = await NetworkSettings.getBangumiServer();
 
       final results = await Future.wait([
         _checkDandanplay(dandanplayServer),
-        _checkBangumi(),
+        _checkBangumi(bangumiServer),
       ]);
 
       _dandanplayAvailable = results[0];
@@ -95,8 +97,8 @@ class ServerConnectivityService {
     }
   }
 
-  Future<bool> _checkBangumi() async {
-    final uri = Uri.parse('https://api.bgm.tv/v0/subjects/1');
+  Future<bool> _checkBangumi(String serverUrl) async {
+    final uri = Uri.parse('$serverUrl/v0/subjects/1');
     const headers = {'User-Agent': 'NipaPlay/1.0'};
     try {
       final response =

--- a/lib/themes/cupertino/pages/cupertino_home_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_home_page.dart
@@ -25,6 +25,7 @@ import 'package:nipaplay/providers/home_sections_settings_provider.dart';
 import 'package:nipaplay/providers/jellyfin_provider.dart';
 import 'package:nipaplay/providers/watch_history_provider.dart';
 import 'package:nipaplay/services/bangumi_service.dart';
+import 'package:nipaplay/utils/network_settings.dart';
 import 'package:nipaplay/services/search_service.dart';
 import 'package:nipaplay/services/emby_service.dart';
 import 'package:nipaplay/services/jellyfin_service.dart';
@@ -912,8 +913,9 @@ class _CupertinoHomePageState extends State<CupertinoHomePage> {
 
   Future<String?> _fetchBangumiHighQualityCover(String bangumiId) async {
     try {
+      final bangumiServer = await NetworkSettings.getBangumiServer();
       final uri = Uri.parse(
-          'https://api.bgm.tv/v0/subjects/$bangumiId/image?type=large');
+          '$bangumiServer/v0/subjects/$bangumiId/image?type=large');
       final response = await http.head(
         WebRemoteAccessService.proxyUri(uri),
         headers: const {'User-Agent': 'NipaPlay/1.0'},

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_network_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_network_settings_page.dart
@@ -20,9 +20,12 @@ class CupertinoNetworkSettingsPage extends StatefulWidget {
 class _CupertinoNetworkSettingsPageState
     extends State<CupertinoNetworkSettingsPage> {
   String _currentServer = '';
+  String _currentBangumiServer = '';
   bool _isLoading = true;
   bool _isSavingCustom = false;
+  bool _isSavingBangumiCustom = false;
   late final TextEditingController _customServerController;
+  late final TextEditingController _customBangumiServerController;
 
   final _connectivity = ServerConnectivityService.instance;
 
@@ -30,6 +33,7 @@ class _CupertinoNetworkSettingsPageState
   void initState() {
     super.initState();
     _customServerController = TextEditingController();
+    _customBangumiServerController = TextEditingController();
     _loadCurrentServer();
     _connectivity.dandanplayNotifier.addListener(_onConnectivityChanged);
     _connectivity.bangumiNotifier.addListener(_onConnectivityChanged);
@@ -42,6 +46,7 @@ class _CupertinoNetworkSettingsPageState
     _connectivity.bangumiNotifier.removeListener(_onConnectivityChanged);
     _connectivity.checkingNotifier.removeListener(_onConnectivityChanged);
     _customServerController.dispose();
+    _customBangumiServerController.dispose();
     super.dispose();
   }
 
@@ -51,14 +56,21 @@ class _CupertinoNetworkSettingsPageState
 
   Future<void> _loadCurrentServer() async {
     final server = await NetworkSettings.getDandanplayServer();
+    final bangumiServer = await NetworkSettings.getBangumiServer();
     if (!mounted) return;
     setState(() {
       _currentServer = server;
+      _currentBangumiServer = bangumiServer;
       _isLoading = false;
       if (NetworkSettings.isCustomServer(server)) {
         _customServerController.text = server;
       } else {
         _customServerController.clear();
+      }
+      if (NetworkSettings.isCustomBangumiServer(bangumiServer)) {
+        _customBangumiServerController.text = bangumiServer;
+      } else {
+        _customBangumiServerController.clear();
       }
     });
   }
@@ -87,11 +99,28 @@ class _CupertinoNetworkSettingsPageState
   Future<void> _saveCustomServer() async {
     final input = _customServerController.text.trim();
     if (input.isEmpty) {
-      AdaptiveSnackBar.show(
-        context,
-        message: context.l10n.enterServerAddress,
-        type: AdaptiveSnackBarType.warning,
-      );
+      setState(() {
+        _isSavingCustom = true;
+      });
+      try {
+        await NetworkSettings.resetToDefaultServer();
+        final server = await NetworkSettings.getDandanplayServer();
+        if (!mounted) return;
+        setState(() {
+          _currentServer = server;
+        });
+        AdaptiveSnackBar.show(
+          context,
+          message: '已切换到默认服务器',
+          type: AdaptiveSnackBarType.success,
+        );
+      } finally {
+        if (mounted) {
+          setState(() {
+            _isSavingCustom = false;
+          });
+        }
+      }
       return;
     }
     if (!NetworkSettings.isValidServerUrl(input)) {
@@ -123,6 +152,67 @@ class _CupertinoNetworkSettingsPageState
       if (mounted) {
         setState(() {
           _isSavingCustom = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _saveCustomBangumiServer() async {
+    final input = _customBangumiServerController.text.trim();
+    if (input.isEmpty) {
+      setState(() {
+        _isSavingBangumiCustom = true;
+      });
+      try {
+        await NetworkSettings.resetBangumiServer();
+        final server = await NetworkSettings.getBangumiServer();
+        if (!mounted) return;
+        setState(() {
+          _currentBangumiServer = server;
+        });
+        AdaptiveSnackBar.show(
+          context,
+          message: '已切换到默认服务器',
+          type: AdaptiveSnackBarType.success,
+        );
+      } finally {
+        if (mounted) {
+          setState(() {
+            _isSavingBangumiCustom = false;
+          });
+        }
+      }
+      return;
+    }
+    if (!NetworkSettings.isValidServerUrl(input)) {
+      AdaptiveSnackBar.show(
+        context,
+        message: context.l10n.invalidServerAddress,
+        type: AdaptiveSnackBarType.error,
+      );
+      return;
+    }
+
+    setState(() {
+      _isSavingBangumiCustom = true;
+    });
+
+    try {
+      await NetworkSettings.setBangumiServer(input);
+      final server = await NetworkSettings.getBangumiServer();
+      if (!mounted) return;
+      setState(() {
+        _currentBangumiServer = server;
+      });
+      AdaptiveSnackBar.show(
+        context,
+        message: 'Bangumi 服务器已切换到自定义服务器',
+        type: AdaptiveSnackBarType.success,
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSavingBangumiCustom = false;
         });
       }
     }
@@ -234,9 +324,9 @@ class _CupertinoNetworkSettingsPageState
                   children: [
                     _buildConnectivityCard(context),
                     const SizedBox(height: 24),
-                    _buildServerSelectorCard(context),
+                    _buildBangumiSectionCard(context),
                     const SizedBox(height: 24),
-                    _buildCustomServerCard(context),
+                    _buildDandanplaySectionCard(context),
                     const SizedBox(height: 24),
                     _buildServerInfoCard(context),
                   ],
@@ -355,20 +445,128 @@ class _CupertinoNetworkSettingsPageState
     );
   }
 
-  Widget _buildServerSelectorCard(BuildContext context) {
-    final Color tileColor = resolveSettingsTileBackground(context);
+  Widget _buildBangumiSectionCard(BuildContext context) {
     final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color tileColor = resolveSettingsTileBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color separatorColor = resolveSettingsSeparatorColor(context);
+    final textTheme = CupertinoTheme.of(context).textTheme.textStyle;
+    final Color subtitleColor = resolveSettingsSecondaryTextColor(context);
 
     return CupertinoSettingsGroupCard(
       margin: EdgeInsets.zero,
       backgroundColor: sectionColor,
-      addDividers: true,
-      dividerIndent: 56,
       children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 4),
+          child: Row(
+            children: [
+              Icon(CupertinoIcons.book, size: 16, color: iconColor),
+              const SizedBox(width: 6),
+              Text(
+                'Bangumi',
+                style: textTheme.copyWith(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: subtitleColor,
+                ),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '自定义 Bangumi API 服务器',
+                style: textTheme.copyWith(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '输入自定义 Bangumi API 服务器地址，留空使用默认服务器 (${NetworkSettings.bangumiDefaultServer})',
+                style: textTheme.copyWith(
+                  fontSize: 13,
+                  color: subtitleColor,
+                ),
+              ),
+              const SizedBox(height: 12),
+              CupertinoTextField(
+                controller: _customBangumiServerController,
+                placeholder: 'https://example.com',
+                keyboardType: TextInputType.url,
+                autocorrect: false,
+                enableSuggestions: false,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                decoration: BoxDecoration(
+                  color: CupertinoDynamicColor.resolve(
+                    CupertinoColors.tertiarySystemFill,
+                    context,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerRight,
+                child: SizedBox(
+                  height: 36,
+                  child: CupertinoButton.filled(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 0),
+                    onPressed:
+                        _isSavingBangumiCustom ? null : _saveCustomBangumiServer,
+                    child: _isSavingBangumiCustom
+                        ? const CupertinoActivityIndicator(radius: 8)
+                        : Text(context.l10n.useThisServer),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDandanplaySectionCard(BuildContext context) {
+    final Color sectionColor = resolveSettingsSectionBackground(context);
+    final Color tileColor = resolveSettingsTileBackground(context);
+    final Color iconColor = resolveSettingsIconColor(context);
+    final Color separatorColor = resolveSettingsSeparatorColor(context);
+    final textTheme = CupertinoTheme.of(context).textTheme.textStyle;
+    final Color subtitleColor = resolveSettingsSecondaryTextColor(context);
+
+    return CupertinoSettingsGroupCard(
+      margin: EdgeInsets.zero,
+      backgroundColor: sectionColor,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 4),
+          child: Row(
+            children: [
+              Icon(CupertinoIcons.chat_bubble_text_fill, size: 16, color: iconColor),
+              const SizedBox(width: 6),
+              Text(
+                '弹弹play',
+                style: textTheme.copyWith(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: subtitleColor,
+                ),
+              ),
+            ],
+          ),
+        ),
         CupertinoSettingsTile(
           leading: Icon(
             CupertinoIcons.cloud,
-            color: resolveSettingsIconColor(context),
+            color: iconColor,
           ),
           title: Text(context.l10n.dandanplayServer),
           subtitle: Text(
@@ -380,40 +578,20 @@ class _CupertinoNetworkSettingsPageState
           showChevron: true,
           onTap: _showServerPicker,
         ),
-      ],
-    );
-  }
-
-  Widget _buildCustomServerCard(BuildContext context) {
-    final Color sectionColor = resolveSettingsSectionBackground(context);
-    final textTheme = CupertinoTheme.of(context).textTheme.textStyle;
-    final Color subtitleColor = resolveSettingsSecondaryTextColor(context);
-    final Color iconColor = resolveSettingsIconColor(context);
-
-    return CupertinoSettingsGroupCard(
-      margin: EdgeInsets.zero,
-      backgroundColor: sectionColor,
-      children: [
+        Container(height: 0.5, color: separatorColor),
         Padding(
-          padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(
-                children: [
-                  Icon(CupertinoIcons.pencil_outline,
-                      size: 18, color: iconColor),
-                  const SizedBox(width: 8),
-                  Text(
-                    context.l10n.customServer,
-                    style: textTheme.copyWith(
-                      fontSize: 15,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
+              Text(
+                '自定义弹弹play API 服务器',
+                style: textTheme.copyWith(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
-              const SizedBox(height: 8),
+              const SizedBox(height: 4),
               Text(
                 context.l10n.customServerInputHint,
                 style: textTheme.copyWith(
@@ -501,14 +679,40 @@ class _CupertinoNetworkSettingsPageState
               ),
               const SizedBox(height: 12),
               Text(
+                'Bangumi',
+                style: textTheme.copyWith(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: secondaryColor,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                _currentBangumiServer,
+                style: textTheme.copyWith(
+                  fontSize: 13,
+                  color: secondaryColor,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Text(
+                '弹弹play',
+                style: textTheme.copyWith(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: secondaryColor,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
                 context.l10n.serverField(
                   _getServerDisplayName(context, _currentServer),
                 ),
                 style: textTheme.copyWith(fontSize: 14),
               ),
-              const SizedBox(height: 4),
+              const SizedBox(height: 2),
               Text(
-                context.l10n.urlField(_currentServer),
+                _currentServer,
                 style: textTheme.copyWith(
                   fontSize: 13,
                   color: secondaryColor,

--- a/lib/themes/cupertino/widgets/cupertino_shared_anime_detail_page.dart
+++ b/lib/themes/cupertino/widgets/cupertino_shared_anime_detail_page.dart
@@ -13,6 +13,7 @@ import 'package:nipaplay/providers/shared_remote_library_provider.dart';
 import 'package:nipaplay/providers/watch_history_provider.dart';
 import 'package:nipaplay/services/playback_service.dart';
 import 'package:nipaplay/services/bangumi_service.dart';
+import 'package:nipaplay/utils/network_settings.dart';
 import 'package:nipaplay/services/bangumi_api_service.dart';
 import 'package:nipaplay/services/dandanplay_service.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
@@ -2566,8 +2567,9 @@ class _CupertinoSharedAnimeDetailPageState
 
   Future<String?> _requestBangumiHighQualityImage(String bangumiId) async {
     try {
+      final bangumiServer = await NetworkSettings.getBangumiServer();
       final uri = Uri.parse(
-        'https://api.bgm.tv/v0/subjects/$bangumiId/image?type=large',
+        '$bangumiServer/v0/subjects/$bangumiId/image?type=large',
       );
       debugPrint('[共享番剧详情] 请求Bangumi高清封面: $uri');
       final response = await http.head(

--- a/lib/themes/nipaplay/pages/settings/network_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/network_settings_page.dart
@@ -18,10 +18,14 @@ class NetworkSettingsPage extends StatefulWidget {
 
 class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
   String _currentServer = '';
+  String _currentBangumiServer = '';
   bool _isLoading = true;
   final GlobalKey _serverDropdownKey = GlobalKey();
   final TextEditingController _customServerController = TextEditingController();
+  final TextEditingController _customBangumiServerController =
+      TextEditingController();
   bool _isSavingCustom = false;
+  bool _isSavingBangumiCustom = false;
 
   final _connectivity = ServerConnectivityService.instance;
 
@@ -40,6 +44,7 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
     _connectivity.bangumiNotifier.removeListener(_onConnectivityChanged);
     _connectivity.checkingNotifier.removeListener(_onConnectivityChanged);
     _customServerController.dispose();
+    _customBangumiServerController.dispose();
     super.dispose();
   }
 
@@ -49,13 +54,20 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
 
   Future<void> _loadCurrentServer() async {
     final server = await NetworkSettings.getDandanplayServer();
+    final bangumiServer = await NetworkSettings.getBangumiServer();
     setState(() {
       _currentServer = server;
+      _currentBangumiServer = bangumiServer;
       _isLoading = false;
       if (NetworkSettings.isCustomServer(server)) {
         _customServerController.text = server;
       } else {
         _customServerController.clear();
+      }
+      if (NetworkSettings.isCustomBangumiServer(bangumiServer)) {
+        _customBangumiServerController.text = bangumiServer;
+      } else {
+        _customBangumiServerController.clear();
       }
     });
   }
@@ -84,7 +96,17 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
   Future<void> _saveCustomServer() async {
     final input = _customServerController.text.trim();
     if (input.isEmpty) {
-      BlurSnackBar.show(context, context.l10n.enterServerAddress);
+      setState(() {
+        _isSavingCustom = true;
+      });
+      await NetworkSettings.resetToDefaultServer();
+      final server = await NetworkSettings.getDandanplayServer();
+      if (!mounted) return;
+      setState(() {
+        _currentServer = server;
+        _isSavingCustom = false;
+      });
+      BlurSnackBar.show(context, '已切换到默认服务器');
       return;
     }
 
@@ -107,6 +129,44 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
     });
 
     BlurSnackBar.show(context, context.l10n.switchedToCustomServer);
+  }
+
+  Future<void> _saveCustomBangumiServer() async {
+    final input = _customBangumiServerController.text.trim();
+    if (input.isEmpty) {
+      setState(() {
+        _isSavingBangumiCustom = true;
+      });
+      await NetworkSettings.resetBangumiServer();
+      final server = await NetworkSettings.getBangumiServer();
+      if (!mounted) return;
+      setState(() {
+        _currentBangumiServer = server;
+        _isSavingBangumiCustom = false;
+      });
+      BlurSnackBar.show(context, '已切换到默认服务器');
+      return;
+    }
+
+    if (!NetworkSettings.isValidServerUrl(input)) {
+      BlurSnackBar.show(context, context.l10n.invalidServerAddress);
+      return;
+    }
+
+    setState(() {
+      _isSavingBangumiCustom = true;
+    });
+
+    await NetworkSettings.setBangumiServer(input);
+    final server = await NetworkSettings.getBangumiServer();
+    if (!mounted) return;
+
+    setState(() {
+      _currentBangumiServer = server;
+      _isSavingBangumiCustom = false;
+    });
+
+    BlurSnackBar.show(context, 'Bangumi 服务器已切换到自定义服务器');
   }
 
   String _getServerDisplayName(BuildContext context, String serverUrl) {
@@ -163,6 +223,82 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
     );
   }
 
+  Widget _buildCustomServerSection({
+    required String title,
+    required String hint,
+    required TextEditingController controller,
+    required bool isSaving,
+    required VoidCallback onSave,
+    required ColorScheme colorScheme,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Ionicons.create_outline,
+                  color: colorScheme.onSurface, size: 18),
+              SizedBox(width: 8),
+              Text(
+                title,
+                style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: 8),
+          Text(
+            hint,
+            style: TextStyle(
+                color: colorScheme.onSurface.withOpacity(0.7), fontSize: 12),
+          ),
+          SizedBox(height: 12),
+          TextField(
+            controller: controller,
+            cursorColor: AppAccentColors.current,
+            decoration: InputDecoration(
+              hintText: 'https://example.com',
+              hintStyle:
+                  TextStyle(color: colorScheme.onSurface.withOpacity(0.38)),
+              filled: true,
+              fillColor: colorScheme.onSurface.withOpacity(0.1),
+              border: OutlineInputBorder(
+                borderSide: BorderSide.none,
+                borderRadius: BorderRadius.all(Radius.circular(8)),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderSide:
+                    BorderSide(color: AppAccentColors.current, width: 2),
+                borderRadius: BorderRadius.all(Radius.circular(8)),
+              ),
+            ),
+            style: TextStyle(color: colorScheme.onSurface),
+          ),
+          SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: BlurButton(
+              icon: isSaving ? null : Ionicons.checkmark_outline,
+              text: isSaving ? context.l10n.saving : context.l10n.useThisServer,
+              onTap: isSaving ? () {} : onSave,
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              fontSize: 13,
+              iconSize: 16,
+              foregroundColor: colorScheme.onSurface,
+              hoverForegroundColor: AppAccentColors.current,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   List<DropdownMenuItemData> _getServerDropdownItems(BuildContext context) {
     final items = [
       DropdownMenuItemData(
@@ -211,6 +347,7 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
       backgroundColor: Colors.transparent,
       body: ListView(
         children: [
+          // 网络诊断
           Padding(
             padding: const EdgeInsets.all(16.0),
             child: Column(
@@ -274,6 +411,61 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
             ),
           ),
           Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+
+          // Bangumi 服务器配置
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+            child: Row(
+              children: [
+                Icon(
+                  Ionicons.book_outline,
+                  color: colorScheme.onSurface,
+                  size: 16,
+                ),
+                SizedBox(width: 6),
+                Text(
+                  'Bangumi',
+                  style: TextStyle(
+                    color: colorScheme.onSurface.withOpacity(0.6),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          _buildCustomServerSection(
+            title: '自定义 Bangumi API 服务器',
+            hint: '输入自定义 Bangumi API 服务器地址，留空使用默认服务器 (${NetworkSettings.bangumiDefaultServer})',
+            controller: _customBangumiServerController,
+            isSaving: _isSavingBangumiCustom,
+            onSave: _saveCustomBangumiServer,
+            colorScheme: colorScheme,
+          ),
+          Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+
+          // 弹弹play 服务器配置
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+            child: Row(
+              children: [
+                Icon(
+                  Ionicons.chatbubble_ellipses_outline,
+                  color: colorScheme.onSurface,
+                  size: 16,
+                ),
+                SizedBox(width: 6),
+                Text(
+                  '弹弹play',
+                  style: TextStyle(
+                    color: colorScheme.onSurface.withOpacity(0.6),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
           SettingsItem.dropdown(
             title: l10n.dandanplayServer,
             subtitle: l10n.networkServerSelectSubtitle,
@@ -283,75 +475,17 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
             dropdownKey: _serverDropdownKey,
           ),
           Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-          Padding(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Icon(Ionicons.create_outline,
-                        color: colorScheme.onSurface, size: 18),
-                    SizedBox(width: 8),
-                    Text(
-                      l10n.customServer,
-                      style: TextStyle(
-                        color: colorScheme.onSurface,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ],
-                ),
-                SizedBox(height: 8),
-                Text(
-                  l10n.customServerInputHint,
-                  style: TextStyle(
-                      color: colorScheme.onSurface.withOpacity(0.7),
-                      fontSize: 12),
-                ),
-                SizedBox(height: 12),
-                TextField(
-                  controller: _customServerController,
-                  cursorColor: AppAccentColors.current,
-                  decoration: InputDecoration(
-                    hintText: l10n.customServerPlaceholder,
-                    hintStyle: TextStyle(
-                        color: colorScheme.onSurface.withOpacity(0.38)),
-                    filled: true,
-                    fillColor: colorScheme.onSurface.withOpacity(0.1),
-                    border: OutlineInputBorder(
-                      borderSide: BorderSide.none,
-                      borderRadius: BorderRadius.all(Radius.circular(8)),
-                    ),
-                    focusedBorder: OutlineInputBorder(
-                      borderSide:
-                          BorderSide(color: AppAccentColors.current, width: 2),
-                      borderRadius: BorderRadius.all(Radius.circular(8)),
-                    ),
-                  ),
-                  style: TextStyle(color: colorScheme.onSurface),
-                ),
-                SizedBox(height: 8),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: BlurButton(
-                    icon: _isSavingCustom ? null : Ionicons.checkmark_outline,
-                    text: _isSavingCustom ? l10n.saving : l10n.useThisServer,
-                    onTap: _isSavingCustom ? () {} : _saveCustomServer,
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 16, vertical: 10),
-                    fontSize: 13,
-                    iconSize: 16,
-                    foregroundColor: colorScheme.onSurface,
-                    hoverForegroundColor: AppAccentColors.current,
-                  ),
-                ),
-              ],
-            ),
+          _buildCustomServerSection(
+            title: '自定义弹弹play API 服务器',
+            hint: l10n.customServerInputHint,
+            controller: _customServerController,
+            isSaving: _isSavingCustom,
+            onSave: _saveCustomServer,
+            colorScheme: colorScheme,
           ),
           Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+
+          // 服务器信息
           Padding(
             padding: const EdgeInsets.all(16.0),
             child: Column(
@@ -366,7 +500,7 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
                     ),
                     SizedBox(width: 8),
                     Text(
-                      l10n.currentServerInfo,
+                      '当前服务器信息',
                       style: TextStyle(
                         color: colorScheme.onSurface,
                         fontSize: 14,
@@ -375,7 +509,34 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
                     ),
                   ],
                 ),
-                SizedBox(height: 8),
+                SizedBox(height: 10),
+                Text(
+                  'Bangumi',
+                  style: TextStyle(
+                    color: colorScheme.onSurface.withOpacity(0.5),
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                SizedBox(height: 2),
+                Text(
+                  _currentBangumiServer,
+                  style: TextStyle(
+                    color: colorScheme.onSurface.withOpacity(0.7),
+                    fontSize: 13,
+                    fontFamily: 'monospace',
+                  ),
+                ),
+                SizedBox(height: 10),
+                Text(
+                  '弹弹play',
+                  style: TextStyle(
+                    color: colorScheme.onSurface.withOpacity(0.5),
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                SizedBox(height: 2),
                 Text(
                   l10n.serverField(
                       _getServerDisplayName(context, _currentServer)),
@@ -384,9 +545,9 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
                     fontSize: 13,
                   ),
                 ),
-                SizedBox(height: 4),
+                SizedBox(height: 2),
                 Text(
-                  l10n.urlField(_currentServer),
+                  _currentServer,
                   style: TextStyle(
                     color: colorScheme.onSurface.withOpacity(0.6),
                     fontSize: 12,

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_image_helpers.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_image_helpers.dart
@@ -109,8 +109,9 @@ extension DashboardHomePageImageHelpers on _DashboardHomePageState {
     try {
       // 使用Bangumi API的图片接口获取large尺寸的图片
       // GET /v0/subjects/{subject_id}/image?type=large
+      final bangumiServer = await NetworkSettings.getBangumiServer();
       final String imageApiUrl =
-          'https://api.bgm.tv/v0/subjects/$bangumiId/image?type=large';
+          '$bangumiServer/v0/subjects/$bangumiId/image?type=large';
 
       final response = await http.head(
         WebRemoteAccessService.proxyUri(Uri.parse(imageApiUrl)),

--- a/lib/utils/network_settings.dart
+++ b/lib/utils/network_settings.dart
@@ -3,13 +3,17 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// 网络设置管理类
 class NetworkSettings {
   static const String _dandanplayServerKey = 'dandanplay_server_url';
+  static const String _bangumiServerKey = 'bangumi_server_url';
 
-  // 服务器常量
+  // 弹弹play 服务器常量
   static const String primaryServer = 'https://api.dandanplay.net';
   static const String backupServer = 'http://139.224.252.88:16001';
 
   // 默认服务器（主服务器）
   static const String defaultServer = primaryServer;
+
+  // Bangumi 服务器常量
+  static const String bangumiDefaultServer = 'https://api.bgm.tv';
 
   /// 获取当前弹弹play服务器地址
   static Future<String> getDandanplayServer() async {
@@ -26,9 +30,40 @@ class NetworkSettings {
     print('[网络设置] 弹弹play服务器已切换到: $normalized');
   }
 
-  /// 重置为默认服务器
+  /// 获取当前 Bangumi 服务器地址
+  static Future<String> getBangumiServer() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_bangumiServerKey) ?? bangumiDefaultServer;
+    return _normalizeServerUrl(stored);
+  }
+
+  /// 设置 Bangumi 服务器地址
+  static Future<void> setBangumiServer(String serverUrl) async {
+    final prefs = await SharedPreferences.getInstance();
+    final normalized = _normalizeServerUrl(serverUrl);
+    await prefs.setString(_bangumiServerKey, normalized);
+    print('[网络设置] Bangumi服务器已切换到: $normalized');
+  }
+
+  /// 检查当前 Bangumi 服务器是否为自定义服务器
+  static bool isCustomBangumiServer(String serverUrl) {
+    if (serverUrl.trim().isEmpty) {
+      return false;
+    }
+    final normalized = _normalizeServerUrl(serverUrl);
+    return normalized != bangumiDefaultServer;
+  }
+
+  /// 重置弹弹play为默认服务器
   static Future<void> resetToDefaultServer() async {
     await setDandanplayServer(defaultServer);
+  }
+
+  /// 重置Bangumi为默认服务器
+  static Future<void> resetBangumiServer() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_bangumiServerKey);
+    print('[网络设置] Bangumi服务器已重置为默认: $bangumiDefaultServer');
   }
 
   /// 检查是否使用备用服务器


### PR DESCRIPTION
## Summary

- 现已支持自定义bangumi镜像地址

同时提供一份可用的 Cloudflare Workers 脚本：

[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/makabaka11/bangumi-proxy-workers)

全 API 功能测试暂无问题

更多详见：https://github.com/makabaka11/bangumi-proxy-workers
