### PR TITLE
Fix Android SAF local library folders

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -124,6 +124,7 @@ dependencies {
     // 增加OpenGL ES库以支持硬件加速
     implementation "androidx.core:core:1.10.1"
     implementation "androidx.annotation:annotation:1.6.0"
+    implementation "androidx.documentfile:documentfile:1.0.1"
     
     // 添加MediaKit需要的库
     implementation "androidx.media:media:1.6.0"

--- a/android/app/src/main/kotlin/com/aimessoft/nipaplay/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/aimessoft/nipaplay/MainActivity.kt
@@ -28,10 +28,13 @@ import android.content.res.Configuration
 import android.graphics.SurfaceTexture
 import android.view.WindowManager
 import android.webkit.MimeTypeMap
+import androidx.documentfile.provider.DocumentFile
+import java.security.MessageDigest
 
 class MainActivity: FlutterActivity() {
     private val STORAGE_CHANNEL = "custom_storage_channel"
     private val FILE_SELECTOR_CHANNEL = "plugins.flutter.io/file_selector"
+    private val SAF_CHANNEL = "nipaplay/android_saf"
     private val FILE_ASSOCIATION_CHANNEL = "file_association_channel"
     private val SYSTEM_SHARE_CHANNEL = "nipaplay/system_share"
     private val DEVICE_PROFILE_CHANNEL = "nipaplay/device_profile"
@@ -178,6 +181,82 @@ class MainActivity: FlutterActivity() {
                                 "smallestScreenWidthDp" to configuration.smallestScreenWidthDp,
                             )
                         )
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, SAF_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "pickDirectory" -> {
+                        if (safDirectoryPickerResult != null) {
+                            result.error("SAF_PICKER_BUSY", "A directory picker is already active", null)
+                            return@setMethodCallHandler
+                        }
+
+                        try {
+                            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+                                addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+                                addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION)
+                            }
+                            safDirectoryPickerResult = result
+                            startActivityForResult(intent, SAF_DIRECTORY_PICKER_REQUEST_CODE)
+                        } catch (e: Exception) {
+                            safDirectoryPickerResult = null
+                            Log.e("MainActivity", "Error launching SAF directory picker", e)
+                            result.error("SAF_PICKER_ERROR", e.message, null)
+                        }
+                    }
+                    "scanDirectory" -> {
+                        val treeUri = call.argument<String>("treeUri")
+                        if (treeUri.isNullOrBlank()) {
+                            result.error("INVALID_ARGUMENT", "treeUri is required", null)
+                            return@setMethodCallHandler
+                        }
+
+                        Thread {
+                            try {
+                                val entries = scanSafDirectory(treeUri)
+                                runOnUiThread { result.success(entries) }
+                            } catch (e: Exception) {
+                                Log.e("MainActivity", "Error scanning SAF directory", e)
+                                runOnUiThread { result.error("SAF_SCAN_ERROR", e.message, null) }
+                            }
+                        }.start()
+                    }
+                    "getFileMetadata" -> {
+                        val uri = call.argument<String>("uri")
+                        if (uri.isNullOrBlank()) {
+                            result.error("INVALID_ARGUMENT", "uri is required", null)
+                            return@setMethodCallHandler
+                        }
+
+                        Thread {
+                            try {
+                                val metadata = getSafFileMetadata(uri)
+                                runOnUiThread { result.success(metadata) }
+                            } catch (e: Exception) {
+                                Log.e("MainActivity", "Error reading SAF file metadata", e)
+                                runOnUiThread { result.error("SAF_METADATA_ERROR", e.message, null) }
+                            }
+                        }.start()
+                    }
+                    "canAccessTree" -> {
+                        val treeUri = call.argument<String>("treeUri")
+                        if (treeUri.isNullOrBlank()) {
+                            result.success(false)
+                            return@setMethodCallHandler
+                        }
+
+                        try {
+                            result.success(canAccessSafTree(treeUri))
+                        } catch (e: Exception) {
+                            Log.e("MainActivity", "Error checking SAF tree access", e)
+                            result.success(false)
+                        }
                     }
                     else -> result.notImplemented()
                 }
@@ -358,11 +437,39 @@ class MainActivity: FlutterActivity() {
     
     // 文件选择请求码和结果回调
     private val FILE_PICKER_REQUEST_CODE = 9421
+    private val SAF_DIRECTORY_PICKER_REQUEST_CODE = 9422
     private var filePickerResult: MethodChannel.Result? = null
+    private var safDirectoryPickerResult: MethodChannel.Result? = null
     
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         
+        if (requestCode == SAF_DIRECTORY_PICKER_REQUEST_CODE && safDirectoryPickerResult != null) {
+            if (resultCode == RESULT_OK && data != null && data.data != null) {
+                val uri = data.data!!
+                try {
+                    val takeFlags = data.flags and (
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                            Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    )
+                    val persistFlags = if (takeFlags != 0) {
+                        takeFlags
+                    } else {
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION
+                    }
+                    contentResolver.takePersistableUriPermission(uri, persistFlags)
+                    safDirectoryPickerResult?.success(uri.toString())
+                } catch (e: Exception) {
+                    Log.e("MainActivity", "Error persisting SAF directory permission", e)
+                    safDirectoryPickerResult?.error("SAF_PERMISSION_ERROR", e.message, null)
+                }
+            } else {
+                safDirectoryPickerResult?.success(null)
+            }
+            safDirectoryPickerResult = null
+            return
+        }
+
         if (requestCode == FILE_PICKER_REQUEST_CODE && filePickerResult != null) {
             if (resultCode == RESULT_OK && data != null && data.data != null) {
                 // 获取文件的真实路径
@@ -407,6 +514,141 @@ class MainActivity: FlutterActivity() {
 
         Log.e("MainActivity", "Failed to resolve file path from URI: $uri")
         return null
+    }
+
+    private fun canAccessSafTree(treeUriString: String): Boolean {
+        val treeUri = Uri.parse(treeUriString)
+        val root = DocumentFile.fromTreeUri(this, treeUri) ?: return false
+        return root.exists() && root.isDirectory && root.canRead()
+    }
+
+    private fun scanSafDirectory(treeUriString: String): List<Map<String, Any>> {
+        val treeUri = Uri.parse(treeUriString)
+        val root = DocumentFile.fromTreeUri(this, treeUri)
+            ?: throw IllegalArgumentException("Cannot open SAF tree URI: $treeUriString")
+        if (!root.exists() || !root.isDirectory || !root.canRead()) {
+            throw IllegalStateException("SAF tree is not readable: $treeUriString")
+        }
+
+        val output = mutableListOf<Map<String, Any>>()
+        collectSafVideoFiles(root, "", output)
+        return output.sortedBy { it["relativePath"] as String }
+    }
+
+    private fun collectSafVideoFiles(
+        current: DocumentFile,
+        relativePrefix: String,
+        output: MutableList<Map<String, Any>>
+    ) {
+        for (entry in current.listFiles()) {
+            val name = entry.name ?: continue
+            val relativePath = if (relativePrefix.isEmpty()) {
+                name
+            } else {
+                "$relativePrefix$name"
+            }
+
+            if (entry.isDirectory) {
+                collectSafVideoFiles(entry, "$relativePath/", output)
+                continue
+            }
+
+            if (!entry.isFile || !isSupportedVideoFileName(name)) {
+                continue
+            }
+
+            val size = entry.length().coerceAtLeast(0L)
+            val modifiedMillis = entry.lastModified().coerceAtLeast(0L)
+            val fileHash = sha256Hex("$size|$modifiedMillis".toByteArray(Charsets.UTF_8))
+                .take(16)
+
+            output.add(
+                mapOf(
+                    "relativePath" to relativePath,
+                    "uri" to entry.uri.toString(),
+                    "name" to name,
+                    "size" to size,
+                    "modifiedMillis" to modifiedMillis,
+                    "fileHash" to fileHash
+                )
+            )
+        }
+    }
+
+    private fun isSupportedVideoFileName(name: String): Boolean {
+        val extension = name.substringAfterLast('.', "").lowercase()
+        return extension == "mp4" || extension == "mkv"
+    }
+
+    private fun getSafFileMetadata(uriString: String): Map<String, Any> {
+        val uri = Uri.parse(uriString)
+        val name = queryDisplayName(uri) ?: uri.lastPathSegment ?: "video"
+        val size = queryFileSize(uri).coerceAtLeast(0L)
+        val contentHash = md5FirstBytes(uri, 16 * 1024 * 1024)
+
+        return mapOf(
+            "uri" to uriString,
+            "name" to name,
+            "size" to size,
+            "contentHash" to contentHash
+        )
+    }
+
+    private fun queryDisplayName(uri: Uri): String? {
+        contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+            ?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (index >= 0) {
+                        return cursor.getString(index)
+                    }
+                }
+            }
+        return null
+    }
+
+    private fun queryFileSize(uri: Uri): Long {
+        contentResolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)
+            ?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val index = cursor.getColumnIndex(OpenableColumns.SIZE)
+                    if (index >= 0 && !cursor.isNull(index)) {
+                        return cursor.getLong(index)
+                    }
+                }
+            }
+
+        return try {
+            contentResolver.openAssetFileDescriptor(uri, "r")?.use { descriptor ->
+                descriptor.length
+            } ?: 0L
+        } catch (e: Exception) {
+            0L
+        }
+    }
+
+    private fun md5FirstBytes(uri: Uri, maxBytes: Int): String {
+        val digest = MessageDigest.getInstance("MD5")
+        contentResolver.openInputStream(uri)?.use { input ->
+            val buffer = ByteArray(64 * 1024)
+            var remaining = maxBytes
+            while (remaining > 0) {
+                val read = input.read(buffer, 0, minOf(buffer.size, remaining))
+                if (read <= 0) {
+                    break
+                }
+                digest.update(buffer, 0, read)
+                remaining -= read
+            }
+        } ?: throw IllegalStateException("Cannot open SAF file: $uri")
+
+        return digest.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
+    }
+
+    private fun sha256Hex(input: ByteArray): String {
+        return MessageDigest.getInstance("SHA-256")
+            .digest(input)
+            .joinToString("") { "%02x".format(it.toInt() and 0xff) }
     }
 
     private fun getPathFromUri(context: Context, uri: Uri): String? {

--- a/lib/services/android_saf_service.dart
+++ b/lib/services/android_saf_service.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/services.dart';
+
+class AndroidSafFileEntry {
+  const AndroidSafFileEntry({
+    required this.relativePath,
+    required this.uri,
+    required this.name,
+    required this.size,
+    required this.modifiedMillis,
+    required this.fileHash,
+  });
+
+  final String relativePath;
+  final String uri;
+  final String name;
+  final int size;
+  final int modifiedMillis;
+  final String fileHash;
+
+  factory AndroidSafFileEntry.fromMap(Map<dynamic, dynamic> map) {
+    return AndroidSafFileEntry(
+      relativePath: map['relativePath'] as String,
+      uri: map['uri'] as String,
+      name: map['name'] as String,
+      size: (map['size'] as num?)?.toInt() ?? 0,
+      modifiedMillis: (map['modifiedMillis'] as num?)?.toInt() ?? 0,
+      fileHash: map['fileHash'] as String,
+    );
+  }
+}
+
+class AndroidSafFileMetadata {
+  const AndroidSafFileMetadata({
+    required this.uri,
+    required this.name,
+    required this.size,
+    required this.contentHash,
+  });
+
+  final String uri;
+  final String name;
+  final int size;
+  final String contentHash;
+
+  factory AndroidSafFileMetadata.fromMap(Map<dynamic, dynamic> map) {
+    return AndroidSafFileMetadata(
+      uri: map['uri'] as String,
+      name: map['name'] as String,
+      size: (map['size'] as num?)?.toInt() ?? 0,
+      contentHash: map['contentHash'] as String,
+    );
+  }
+}
+
+class AndroidSafService {
+  AndroidSafService._();
+
+  static const MethodChannel _channel = MethodChannel('nipaplay/android_saf');
+
+  static bool isSafUri(String value) {
+    return value.toLowerCase().startsWith('content://');
+  }
+
+  static Future<String?> pickDirectory() async {
+    return _channel.invokeMethod<String>('pickDirectory');
+  }
+
+  static Future<bool> canAccessTree(String treeUri) async {
+    final result = await _channel.invokeMethod<bool>(
+      'canAccessTree',
+      {'treeUri': treeUri},
+    );
+    return result == true;
+  }
+
+  static Future<List<AndroidSafFileEntry>> scanDirectory(
+    String treeUri,
+  ) async {
+    final rawEntries = await _channel.invokeMethod<List<dynamic>>(
+      'scanDirectory',
+      {'treeUri': treeUri},
+    );
+    return (rawEntries ?? const <dynamic>[])
+        .cast<Map<dynamic, dynamic>>()
+        .map(AndroidSafFileEntry.fromMap)
+        .toList(growable: false);
+  }
+
+  static Future<AndroidSafFileMetadata> getFileMetadata(String uri) async {
+    final raw = await _channel.invokeMethod<Map<dynamic, dynamic>>(
+      'getFileMetadata',
+      {'uri': uri},
+    );
+    if (raw == null) {
+      throw PlatformException(
+        code: 'SAF_METADATA_EMPTY',
+        message: 'Android SAF metadata result is empty.',
+      );
+    }
+    return AndroidSafFileMetadata.fromMap(raw);
+  }
+}

--- a/lib/services/concurrent_video_processor.dart
+++ b/lib/services/concurrent_video_processor.dart
@@ -14,7 +14,7 @@ class VideoProcessResult {
   final String? errorMessage;
   final WatchHistoryItem? historyItem;
   final String? animeTitle;
-  
+
   VideoProcessResult({
     required this.filePath,
     required this.success,
@@ -28,57 +28,74 @@ class VideoProcessResult {
 class ConcurrentVideoProcessor {
   static const int _maxConcurrency = 4; // 最大并发数
   static const Duration _requestTimeout = Duration(seconds: 20);
-  
+
   /// 并发处理视频文件列表
   static Future<List<VideoProcessResult>> processVideos(
     List<File> videoFiles, {
     bool skipPreviouslyMatchedUnwatched = false,
     Function(int processed, int total, String currentFile)? onProgress,
   }) async {
-    if (videoFiles.isEmpty) return [];
-    
+    return processVideoPaths(
+      videoFiles.map((file) => file.path).toList(growable: false),
+      skipPreviouslyMatchedUnwatched: skipPreviouslyMatchedUnwatched,
+      onProgress: onProgress,
+    );
+  }
+
+  /// 并发处理视频路径列表。本地文件路径与 Android content:// URI 都通过这里处理。
+  static Future<List<VideoProcessResult>> processVideoPaths(
+    List<String> videoPaths, {
+    bool skipPreviouslyMatchedUnwatched = false,
+    Function(int processed, int total, String currentFile)? onProgress,
+  }) async {
+    if (videoPaths.isEmpty) return [];
+
     // 根据文件数量决定并发数
-    final int concurrency = _calculateOptimalConcurrency(videoFiles.length);
-    debugPrint('ConcurrentVideoProcessor: 开始处理 ${videoFiles.length} 个视频文件，并发数: $concurrency');
-    
+    final int concurrency = _calculateOptimalConcurrency(videoPaths.length);
+    debugPrint(
+        'ConcurrentVideoProcessor: 开始处理 ${videoPaths.length} 个视频文件，并发数: $concurrency');
+
     final List<VideoProcessResult> results = [];
-    final List<File> filesToProcess = [];
+    final List<String> pathsToProcess = [];
     int skippedCount = 0;
-    
+
     // 第一阶段：过滤需要处理的文件
     if (skipPreviouslyMatchedUnwatched) {
-      for (File file in videoFiles) {
-        WatchHistoryItem? existingItem = await WatchHistoryManager.getHistoryItem(file.path);
-        if (existingItem != null && 
-            existingItem.animeId != null && 
-            existingItem.episodeId != null && 
+      for (String videoPath in videoPaths) {
+        WatchHistoryItem? existingItem =
+            await WatchHistoryManager.getHistoryItem(videoPath);
+        if (existingItem != null &&
+            existingItem.animeId != null &&
+            existingItem.episodeId != null &&
             existingItem.watchProgress <= 0.01) {
           skippedCount++;
-          onProgress?.call(skippedCount, videoFiles.length, p.basename(file.path));
+          onProgress?.call(
+              skippedCount, videoPaths.length, _displayName(videoPath));
           continue;
         }
-        filesToProcess.add(file);
+        pathsToProcess.add(videoPath);
       }
     } else {
-      filesToProcess.addAll(videoFiles);
+      pathsToProcess.addAll(videoPaths);
     }
-    
-    if (filesToProcess.isEmpty) {
+
+    if (pathsToProcess.isEmpty) {
       debugPrint('ConcurrentVideoProcessor: 所有文件都被跳过，无需处理');
       return results;
     }
-    
+
     // 第二阶段：并发处理
     int processedCount = skippedCount;
     final Semaphore semaphore = Semaphore(concurrency);
     final List<Future<VideoProcessResult>> futures = [];
-    
-    for (File file in filesToProcess) {
+
+    for (String videoPath in pathsToProcess) {
       final future = semaphore.acquire().then((_) async {
         try {
-          final result = await _processSingleVideo(file);
+          final result = await _processSingleVideoPath(videoPath);
           processedCount++;
-          onProgress?.call(processedCount, videoFiles.length, p.basename(file.path));
+          onProgress?.call(
+              processedCount, videoPaths.length, _displayName(videoPath));
           return result;
         } finally {
           semaphore.release();
@@ -86,133 +103,144 @@ class ConcurrentVideoProcessor {
       });
       futures.add(future);
     }
-    
+
     // 等待所有任务完成
     final processingResults = await Future.wait(futures);
     results.addAll(processingResults);
-    
-    debugPrint('ConcurrentVideoProcessor: 处理完成。成功: ${results.where((r) => r.success).length}, 失败: ${results.where((r) => !r.success).length}, 跳过: $skippedCount');
+
+    debugPrint(
+        'ConcurrentVideoProcessor: 处理完成。成功: ${results.where((r) => r.success).length}, 失败: ${results.where((r) => !r.success).length}, 跳过: $skippedCount');
     return results;
   }
-  
-  /// 处理单个视频文件
-  static Future<VideoProcessResult> _processSingleVideo(File videoFile) async {
+
+  static Future<VideoProcessResult> _processSingleVideoPath(
+      String videoPath) async {
     try {
-      final videoInfo = await DandanplayService.getVideoInfo(videoFile.path)
+      final videoInfo = await DandanplayService.getVideoInfo(videoPath)
           .timeout(_requestTimeout, onTimeout: () {
-        throw TimeoutException('获取视频信息超时 (${p.basename(videoFile.path)})');
+        throw TimeoutException('获取视频信息超时 (${_displayName(videoPath)})');
       });
-      
-      if (videoInfo['isMatched'] == true && 
-          videoInfo['matches'] != null && 
+
+      if (videoInfo['isMatched'] == true &&
+          videoInfo['matches'] != null &&
           (videoInfo['matches'] as List).isNotEmpty) {
-        
         final match = videoInfo['matches'][0];
         final animeIdFromMatch = match['animeId'] as int?;
         final episodeIdFromMatch = match['episodeId'] as int?;
-        final animeTitleFromMatch = (match['animeTitle'] as String?)?.isNotEmpty == true
-            ? match['animeTitle'] as String
-            : p.basenameWithoutExtension(videoFile.path);
+        final animeTitleFromMatch =
+            (match['animeTitle'] as String?)?.isNotEmpty == true
+                ? match['animeTitle'] as String
+                : p.basenameWithoutExtension(_displayName(videoPath));
         final episodeTitleFromMatch = match['episodeTitle'] as String?;
-        
+
         if (animeIdFromMatch != null && episodeIdFromMatch != null) {
-          WatchHistoryItem? existingItem = await WatchHistoryManager.getHistoryItem(videoFile.path);
+          WatchHistoryItem? existingItem =
+              await WatchHistoryManager.getHistoryItem(videoPath);
           final int durationFromMatch = (videoInfo['duration'] is int)
               ? videoInfo['duration'] as int
               : (existingItem?.duration ?? 0);
-          
+
           WatchHistoryItem itemToSave;
           if (existingItem != null) {
             if (existingItem.watchProgress > 0.01 && !existingItem.isFromScan) {
               // 保留用户的观看进度
               itemToSave = WatchHistoryItem(
-                filePath: existingItem.filePath,
-                animeName: animeTitleFromMatch,
-                episodeTitle: episodeTitleFromMatch,
-                episodeId: episodeIdFromMatch,
-                animeId: animeIdFromMatch,
-                watchProgress: existingItem.watchProgress,
-                lastPosition: existingItem.lastPosition,
-                duration: durationFromMatch,
-                lastWatchTime: DateTime.now(),
-                thumbnailPath: existingItem.thumbnailPath,
-                isFromScan: false
-              );
+                  filePath: existingItem.filePath,
+                  animeName: animeTitleFromMatch,
+                  episodeTitle: episodeTitleFromMatch,
+                  episodeId: episodeIdFromMatch,
+                  animeId: animeIdFromMatch,
+                  watchProgress: existingItem.watchProgress,
+                  lastPosition: existingItem.lastPosition,
+                  duration: durationFromMatch,
+                  lastWatchTime: DateTime.now(),
+                  thumbnailPath: existingItem.thumbnailPath,
+                  isFromScan: false);
             } else {
               // 更新扫描项目
               itemToSave = WatchHistoryItem(
-                filePath: videoFile.path,
-                animeName: animeTitleFromMatch,
-                episodeTitle: episodeTitleFromMatch,
-                episodeId: episodeIdFromMatch,
-                animeId: animeIdFromMatch,
-                watchProgress: existingItem.watchProgress,
-                lastPosition: existingItem.lastPosition,
-                duration: durationFromMatch,
-                lastWatchTime: DateTime.now(),
-                thumbnailPath: existingItem.thumbnailPath,
-                isFromScan: true
-              );
+                  filePath: videoPath,
+                  animeName: animeTitleFromMatch,
+                  episodeTitle: episodeTitleFromMatch,
+                  episodeId: episodeIdFromMatch,
+                  animeId: animeIdFromMatch,
+                  watchProgress: existingItem.watchProgress,
+                  lastPosition: existingItem.lastPosition,
+                  duration: durationFromMatch,
+                  lastWatchTime: DateTime.now(),
+                  thumbnailPath: existingItem.thumbnailPath,
+                  isFromScan: true);
             }
           } else {
             // 新扫描项目
             itemToSave = WatchHistoryItem(
-              filePath: videoFile.path,
-              animeName: animeTitleFromMatch,
-              episodeTitle: episodeTitleFromMatch,
-              episodeId: episodeIdFromMatch,
-              animeId: animeIdFromMatch,
-              watchProgress: 0.0,
-              lastPosition: 0,
-              duration: durationFromMatch,
-              lastWatchTime: DateTime.now(),
-              thumbnailPath: null,
-              isFromScan: true
-            );
+                filePath: videoPath,
+                animeName: animeTitleFromMatch,
+                episodeTitle: episodeTitleFromMatch,
+                episodeId: episodeIdFromMatch,
+                animeId: animeIdFromMatch,
+                watchProgress: 0.0,
+                lastPosition: 0,
+                duration: durationFromMatch,
+                lastWatchTime: DateTime.now(),
+                thumbnailPath: null,
+                isFromScan: true);
           }
-          
+
           await WatchHistoryManager.addOrUpdateHistory(itemToSave);
-          
+
           return VideoProcessResult(
-            filePath: videoFile.path,
+            filePath: videoPath,
             success: true,
             historyItem: itemToSave,
             animeTitle: animeTitleFromMatch,
           );
         } else {
           return VideoProcessResult(
-            filePath: videoFile.path,
+            filePath: videoPath,
             success: false,
             errorMessage: '缺少ID',
           );
         }
       } else {
         return VideoProcessResult(
-          filePath: videoFile.path,
+          filePath: videoPath,
           success: false,
           errorMessage: '未匹配',
         );
       }
     } on TimeoutException {
       return VideoProcessResult(
-        filePath: videoFile.path,
+        filePath: videoPath,
         success: false,
         errorMessage: '超时',
       );
     } catch (e) {
       return VideoProcessResult(
-        filePath: videoFile.path,
+        filePath: videoPath,
         success: false,
-        errorMessage: '错误: ${e.toString().substring(0, min(e.toString().length, 30))}',
+        errorMessage:
+            '错误: ${e.toString().substring(0, min(e.toString().length, 30))}',
       );
     }
   }
-  
+
   /// 根据文件数量计算最优并发数
   static int _calculateOptimalConcurrency(int fileCount) {
     if (fileCount <= 2) return fileCount;
     if (fileCount <= 4) return fileCount;
     return _maxConcurrency; // 最多4个并发
+  }
+
+  static String _displayName(String path) {
+    final uri = Uri.tryParse(path);
+    if (uri != null && uri.scheme == 'content') {
+      final segments = uri.pathSegments;
+      if (segments.isNotEmpty) {
+        return Uri.decodeComponent(segments.last);
+      }
+    }
+    return p.basename(path);
   }
 }
 
@@ -221,20 +249,20 @@ class Semaphore {
   final int maxCount;
   int _currentCount;
   final Queue<Completer<void>> _waitQueue = Queue<Completer<void>>();
-  
+
   Semaphore(this.maxCount) : _currentCount = maxCount;
-  
+
   Future<void> acquire() async {
     if (_currentCount > 0) {
       _currentCount--;
       return;
     }
-    
+
     final completer = Completer<void>();
     _waitQueue.addLast(completer);
     return completer.future;
   }
-  
+
   void release() {
     if (_waitQueue.isNotEmpty) {
       final completer = _waitQueue.removeFirst();

--- a/lib/services/dandanplay_service_io.dart
+++ b/lib/services/dandanplay_service_io.dart
@@ -9,6 +9,7 @@ import 'package:nipaplay/utils/network_settings.dart';
 import 'package:nipaplay/constants/settings_keys.dart';
 import 'danmaku_cache_manager.dart';
 import 'debug_log_service.dart';
+import 'android_saf_service.dart';
 import 'package:nipaplay/utils/remote_media_fetcher.dart';
 import 'package:nipaplay/utils/media_filename_parser.dart';
 
@@ -936,6 +937,15 @@ class DandanplayService {
           debugPrint('DandanplayService: 获取远程媒体信息失败: $e');
           rethrow;
         }
+      }
+
+      if (AndroidSafService.isSafUri(videoPath)) {
+        final metadata = await AndroidSafService.getFileMetadata(videoPath);
+        return _getVideoInfoWithMetadata(
+          fileName: metadata.name,
+          fileHash: metadata.contentHash,
+          fileSize: metadata.size,
+        );
       }
 
       final file = File(videoPath);

--- a/lib/services/file_picker_service.dart
+++ b/lib/services/file_picker_service.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:universal_html/html.dart' as web_html;
+import 'android_saf_service.dart';
 import 'security_bookmark_service.dart';
 import 'package:nipaplay/utils/storage_service.dart';
 import 'dart:io' as io;
@@ -33,6 +34,12 @@ class FilePickerService {
 
   // 内部方法：规范化文件路径（处理iOS的/private前缀）
   String _normalizePath(String path) {
+    if (AndroidSafService.isSafUri(path) ||
+        path.startsWith('http://') ||
+        path.startsWith('https://')) {
+      return path;
+    }
+
     // 移除可能的重复斜杠
     String normalizedPath = path.replaceAll('//', '/');
 
@@ -618,6 +625,15 @@ class FilePickerService {
       // 获取上次目录
       initialDirectory ??= await _getLastDirectory(_lastDirKey);
 
+      if (io.Platform.isAndroid) {
+        final selectedDirectory = await AndroidSafService.pickDirectory();
+        if (selectedDirectory == null) {
+          return null;
+        }
+        await _saveLastDirectory(selectedDirectory, _lastDirKey);
+        return _normalizePath(selectedDirectory);
+      }
+
       // macOS上尝试恢复之前的书签访问
       if (io.Platform.isMacOS && initialDirectory != null) {
         final resolvedPath =
@@ -669,7 +685,8 @@ class FilePickerService {
   Future<void> _saveLastDirectory(String filePath, String primaryKey,
       [String? secondaryKey]) async {
     try {
-      final directory = p.dirname(filePath);
+      final directory =
+          AndroidSafService.isSafUri(filePath) ? filePath : p.dirname(filePath);
       final prefs = await SharedPreferences.getInstance();
 
       // 保存主键

--- a/lib/services/scan_service.dart
+++ b/lib/services/scan_service.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:nipaplay/models/watch_history_model.dart';
 import 'package:nipaplay/services/concurrent_video_processor.dart';
 import 'package:nipaplay/services/rust_file_scan_service.dart';
+import 'package:nipaplay/services/android_saf_service.dart';
 import 'package:nipaplay/utils/ios_container_path_fixer.dart';
 import 'dart:convert';
 // Import Provider if ScanService needs to directly refresh other providers,
@@ -93,6 +94,7 @@ class _FolderFileDiff {
   final List<String> modifiedFiles;
   final List<String> deletedFiles;
   final Map<String, String>? currentHashes;
+  final Map<String, String>? filePathsByRelativePath;
 
   _FolderFileDiff({
     required this.currentCount,
@@ -102,6 +104,7 @@ class _FolderFileDiff {
     required this.modifiedFiles,
     required this.deletedFiles,
     this.currentHashes,
+    this.filePathsByRelativePath,
   });
 
   List<String> get filesToProcess => [...newFiles, ...modifiedFiles];
@@ -175,6 +178,10 @@ class ScanService with ChangeNotifier {
     _loadSubFolderHashCache();
     // 启动时自动检测变化
     _performStartupChangeDetection();
+  }
+
+  bool _isAndroidSafPath(String path) {
+    return !kIsWeb && Platform.isAndroid && AndroidSafService.isSafUri(path);
   }
 
   Future<void> _loadScannedFolders() async {
@@ -287,6 +294,10 @@ class ScanService with ChangeNotifier {
   Future<_FolderFileDiff> _calculateFolderFileDiffWithRust(
     String folderPath,
   ) async {
+    if (_isAndroidSafPath(folderPath)) {
+      return _calculateFolderFileDiffWithSaf(folderPath);
+    }
+
     final result = await RustFileScanService.calculateDiff(
       folderPath: folderPath,
       cachedHashes: _subFolderHashCache[folderPath] ?? {},
@@ -295,6 +306,52 @@ class ScanService with ChangeNotifier {
       "Rust 文件扫描完成 $folderPath: ${result.currentCount} 个视频文件",
     );
     return _diffFromRustResult(result);
+  }
+
+  Future<_FolderFileDiff> _calculateFolderFileDiffWithSaf(
+    String folderUri,
+  ) async {
+    final entries = await AndroidSafService.scanDirectory(folderUri);
+    final cachedHashes = _subFolderHashCache[folderUri] ?? {};
+    final currentHashes = <String, String>{
+      for (final entry in entries) entry.relativePath: entry.fileHash,
+    };
+    final currentFiles = currentHashes.keys.toList()..sort();
+    final newFiles = <String>[];
+    final modifiedFiles = <String>[];
+
+    for (final entry in entries) {
+      final cachedHash = cachedHashes[entry.relativePath];
+      if (cachedHash == null) {
+        newFiles.add(entry.relativePath);
+      } else if (cachedHash != entry.fileHash) {
+        modifiedFiles.add(entry.relativePath);
+      }
+    }
+
+    final deletedFiles = cachedHashes.keys
+        .where((relativePath) => !currentHashes.containsKey(relativePath))
+        .toList()
+      ..sort();
+    newFiles.sort();
+    modifiedFiles.sort();
+
+    debugPrint(
+      "Android SAF 文件扫描完成 $folderUri: ${entries.length} 个视频文件",
+    );
+
+    return _FolderFileDiff(
+      currentCount: currentFiles.length,
+      cachedCount: cachedHashes.length,
+      currentFiles: currentFiles,
+      newFiles: newFiles,
+      modifiedFiles: modifiedFiles,
+      deletedFiles: deletedFiles,
+      currentHashes: currentHashes,
+      filePathsByRelativePath: {
+        for (final entry in entries) entry.relativePath: entry.uri,
+      },
+    );
   }
 
   Future<void> _storeFileHashes(
@@ -332,8 +389,16 @@ class ScanService with ChangeNotifier {
     final keysToRemove = <String>[];
 
     for (final folderPath in _subFolderHashCache.keys) {
-      if (!_scannedFolders.contains(folderPath) ||
-          !await Directory(folderPath).exists()) {
+      if (!_scannedFolders.contains(folderPath)) {
+        keysToRemove.add(folderPath);
+        continue;
+      }
+
+      if (_isAndroidSafPath(folderPath)) {
+        if (!await AndroidSafService.canAccessTree(folderPath)) {
+          keysToRemove.add(folderPath);
+        }
+      } else if (!await Directory(folderPath).exists()) {
         keysToRemove.add(folderPath);
       }
     }
@@ -389,8 +454,17 @@ class ScanService with ChangeNotifier {
   Future<FolderChangeInfo?> _detectDetailedFolderChanges(
       String folderPath) async {
     if (kIsWeb) return null;
-    final directory = Directory(folderPath);
-    if (!await directory.exists()) {
+    if (!_isAndroidSafPath(folderPath)) {
+      final directory = Directory(folderPath);
+      if (!await directory.exists()) {
+        // 文件夹已删除
+        return FolderChangeInfo(
+          folderPath: folderPath,
+          changeType: 'deleted',
+          detectedAt: DateTime.now(),
+        );
+      }
+    } else if (!await AndroidSafService.canAccessTree(folderPath)) {
       // 文件夹已删除
       return FolderChangeInfo(
         folderPath: folderPath,
@@ -572,8 +646,7 @@ class ScanService with ChangeNotifier {
       } catch (e) {
         // Rust diff failed for this folder — fall back to a full scan
         // instead of aborting the entire batch.
-        debugPrint(
-            'Rust 文件 diff 失败，回退到全量扫描: $folderPath — $e');
+        debugPrint('Rust 文件 diff 失败，回退到全量扫描: $folderPath — $e');
         foldersNeedingScan.add(folderPath);
       }
     }
@@ -761,8 +834,11 @@ class ScanService with ChangeNotifier {
     _updateScanState(
         message: "发现 ${filesToProcess.length} 个需要处理的视频文件$detail，开始并发扫描...");
 
-    final List<File> videoFiles = filesToProcess
-        .map((relativePath) => File(p.join(directoryPath, relativePath)))
+    final filePathsByRelativePath = diff.filePathsByRelativePath;
+    final List<String> videoPaths = filesToProcess
+        .map((relativePath) =>
+            filePathsByRelativePath?[relativePath] ??
+            p.join(directoryPath, relativePath))
         .toList();
 
     if (!_isScanning && !isPartOfBatch) {
@@ -772,7 +848,7 @@ class ScanService with ChangeNotifier {
     }
 
     // 第二阶段：并发处理视频文件
-    final results = await ConcurrentVideoProcessor.processVideos(videoFiles,
+    final results = await ConcurrentVideoProcessor.processVideoPaths(videoPaths,
         skipPreviouslyMatchedUnwatched: skipPreviouslyMatchedUnwatched,
         onProgress: (processed, total, currentFile) {
       if (!_isScanning) return;
@@ -795,10 +871,10 @@ class ScanService with ChangeNotifier {
         .where((r) => r.animeTitle != null)
         .map((r) => r.animeTitle!)
         .toSet();
-    final skippedFilesCount = videoFiles.length - results.length;
+    final skippedFilesCount = videoPaths.length - results.length;
 
     if (!isPartOfBatch && _isScanning) {
-      _totalFilesFound = videoFiles.length;
+      _totalFilesFound = videoPaths.length;
 
       String completionMessage = "";
       if (failedResults.isNotEmpty) {
@@ -820,7 +896,7 @@ class ScanService with ChangeNotifier {
           message: completionMessage,
           completed: true);
     } else if (isPartOfBatch) {
-      _totalFilesFound += videoFiles.length;
+      _totalFilesFound += videoPaths.length;
       await _updateFileHashes(directoryPath, precomputedDiff: diff);
     }
   }
@@ -922,6 +998,13 @@ class ScanService with ChangeNotifier {
 
     final missingFolders = <String>[];
     for (final folderPath in List<String>.from(_scannedFolders)) {
+      if (_isAndroidSafPath(folderPath)) {
+        if (!await AndroidSafService.canAccessTree(folderPath)) {
+          missingFolders.add(folderPath);
+        }
+        continue;
+      }
+
       final directory = Directory(folderPath);
       if (!await directory.exists()) {
         missingFolders.add(folderPath);

--- a/lib/themes/nipaplay/widgets/library_management_tab.dart
+++ b/lib/themes/nipaplay/widgets/library_management_tab.dart
@@ -639,29 +639,62 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
 
   Future<List<io.FileSystemEntity>> _getDirectoryContents(String path) async {
     final List<io.FileSystemEntity> contents = [];
-    final io.Directory directory = io.Directory(path);
-    if (await directory.exists()) {
+
+    // 处理 Android SAF content:// URI
+    if (io.Platform.isAndroid && AndroidSafService.isSafUri(path)) {
       try {
-        await for (var entity
-            in directory.list(recursive: false, followLinks: false)) {
-          if (entity is io.Directory) {
-            contents.add(entity);
-          } else if (entity is io.File) {
-            String extension = p.extension(entity.path).toLowerCase();
+        final List<AndroidSafFileEntry> safEntries =
+            await AndroidSafService.scanDirectory(path);
+        for (final entry in safEntries) {
+          if (entry.size == 0 && entry.relativePath.endsWith('/')) {
+            // 这是一个目录，创建一个虚拟的 Directory 对象
+            // 注意：SAF 目录无法直接转为 io.Directory，我们跳过它
+            // 实际的子目录展开需要通过 SAF 重新扫描
+            continue;
+          } else {
+            // 这是一个文件
+            String extension = p.extension(entry.name).toLowerCase();
             if (extension == '.mp4' || extension == '.mkv') {
-              contents.add(entity);
+              // 创建一个虚拟的 File 对象用于显示
+              // 使用 relativePath 构造一个本地路径用于显示
+              contents.add(io.File(entry.uri));
             }
           }
         }
       } catch (e) {
-        //debugPrint("Error listing directory contents for $path: $e");
         if (mounted) {
           setState(() {
-            // _scanMessage = "加载文件夹内容失败: $path ($e)";
+            // _scanMessage = "加载SAF文件夹内容失败: $path ($e)";
           });
         }
       }
+    } else {
+      // 处理普通文件系统路径
+      final io.Directory directory = io.Directory(path);
+      if (await directory.exists()) {
+        try {
+          await for (var entity
+              in directory.list(recursive: false, followLinks: false)) {
+            if (entity is io.Directory) {
+              contents.add(entity);
+            } else if (entity is io.File) {
+              String extension = p.extension(entity.path).toLowerCase();
+              if (extension == '.mp4' || extension == '.mkv') {
+                contents.add(entity);
+              }
+            }
+          }
+        } catch (e) {
+          //debugPrint("Error listing directory contents for $path: $e");
+          if (mounted) {
+            setState(() {
+              // _scanMessage = "加载文件夹内容失败: $path ($e)";
+            });
+          }
+        }
+      }
     }
+
     // 应用选择的排序方式
     _sortContents(contents);
     return contents;

--- a/lib/themes/nipaplay/widgets/library_management_tab.dart
+++ b/lib/themes/nipaplay/widgets/library_management_tab.dart
@@ -11,6 +11,7 @@ import 'package:glassmorphism/glassmorphism.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/services/scan_service.dart';
+import 'package:nipaplay/services/android_saf_service.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart'; // Import Ionicons
 import 'package:nipaplay/services/file_picker_service.dart';
 import 'package:nipaplay/utils/storage_service.dart'; // 导入StorageService
@@ -452,7 +453,8 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
 
       // 验证选择的目录是否可访问
       bool accessCheck = false;
-      if (io.Platform.isAndroid) {
+      if (io.Platform.isAndroid &&
+          !AndroidSafService.isSafUri(selectedDirectory)) {
         // 使用原生方法检查目录权限
         final dirCheck = await AndroidStorageHelper.checkDirectoryPermissions(
             selectedDirectory);
@@ -550,7 +552,8 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
     }
 
     // Android平台检查是否有访问所选文件夹的权限
-    if (io.Platform.isAndroid) {
+    if (io.Platform.isAndroid &&
+        !AndroidSafService.isSafUri(selectedDirectory)) {
       try {
         // 尝试读取文件夹内容以检查权限
         final dir = io.Directory(selectedDirectory);


### PR DESCRIPTION
## Summary
- Add an Android SAF bridge for persisted directory permissions, DocumentFile traversal, and content URI metadata/hash access.
- Let local library scans handle Android `content://` tree URIs from SD cards and USB storage without converting them to filesystem paths.
- Allow video matching and scan processing to work with both normal file paths and Android content URIs.

## Verification
- `flutter analyze lib/services/android_saf_service.dart lib/services/scan_service.dart`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home PATH=/Library/Afolder/FlutterProject/flutter/bin:$PATH ./gradlew :app:assembleDebug`

Fixes #595