### PR TITLE
修复详情页文字样式并完善 next2/dfm+ 显存共享绘制

### DIFF
--- a/lib/pages/anime_detail_page.dart
+++ b/lib/pages/anime_detail_page.dart
@@ -1116,13 +1116,22 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
 
     final baseTextStyle = DefaultTextStyle.of(context).style;
     final valueStyle = baseTextStyle.copyWith(
-        color: textColor.withOpacity(0.85), fontSize: 13, height: 1.5);
+      color: textColor.withOpacity(0.85),
+      fontSize: 13,
+      height: 1.5,
+      fontWeight: FontWeight.normal,
+      decoration: TextDecoration.none,
+      decorationColor: Colors.transparent,
+    );
     final boldWhiteKeyStyle =
         valueStyle.copyWith(color: textColor, fontWeight: FontWeight.w600);
-    final sectionTitleStyle = Theme.of(context)
-        .textTheme
-        .titleMedium
-        ?.copyWith(color: textColor, fontWeight: FontWeight.bold);
+    final sectionTitleStyle =
+        baseTextStyle.merge(Theme.of(context).textTheme.titleMedium).copyWith(
+              color: textColor,
+              fontWeight: FontWeight.w600,
+              decoration: TextDecoration.none,
+              decorationColor: Colors.transparent,
+            );
 
     List<Widget> metadataWidgets = [];
     if (anime.metadata != null && anime.metadata!.isNotEmpty) {
@@ -1158,8 +1167,11 @@ class _AnimeDetailPageState extends State<AnimeDetailPage>
       titlesWidgets.add(SizedBox(height: 8));
       titlesWidgets.add(Text('其他标题:', style: sectionTitleStyle));
       titlesWidgets.add(SizedBox(height: 4));
-      TextStyle aliasTextStyle =
-          baseTextStyle.copyWith(color: secondaryTextColor, fontSize: 12);
+      TextStyle aliasTextStyle = valueStyle.copyWith(
+        color: secondaryTextColor,
+        fontSize: 12,
+        fontWeight: FontWeight.normal,
+      );
       for (var titleEntry in anime.titles!) {
         String titleText = titleEntry['title'] ?? '未知标题';
         String languageText = '';

--- a/lib/themes/nipaplay/widgets/system_resource_display.dart
+++ b/lib/themes/nipaplay/widgets/system_resource_display.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 import 'package:nipaplay/providers/developer_options_provider.dart';
 import 'package:nipaplay/utils/app_theme.dart';
 import 'package:nipaplay/utils/system_resource_monitor.dart';
@@ -19,6 +20,7 @@ class SystemResourceDisplay extends StatefulWidget {
 
 class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
   Timer? _refreshTimer;
+  StreamSubscription<DanmakuRenderEngine>? _danmakuKernelSubscription;
   bool _registered = false;
 
   double _cpuUsage = 0.0;
@@ -54,12 +56,15 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
       _registered = false;
       _refreshTimer?.cancel();
       _refreshTimer = null;
+      _danmakuKernelSubscription?.cancel();
+      _danmakuKernelSubscription = null;
     }
   }
 
   @override
   void dispose() {
     _refreshTimer?.cancel();
+    _danmakuKernelSubscription?.cancel();
     if (_registered) {
       SystemResourceMonitor.unregisterConsumer();
       _registered = false;
@@ -84,6 +89,14 @@ class _SystemResourceDisplayState extends State<SystemResourceDisplay> {
       });
     }
 
+    _danmakuKernelSubscription?.cancel();
+    _danmakuKernelSubscription =
+        DanmakuKernelFactory.onKernelChanged.listen((_) {
+      SystemResourceMonitor().updateDanmakuKernelType();
+      refreshMetrics();
+    });
+
+    SystemResourceMonitor().updateDanmakuKernelType();
     refreshMetrics();
     if (_isMacOSNativeVideoActive) return;
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -188,9 +188,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -438,6 +438,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "commoncrypto"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
+dependencies = [
+ "commoncrypto-sys",
+]
+
+[[package]]
+name = "commoncrypto-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +493,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -496,7 +524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -529,6 +557,18 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
  "typenum",
+]
+
+[[package]]
+name = "crypto-hash"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca"
+dependencies = [
+ "commoncrypto",
+ "hex 0.3.2",
+ "openssl",
+ "winapi",
 ]
 
 [[package]]
@@ -715,6 +755,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fdsm"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,7 +844,7 @@ version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b5ce32f35f710ced8c5aa557f023f1a624e737b5460cee2b70fcd3a8df09e1b"
 dependencies = [
- "hex",
+ "hex 0.4.3",
  "md-5",
  "proc-macro2",
  "quote",
@@ -809,12 +865,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -827,6 +892,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1290,6 +1361,12 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+
+[[package]]
+name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
@@ -1373,6 +1450,22 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1750,7 +1843,7 @@ dependencies = [
  "dashmap 6.1.0",
  "futures",
  "governor",
- "hex",
+ "hex 0.4.3",
  "http",
  "intervaltree",
  "itertools",
@@ -1831,7 +1924,7 @@ dependencies = [
  "bytes",
  "data-encoding",
  "directories",
- "hex",
+ "hex 0.4.3",
  "itertools",
  "librqbit-bencode",
  "librqbit-buffers",
@@ -1858,7 +1951,7 @@ dependencies = [
  "chrono",
  "dashmap 6.1.0",
  "futures",
- "hex",
+ "hex 0.4.3",
  "indexmap 2.14.0",
  "leaky-bucket",
  "librqbit-bencode",
@@ -1901,6 +1994,7 @@ checksum = "79373a02db73159e4de7ca5d27b6eeae2d540df66c6801db2b01c5513d087524"
 dependencies = [
  "assert_cfg",
  "aws-lc-rs",
+ "crypto-hash",
 ]
 
 [[package]]
@@ -1945,6 +2039,12 @@ dependencies = [
  "tracing",
  "url",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -2026,7 +2126,7 @@ dependencies = [
  "bitflags",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
  "paste",
@@ -2157,6 +2257,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2319,6 +2436,50 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -2703,11 +2864,13 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2719,6 +2882,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-socks",
  "tokio-util",
@@ -2805,6 +2969,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,6 +3055,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2906,6 +3092,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2976,7 +3185,7 @@ checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
  "base64",
  "chrono",
- "hex",
+ "hex 0.4.3",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
@@ -3145,6 +3354,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3267,6 +3489,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3455,6 +3687,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -40,6 +40,9 @@ windows = { version = "0.58", features = [
     "Win32_Foundation",
 ] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+wgpu-hal = { version = "27.0.4", features = ["gles"] }
+
 [target.'cfg(target_os = "android")'.dependencies]
 jni-sys = "0.4.1"
 ndk-sys = "0.6.0+11769913"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,6 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 flutter_rust_bridge = "=2.12.0"
 libc = "0.2"
-librqbit = { version = "8.1.1", default-features = false, features = ["rust-tls"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 serde = "1"
 serde_json = "1"
@@ -32,13 +31,21 @@ wgpu-hal = { version = "27.0.4", features = ["metal"] }
 metal = "0.32.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
+librqbit = { version = "8.1.1", default-features = false, features = ["default-tls"] }
 wgpu-hal = { version = "27.0.4", features = ["dx12"] }
 windows = { version = "0.58", features = [
     "Win32_System_Performance",
     "Win32_System_ProcessStatus",
     "Win32_System_Threading",
     "Win32_Foundation",
+    "Win32_Graphics_Direct3D",
+    "Win32_Graphics_Direct3D12",
+    "Win32_Graphics_Dxgi_Common",
+    "Win32_Security",
 ] }
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+librqbit = { version = "8.1.1", default-features = false, features = ["rust-tls"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 wgpu-hal = { version = "27.0.4", features = ["gles"] }

--- a/rust/src/api/dfm_plus.rs
+++ b/rust/src/api/dfm_plus.rs
@@ -5,7 +5,6 @@
 ///
 /// Output format is compatible with Next2's FrameItemPayload (JSON),
 /// allowing direct reuse of Next2's GPU rendering pipeline.
-
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 use std::hash::{Hash, Hasher};
@@ -208,7 +207,9 @@ fn calc_frame_cache_key(layout: &DfmPlusPreparedLayout, current_time_seconds: f6
 /// One-time layout preparation.
 /// Computes track assignments, collision avoidance, filtering, and merge.
 /// Ported from DanmakuFlameMaster's DrawTask + DanmakusRetainer pipeline.
-pub fn dfm_plus_prepare_layout(request: DfmPlusPrepareRequest) -> Result<DfmPlusPreparedLayout, String> {
+pub fn dfm_plus_prepare_layout(
+    request: DfmPlusPrepareRequest,
+) -> Result<DfmPlusPreparedLayout, String> {
     let width = request.width.max(1.0) as f32;
     let height = request.height.max(1.0) as f32;
     let font_size = request.font_size.max(1.0) as f32;
@@ -376,7 +377,11 @@ pub fn dfm_plus_prepare_layout(request: DfmPlusPrepareRequest) -> Result<DfmPlus
         }
         let type_code = item.danmaku_type as i32;
         let is_scroll = item.danmaku_type.is_scroll();
-        let centered_x = if is_scroll { 0.0 } else { (width as f64 - item.paint_width as f64) / 2.0 };
+        let centered_x = if is_scroll {
+            0.0
+        } else {
+            (width as f64 - item.paint_width as f64) / 2.0
+        };
         prepared_items.push(DfmPlusPreparedItem {
             time_seconds: item.time_ms as f64 / 1000.0,
             text: std::mem::take(&mut item.text),
@@ -396,7 +401,11 @@ pub fn dfm_plus_prepare_layout(request: DfmPlusPrepareRequest) -> Result<DfmPlus
         });
     }
 
-    prepared_items.sort_by(|a, b| a.time_seconds.partial_cmp(&b.time_seconds).unwrap_or(std::cmp::Ordering::Equal));
+    prepared_items.sort_by(|a, b| {
+        a.time_seconds
+            .partial_cmp(&b.time_seconds)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     let sorted_times: Vec<f64> = prepared_items.iter().map(|i| i.time_seconds).collect();
 
     let cache_key = {
@@ -711,42 +720,52 @@ mod tests {
             outline_width: 0.0,
             block_words: vec![],
         };
-        
+
         let layout = dfm_plus_prepare_layout(req).expect("prepare should work");
         eprintln!("Prepared {} items", layout.items.len());
-        
+
         for item in &layout.items {
-            eprintln!(" - text={}, y={}, type={}", item.text, item.y_position, item.type_code);
+            eprintln!(
+                " - text={}, y={}, type={}",
+                item.text, item.y_position, item.type_code
+            );
         }
-        
+
         assert_eq!(layout.items.len(), 2, "should have 2 items");
-        
+
         let frame = dfm_plus_layout_frame(DfmPlusFrameRequest {
             layout_handle: layout.handle,
             current_time_seconds: 0.5,
         });
-        
+
         eprintln!("Frame at 0.5s has {} items", frame.items.len());
         for fi in &frame.items {
             let pi = &layout.items[fi.item_index as usize];
-            eprintln!(" - text={}, y={}, x={}, type={}", pi.text, fi.y, fi.x, pi.type_code);
+            eprintln!(
+                " - text={}, y={}, x={}, type={}",
+                pi.text, fi.y, fi.x, pi.type_code
+            );
         }
-        
+
         assert_eq!(frame.items.len(), 2, "frame should have 2 items");
     }
 
     #[test]
     fn test_real_danmaku_no_top_overlap() {
-        let json_str = fs::read_to_string("/Users/retr0/Documents/program_works/NipaPlay-Reload/测试弹幕.json")
-            .expect("Failed to read danmaku data");
-        let data: serde_json::Value = serde_json::from_str(&json_str)
-            .expect("Failed to parse JSON");
-        let comments = data.get("comments")
+        let json_str = fs::read_to_string(
+            "/Users/retr0/Documents/program_works/NipaPlay-Reload/测试弹幕.json",
+        )
+        .expect("Failed to read danmaku data");
+        let data: serde_json::Value =
+            serde_json::from_str(&json_str).expect("Failed to parse JSON");
+        let comments = data
+            .get("comments")
             .expect("No comments field")
             .as_array()
             .expect("Comments is not an array");
 
-        let items: Vec<DfmPlusDanmakuItem> = comments.iter()
+        let items: Vec<DfmPlusDanmakuItem> = comments
+            .iter()
             .filter_map(|c| {
                 let ctype = c.get("type")?.as_str()?;
                 if ctype != "top" {
@@ -754,18 +773,27 @@ mod tests {
                 }
                 let time = c.get("time")?.as_f64()?;
                 let text = c.get("content")?.as_str()?.to_string();
-                let color = c.get("color").and_then(|v| {
-                    let s = v.as_str()?;
-                    let rgb = s.trim_start_matches("rgb(").trim_end_matches(")");
-                    let parts: Vec<u8> = rgb.split(',')
-                        .map(|p| p.trim().parse().unwrap_or(255))
-                        .collect();
-                    if parts.len() >= 3 {
-                        Some((((255u32) << 24) | ((parts[0] as u32) << 16) | ((parts[1] as u32) << 8) | (parts[2] as u32)) as i32)
-                    } else {
-                        Some(-1i32)
-                    }
-                }).unwrap_or(-1);
+                let color = c
+                    .get("color")
+                    .and_then(|v| {
+                        let s = v.as_str()?;
+                        let rgb = s.trim_start_matches("rgb(").trim_end_matches(")");
+                        let parts: Vec<u8> = rgb
+                            .split(',')
+                            .map(|p| p.trim().parse().unwrap_or(255))
+                            .collect();
+                        if parts.len() >= 3 {
+                            Some(
+                                (((255u32) << 24)
+                                    | ((parts[0] as u32) << 16)
+                                    | ((parts[1] as u32) << 8)
+                                    | (parts[2] as u32)) as i32,
+                            )
+                        } else {
+                            Some(-1i32)
+                        }
+                    })
+                    .unwrap_or(-1);
 
                 Some(DfmPlusDanmakuItem {
                     time_seconds: time,
@@ -786,7 +814,7 @@ mod tests {
             width: 1920.0,
             height: 1080.0,
             font_size: 25.0,
-            display_area: 1.0,  // Use full screen for top danmaku
+            display_area: 1.0, // Use full screen for top danmaku
             scroll_duration_seconds: 5.0,
             allow_stacking: false,
             merge_danmaku: false,
@@ -806,35 +834,55 @@ mod tests {
         // Print the first few items in the layout with their times
         eprintln!("First 10 items in layout:");
         for (i, item) in layout.items.iter().take(10).enumerate() {
-            eprintln!("  [{}] text={:.30}, time={:.2}s, y={:.1}, track={}", 
-                i, item.text, item.time_seconds, item.y_position, item.track_index);
+            eprintln!(
+                "  [{}] text={:.30}, time={:.2}s, y={:.1}, track={}",
+                i, item.text, item.time_seconds, item.y_position, item.track_index
+            );
         }
 
         // Test at a time where we have prepared items (around 1042-1050 seconds)
-        for test_time in [1042.0, 1043.0, 1046.0, 1346.0, 1350.0, 1399.0, 1400.0, 1409.0, 1420.0, 1432.0, 1448.0] {
+        for test_time in [
+            1042.0, 1043.0, 1046.0, 1346.0, 1350.0, 1399.0, 1400.0, 1409.0, 1420.0, 1432.0, 1448.0,
+        ] {
             let frame = dfm_plus_layout_frame(DfmPlusFrameRequest {
                 layout_handle: layout.handle,
                 current_time_seconds: test_time,
             });
 
-            let top_items: Vec<_> = frame.items.iter()
+            let top_items: Vec<_> = frame
+                .items
+                .iter()
                 .filter(|fi| layout.items[fi.item_index as usize].type_code == 5)
                 .collect();
 
-            eprintln!("Frame at t={:.2}s, total items: {}, top items: {}", test_time, frame.items.len(), top_items.len());
+            eprintln!(
+                "Frame at t={:.2}s, total items: {}, top items: {}",
+                test_time,
+                frame.items.len(),
+                top_items.len()
+            );
             for fi in &top_items {
                 let pi = &layout.items[fi.item_index as usize];
-                eprintln!("  text={:.20}, y={:.1}, time={:.2}", pi.text, fi.y, pi.time_seconds);
+                eprintln!(
+                    "  text={:.20}, y={:.1}, time={:.2}",
+                    pi.text, fi.y, pi.time_seconds
+                );
             }
 
             for i in 0..top_items.len() {
-                for j in (i+1)..top_items.len() {
+                for j in (i + 1)..top_items.len() {
                     let y_diff = (top_items[i].y - top_items[j].y).abs();
                     let pi_i = &layout.items[top_items[i].item_index as usize];
                     let pi_j = &layout.items[top_items[j].item_index as usize];
-                    assert!(y_diff > 1.0,
+                    assert!(
+                        y_diff > 1.0,
                         "At t={:.2}s, top items '{}' (y={:.1}) and '{}' (y={:.1}) share same y!",
-                        test_time, pi_i.text, top_items[i].y, pi_j.text, top_items[j].y);
+                        test_time,
+                        pi_i.text,
+                        top_items[i].y,
+                        pi_j.text,
+                        top_items[j].y
+                    );
                 }
             }
         }
@@ -887,17 +935,15 @@ mod tests {
     #[test]
     fn test_layout_frame() {
         let req = DfmPlusPrepareRequest {
-            items: vec![
-                DfmPlusDanmakuItem {
-                    time_seconds: 1.0,
-                    text: "test".into(),
-                    type_code: 0,
-                    color_argb: -1i32,
-                    is_me: false,
-                    paint_width: 0.0,
-                    paint_height: 0.0,
-                },
-            ],
+            items: vec![DfmPlusDanmakuItem {
+                time_seconds: 1.0,
+                text: "test".into(),
+                type_code: 0,
+                color_argb: -1i32,
+                is_me: false,
+                paint_width: 0.0,
+                paint_height: 0.0,
+            }],
             width: 1920.0,
             height: 1080.0,
             font_size: 25.0,
@@ -982,7 +1028,9 @@ mod tests {
             current_time_seconds: 1.0,
         });
 
-        let top_items: Vec<_> = frame.items.iter()
+        let top_items: Vec<_> = frame
+            .items
+            .iter()
             .filter(|fi| layout.items[fi.item_index as usize].type_code == 5)
             .collect();
 
@@ -993,13 +1041,17 @@ mod tests {
         }
 
         for i in 0..top_items.len() {
-            for j in (i+1)..top_items.len() {
+            for j in (i + 1)..top_items.len() {
                 let y_diff = (top_items[i].y - top_items[j].y).abs();
                 let pi_i = &layout.items[top_items[i].item_index as usize];
                 let pi_j = &layout.items[top_items[j].item_index as usize];
-                assert!(y_diff > 1.0, 
-                    "TOP items {} and {} share y={}, causing visual overlap!", 
-                    pi_i.text, pi_j.text, top_items[i].y);
+                assert!(
+                    y_diff > 1.0,
+                    "TOP items {} and {} share y={}, causing visual overlap!",
+                    pi_i.text,
+                    pi_j.text,
+                    top_items[i].y
+                );
             }
         }
     }
@@ -1008,36 +1060,47 @@ mod tests {
     fn debug_real_danmaku() {
         let json_str = std::fs::read_to_string("/Users/retr0/Documents/program_works/NipaPlay-Reload/上伊那牡丹，酒醉身姿似百合花般_danmaku_20260527_233650.json")
             .expect("Failed to read real danmaku data");
-        let data: serde_json::Value = serde_json::from_str(&json_str)
-            .expect("Failed to parse JSON");
-        let comments = data.get("comments")
+        let data: serde_json::Value =
+            serde_json::from_str(&json_str).expect("Failed to parse JSON");
+        let comments = data
+            .get("comments")
             .expect("No comments field")
             .as_array()
             .expect("Comments is not an array");
 
-        let items: Vec<DfmPlusDanmakuItem> = comments.iter()
+        let items: Vec<DfmPlusDanmakuItem> = comments
+            .iter()
             .filter_map(|c| {
                 let time = c.get("time")?.as_f64()?;
                 let text = c.get("content")?.as_str()?.to_string();
                 let type_str = c.get("type")?.as_str()?;
                 let type_code = match type_str {
                     "top" => 5,
-                    "bottom" =>4,
-                    "scroll" =>1,
+                    "bottom" => 4,
+                    "scroll" => 1,
                     _ => 1,
                 };
-                let color = c.get("color").and_then(|v| {
-                    let s = v.as_str()?;
-                    let rgb = s.trim_start_matches("rgb(").trim_end_matches(")");
-                    let parts: Vec<u8> = rgb.split(',')
-                        .map(|p| p.trim().parse().unwrap_or(255))
-                        .collect();
-                    if parts.len() >= 3 {
-                        Some((((255u32) << 24) | ((parts[0] as u32) << 16) | ((parts[1] as u32) << 8) | (parts[2] as u32)) as i32)
-                    } else {
-                        Some(-1i32)
-                    }
-                }).unwrap_or(-1);
+                let color = c
+                    .get("color")
+                    .and_then(|v| {
+                        let s = v.as_str()?;
+                        let rgb = s.trim_start_matches("rgb(").trim_end_matches(")");
+                        let parts: Vec<u8> = rgb
+                            .split(',')
+                            .map(|p| p.trim().parse().unwrap_or(255))
+                            .collect();
+                        if parts.len() >= 3 {
+                            Some(
+                                (((255u32) << 24)
+                                    | ((parts[0] as u32) << 16)
+                                    | ((parts[1] as u32) << 8)
+                                    | (parts[2] as u32)) as i32,
+                            )
+                        } else {
+                            Some(-1i32)
+                        }
+                    })
+                    .unwrap_or(-1);
 
                 Some(DfmPlusDanmakuItem {
                     time_seconds: time,
@@ -1056,7 +1119,7 @@ mod tests {
         let width = 1920.0_f64.max(1.0) as f32;
         let height = 1080.0_f64.max(1.0) as f32;
         let font_size = 25.0_f64.max(1.0) as f32;
-        let display_area = 0.5_f64.clamp(0.1,1.0) as f32;
+        let display_area = 0.5_f64.clamp(0.1, 1.0) as f32;
         let scroll_dur_secs = 8.0_f64.max(1.0);
         let scroll_dur_ms = (scroll_dur_secs * 1000.0) as i64;
         let global_flags = crate::dfm_core::model::GlobalFlags::default();
@@ -1082,8 +1145,8 @@ mod tests {
                     dur_ms,
                 );
                 item.index = i as u32;
-                if raw.paint_width > 0.0 && raw.paint_height >0.0 {
-                    item.paint_width = raw.paint_width as f32 + outline_px *2.0;
+                if raw.paint_width > 0.0 && raw.paint_height > 0.0 {
+                    item.paint_width = raw.paint_width as f32 + outline_px * 2.0;
                     item.paint_height = raw.paint_height as f32;
                     item.flags.measure = global_flags.measure_flag;
                 }
@@ -1092,7 +1155,7 @@ mod tests {
             .collect();
 
         // 检查是否被 filter_primary，不应用过滤器，而是直接打印它们的 type
-        let mut top_filtered_by_param = [0;7].map(|_| 0);
+        let mut top_filtered_by_param = [0; 7].map(|_| 0);
         let mut top_total = 0;
         for item in &danmaku_items {
             if item.danmaku_type == crate::dfm_core::model::DanmakuType::FixTop {
@@ -1124,14 +1187,22 @@ mod tests {
             if was_top {
                 param_counts[item.filter_param as usize] += 1;
                 if item.is_filtered {
-                    eprintln!("FILTERED TOP danmaku at {}: param={}", item.text, item.filter_param);
+                    eprintln!(
+                        "FILTERED TOP danmaku at {}: param={}",
+                        item.text, item.filter_param
+                    );
                 }
             }
         }
 
         eprintln!("TOP filter params: {:?}", param_counts);
 
-        let mut top_after_filter = danmaku_items.iter().filter(|i| i.danmaku_type == crate::dfm_core::model::DanmakuType::FixTop && !i.is_filtered).count();
+        let mut top_after_filter = danmaku_items
+            .iter()
+            .filter(|i| {
+                i.danmaku_type == crate::dfm_core::model::DanmakuType::FixTop && !i.is_filtered
+            })
+            .count();
 
         eprintln!("TOP AFTER filter_primary: {}", top_after_filter);
 
@@ -1154,25 +1225,22 @@ mod tests {
             }
             item.measure(width, height, &global_flags);
             let is_top = item.danmaku_type == crate::dfm_core::model::DanmakuType::FixTop;
-            let (placed, _displaced_index) = retainer.fix(
-                item,
-                width,
-                height,
-                &global_flags,
-                display_area,
-                false,
-            );
+            let (placed, _displaced_index) =
+                retainer.fix(item, width, height, &global_flags, display_area, false);
             if is_top {
                 if placed {
-                    top_placed +=1;
+                    top_placed += 1;
                     eprintln!("PLACED TOP: {}", item.text);
                 } else {
-                    top_skipped +=1;
+                    top_skipped += 1;
                 }
             }
         }
 
-        eprintln!("Top before: {}, placed: {}, skipped: {}", top_count_before_retainer, top_placed, top_skipped);
+        eprintln!(
+            "Top before: {}, placed: {}, skipped: {}",
+            top_count_before_retainer, top_placed, top_skipped
+        );
     }
 
     #[test]
@@ -1182,36 +1250,47 @@ mod tests {
 
         let json_str = std::fs::read_to_string("/Users/retr0/Documents/program_works/NipaPlay-Reload/上伊那牡丹，酒醉身姿似百合花般_danmaku_20260527_233650.json")
             .expect("Failed to read real danmaku data");
-        let data: serde_json::Value = serde_json::from_str(&json_str)
-            .expect("Failed to parse JSON");
-        let comments = data.get("comments")
+        let data: serde_json::Value =
+            serde_json::from_str(&json_str).expect("Failed to parse JSON");
+        let comments = data
+            .get("comments")
             .expect("No comments field")
             .as_array()
             .expect("Comments is not an array");
 
-        let items: Vec<DfmPlusDanmakuItem> = comments.iter()
+        let items: Vec<DfmPlusDanmakuItem> = comments
+            .iter()
             .filter_map(|c| {
                 let time = c.get("time")?.as_f64()?;
                 let text = c.get("content")?.as_str()?.to_string();
                 let type_str = c.get("type")?.as_str()?;
                 let type_code = match type_str {
                     "top" => 5,
-                    "bottom" =>4,
-                    "scroll" =>1,
+                    "bottom" => 4,
+                    "scroll" => 1,
                     _ => 1,
                 };
-                let color = c.get("color").and_then(|v| {
-                    let s = v.as_str()?;
-                    let rgb = s.trim_start_matches("rgb(").trim_end_matches(")");
-                    let parts: Vec<u8> = rgb.split(',')
-                        .map(|p| p.trim().parse().unwrap_or(255))
-                        .collect();
-                    if parts.len() >=3 {
-                        Some((((255u32) << 24) | ((parts[0] as u32) << 16) | ((parts[1] as u32) << 8) | (parts[2] as u32)) as i32)
-                    } else {
-                        Some(-1i32)
-                    }
-                }).unwrap_or(-1);
+                let color = c
+                    .get("color")
+                    .and_then(|v| {
+                        let s = v.as_str()?;
+                        let rgb = s.trim_start_matches("rgb(").trim_end_matches(")");
+                        let parts: Vec<u8> = rgb
+                            .split(',')
+                            .map(|p| p.trim().parse().unwrap_or(255))
+                            .collect();
+                        if parts.len() >= 3 {
+                            Some(
+                                (((255u32) << 24)
+                                    | ((parts[0] as u32) << 16)
+                                    | ((parts[1] as u32) << 8)
+                                    | (parts[2] as u32)) as i32,
+                            )
+                        } else {
+                            Some(-1i32)
+                        }
+                    })
+                    .unwrap_or(-1);
 
                 Some(DfmPlusDanmakuItem {
                     time_seconds: time,
@@ -1219,8 +1298,8 @@ mod tests {
                     type_code,
                     color_argb: color,
                     is_me: false,
-                    paint_width:100.0,
-                    paint_height:30.0,
+                    paint_width: 100.0,
+                    paint_height: 30.0,
                 })
             })
             .collect();
@@ -1229,25 +1308,28 @@ mod tests {
 
         let req = DfmPlusPrepareRequest {
             items,
-            width:1920.0,
-            height:1080.0,
-            font_size:25.0,
-            display_area:0.5,
-            scroll_duration_seconds:8.0,
+            width: 1920.0,
+            height: 1080.0,
+            font_size: 25.0,
+            display_area: 0.5,
+            scroll_duration_seconds: 8.0,
             allow_stacking: false,
             merge_danmaku: false,
             max_quantity: None,
             max_lines_per_type: None,
-            track_gap_ratio:0.5,
-            outline_width:0.0,
+            track_gap_ratio: 0.5,
+            outline_width: 0.0,
             block_words: vec![],
         };
 
         let layout = dfm_plus_prepare_layout(req).expect("prepare layout failed");
         eprintln!("Prepared items: {}", layout.items.len());
-        let top_prepared = layout.items.iter().filter(|i| i.type_code ==5).count();
-        let bottom_prepared = layout.items.iter().filter(|i| i.type_code ==4).count();
-        eprintln!("Top prepared: {}, Bottom prepared: {}", top_prepared, bottom_prepared);
+        let top_prepared = layout.items.iter().filter(|i| i.type_code == 5).count();
+        let bottom_prepared = layout.items.iter().filter(|i| i.type_code == 4).count();
+        eprintln!(
+            "Top prepared: {}, Bottom prepared: {}",
+            top_prepared, bottom_prepared
+        );
 
         // Test t= 1.0 看看有没有
         let test_time = 1.0;
@@ -1255,16 +1337,45 @@ mod tests {
             layout_handle: layout.handle,
             current_time_seconds: test_time,
         });
-        eprintln!("Frame at {}s has {} items total", test_time, frame.items.len());
-        let top_in_frame = frame.items.iter().filter(|fi| layout.items[fi.item_index as usize].type_code ==5).count();
-        let bottom_in_frame = frame.items.iter().filter(|fi| layout.items[fi.item_index as usize].type_code ==4).count();
-        let scroll_in_frame = frame.items.iter().filter(|fi| { let tc = layout.items[fi.item_index as usize].type_code; tc ==1 || tc ==6 }).count();
-        eprintln!("Top in frame: {}, bottom: {}, scroll: {}", top_in_frame, bottom_in_frame, scroll_in_frame);
+        eprintln!(
+            "Frame at {}s has {} items total",
+            test_time,
+            frame.items.len()
+        );
+        let top_in_frame = frame
+            .items
+            .iter()
+            .filter(|fi| layout.items[fi.item_index as usize].type_code == 5)
+            .count();
+        let bottom_in_frame = frame
+            .items
+            .iter()
+            .filter(|fi| layout.items[fi.item_index as usize].type_code == 4)
+            .count();
+        let scroll_in_frame = frame
+            .items
+            .iter()
+            .filter(|fi| {
+                let tc = layout.items[fi.item_index as usize].type_code;
+                tc == 1 || tc == 6
+            })
+            .count();
+        eprintln!(
+            "Top in frame: {}, bottom: {}, scroll: {}",
+            top_in_frame, bottom_in_frame, scroll_in_frame
+        );
 
         eprintln!("Top in frame:");
-        for fi in frame.items.iter().filter(|fi| layout.items[fi.item_index as usize].type_code ==5) {
+        for fi in frame
+            .items
+            .iter()
+            .filter(|fi| layout.items[fi.item_index as usize].type_code == 5)
+        {
             let pi = &layout.items[fi.item_index as usize];
-            eprintln!("  text=\"{}\", y={}, time={}", pi.text, fi.y, pi.time_seconds);
+            eprintln!(
+                "  text=\"{}\", y={}, time={}",
+                pi.text, fi.y, pi.time_seconds
+            );
         }
     }
 
@@ -1329,7 +1440,9 @@ mod tests {
             layout_handle: layout.handle,
             current_time_seconds: 1.0,
         });
-        let top_at_1s: Vec<_> = frame_at_1s.items.iter()
+        let top_at_1s: Vec<_> = frame_at_1s
+            .items
+            .iter()
             .filter(|fi| layout.items[fi.item_index as usize].type_code == 5)
             .collect();
 
@@ -1343,7 +1456,9 @@ mod tests {
             layout_handle: layout.handle,
             current_time_seconds: 5.0,
         });
-        let top_at_5s: Vec<_> = frame_at_5s.items.iter()
+        let top_at_5s: Vec<_> = frame_at_5s
+            .items
+            .iter()
             .filter(|fi| layout.items[fi.item_index as usize].type_code == 5)
             .collect();
 
@@ -1354,24 +1469,32 @@ mod tests {
         }
 
         for i in 0..top_at_1s.len() {
-            for j in (i+1)..top_at_1s.len() {
+            for j in (i + 1)..top_at_1s.len() {
                 let y_diff = (top_at_1s[i].y - top_at_1s[j].y).abs();
                 let pi_i = &layout.items[top_at_1s[i].item_index as usize];
                 let pi_j = &layout.items[top_at_1s[j].item_index as usize];
-                assert!(y_diff > 1.0, 
-                    "At t=1.0, top items {} and {} share y={}!", 
-                    pi_i.text, pi_j.text, top_at_1s[i].y);
+                assert!(
+                    y_diff > 1.0,
+                    "At t=1.0, top items {} and {} share y={}!",
+                    pi_i.text,
+                    pi_j.text,
+                    top_at_1s[i].y
+                );
             }
         }
 
         for i in 0..top_at_5s.len() {
-            for j in (i+1)..top_at_5s.len() {
+            for j in (i + 1)..top_at_5s.len() {
                 let y_diff = (top_at_5s[i].y - top_at_5s[j].y).abs();
                 let pi_i = &layout.items[top_at_5s[i].item_index as usize];
                 let pi_j = &layout.items[top_at_5s[j].item_index as usize];
-                assert!(y_diff > 1.0, 
-                    "At t=5.0, top items {} and {} share y={}!", 
-                    pi_i.text, pi_j.text, top_at_5s[i].y);
+                assert!(
+                    y_diff > 1.0,
+                    "At t=5.0, top items {} and {} share y={}!",
+                    pi_i.text,
+                    pi_j.text,
+                    top_at_5s[i].y
+                );
             }
         }
     }

--- a/rust/src/api/next2.rs
+++ b/rust/src/api/next2.rs
@@ -654,9 +654,8 @@ fn scroll_items_will_collide_in_duration(
     if end_t <= start_t {
         return false;
     }
-    let d_start =
-        scroll_item_x_at_time(new_item, start_t, width, scroll_duration_seconds)
-            - scroll_item_x_at_time(existing, start_t, width, scroll_duration_seconds);
+    let d_start = scroll_item_x_at_time(new_item, start_t, width, scroll_duration_seconds)
+        - scroll_item_x_at_time(existing, start_t, width, scroll_duration_seconds);
     let d_end = scroll_item_x_at_time(new_item, end_t, width, scroll_duration_seconds)
         - scroll_item_x_at_time(existing, end_t, width, scroll_duration_seconds);
 
@@ -743,12 +742,8 @@ fn static_will_collide_with_any(
             existing.font_size_multiplier,
             base_danmaku_height,
             base_track_height,
-        ) && static_items_will_collide(
-            new_item,
-            existing,
-            static_duration_seconds,
-            width,
-        ) {
+        ) && static_items_will_collide(new_item, existing, static_duration_seconds, width)
+        {
             return true;
         }
     }
@@ -1152,10 +1147,7 @@ mod tests {
         let new_item = mk_working_scroll_item(1.0, "wide", 420.0, 1.0, -1, None);
 
         assert!(scroll_items_will_collide_in_duration(
-            &new_item,
-            &existing,
-            width,
-            duration,
+            &new_item, &existing, width, duration,
         ));
     }
 

--- a/rust/src/api/performance.rs
+++ b/rust/src/api/performance.rs
@@ -428,9 +428,8 @@ fn sample_process_memory_windows() -> Result<RustMemorySample, String> {
 
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Performance::{
-    PdhAddEnglishCounterW, PdhCloseQuery, PdhCollectQueryData,
-    PdhGetFormattedCounterArrayW, PdhOpenQueryW,
-    PDH_FMT_COUNTERVALUE_ITEM_W, PDH_FMT_DOUBLE,
+    PdhAddEnglishCounterW, PdhCloseQuery, PdhCollectQueryData, PdhGetFormattedCounterArrayW,
+    PdhOpenQueryW, PDH_FMT_COUNTERVALUE_ITEM_W, PDH_FMT_DOUBLE,
 };
 
 #[cfg(target_os = "windows")]
@@ -445,11 +444,7 @@ fn sample_gpu_windows() -> Result<RustGpuSample, String> {
     unsafe {
         if PDH_QUERY.is_none() {
             let mut query: isize = 0;
-            let result = PdhOpenQueryW(
-                windows::core::PCWSTR(std::ptr::null()),
-                0,
-                &mut query,
-            );
+            let result = PdhOpenQueryW(windows::core::PCWSTR(std::ptr::null()), 0, &mut query);
             if result != 0 {
                 return Err(format!("PdhOpenQueryW failed with code {result}"));
             }
@@ -460,12 +455,8 @@ fn sample_gpu_windows() -> Result<RustGpuSample, String> {
                 .collect();
 
             let mut counter: isize = 0;
-            let result = PdhAddEnglishCounterW(
-                query,
-                windows::core::PCWSTR(path.as_ptr()),
-                0,
-                &mut counter,
-            );
+            let result =
+                PdhAddEnglishCounterW(query, windows::core::PCWSTR(path.as_ptr()), 0, &mut counter);
             if result != 0 {
                 let _ = PdhCloseQuery(query);
                 return Err(format!("PdhAddEnglishCounterW failed with code {result}"));
@@ -479,14 +470,18 @@ fn sample_gpu_windows() -> Result<RustGpuSample, String> {
 
         let result = PdhCollectQueryData(query);
         if result != 0 {
-            return Err(format!("PdhCollectQueryData (1st) failed with code {result}"));
+            return Err(format!(
+                "PdhCollectQueryData (1st) failed with code {result}"
+            ));
         }
 
         std::thread::sleep(std::time::Duration::from_millis(250));
 
         let result = PdhCollectQueryData(query);
         if result != 0 {
-            return Err(format!("PdhCollectQueryData (2nd) failed with code {result}"));
+            return Err(format!(
+                "PdhCollectQueryData (2nd) failed with code {result}"
+            ));
         }
 
         let mut buf_size: u32 = 0;
@@ -499,7 +494,9 @@ fn sample_gpu_windows() -> Result<RustGpuSample, String> {
             None,
         );
         if result != 0 && result != PDH_MORE_DATA {
-            return Err(format!("PdhGetFormattedCounterArrayW (size) failed with code {result}"));
+            return Err(format!(
+                "PdhGetFormattedCounterArrayW (size) failed with code {result}"
+            ));
         }
 
         if item_count == 0 || buf_size == 0 {
@@ -522,7 +519,9 @@ fn sample_gpu_windows() -> Result<RustGpuSample, String> {
             Some(items.as_mut_ptr()),
         );
         if result != 0 {
-            return Err(format!("PdhGetFormattedCounterArrayW (data) failed with code {result}"));
+            return Err(format!(
+                "PdhGetFormattedCounterArrayW (data) failed with code {result}"
+            ));
         }
 
         let values: Vec<f64> = items[..item_count as usize]

--- a/rust/src/dfm_core/factory.rs
+++ b/rust/src/dfm_core/factory.rs
@@ -1,6 +1,5 @@
 /// Duration computation and viewport scaling.
 /// Ported from DanmakuFactory.java.
-
 use crate::dfm_core::model::Duration;
 
 /// Reference Bilibili player width for duration scaling.
@@ -35,10 +34,7 @@ pub fn create_fixed_duration() -> Duration {
 }
 
 /// Compute the global maximum danmaku duration across all types.
-pub fn compute_max_duration(
-    scroll_duration: i64,
-    special_durations: &[i64],
-) -> i64 {
+pub fn compute_max_duration(scroll_duration: i64, special_durations: &[i64]) -> i64 {
     let mut max_dur = scroll_duration;
     max_dur = max_dur.max(COMMON_DANMAKU_DURATION as i64);
     max_dur = max_dur.max(compute_fixed_duration());
@@ -50,11 +46,21 @@ pub fn compute_max_duration(
 
 /// Compute scale factors for viewport changes (used by SpecialDanmaku).
 pub fn compute_scale_factors(
-    old_width: f32, old_height: f32,
-    new_width: f32, new_height: f32,
+    old_width: f32,
+    old_height: f32,
+    new_width: f32,
+    new_height: f32,
 ) -> (f32, f32) {
-    let sx = if old_width > 0.0 { new_width / old_width } else { 1.0 };
-    let sy = if old_height > 0.0 { new_height / old_height } else { 1.0 };
+    let sx = if old_width > 0.0 {
+        new_width / old_width
+    } else {
+        1.0
+    };
+    let sy = if old_height > 0.0 {
+        new_height / old_height
+    } else {
+        1.0
+    };
     (sx, sy)
 }
 

--- a/rust/src/dfm_core/filters.rs
+++ b/rust/src/dfm_core/filters.rs
@@ -1,3 +1,5 @@
+use aho_corasick::AhoCorasick;
+use regex::Regex;
 /// Danmaku filtering system.
 /// Ported from DanmakuFilters.java with support for:
 /// - Type blocking
@@ -7,10 +9,7 @@
 /// - Duplicate merging
 /// - Overlapping detection
 /// - Keyword/user blocking
-
 use rustc_hash::{FxHashMap, FxHashSet};
-use regex::Regex;
-use aho_corasick::AhoCorasick;
 
 use crate::dfm_core::model::{DanmakuItem, DanmakuType, Duration, GlobalFlags};
 
@@ -94,7 +93,9 @@ impl FilterSystem {
         }
 
         // Elapsed time filter (performance protection)
-        if ctx.frame_elapsed_ms >= self.elapsed_time_limit_ms && item.is_outside(ctx.timer_ms, &ctx.global_flags) {
+        if ctx.frame_elapsed_ms >= self.elapsed_time_limit_ms
+            && item.is_outside(ctx.timer_ms, &ctx.global_flags)
+        {
             item.is_filtered = true;
             item.filter_param = 3;
             item.flags.filter = ctx.global_flags.filter_flag;
@@ -125,7 +126,12 @@ impl FilterSystem {
     /// Secondary filter: runs after collision avoidance.
     /// Returns true if the danmaku should be filtered.
     /// Ported from DanmakuFilters.filterSecondary().
-    pub fn filter_secondary(&self, item: &mut DanmakuItem, state: &RetainerState, _flags: &GlobalFlags) -> bool {
+    pub fn filter_secondary(
+        &self,
+        item: &mut DanmakuItem,
+        state: &RetainerState,
+        _flags: &GlobalFlags,
+    ) -> bool {
         // Maximum lines filter
         if let Some(&max) = self.max_lines.get(&item.danmaku_type) {
             if state.line_number >= max {
@@ -193,9 +199,8 @@ impl FilterSystem {
         let text = &item.text;
 
         if self.current_duplicates.len() > 128 {
-            self.current_duplicates.retain(|_, &mut time| {
-                ctx.timer_ms - time < 10000
-            });
+            self.current_duplicates
+                .retain(|_, &mut time| ctx.timer_ms - time < 10000);
         }
 
         if self.blocked_duplicates.contains(text) {
@@ -211,7 +216,8 @@ impl FilterSystem {
             return true;
         }
 
-        self.current_duplicates.insert(text.clone(), item.get_actual_time(&ctx.global_flags));
+        self.current_duplicates
+            .insert(text.clone(), item.get_actual_time(&ctx.global_flags));
         self.passed_duplicates.insert(text.clone());
         false
     }
@@ -284,7 +290,14 @@ mod tests {
         let mut filters = FilterSystem::default();
         filters.blocked_types.insert(DanmakuType::FixTop);
         let ctx = make_ctx(0);
-        let mut item = DanmakuItem::new(0, "test".into(), 0xFFFFFFFF, 25.0, DanmakuType::FixTop, 3800);
+        let mut item = DanmakuItem::new(
+            0,
+            "test".into(),
+            0xFFFFFFFF,
+            25.0,
+            DanmakuType::FixTop,
+            3800,
+        );
         assert!(filters.filter_primary(&mut item, &ctx));
     }
 
@@ -293,7 +306,14 @@ mod tests {
         let mut filters = FilterSystem::default();
         filters.set_block_words(&["bad".to_string()]);
         let ctx = make_ctx(0);
-        let mut item = DanmakuItem::new(0, "this is bad content".into(), 0xFFFFFFFF, 25.0, DanmakuType::ScrollRL, 5000);
+        let mut item = DanmakuItem::new(
+            0,
+            "this is bad content".into(),
+            0xFFFFFFFF,
+            25.0,
+            DanmakuType::ScrollRL,
+            5000,
+        );
         assert!(filters.filter_primary(&mut item, &ctx));
     }
 
@@ -303,7 +323,14 @@ mod tests {
         filters.elapsed_time_limit_ms = 20;
         let mut ctx = make_ctx(0);
         ctx.frame_elapsed_ms = 25; // exceeded limit
-        let mut item = DanmakuItem::new(10000, "future".into(), 0xFFFFFFFF, 25.0, DanmakuType::ScrollRL, 5000);
+        let mut item = DanmakuItem::new(
+            10000,
+            "future".into(),
+            0xFFFFFFFF,
+            25.0,
+            DanmakuType::ScrollRL,
+            5000,
+        );
         // item.is_outside(0) = true (time 10000 > 0, dtime > 0 and dtime < duration → not outside)
         // Actually is_outside checks dtime <= 0 || dtime >= duration
         // dtime = 0 - 10000 = -10000 <= 0 → outside

--- a/rust/src/dfm_core/measure.rs
+++ b/rust/src/dfm_core/measure.rs
@@ -48,7 +48,12 @@ mod tests {
     fn test_measure_cjk() {
         let w_cjk = measure_text_width_heuristic("你好世界", 25.0);
         let w_ascii = measure_text_width_heuristic("Hello", 25.0);
-        assert!(w_cjk > w_ascii, "CJK ({}) should be wider than ASCII ({})", w_cjk, w_ascii);
+        assert!(
+            w_cjk > w_ascii,
+            "CJK ({}) should be wider than ASCII ({})",
+            w_cjk,
+            w_ascii
+        );
     }
 
     #[test]
@@ -61,13 +66,21 @@ mod tests {
     #[test]
     fn test_empty_string() {
         let w = measure_text_width_heuristic("", 25.0);
-        assert!((w - 1.0).abs() < 0.001, "empty string should return 1.0, got {}", w);
+        assert!(
+            (w - 1.0).abs() < 0.001,
+            "empty string should return 1.0, got {}",
+            w
+        );
     }
 
     #[test]
     fn test_font_metrics() {
         let height = measure_line_height_heuristic(25.0);
-        assert!((height - 30.0).abs() < 0.001, "height should be 30.0, got {}", height);
+        assert!(
+            (height - 30.0).abs() < 0.001,
+            "height should be 30.0, got {}",
+            height
+        );
     }
 
     #[test]
@@ -75,6 +88,10 @@ mod tests {
         let h25 = measure_line_height_heuristic(25.0);
         let h50 = measure_line_height_heuristic(50.0);
         let ratio = h50 / h25;
-        assert!((ratio - 2.0).abs() < 0.01, "ratio should be 2.0, got {}", ratio);
+        assert!(
+            (ratio - 2.0).abs() < 0.01,
+            "ratio should be 2.0, got {}",
+            ratio
+        );
     }
 }

--- a/rust/src/dfm_core/mod.rs
+++ b/rust/src/dfm_core/mod.rs
@@ -1,7 +1,7 @@
-pub mod model;
-pub mod types;
-pub mod retainer;
-pub mod filters;
 pub mod factory;
-pub mod timer;
+pub mod filters;
 pub mod measure;
+pub mod model;
+pub mod retainer;
+pub mod timer;
+pub mod types;

--- a/rust/src/dfm_core/model.rs
+++ b/rust/src/dfm_core/model.rs
@@ -98,12 +98,24 @@ impl GlobalFlags {
         self.prepare_flag = 0;
     }
 
-    pub fn update_measure(&mut self) { self.measure_flag += 1; }
-    pub fn update_visible(&mut self) { self.visible_flag += 1; }
-    pub fn update_filter(&mut self) { self.filter_flag += 1; }
-    pub fn update_first_shown(&mut self) { self.first_shown_flag += 1; }
-    pub fn update_sync_offset(&mut self) { self.sync_offset_flag += 1; }
-    pub fn update_prepare(&mut self) { self.prepare_flag += 1; }
+    pub fn update_measure(&mut self) {
+        self.measure_flag += 1;
+    }
+    pub fn update_visible(&mut self) {
+        self.visible_flag += 1;
+    }
+    pub fn update_filter(&mut self) {
+        self.filter_flag += 1;
+    }
+    pub fn update_first_shown(&mut self) {
+        self.first_shown_flag += 1;
+    }
+    pub fn update_sync_offset(&mut self) {
+        self.sync_offset_flag += 1;
+    }
+    pub fn update_prepare(&mut self) {
+        self.prepare_flag += 1;
+    }
 }
 
 /// Per-item epoch flags, matching GlobalFlags for dirty-checking.
@@ -270,7 +282,13 @@ impl DanmakuItem {
     }
 
     /// Measure with explicit outline width for accurate collision detection.
-    pub fn measure_with_outline(&mut self, view_width: f32, _view_height: f32, global_flags: &GlobalFlags, outline_width: f32) {
+    pub fn measure_with_outline(
+        &mut self,
+        view_width: f32,
+        _view_height: f32,
+        global_flags: &GlobalFlags,
+        outline_width: f32,
+    ) {
         if self.is_measured(global_flags) {
             return;
         }
@@ -289,7 +307,12 @@ impl DanmakuItem {
 
     /// Get the bounding rectangle at a specific time.
     /// Returns [left, top, right, bottom].
-    pub fn get_rect_at_time(&self, view_width: f32, time_ms: i64, global_flags: &GlobalFlags) -> [f32; 4] {
+    pub fn get_rect_at_time(
+        &self,
+        view_width: f32,
+        time_ms: i64,
+        global_flags: &GlobalFlags,
+    ) -> [f32; 4] {
         let actual_time = self.get_actual_time(global_flags);
         let elapsed = time_ms - actual_time;
         let left = match self.danmaku_type {
@@ -307,17 +330,23 @@ impl DanmakuItem {
                     elapsed as f32 * self.step_x - self.paint_width
                 }
             }
-            DanmakuType::FixTop | DanmakuType::FixBottom => {
-                (view_width - self.paint_width) / 2.0
-            }
-            DanmakuType::Special => {
-                self.get_special_x_at_time(view_width, time_ms, global_flags)
-            }
+            DanmakuType::FixTop | DanmakuType::FixBottom => (view_width - self.paint_width) / 2.0,
+            DanmakuType::Special => self.get_special_x_at_time(view_width, time_ms, global_flags),
         };
-        [left, self.y, left + self.paint_width, self.y + self.paint_height]
+        [
+            left,
+            self.y,
+            left + self.paint_width,
+            self.y + self.paint_height,
+        ]
     }
 
-    fn get_special_x_at_time(&self, _view_width: f32, time_ms: i64, global_flags: &GlobalFlags) -> f32 {
+    fn get_special_x_at_time(
+        &self,
+        _view_width: f32,
+        time_ms: i64,
+        global_flags: &GlobalFlags,
+    ) -> f32 {
         let actual_time = self.get_actual_time(global_flags);
         let elapsed = (time_ms - actual_time).max(0) as f32;
         let Some(ref paths) = self.line_paths else {
@@ -327,12 +356,14 @@ impl DanmakuItem {
             elapsed / self.duration_ms as f32
         } else {
             1.0
-        }.clamp(0.0, 1.0);
+        }
+        .clamp(0.0, 1.0);
 
         // Find the current path segment
-        let total_len: f32 = paths.iter().map(|p| {
-            ((p.end_x - p.begin_x).powi(2) + (p.end_y - p.begin_y).powi(2)).sqrt()
-        }).sum();
+        let total_len: f32 = paths
+            .iter()
+            .map(|p| ((p.end_x - p.begin_x).powi(2) + (p.end_y - p.begin_y).powi(2)).sqrt())
+            .sum();
         if total_len <= 0.0 {
             return self.x;
         }
@@ -340,7 +371,8 @@ impl DanmakuItem {
         let target_dist = progress * total_len;
         let mut accumulated = 0.0f32;
         for path in paths {
-            let seg_len = ((path.end_x - path.begin_x).powi(2) + (path.end_y - path.begin_y).powi(2)).sqrt();
+            let seg_len =
+                ((path.end_x - path.begin_x).powi(2) + (path.end_y - path.begin_y).powi(2)).sqrt();
             if accumulated + seg_len >= target_dist {
                 let seg_progress = if seg_len > 0.0 {
                     (target_dist - accumulated) / seg_len
@@ -449,7 +481,14 @@ mod tests {
     #[test]
     fn test_r2l_position() {
         let flags = GlobalFlags::default();
-        let mut item = DanmakuItem::new(0, "test".into(), 0xFFFFFFFF, 25.0, DanmakuType::ScrollRL, 5000);
+        let mut item = DanmakuItem::new(
+            0,
+            "test".into(),
+            0xFFFFFFFF,
+            25.0,
+            DanmakuType::ScrollRL,
+            5000,
+        );
         item.measure(1920.0, 1080.0, &flags);
         // At time 0, x should be at the right edge
         let rect = item.get_rect_at_time(1920.0, 0, &flags);

--- a/rust/src/dfm_core/retainer.rs
+++ b/rust/src/dfm_core/retainer.rs
@@ -4,7 +4,6 @@
 /// Key design: per-type track arrays storing lightweight collision records,
 /// compact expired items before each placement, assign to first non-colliding track,
 /// compute Y from track index.
-
 use smallvec::SmallVec;
 
 use crate::dfm_core::model::{DanmakuItem, DanmakuType, GlobalFlags};
@@ -72,9 +71,7 @@ impl TrackData {
         }
         self.last_compact_ms = current_time_ms;
         for track in self.tracks.iter_mut() {
-            track.retain(|existing| {
-                current_time_ms < existing.end_ms()
-            });
+            track.retain(|existing| current_time_ms < existing.end_ms());
         }
     }
 
@@ -152,7 +149,13 @@ impl DanmakuRetainer {
         match item.danmaku_type {
             DanmakuType::ScrollRL => {
                 self.r2l_tracks.ensure_track_count(track_count);
-                match select_scroll_track(&entry, &mut self.r2l_tracks, track_count, view_width, is_me) {
+                match select_scroll_track(
+                    &entry,
+                    &mut self.r2l_tracks,
+                    track_count,
+                    view_width,
+                    is_me,
+                ) {
                     Some((row, displaced)) => {
                         item.y = self.margin + row as f32 * track_height;
                         item.is_shown = true;
@@ -164,7 +167,13 @@ impl DanmakuRetainer {
             }
             DanmakuType::ScrollLR => {
                 self.lr_tracks.ensure_track_count(track_count);
-                match select_scroll_track(&entry, &mut self.lr_tracks, track_count, view_width, is_me) {
+                match select_scroll_track(
+                    &entry,
+                    &mut self.lr_tracks,
+                    track_count,
+                    view_width,
+                    is_me,
+                ) {
                     Some((row, displaced)) => {
                         item.y = self.margin + row as f32 * track_height;
                         item.is_shown = true;
@@ -227,7 +236,9 @@ fn select_scroll_track(
 ) -> Option<(usize, DisplacedIndices)> {
     track_data.compact(new_entry.time_ms, new_entry.duration_ms);
 
-    let overwrite_count = ((track_count as f32 * 0.6).ceil() as usize).max(1).min(track_count);
+    let overwrite_count = ((track_count as f32 * 0.6).ceil() as usize)
+        .max(1)
+        .min(track_count);
     let overwrite_start = track_count - overwrite_count;
 
     let mut best_track = overwrite_start;
@@ -260,14 +271,20 @@ fn select_scroll_track(
     }
 
     if is_me && track_count > 0 {
-        let displaced: DisplacedIndices = track_data.tracks[0].iter().map(|e| e.danmaku_index).collect();
+        let displaced: DisplacedIndices = track_data.tracks[0]
+            .iter()
+            .map(|e| e.danmaku_index)
+            .collect();
         track_data.tracks[0].clear();
         track_data.tracks[0].push(new_entry.clone());
         return Some((0, displaced));
     }
 
     if min_right_edge < f32::MAX {
-        let displaced: DisplacedIndices = track_data.tracks[best_track].iter().map(|e| e.danmaku_index).collect();
+        let displaced: DisplacedIndices = track_data.tracks[best_track]
+            .iter()
+            .map(|e| e.danmaku_index)
+            .collect();
         track_data.tracks[best_track].clear();
         track_data.tracks[best_track].push(new_entry.clone());
         return Some((best_track, displaced));
@@ -352,11 +369,11 @@ fn scroll_entries_collide(entry_a: &TrackEntry, entry_b: &TrackEntry, view_width
     };
 
     let d_time = d2.time_ms - d1.time_ms;
-    
+
     if d_time <= 0 {
         return true;
     }
-    
+
     if d_time >= d1.duration_ms as i64 {
         return false;
     }
@@ -365,7 +382,13 @@ fn scroll_entries_collide(entry_a: &TrackEntry, entry_b: &TrackEntry, view_width
     let d1_right_at_d2_start = d1_left_at_d2_start + d1.paint_width;
     let d2_left_at_start = entry_left_at_start(d2, view_width);
 
-    if check_hit_same_type(d1.danmaku_type, d1_left_at_d2_start, d1_right_at_d2_start, d2_left_at_start, d2_left_at_start + d2.paint_width) {
+    if check_hit_same_type(
+        d1.danmaku_type,
+        d1_left_at_d2_start,
+        d1_right_at_d2_start,
+        d2_left_at_start,
+        d2_left_at_start + d2.paint_width,
+    ) {
         return true;
     }
 
@@ -373,7 +396,13 @@ fn scroll_entries_collide(entry_a: &TrackEntry, entry_b: &TrackEntry, view_width
     let d1_right_at_d1_end = d1_left_at_d1_end + d1.paint_width;
     let d2_left_at_d1_end = entry_left_at(d2, d1.end_ms(), view_width);
 
-    check_hit_same_type(d1.danmaku_type, d1_left_at_d1_end, d1_right_at_d1_end, d2_left_at_d1_end, d2_left_at_d1_end + d2.paint_width)
+    check_hit_same_type(
+        d1.danmaku_type,
+        d1_left_at_d1_end,
+        d1_right_at_d1_end,
+        d2_left_at_d1_end,
+        d2_left_at_d1_end + d2.paint_width,
+    )
 }
 
 #[inline]
@@ -406,17 +435,17 @@ fn entry_left_at(entry: &TrackEntry, time_ms: i64, view_width: f32) -> f32 {
     if entry.danmaku_type == DanmakuType::ScrollLR {
         return entry_x_at(entry, time_ms, view_width);
     }
-    
+
     let elapsed = (time_ms - entry.time_ms).max(0) as f32;
-    
+
     if entry.step_x <= 0.0 {
         return view_width;
     }
-    
+
     if elapsed >= entry.duration_ms as f32 {
         return -entry.paint_width;
     }
-    
+
     let pos = view_width - elapsed * entry.step_x;
     pos.max(-entry.paint_width)
 }
@@ -437,12 +466,8 @@ fn entry_x_at(entry: &TrackEntry, time_ms: i64, view_width: f32) -> f32 {
         };
     }
     match entry.danmaku_type {
-        DanmakuType::ScrollRL => {
-            view_width - elapsed * entry.step_x
-        }
-        DanmakuType::ScrollLR => {
-            elapsed * entry.step_x - entry.paint_width
-        }
+        DanmakuType::ScrollRL => view_width - elapsed * entry.step_x,
+        DanmakuType::ScrollLR => elapsed * entry.step_x - entry.paint_width,
         _ => 0.0,
     }
 }
@@ -456,16 +481,42 @@ mod tests {
         (view_width + paint_width) / duration_ms as f32
     }
 
-    fn make_scroll_item(time_ms: i64, text: &str, paint_width: f32, danmaku_type: DanmakuType, duration_ms: i64, view_width: f32) -> DanmakuItem {
-        let mut item = DanmakuItem::new(time_ms, text.into(), 0xFFFFFFFF, 25.0, danmaku_type, duration_ms);
+    fn make_scroll_item(
+        time_ms: i64,
+        text: &str,
+        paint_width: f32,
+        danmaku_type: DanmakuType,
+        duration_ms: i64,
+        view_width: f32,
+    ) -> DanmakuItem {
+        let mut item = DanmakuItem::new(
+            time_ms,
+            text.into(),
+            0xFFFFFFFF,
+            25.0,
+            danmaku_type,
+            duration_ms,
+        );
         item.paint_width = paint_width;
         item.paint_height = 30.0;
         item.step_x = calc_step_x(paint_width, duration_ms, view_width);
         item
     }
 
-    fn make_fixed_item(time_ms: i64, text: &str, danmaku_type: DanmakuType, duration_ms: i64) -> DanmakuItem {
-        let mut item = DanmakuItem::new(time_ms, text.into(), 0xFFFFFFFF, 25.0, danmaku_type, duration_ms);
+    fn make_fixed_item(
+        time_ms: i64,
+        text: &str,
+        danmaku_type: DanmakuType,
+        duration_ms: i64,
+    ) -> DanmakuItem {
+        let mut item = DanmakuItem::new(
+            time_ms,
+            text.into(),
+            0xFFFFFFFF,
+            25.0,
+            danmaku_type,
+            duration_ms,
+        );
         item.paint_width = 100.0;
         item.paint_height = 30.0;
         item
@@ -480,7 +531,11 @@ mod tests {
         let (placed, _) = retainer.fix(&mut item, 1920.0, 1080.0, &flags, 1.0, false);
         assert!(placed);
         assert!(item.is_shown);
-        assert!((item.y - 2.0).abs() < 1.0, "first item y={} should be ~2.0", item.y);
+        assert!(
+            (item.y - 2.0).abs() < 1.0,
+            "first item y={} should be ~2.0",
+            item.y
+        );
     }
 
     #[test]
@@ -498,7 +553,12 @@ mod tests {
 
         let (placed2, _) = retainer.fix(&mut items[1], 1920.0, 1080.0, &flags, 1.0, false);
         assert!(placed2);
-        assert!(items[1].y > first_y, "same-time items should be on different tracks: first_y={}, second_y={}", first_y, items[1].y);
+        assert!(
+            items[1].y > first_y,
+            "same-time items should be on different tracks: first_y={}, second_y={}",
+            first_y,
+            items[1].y
+        );
     }
 
     #[test]
@@ -514,8 +574,12 @@ mod tests {
         let first_y = items[0].y;
 
         retainer.fix(&mut items[1], 1920.0, 1080.0, &flags, 1.0, false);
-        assert!((items[1].y - first_y).abs() < 1.0,
-            "non-overlapping items should share track: first_y={}, second_y={}", first_y, items[1].y);
+        assert!(
+            (items[1].y - first_y).abs() < 1.0,
+            "non-overlapping items should share track: first_y={}, second_y={}",
+            first_y,
+            items[1].y
+        );
     }
 
     #[test]
@@ -531,7 +595,10 @@ mod tests {
         let first_y = items[0].y;
 
         retainer.fix(&mut items[1], 1920.0, 1080.0, &flags, 1.0, false);
-        assert!(items[1].y > first_y, "same-time fixed items should be on different tracks");
+        assert!(
+            items[1].y > first_y,
+            "same-time fixed items should be on different tracks"
+        );
     }
 
     #[test]
@@ -547,27 +614,66 @@ mod tests {
         let first_y = items[0].y;
 
         retainer.fix(&mut items[1], 1920.0, 1080.0, &flags, 1.0, false);
-        assert!((items[1].y - first_y).abs() < 1.0,
-            "expired fixed item should be replaced: first_y={}, second_y={}", first_y, items[1].y);
+        assert!(
+            (items[1].y - first_y).abs() < 1.0,
+            "expired fixed item should be replaced: first_y={}, second_y={}",
+            first_y,
+            items[1].y
+        );
     }
 
     #[test]
     fn test_scroll_collision_same_time() {
-        let d1 = TrackEntry { time_ms: 0, duration_ms: 5000, paint_width: 100.0, step_x: calc_step_x(100.0, 5000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 0 };
-        let d2 = TrackEntry { time_ms: 0, duration_ms: 5000, paint_width: 100.0, step_x: calc_step_x(100.0, 5000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 1 };
+        let d1 = TrackEntry {
+            time_ms: 0,
+            duration_ms: 5000,
+            paint_width: 100.0,
+            step_x: calc_step_x(100.0, 5000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 0,
+        };
+        let d2 = TrackEntry {
+            time_ms: 0,
+            duration_ms: 5000,
+            paint_width: 100.0,
+            step_x: calc_step_x(100.0, 5000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 1,
+        };
         assert!(scroll_entries_collide(&d1, &d2, 1920.0));
     }
 
     #[test]
     fn test_scroll_no_collision_far_apart() {
-        let d1 = TrackEntry { time_ms: 0, duration_ms: 3000, paint_width: 100.0, step_x: calc_step_x(100.0, 3000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 0 };
-        let d2 = TrackEntry { time_ms: 10000, duration_ms: 3000, paint_width: 100.0, step_x: calc_step_x(100.0, 3000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 1 };
+        let d1 = TrackEntry {
+            time_ms: 0,
+            duration_ms: 3000,
+            paint_width: 100.0,
+            step_x: calc_step_x(100.0, 3000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 0,
+        };
+        let d2 = TrackEntry {
+            time_ms: 10000,
+            duration_ms: 3000,
+            paint_width: 100.0,
+            step_x: calc_step_x(100.0, 3000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 1,
+        };
         assert!(!scroll_entries_collide(&d1, &d2, 1920.0));
     }
 
     #[test]
     fn test_scroll_x_position() {
-        let entry = TrackEntry { time_ms: 0, duration_ms: 5000, paint_width: 100.0, step_x: calc_step_x(100.0, 5000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 0 };
+        let entry = TrackEntry {
+            time_ms: 0,
+            duration_ms: 5000,
+            paint_width: 100.0,
+            step_x: calc_step_x(100.0, 5000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 0,
+        };
         let x0 = entry_x_at(&entry, 0, 1920.0);
         assert!((x0 - 1920.0).abs() < 1.0);
         let x5 = entry_x_at(&entry, 5000, 1920.0);
@@ -589,7 +695,10 @@ mod tests {
 
         // Second item: track still occupied → dropped (Next2 behavior).
         let (placed1, _) = retainer.fix(&mut items[1], 1920.0, 60.0, &flags, 1.0, false);
-        assert!(!placed1, "second item should be dropped when all tracks are full");
+        assert!(
+            !placed1,
+            "second item should be dropped when all tracks are full"
+        );
     }
 
     #[test]
@@ -603,8 +712,12 @@ mod tests {
 
         retainer.fix(&mut items[0], 1920.0, 1080.0, &flags, 1.0, false);
         retainer.fix(&mut items[1], 1920.0, 1080.0, &flags, 1.0, false);
-        assert!((items[0].y - items[1].y).abs() > 1.0,
-            "different-width same-time items must be on different tracks: wide_y={}, narrow_y={}", items[0].y, items[1].y);
+        assert!(
+            (items[0].y - items[1].y).abs() > 1.0,
+            "different-width same-time items must be on different tracks: wide_y={}, narrow_y={}",
+            items[0].y,
+            items[1].y
+        );
     }
 
     #[test]
@@ -613,9 +726,10 @@ mod tests {
         let mut retainer = DanmakuRetainer::new(2.0, 0.5);
 
         let texts: Vec<String> = (0..15).map(|i| format!("弹幕{}", i)).collect();
-        let mut items: Vec<DanmakuItem> = texts.iter().map(|text| {
-            make_scroll_item(1000, text, 150.0, DanmakuType::ScrollRL, 5000, 1920.0)
-        }).collect();
+        let mut items: Vec<DanmakuItem> = texts
+            .iter()
+            .map(|text| make_scroll_item(1000, text, 150.0, DanmakuType::ScrollRL, 5000, 1920.0))
+            .collect();
 
         let mut placed_ys = Vec::new();
         for item in &mut items {
@@ -626,9 +740,14 @@ mod tests {
         }
 
         for i in 0..placed_ys.len() {
-            for j in (i+1)..placed_ys.len() {
-                assert!((placed_ys[i] - placed_ys[j]).abs() > 1.0,
-                    "items {} and {} share y={}", i, j, placed_ys[i]);
+            for j in (i + 1)..placed_ys.len() {
+                assert!(
+                    (placed_ys[i] - placed_ys[j]).abs() > 1.0,
+                    "items {} and {} share y={}",
+                    i,
+                    j,
+                    placed_ys[i]
+                );
             }
         }
     }
@@ -637,11 +756,13 @@ mod tests {
     fn test_chain_queue_fixed_items() {
         let flags = GlobalFlags::default();
         let mut retainer = DanmakuRetainer::new(2.0, 0.5);
-        let mut items: Vec<DanmakuItem> = (0..4).map(|i| {
-            let mut item = make_fixed_item(0, &format!("top{}", i), DanmakuType::FixTop, 3800);
-            item.index = i as u32;
-            item
-        }).collect();
+        let mut items: Vec<DanmakuItem> = (0..4)
+            .map(|i| {
+                let mut item = make_fixed_item(0, &format!("top{}", i), DanmakuType::FixTop, 3800);
+                item.index = i as u32;
+                item
+            })
+            .collect();
 
         // Only one track fits (view_height=60, track_height=45).
         // First item gets placed; subsequent items are dropped (Next2 behavior).
@@ -652,7 +773,11 @@ mod tests {
                 assert!(placed, "item 0 should be placed (first on empty track)");
                 assert_eq!(items[0].time_ms, 0);
             } else {
-                assert!(!placed, "item {} should be dropped when all tracks are full", i);
+                assert!(
+                    !placed,
+                    "item {} should be dropped when all tracks are full",
+                    i
+                );
             }
         }
     }
@@ -662,22 +787,33 @@ mod tests {
         let flags = GlobalFlags::default();
         let mut retainer = DanmakuRetainer::new(2.0, 0.5);
 
-        let mut items: Vec<DanmakuItem> = (0..10).map(|i| {
-            make_scroll_item(i * 100, &format!("item_{}", i), 150.0, DanmakuType::ScrollRL, 5000, 1920.0)
-        }).collect();
+        let mut items: Vec<DanmakuItem> = (0..10)
+            .map(|i| {
+                make_scroll_item(
+                    i * 100,
+                    &format!("item_{}", i),
+                    150.0,
+                    DanmakuType::ScrollRL,
+                    5000,
+                    1920.0,
+                )
+            })
+            .collect();
 
         for item in &mut items {
             retainer.fix(item, 1920.0, 1080.0, &flags, 1.0, false);
         }
 
         for i in 0..items.len() {
-            for j in (i+1)..items.len() {
+            for j in (i + 1)..items.len() {
                 let time_diff = (items[j].time_ms - items[i].time_ms).abs();
                 if time_diff < 5000 {
                     let y_diff = (items[i].y - items[j].y).abs();
                     if y_diff < 1.0 && items[i].y >= 0.0 && items[j].y >= 0.0 {
-                        println!("Same track: item_{} (t={}) and item_{} (t={}), y={}",
-                            i, items[i].time_ms, j, items[j].time_ms, items[i].y);
+                        println!(
+                            "Same track: item_{} (t={}) and item_{} (t={}), y={}",
+                            i, items[i].time_ms, j, items[j].time_ms, items[i].y
+                        );
                     }
                 }
             }
@@ -688,9 +824,9 @@ mod tests {
     fn test_fixed_top_overlap_no_visual_overlap() {
         let flags = GlobalFlags::default();
         let mut retainer = DanmakuRetainer::new(2.0, 0.5);
-        let mut items: Vec<DanmakuItem> = (0..5).map(|i| {
-            make_fixed_item(0, &format!("top{}", i), DanmakuType::FixTop, 3800)
-        }).collect();
+        let mut items: Vec<DanmakuItem> = (0..5)
+            .map(|i| make_fixed_item(0, &format!("top{}", i), DanmakuType::FixTop, 3800))
+            .collect();
 
         for i in 0..items.len() {
             let (_, displaced) = retainer.fix(&mut items[i], 1920.0, 1080.0, &flags, 1.0, false);
@@ -708,9 +844,14 @@ mod tests {
         }
 
         for i in 0..visible_ys.len() {
-            for j in (i+1)..visible_ys.len() {
-                assert!((visible_ys[i] - visible_ys[j]).abs() > 1.0,
-                    "visible items {} and {} share y={}, causing visual overlap", i, j, visible_ys[i]);
+            for j in (i + 1)..visible_ys.len() {
+                assert!(
+                    (visible_ys[i] - visible_ys[j]).abs() > 1.0,
+                    "visible items {} and {} share y={}, causing visual overlap",
+                    i,
+                    j,
+                    visible_ys[i]
+                );
             }
         }
     }
@@ -719,11 +860,14 @@ mod tests {
     fn test_fix_bottom_overflow_queues_correctly() {
         let flags = GlobalFlags::default();
         let mut retainer = DanmakuRetainer::new(2.0, 0.5);
-        let mut items: Vec<DanmakuItem> = (0..4).map(|i| {
-            let mut item = make_fixed_item(0, &format!("bottom{}", i), DanmakuType::FixBottom, 3800);
-            item.index = i as u32;
-            item
-        }).collect();
+        let mut items: Vec<DanmakuItem> = (0..4)
+            .map(|i| {
+                let mut item =
+                    make_fixed_item(0, &format!("bottom{}", i), DanmakuType::FixBottom, 3800);
+                item.index = i as u32;
+                item
+            })
+            .collect();
 
         // Only one track fits (view_height=60, track_height=45).
         // First item gets placed in the only track; rest are dropped.
@@ -734,47 +878,115 @@ mod tests {
                 assert!(placed, "item 0 should be placed");
                 assert_eq!(items[0].time_ms, 0);
             } else {
-                assert!(!placed, "item {} should be dropped when all tracks are full", i);
+                assert!(
+                    !placed,
+                    "item {} should be dropped when all tracks are full",
+                    i
+                );
             }
         }
     }
 
     #[test]
     fn test_long_danmaku_catches_short() {
-        let short = TrackEntry { time_ms: 0, duration_ms: 8000, paint_width: 50.0, step_x: calc_step_x(50.0, 8000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 0 };
-        let long = TrackEntry { time_ms: 1000, duration_ms: 8000, paint_width: 400.0, step_x: calc_step_x(400.0, 8000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 1 };
-        assert!(scroll_entries_collide(&short, &long, 1920.0),
-            "long danmaku starting later should catch up to short danmaku on same track");
+        let short = TrackEntry {
+            time_ms: 0,
+            duration_ms: 8000,
+            paint_width: 50.0,
+            step_x: calc_step_x(50.0, 8000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 0,
+        };
+        let long = TrackEntry {
+            time_ms: 1000,
+            duration_ms: 8000,
+            paint_width: 400.0,
+            step_x: calc_step_x(400.0, 8000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 1,
+        };
+        assert!(
+            scroll_entries_collide(&short, &long, 1920.0),
+            "long danmaku starting later should catch up to short danmaku on same track"
+        );
     }
 
     #[test]
     fn test_no_false_positive_at_start() {
-        let short = TrackEntry { time_ms: 0, duration_ms: 8000, paint_width: 50.0, step_x: calc_step_x(50.0, 8000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 0 };
-        let long = TrackEntry { time_ms: 1000, duration_ms: 8000, paint_width: 400.0, step_x: calc_step_x(400.0, 8000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 1 };
+        let short = TrackEntry {
+            time_ms: 0,
+            duration_ms: 8000,
+            paint_width: 50.0,
+            step_x: calc_step_x(50.0, 8000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 0,
+        };
+        let long = TrackEntry {
+            time_ms: 1000,
+            duration_ms: 8000,
+            paint_width: 400.0,
+            step_x: calc_step_x(400.0, 8000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 1,
+        };
         let short_left = entry_left_at(&short, 1000, 1920.0);
         let short_right = short_left + short.paint_width;
         let long_left = entry_left_at(&long, 1000, 1920.0);
-        assert!(long_left >= short_right,
+        assert!(
+            long_left >= short_right,
             "at d2 start: long.left={} should be >= short.right={} (no overlap yet)",
-            long_left, short_right);
+            long_left,
+            short_right
+        );
     }
 
     #[test]
     fn test_catch_up_at_end() {
-        let short = TrackEntry { time_ms: 0, duration_ms: 8000, paint_width: 50.0, step_x: calc_step_x(50.0, 8000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 0 };
-        let long = TrackEntry { time_ms: 1000, duration_ms: 8000, paint_width: 400.0, step_x: calc_step_x(400.0, 8000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 1 };
+        let short = TrackEntry {
+            time_ms: 0,
+            duration_ms: 8000,
+            paint_width: 50.0,
+            step_x: calc_step_x(50.0, 8000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 0,
+        };
+        let long = TrackEntry {
+            time_ms: 1000,
+            duration_ms: 8000,
+            paint_width: 400.0,
+            step_x: calc_step_x(400.0, 8000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 1,
+        };
         let short_left = entry_left_at(&short, 8000, 1920.0);
         let short_right = short_left + short.paint_width;
         let long_left = entry_left_at(&long, 8000, 1920.0);
-        assert!(long_left < short_right,
+        assert!(
+            long_left < short_right,
             "at d1 end: long.left={} should be < short.right={} (catch-up happened)",
-            long_left, short_right);
+            long_left,
+            short_right
+        );
     }
 
     #[test]
     fn test_no_collision_when_far_apart_in_time() {
-        let short = TrackEntry { time_ms: 0, duration_ms: 8000, paint_width: 50.0, step_x: calc_step_x(50.0, 8000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 0 };
-        let long = TrackEntry { time_ms: 7000, duration_ms: 8000, paint_width: 400.0, step_x: calc_step_x(400.0, 8000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 1 };
+        let short = TrackEntry {
+            time_ms: 0,
+            duration_ms: 8000,
+            paint_width: 50.0,
+            step_x: calc_step_x(50.0, 8000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 0,
+        };
+        let long = TrackEntry {
+            time_ms: 7000,
+            duration_ms: 8000,
+            paint_width: 400.0,
+            step_x: calc_step_x(400.0, 8000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 1,
+        };
         assert!(!scroll_entries_collide(&short, &long, 1920.0),
             "long danmaku starting 7s later should not catch short (short ends at 8s, only 1s overlap window not enough)");
     }
@@ -784,42 +996,90 @@ mod tests {
         let flags = GlobalFlags::default();
         let mut retainer = DanmakuRetainer::new(2.0, 0.15);
         let mut short_item = make_scroll_item(0, "短", 50.0, DanmakuType::ScrollRL, 8000, 1920.0);
-        let mut long_item = make_scroll_item(1000, "很长很长的弹幕内容在这里", 400.0, DanmakuType::ScrollRL, 8000, 1920.0);
+        let mut long_item = make_scroll_item(
+            1000,
+            "很长很长的弹幕内容在这里",
+            400.0,
+            DanmakuType::ScrollRL,
+            8000,
+            1920.0,
+        );
 
         retainer.fix(&mut short_item, 1920.0, 1080.0, &flags, 1.0, false);
         retainer.fix(&mut long_item, 1920.0, 1080.0, &flags, 1.0, false);
 
-        assert!((short_item.y - long_item.y).abs() > 1.0,
+        assert!(
+            (short_item.y - long_item.y).abs() > 1.0,
             "long danmaku (y={}) should be on different track from short (y={}) to avoid catch-up",
-            long_item.y, short_item.y);
+            long_item.y,
+            short_item.y
+        );
     }
 
     #[test]
     fn test_check_hit_direction_rtl() {
-        let d1 = TrackEntry { time_ms: 0, duration_ms: 5000, paint_width: 100.0, step_x: calc_step_x(100.0, 5000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 0 };
-        let d2 = TrackEntry { time_ms: 500, duration_ms: 5000, paint_width: 100.0, step_x: calc_step_x(100.0, 5000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 1 };
+        let d1 = TrackEntry {
+            time_ms: 0,
+            duration_ms: 5000,
+            paint_width: 100.0,
+            step_x: calc_step_x(100.0, 5000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 0,
+        };
+        let d2 = TrackEntry {
+            time_ms: 500,
+            duration_ms: 5000,
+            paint_width: 100.0,
+            step_x: calc_step_x(100.0, 5000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 1,
+        };
 
-        assert!(!scroll_entries_collide(&d1, &d2, 1920.0),
-            "same-speed danmaku 500ms apart should NOT collide (they maintain distance)");
+        assert!(
+            !scroll_entries_collide(&d1, &d2, 1920.0),
+            "same-speed danmaku 500ms apart should NOT collide (they maintain distance)"
+        );
 
-        let d1_fast = TrackEntry { time_ms: 0, duration_ms: 8000, paint_width: 50.0, step_x: calc_step_x(50.0, 8000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 0 };
-        let d2_slow = TrackEntry { time_ms: 1000, duration_ms: 8000, paint_width: 400.0, step_x: calc_step_x(400.0, 8000, 1920.0), danmaku_type: DanmakuType::ScrollRL, danmaku_index: 1 };
+        let d1_fast = TrackEntry {
+            time_ms: 0,
+            duration_ms: 8000,
+            paint_width: 50.0,
+            step_x: calc_step_x(50.0, 8000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 0,
+        };
+        let d2_slow = TrackEntry {
+            time_ms: 1000,
+            duration_ms: 8000,
+            paint_width: 400.0,
+            step_x: calc_step_x(400.0, 8000, 1920.0),
+            danmaku_type: DanmakuType::ScrollRL,
+            danmaku_index: 1,
+        };
 
         let t_start = 1000;
         let d1_right_at_start = entry_left_at(&d1_fast, t_start, 1920.0) + d1_fast.paint_width;
         let d2_left_at_start = entry_left_at(&d2_slow, t_start, 1920.0);
-        assert!(d2_left_at_start >= d1_right_at_start,
+        assert!(
+            d2_left_at_start >= d1_right_at_start,
             "at d2 start: d2.left={} should be >= d1.right={} (no overlap yet, d2 just entered)",
-            d2_left_at_start, d1_right_at_start);
+            d2_left_at_start,
+            d1_right_at_start
+        );
 
         let t_end = 8000;
         let d1_right_at_end = entry_left_at(&d1_fast, t_end, 1920.0) + d1_fast.paint_width;
         let d2_left_at_end = entry_left_at(&d2_slow, t_end, 1920.0);
-        assert!(d2_left_at_end < d1_right_at_end,
+        assert!(
+            d2_left_at_end < d1_right_at_end,
             "at d1 end: d2.left={} should be < d1.right={} (long danmaku caught up!)",
-            d2_left_at_end, d1_right_at_end);
+            d2_left_at_end,
+            d1_right_at_end
+        );
 
-        assert!(scroll_entries_collide(&d1_fast, &d2_slow, 1920.0),
-            "long fast danmaku should collide with short slow danmaku");
+        assert!(
+            scroll_entries_collide(&d1_fast, &d2_slow, 1920.0),
+            "long fast danmaku should collide with short slow danmaku"
+        );
     }
 }

--- a/rust/src/dfm_core/timer.rs
+++ b/rust/src/dfm_core/timer.rs
@@ -1,6 +1,5 @@
 /// Adaptive frame rate timer.
 /// Ported from DrawHandler.syncTimer() to handle frame drops and maintain smooth animation.
-
 use std::collections::VecDeque;
 
 /// Maximum number of frame times to track for averaging.
@@ -27,7 +26,7 @@ impl Default for AdaptiveTimer {
         Self {
             draw_times: VecDeque::with_capacity(MAX_DRAW_TIMES),
             frame_update_rate: 16.67, // ~60fps
-            cordon_time: 33.33,        // ~30fps
+            cordon_time: 33.33,       // ~30fps
             remaining_time: 0.0,
             prev_increment: 16.67,
         }

--- a/rust/src/dfm_core/types.rs
+++ b/rust/src/dfm_core/types.rs
@@ -1,6 +1,5 @@
 /// Danmaku type-specific position computation.
 /// Ported from R2LDanmaku, L2RDanmaku, FTDanmaku, FBDanmaku, SpecialDanmaku.
-
 use crate::dfm_core::model::{DanmakuItem, DanmakuType, GlobalFlags, LinePath};
 
 /// Layout result for a single danmaku item.
@@ -12,7 +11,12 @@ pub struct LayoutResult {
 }
 
 /// Compute the X position for a danmaku at a given time.
-pub fn get_x_at_time(item: &DanmakuItem, view_width: f32, time_ms: i64, flags: &GlobalFlags) -> f32 {
+pub fn get_x_at_time(
+    item: &DanmakuItem,
+    view_width: f32,
+    time_ms: i64,
+    flags: &GlobalFlags,
+) -> f32 {
     match item.danmaku_type {
         DanmakuType::ScrollRL => get_r2l_x(item, view_width, time_ms, flags),
         DanmakuType::ScrollLR => get_l2r_x(item, view_width, time_ms, flags),
@@ -65,7 +69,8 @@ fn get_special_x(item: &DanmakuItem, _view_width: f32, time_ms: i64, flags: &Glo
         elapsed / item.duration_ms as f32
     } else {
         1.0
-    }.clamp(0.0, 1.0);
+    }
+    .clamp(0.0, 1.0);
 
     interpolate_path_x(paths, progress, item.x)
 }
@@ -111,7 +116,14 @@ pub fn get_special_alpha(item: &DanmakuItem, time_ms: i64, flags: &GlobalFlags) 
 
 /// Layout a danmaku item: compute position and set visibility.
 /// Ported from R2LDanmaku.layout().
-pub fn layout_item(item: &mut DanmakuItem, view_width: f32, _x: f32, y: f32, timer_ms: i64, flags: &GlobalFlags) {
+pub fn layout_item(
+    item: &mut DanmakuItem,
+    view_width: f32,
+    _x: f32,
+    y: f32,
+    timer_ms: i64,
+    flags: &GlobalFlags,
+) {
     let actual_time = item.get_actual_time(flags);
     let delta = timer_ms - actual_time;
 
@@ -139,7 +151,14 @@ mod tests {
     #[test]
     fn test_r2l_x_at_start() {
         let flags = GlobalFlags::default();
-        let mut item = DanmakuItem::new(0, "test".into(), 0xFFFFFFFF, 25.0, DanmakuType::ScrollRL, 5000);
+        let mut item = DanmakuItem::new(
+            0,
+            "test".into(),
+            0xFFFFFFFF,
+            25.0,
+            DanmakuType::ScrollRL,
+            5000,
+        );
         item.measure(1920.0, 1080.0, &flags);
         let x = get_r2l_x(&item, 1920.0, 0, &flags);
         assert!((x - 1920.0).abs() < 1.0);
@@ -148,7 +167,14 @@ mod tests {
     #[test]
     fn test_r2l_x_at_end() {
         let flags = GlobalFlags::default();
-        let mut item = DanmakuItem::new(0, "test".into(), 0xFFFFFFFF, 25.0, DanmakuType::ScrollRL, 5000);
+        let mut item = DanmakuItem::new(
+            0,
+            "test".into(),
+            0xFFFFFFFF,
+            25.0,
+            DanmakuType::ScrollRL,
+            5000,
+        );
         item.measure(1920.0, 1080.0, &flags);
         let x = get_r2l_x(&item, 1920.0, 5000, &flags);
         assert!(x <= 0.0);
@@ -157,7 +183,14 @@ mod tests {
     #[test]
     fn test_l2r_x_at_start() {
         let flags = GlobalFlags::default();
-        let mut item = DanmakuItem::new(0, "test".into(), 0xFFFFFFFF, 25.0, DanmakuType::ScrollLR, 5000);
+        let mut item = DanmakuItem::new(
+            0,
+            "test".into(),
+            0xFFFFFFFF,
+            25.0,
+            DanmakuType::ScrollLR,
+            5000,
+        );
         item.measure(1920.0, 1080.0, &flags);
         let x = get_l2r_x(&item, 1920.0, 0, &flags);
         assert!(x <= 0.0); // starts offscreen left
@@ -167,7 +200,14 @@ mod tests {
     fn test_fixed_centered() {
         let item = DanmakuItem {
             paint_width: 100.0,
-            ..DanmakuItem::new(0, "test".into(), 0xFFFFFFFF, 25.0, DanmakuType::FixTop, 3800)
+            ..DanmakuItem::new(
+                0,
+                "test".into(),
+                0xFFFFFFFF,
+                25.0,
+                DanmakuType::FixTop,
+                3800,
+            )
         };
         let x = get_fixed_x(&item, 1920.0);
         assert!((x - 910.0).abs() < 1.0); // (1920 - 100) / 2

--- a/rust/src/next2_engine/engine/renderer_core.rs
+++ b/rust/src/next2_engine/engine/renderer_core.rs
@@ -290,6 +290,9 @@ impl Next2Renderer {
             ctx,
             #[cfg(target_os = "android")]
             surface_pipeline: None,
+            texture_format: wgpu::TextureFormat::Bgra8Unorm,
+            texture_pipeline: None,
+            texture_screen_pipeline: None,
             offscreen_pipeline,
             blur_pipeline_horizontal,
             blur_pipeline_vertical,
@@ -482,15 +485,40 @@ impl Next2Renderer {
             PresentTarget::Texture(texture_target) => {
                 self.width = texture_target.width.max(1);
                 self.height = texture_target.height.max(1);
-                let glyph_pipeline = self.offscreen_pipeline.clone();
-                let screen_pipeline = self.screen_pipeline.clone();
-                let view =
-                    texture_target
-                        .render_texture()
-                        .create_view(&wgpu::TextureViewDescriptor {
-                            format: Some(wgpu::TextureFormat::Bgra8Unorm),
-                            ..Default::default()
-                        });
+                let target_format = texture_target.format();
+                let (glyph_pipeline, screen_pipeline) = if target_format == wgpu::TextureFormat::Bgra8Unorm {
+                    (self.offscreen_pipeline.clone(), self.screen_pipeline.clone())
+                } else {
+                    if self.texture_format != target_format
+                        || self.texture_pipeline.is_none()
+                        || self.texture_screen_pipeline.is_none()
+                    {
+                        self.texture_pipeline = Some(Self::create_pipeline(
+                            self.ctx.device.as_ref(),
+                            &self.atlas_bind_group_layout,
+                            target_format,
+                            "next2 texture render pipeline",
+                        ));
+                        self.texture_screen_pipeline = Some(Self::create_screen_pipeline(
+                            self.ctx.device.as_ref(),
+                            &self.screen_bind_group_layout,
+                            target_format,
+                            NEXT2_SCREEN_COPY_WGSL,
+                            "next2 texture composite pipeline",
+                        ));
+                        self.texture_format = target_format;
+                    }
+                    (
+                        self.texture_pipeline.as_ref().unwrap().clone(),
+                        self.texture_screen_pipeline.as_ref().unwrap().clone(),
+                    )
+                };
+                let view = texture_target.render_texture().create_view(
+                    &wgpu::TextureViewDescriptor {
+                        format: Some(target_format),
+                        ..Default::default()
+                    },
+                );
                 self.draw_to_view(&view, &glyph_pipeline, &screen_pipeline);
             }
         }

--- a/rust/src/next2_engine/engine/renderer_core.rs
+++ b/rust/src/next2_engine/engine/renderer_core.rs
@@ -269,12 +269,6 @@ impl Next2Renderer {
             mapped_at_creation: false,
         });
 
-        let offscreen_texture = create_render_texture(
-            ctx.device.as_ref(),
-            width.max(1),
-            height.max(1),
-            Some("next2 offscreen texture"),
-        );
         let shadow_width = width.max(1).saturating_mul(SHADOW_RENDER_SCALE);
         let shadow_height = height.max(1).saturating_mul(SHADOW_RENDER_SCALE);
         let shadow_mask_texture = create_render_texture_with_usage(
@@ -316,7 +310,6 @@ impl Next2Renderer {
             clear_color: [0.0, 0.0, 0.0, 0.0],
             width: width.max(1),
             height: height.max(1),
-            offscreen_texture,
             shadow_mask_texture,
             shadow_blur_texture,
             shadow_width,
@@ -331,12 +324,6 @@ impl Next2Renderer {
     fn resize(&mut self, width: u32, height: u32) -> bool {
         self.width = width.max(1);
         self.height = height.max(1);
-        self.offscreen_texture = create_render_texture(
-            self.ctx.device.as_ref(),
-            self.width,
-            self.height,
-            Some("next2 offscreen texture"),
-        );
         self.shadow_width = self.width.saturating_mul(SHADOW_RENDER_SCALE);
         self.shadow_height = self.height.saturating_mul(SHADOW_RENDER_SCALE);
         self.shadow_mask_texture = create_render_texture_with_usage(
@@ -362,10 +349,6 @@ impl Next2Renderer {
         self.shadow_vertices.clear();
         self.atlas.clear();
         self.emoji_atlas.clear();
-    }
-
-    fn frame_items(&self) -> &[FrameItem] {
-        &self.frame_items
     }
 
     fn update_frame(&mut self, input: RenderFrameInput, custom_font: Option<FontSource>) -> bool {
@@ -501,133 +484,15 @@ impl Next2Renderer {
                 self.height = texture_target.height.max(1);
                 let glyph_pipeline = self.offscreen_pipeline.clone();
                 let screen_pipeline = self.screen_pipeline.clone();
-                let offscreen_view =
-                    self.offscreen_texture
+                let view =
+                    texture_target
+                        .render_texture()
                         .create_view(&wgpu::TextureViewDescriptor {
                             format: Some(wgpu::TextureFormat::Bgra8Unorm),
                             ..Default::default()
                         });
-                self.draw_to_view(&offscreen_view, &glyph_pipeline, &screen_pipeline);
-
-                let mut encoder =
-                    self.ctx
-                        .device
-                        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                            label: Some("next2 present blit encoder"),
-                        });
-                encoder.copy_texture_to_texture(
-                    wgpu::TexelCopyTextureInfo {
-                        texture: &self.offscreen_texture,
-                        mip_level: 0,
-                        origin: wgpu::Origin3d::ZERO,
-                        aspect: wgpu::TextureAspect::All,
-                    },
-                    wgpu::TexelCopyTextureInfo {
-                        texture: texture_target.render_texture(),
-                        mip_level: 0,
-                        origin: wgpu::Origin3d::ZERO,
-                        aspect: wgpu::TextureAspect::All,
-                    },
-                    wgpu::Extent3d {
-                        width: self.width.max(1),
-                        height: self.height.max(1),
-                        depth_or_array_layers: 1,
-                    },
-                );
-                self.ctx.queue.submit(std::iter::once(encoder.finish()));
+                self.draw_to_view(&view, &glyph_pipeline, &screen_pipeline);
             }
         }
-    }
-
-    fn draw_to_offscreen(&mut self) {
-        let view = self
-            .offscreen_texture
-            .create_view(&wgpu::TextureViewDescriptor {
-                format: Some(wgpu::TextureFormat::Bgra8Unorm),
-                ..Default::default()
-            });
-        let glyph_pipeline = self.offscreen_pipeline.clone();
-        let screen_pipeline = self.screen_pipeline.clone();
-        self.draw_to_view(&view, &glyph_pipeline, &screen_pipeline);
-    }
-
-    fn readback_pixels(&self) -> Option<Next2ReadbackFrame> {
-        let width = self.width.max(1);
-        let height = self.height.max(1);
-        let bytes_per_pixel = 4u32;
-        let unpadded_bytes_per_row = width.checked_mul(bytes_per_pixel)?;
-        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
-        let padded_bytes_per_row = unpadded_bytes_per_row.div_ceil(align) * align;
-        let output_size = padded_bytes_per_row.checked_mul(height)? as u64;
-
-        let output_buffer = self.ctx.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("next2 readback buffer"),
-            size: output_size,
-            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
-            mapped_at_creation: false,
-        });
-
-        let mut encoder = self
-            .ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("next2 readback encoder"),
-            });
-        encoder.copy_texture_to_buffer(
-            wgpu::TexelCopyTextureInfo {
-                texture: &self.offscreen_texture,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                aspect: wgpu::TextureAspect::All,
-            },
-            wgpu::TexelCopyBufferInfo {
-                buffer: &output_buffer,
-                layout: wgpu::TexelCopyBufferLayout {
-                    offset: 0,
-                    bytes_per_row: Some(padded_bytes_per_row),
-                    rows_per_image: Some(height),
-                },
-            },
-            wgpu::Extent3d {
-                width,
-                height,
-                depth_or_array_layers: 1,
-            },
-        );
-        self.ctx.queue.submit(std::iter::once(encoder.finish()));
-
-        let slice = output_buffer.slice(..);
-        let (tx, rx) = mpsc::channel();
-        slice.map_async(wgpu::MapMode::Read, move |result| {
-            let _ = tx.send(result.is_ok());
-        });
-        let _ = self.ctx.device.poll(wgpu::PollType::wait_indefinitely());
-        if rx.recv().ok()? != true {
-            n2log("readback: map_async failed");
-            return None;
-        }
-
-        let mapped = slice.get_mapped_range();
-        let mut pixels = vec![0u8; unpadded_bytes_per_row.checked_mul(height)? as usize];
-        for row in 0..height as usize {
-            let src_start = row * padded_bytes_per_row as usize;
-            let src_end = src_start + unpadded_bytes_per_row as usize;
-            let dst_start = row * unpadded_bytes_per_row as usize;
-            let dst_end = dst_start + unpadded_bytes_per_row as usize;
-            pixels[dst_start..dst_end].copy_from_slice(&mapped[src_start..src_end]);
-        }
-        drop(mapped);
-        output_buffer.unmap();
-
-        Some(Next2ReadbackFrame {
-            width,
-            height,
-            pixels,
-        })
-    }
-
-    fn readback_frame_bgra(&mut self) -> Option<Next2ReadbackFrame> {
-        self.draw_to_offscreen();
-        self.readback_pixels()
     }
 }

--- a/rust/src/next2_engine/engine/renderer_draw.rs
+++ b/rust/src/next2_engine/engine/renderer_draw.rs
@@ -57,7 +57,8 @@ impl Next2Renderer {
                     occlusion_query_set: None,
                 });
 
-                pass.set_pipeline(glyph_pipeline);
+                let shadow_pipeline = self.offscreen_pipeline.clone();
+                pass.set_pipeline(&shadow_pipeline);
                 pass.set_bind_group(0, &self.atlas_bind_group, &[]);
                 pass.set_vertex_buffer(0, self.shadow_vertex_buffer.slice(..));
                 pass.draw(0..self.shadow_vertices.len() as u32, 0..1);

--- a/rust/src/next2_engine/engine/renderer_draw.rs
+++ b/rust/src/next2_engine/engine/renderer_draw.rs
@@ -596,21 +596,6 @@ impl Next2Renderer {
     }
 }
 
-fn create_render_texture(
-    device: &wgpu::Device,
-    width: u32,
-    height: u32,
-    label: Option<&'static str>,
-) -> wgpu::Texture {
-    create_render_texture_with_usage(
-        device,
-        width,
-        height,
-        label,
-        wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
-    )
-}
-
 fn create_render_texture_with_usage(
     device: &wgpu::Device,
     width: u32,

--- a/rust/src/next2_engine/engine/rendering.rs
+++ b/rust/src/next2_engine/engine/rendering.rs
@@ -799,6 +799,9 @@ struct Next2Renderer {
     ctx: Arc<EngineDeviceContext>,
     #[cfg(target_os = "android")]
     surface_pipeline: Option<wgpu::RenderPipeline>,
+    texture_format: wgpu::TextureFormat,
+    texture_pipeline: Option<wgpu::RenderPipeline>,
+    texture_screen_pipeline: Option<wgpu::RenderPipeline>,
     offscreen_pipeline: wgpu::RenderPipeline,
     blur_pipeline_horizontal: wgpu::RenderPipeline,
     blur_pipeline_vertical: wgpu::RenderPipeline,

--- a/rust/src/next2_engine/engine/rendering.rs
+++ b/rust/src/next2_engine/engine/rendering.rs
@@ -819,7 +819,6 @@ struct Next2Renderer {
     clear_color: [f64; 4],
     width: u32,
     height: u32,
-    offscreen_texture: wgpu::Texture,
     shadow_mask_texture: wgpu::Texture,
     shadow_blur_texture: wgpu::Texture,
     shadow_width: u32,

--- a/rust/src/next2_engine/engine/runtime.rs
+++ b/rust/src/next2_engine/engine/runtime.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
+#[cfg(target_os = "linux")]
+use std::ffi::{c_char, CString};
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
@@ -35,6 +37,8 @@ use nalgebra::{Affine2, Similarity2, Vector2};
 use serde::Deserialize;
 use ttf_parser::{Face, GlyphId};
 
+#[cfg(target_os = "linux")]
+use super::present::attach_present_gl_texture;
 use super::present::{attach_present_texture, signal_frame_ready, PresentTarget};
 
 #[cfg(target_os = "android")]
@@ -156,6 +160,294 @@ pub fn poll_frame_ready(handle: u64) -> bool {
         return false;
     };
     entry.frame_ready.swap(false, Ordering::AcqRel)
+}
+
+#[cfg(target_os = "linux")]
+pub type GlProcLoader = unsafe extern "C" fn(*const c_char) -> *const c_void;
+
+#[cfg(target_os = "linux")]
+struct LinuxGlEngineEntry {
+    width: u32,
+    height: u32,
+    frame_ready: Arc<AtomicBool>,
+    pending_input: Option<RenderFrameInput>,
+    pending_reset: bool,
+    ctx: Option<Arc<EngineDeviceContext>>,
+    renderer: Option<Next2Renderer>,
+}
+
+#[cfg(target_os = "linux")]
+struct LinuxGlEngineRegistry {
+    next_handle: AtomicU64,
+    entries: Mutex<HashMap<u64, LinuxGlEngineEntry>>,
+}
+
+#[cfg(target_os = "linux")]
+static LINUX_GL_REGISTRY: OnceLock<LinuxGlEngineRegistry> = OnceLock::new();
+
+#[cfg(target_os = "linux")]
+fn linux_gl_registry() -> &'static LinuxGlEngineRegistry {
+    LINUX_GL_REGISTRY.get_or_init(|| LinuxGlEngineRegistry {
+        next_handle: AtomicU64::new(1),
+        entries: Mutex::new(HashMap::new()),
+    })
+}
+
+#[cfg(target_os = "linux")]
+pub fn create_linux_gl_engine(width: u32, height: u32) -> Result<u64, String> {
+    let handle = linux_gl_registry()
+        .next_handle
+        .fetch_add(1, Ordering::Relaxed)
+        .max(1);
+
+    let mut guard = linux_gl_registry()
+        .entries
+        .lock()
+        .map_err(|_| "linux GL engine registry lock poisoned".to_string())?;
+    guard.insert(
+        handle,
+        LinuxGlEngineEntry {
+            width: width.max(INITIAL_WIDTH),
+            height: height.max(INITIAL_HEIGHT),
+            frame_ready: Arc::new(AtomicBool::new(true)),
+            pending_input: None,
+            pending_reset: false,
+            ctx: None,
+            renderer: None,
+        },
+    );
+
+    n2log(&format!(
+        "linux GL engine created: {}x{}",
+        width.max(INITIAL_WIDTH),
+        height.max(INITIAL_HEIGHT)
+    ));
+    Ok(handle)
+}
+
+#[cfg(target_os = "linux")]
+pub fn remove_linux_gl_engine(handle: u64) -> bool {
+    if handle == 0 {
+        return false;
+    }
+    match linux_gl_registry().entries.lock() {
+        Ok(mut guard) => guard.remove(&handle).is_some(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn poll_linux_gl_frame_ready(handle: u64) -> bool {
+    if handle == 0 {
+        return false;
+    }
+    let Ok(guard) = linux_gl_registry().entries.lock() else {
+        return false;
+    };
+    guard
+        .get(&handle)
+        .map(|entry| entry.frame_ready.load(Ordering::Acquire))
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+pub fn resize_linux_gl_engine(handle: u64, width: u32, height: u32) -> bool {
+    if handle == 0 {
+        return false;
+    }
+    let Ok(mut guard) = linux_gl_registry().entries.lock() else {
+        return false;
+    };
+    let Some(entry) = guard.get_mut(&handle) else {
+        return false;
+    };
+    entry.width = width.max(INITIAL_WIDTH);
+    entry.height = height.max(INITIAL_HEIGHT);
+    entry.frame_ready.store(true, Ordering::Release);
+    true
+}
+
+#[cfg(target_os = "linux")]
+pub fn reset_linux_gl_engine(handle: u64) -> bool {
+    if handle == 0 {
+        return false;
+    }
+    let Ok(mut guard) = linux_gl_registry().entries.lock() else {
+        return false;
+    };
+    let Some(entry) = guard.get_mut(&handle) else {
+        return false;
+    };
+    entry.pending_reset = true;
+    entry.frame_ready.store(true, Ordering::Release);
+    true
+}
+
+#[cfg(target_os = "linux")]
+pub fn set_linux_gl_frame(handle: u64, input: RenderFrameInput) -> bool {
+    if handle == 0 {
+        return false;
+    }
+    let Ok(mut guard) = linux_gl_registry().entries.lock() else {
+        return false;
+    };
+    let Some(entry) = guard.get_mut(&handle) else {
+        return false;
+    };
+    entry.pending_input = Some(input);
+    entry.frame_ready.store(true, Ordering::Release);
+    true
+}
+
+#[cfg(target_os = "linux")]
+fn create_linux_gl_device_context(loader: GlProcLoader) -> Result<Arc<EngineDeviceContext>, String> {
+    use wgpu_hal::Adapter as _;
+
+    let exposed = unsafe {
+        <wgpu_hal::api::Gles as wgpu_hal::Api>::Adapter::new_external(
+            |name| {
+                let Ok(name) = CString::new(name) else {
+                    return std::ptr::null();
+                };
+                loader(name.as_ptr())
+            },
+            wgpu::GlBackendOptions::default(),
+        )
+    }
+    .ok_or_else(|| "wgpu-hal: external GLES adapter init failed".to_string())?;
+
+    let limits = exposed.capabilities.limits.clone();
+    let open = unsafe {
+        exposed.adapter.open(
+            wgpu::Features::empty(),
+            &limits,
+            &wgpu::MemoryHints::Performance,
+        )
+    }
+    .map_err(|err| format!("wgpu-hal: open external GLES device failed: {err:?}"))?;
+
+    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::GL,
+        flags: wgpu::InstanceFlags::default(),
+        memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+        backend_options: wgpu::BackendOptions::default(),
+    });
+    let adapter = unsafe { instance.create_adapter_from_hal::<wgpu_hal::api::Gles>(exposed) };
+    let device_desc = wgpu::DeviceDescriptor {
+        label: Some("next2 linux external GL device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: limits,
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::Performance,
+        trace: wgpu::Trace::Off,
+    };
+    let (device, queue) = unsafe {
+        adapter.create_device_from_hal::<wgpu_hal::api::Gles>(open, &device_desc)
+    }
+    .map_err(|err| format!("wgpu: create external GLES device failed: {err:?}"))?;
+
+    device.on_uncaptured_error(Arc::new(|err| {
+        eprintln!("wgpu linux GL uncaptured error: {err}");
+    }));
+
+    Ok(Arc::new(EngineDeviceContext {
+        device: Arc::new(device),
+        queue: Arc::new(queue),
+    }))
+}
+
+#[cfg(target_os = "linux")]
+pub fn render_linux_gl_texture(
+    handle: u64,
+    texture_name: u32,
+    width: u32,
+    height: u32,
+    loader: GlProcLoader,
+) -> bool {
+    if handle == 0 || texture_name == 0 {
+        return false;
+    }
+
+    let width = width.max(INITIAL_WIDTH);
+    let height = height.max(INITIAL_HEIGHT);
+    let Ok(mut guard) = linux_gl_registry().entries.lock() else {
+        return false;
+    };
+    let Some(entry) = guard.get_mut(&handle) else {
+        return false;
+    };
+
+    if entry.ctx.is_none() {
+        let ctx = match create_linux_gl_device_context(loader) {
+            Ok(ctx) => ctx,
+            Err(err) => {
+                n2log(&format!("linux GL context init failed: {err}"));
+                return false;
+            }
+        };
+        entry.ctx = Some(ctx);
+    }
+    let ctx = Arc::clone(entry.ctx.as_ref().unwrap());
+
+    if entry.renderer.is_none() {
+        let renderer = match Next2Renderer::new(Arc::clone(&ctx), width, height, None) {
+            Ok(renderer) => renderer,
+            Err(err) => {
+                n2log(&format!("linux GL renderer init failed: {err}"));
+                return false;
+            }
+        };
+        entry.renderer = Some(renderer);
+        entry.width = width;
+        entry.height = height;
+        entry.frame_ready.store(true, Ordering::Release);
+    }
+
+    let size_changed = entry.width != width || entry.height != height;
+    if size_changed {
+        entry.width = width;
+        entry.height = height;
+    }
+    let pending_reset = std::mem::take(&mut entry.pending_reset);
+    let pending_input = entry.pending_input.take();
+    let mut should_draw = entry.frame_ready.load(Ordering::Acquire) || size_changed;
+
+    let renderer = entry.renderer.as_mut().unwrap();
+    if size_changed {
+        let _ = renderer.resize(width, height);
+    }
+    if pending_reset {
+        renderer.reset_scene();
+        should_draw = true;
+    }
+    if let Some(input) = pending_input {
+        let font_source = load_custom_font_source(
+            input.custom_font_family.as_str(),
+            input.custom_font_file_path.as_str(),
+        )
+        .ok()
+        .flatten();
+        if renderer.update_frame(input, font_source) {
+            should_draw = true;
+        } else {
+            entry.frame_ready.store(false, Ordering::Release);
+            return false;
+        }
+    }
+
+    if !should_draw {
+        return true;
+    }
+
+    let Some(mut target) = attach_present_gl_texture(ctx.device.as_ref(), texture_name, width, height)
+    else {
+        n2log("linux GL attach present texture failed");
+        return false;
+    };
+    renderer.draw_to_present(&mut target);
+    let _ = ctx.device.poll(wgpu::PollType::wait_indefinitely());
+    entry.frame_ready.store(false, Ordering::Release);
+    true
 }
 
 pub fn create_engine(width: u32, height: u32) -> Result<u64, String> {

--- a/rust/src/next2_engine/engine/runtime.rs
+++ b/rust/src/next2_engine/engine/runtime.rs
@@ -3,7 +3,7 @@ use std::ffi::c_void;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
@@ -35,7 +35,7 @@ use nalgebra::{Affine2, Similarity2, Vector2};
 use serde::Deserialize;
 use ttf_parser::{Face, GlyphId};
 
-use super::present::{attach_present_texture, PresentTarget};
+use super::present::{attach_present_texture, signal_frame_ready, PresentTarget};
 
 #[cfg(target_os = "android")]
 use ndk_sys::ANativeWindow;
@@ -84,13 +84,6 @@ pub struct RenderFrameInput {
     pub custom_font_file_path: String,
 }
 
-#[derive(Clone)]
-pub struct Next2ReadbackFrame {
-    pub width: u32,
-    pub height: u32,
-    pub pixels: Vec<u8>,
-}
-
 pub enum EngineCommand {
     AttachPresentTexture {
         raw_target_ptr: usize,
@@ -113,7 +106,7 @@ pub enum EngineCommand {
 
 pub struct EngineEntry {
     pub cmd_tx: mpsc::Sender<EngineCommand>,
-    pub latest_frame: Arc<Mutex<Option<Next2ReadbackFrame>>>,
+    pub frame_ready: Arc<AtomicBool>,
     pub mtl_device_ptr: usize,
 }
 
@@ -145,7 +138,7 @@ pub fn lookup_engine(handle: u64) -> Option<EngineEntry> {
     let entry = guard.get(&handle)?;
     Some(EngineEntry {
         cmd_tx: entry.cmd_tx.clone(),
-        latest_frame: Arc::clone(&entry.latest_frame),
+        frame_ready: Arc::clone(&entry.frame_ready),
         mtl_device_ptr: entry.mtl_device_ptr,
     })
 }
@@ -162,20 +155,7 @@ pub fn poll_frame_ready(handle: u64) -> bool {
     let Some(entry) = lookup_engine(handle) else {
         return false;
     };
-    let latest_frame = Arc::clone(&entry.latest_frame);
-    drop(entry);
-    latest_frame
-        .try_lock()
-        .map(|guard| guard.is_some())
-        .unwrap_or(false)
-}
-
-pub fn readback_frame_bgra(handle: u64) -> Option<Next2ReadbackFrame> {
-    let entry = lookup_engine(handle)?;
-    let latest_frame = Arc::clone(&entry.latest_frame);
-    drop(entry);
-    let guard = latest_frame.try_lock().ok()?;
-    guard.clone()
+    entry.frame_ready.swap(false, Ordering::AcqRel)
 }
 
 pub fn create_engine(width: u32, height: u32) -> Result<u64, String> {
@@ -189,14 +169,14 @@ pub fn create_engine(width: u32, height: u32) -> Result<u64, String> {
     let mtl_device_ptr = extract_mtl_device_ptr(ctx.device.as_ref()) as usize;
 
     let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>();
-    let latest_frame: Arc<Mutex<Option<Next2ReadbackFrame>>> = Arc::new(Mutex::new(None));
-    let latest_frame_thread = Arc::clone(&latest_frame);
+    let frame_ready = Arc::new(AtomicBool::new(false));
+    let frame_ready_thread = Arc::clone(&frame_ready);
 
     thread::Builder::new()
         .name("next2-engine".to_string())
         .spawn(move || {
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                run_engine_loop(ctx, width, height, latest_frame_thread, cmd_rx);
+                run_engine_loop(ctx, width, height, frame_ready_thread, cmd_rx);
             }));
             if let Err(e) = result {
                 if let Some(s) = e.downcast_ref::<String>() {
@@ -223,7 +203,7 @@ pub fn create_engine(width: u32, height: u32) -> Result<u64, String> {
         handle,
         EngineEntry {
             cmd_tx,
-            latest_frame,
+            frame_ready,
             mtl_device_ptr,
         },
     );
@@ -371,7 +351,7 @@ fn run_engine_loop(
     ctx: Arc<EngineDeviceContext>,
     mut width: u32,
     mut height: u32,
-    latest_frame: Arc<Mutex<Option<Next2ReadbackFrame>>>,
+    frame_ready: Arc<AtomicBool>,
     cmd_rx: mpsc::Receiver<EngineCommand>,
 ) {
     let mut renderer = match Next2Renderer::new(Arc::clone(&ctx), width, height, None) {
@@ -501,13 +481,10 @@ fn run_engine_loop(
         if has_pending_frame {
             if let Some(target) = present_target.as_mut() {
                 renderer.draw_to_present(target);
-                renderer.draw_to_offscreen();
+                signal_frame_ready(ctx.queue.as_ref(), Arc::clone(&frame_ready));
             } else {
-                renderer.draw_to_offscreen();
+                frame_ready.store(false, Ordering::Release);
             }
-
-            let frame = renderer.readback_pixels();
-            *latest_frame.lock().unwrap() = frame;
 
             has_pending_frame = false;
         }

--- a/rust/src/next2_engine/engine/runtime.rs
+++ b/rust/src/next2_engine/engine/runtime.rs
@@ -39,6 +39,8 @@ use ttf_parser::{Face, GlyphId};
 
 #[cfg(target_os = "linux")]
 use super::present::attach_present_gl_texture;
+#[cfg(target_os = "windows")]
+use super::present::create_dx12_shared_present_texture;
 use super::present::{attach_present_texture, signal_frame_ready, PresentTarget};
 
 #[cfg(target_os = "android")]
@@ -88,6 +90,14 @@ pub struct RenderFrameInput {
     pub custom_font_file_path: String,
 }
 
+#[cfg(target_os = "windows")]
+#[derive(Clone, Copy)]
+pub struct DxgiSharedTextureInfo {
+    pub shared_handle: usize,
+    pub width: u32,
+    pub height: u32,
+}
+
 pub enum EngineCommand {
     AttachPresentTexture {
         raw_target_ptr: usize,
@@ -95,6 +105,12 @@ pub enum EngineCommand {
         height: u32,
         bytes_per_row: u32,
         reply: Option<mpsc::Sender<bool>>,
+    },
+    #[cfg(target_os = "windows")]
+    CreateDxgiSharedTexture {
+        width: u32,
+        height: u32,
+        reply: mpsc::Sender<Option<DxgiSharedTextureInfo>>,
     },
     Resize {
         width: u32,
@@ -639,6 +655,25 @@ pub fn attach_present_surface(
     false
 }
 
+#[cfg(target_os = "windows")]
+pub fn create_windows_dxgi_shared_texture(
+    handle: u64,
+    width: u32,
+    height: u32,
+) -> Option<DxgiSharedTextureInfo> {
+    let entry = lookup_engine(handle)?;
+    let (reply_tx, reply_rx) = mpsc::channel();
+    entry
+        .cmd_tx
+        .send(EngineCommand::CreateDxgiSharedTexture {
+            width,
+            height,
+            reply: reply_tx,
+        })
+        .ok()?;
+    reply_rx.recv_timeout(Duration::from_secs(2)).ok().flatten()
+}
+
 fn run_engine_loop(
     ctx: Arc<EngineDeviceContext>,
     mut width: u32,
@@ -732,6 +767,33 @@ fn run_engine_loop(
                     height = h.max(1);
                     let _ = renderer.resize(width, height);
                     has_pending_frame = true;
+                }
+                #[cfg(target_os = "windows")]
+                EngineCommand::CreateDxgiSharedTexture {
+                    width: w,
+                    height: h,
+                    reply,
+                } => {
+                    let w = w.max(1);
+                    let h = h.max(1);
+                    let response = if let Some((target, shared_handle)) =
+                        create_dx12_shared_present_texture(ctx.device.as_ref(), w, h)
+                    {
+                        present_target = Some(target);
+                        width = w;
+                        height = h;
+                        let _ = renderer.resize(width, height);
+                        has_pending_frame = true;
+                        Some(DxgiSharedTextureInfo {
+                            shared_handle,
+                            width,
+                            height,
+                        })
+                    } else {
+                        present_target = None;
+                        None
+                    };
+                    let _ = reply.send(response);
                 }
                 EngineCommand::Resize {
                     width: w,

--- a/rust/src/next2_engine/ffi.rs
+++ b/rust/src/next2_engine/ffi.rs
@@ -1,8 +1,16 @@
 use std::ffi::{c_char, c_void, CStr};
+#[cfg(not(target_os = "linux"))]
 use std::sync::mpsc;
 
+#[cfg(not(target_os = "linux"))]
 use super::engine::{
     create_engine, lookup_engine, n2log, remove_engine, EngineCommand, RenderFrameInput,
+};
+#[cfg(target_os = "linux")]
+use super::engine::{
+    create_linux_gl_engine, n2log, poll_linux_gl_frame_ready, remove_linux_gl_engine,
+    render_linux_gl_texture, reset_linux_gl_engine, resize_linux_gl_engine, set_linux_gl_frame,
+    GlProcLoader, RenderFrameInput,
 };
 
 fn parse_c_string(ptr: *const c_char) -> Option<String> {
@@ -16,7 +24,14 @@ fn parse_c_string(ptr: *const c_char) -> Option<String> {
 #[no_mangle]
 pub extern "C" fn next2_engine_create(width: u32, height: u32) -> u64 {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        create_engine(width, height).unwrap_or(0)
+        #[cfg(target_os = "linux")]
+        {
+            create_linux_gl_engine(width, height).unwrap_or(0)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            create_engine(width, height).unwrap_or(0)
+        }
     }));
     match result {
         Ok(handle) => handle,
@@ -34,15 +49,30 @@ pub extern "C" fn next2_engine_create(width: u32, height: u32) -> u64 {
 
 #[no_mangle]
 pub extern "C" fn next2_engine_get_mtl_device(handle: u64) -> *mut c_void {
-    lookup_engine(handle)
-        .map(|entry| entry.mtl_device_ptr as *mut c_void)
-        .unwrap_or(std::ptr::null_mut())
+    #[cfg(target_os = "linux")]
+    {
+        let _ = handle;
+        std::ptr::null_mut()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        lookup_engine(handle)
+            .map(|entry| entry.mtl_device_ptr as *mut c_void)
+            .unwrap_or(std::ptr::null_mut())
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn next2_engine_poll_frame_ready(handle: u64) -> bool {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        super::engine::poll_frame_ready(handle)
+        #[cfg(target_os = "linux")]
+        {
+            poll_linux_gl_frame_ready(handle)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            super::engine::poll_frame_ready(handle)
+        }
     }));
     match result {
         Ok(ready) => ready,
@@ -58,6 +88,7 @@ pub extern "C" fn next2_engine_poll_frame_ready(handle: u64) -> bool {
     }
 }
 
+#[cfg(not(target_os = "linux"))]
 #[no_mangle]
 pub extern "C" fn next2_engine_attach_present_texture(
     handle: u64,
@@ -76,6 +107,17 @@ pub extern "C" fn next2_engine_attach_present_texture(
         bytes_per_row,
         reply: None,
     });
+}
+
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub extern "C" fn next2_engine_attach_present_texture(
+    _handle: u64,
+    _mtl_texture_ptr: *mut c_void,
+    _width: u32,
+    _height: u32,
+    _bytes_per_row: u32,
+) {
 }
 
 #[cfg(target_os = "android")]
@@ -110,28 +152,53 @@ pub extern "C" fn next2_engine_attach_present_surface(
 
 #[no_mangle]
 pub extern "C" fn next2_engine_dispose(handle: u64) {
-    let Some(entry) = remove_engine(handle) else {
-        return;
-    };
-    let _ = entry.cmd_tx.send(EngineCommand::Stop);
+    #[cfg(target_os = "linux")]
+    {
+        let _ = remove_linux_gl_engine(handle);
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let Some(entry) = remove_engine(handle) else {
+            return;
+        };
+        let _ = entry.cmd_tx.send(EngineCommand::Stop);
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn next2_engine_resize(handle: u64, width: u32, height: u32) -> u8 {
-    let Some(entry) = lookup_engine(handle) else {
-        return 0;
-    };
-    let _ = entry.cmd_tx.send(EngineCommand::Resize { width, height });
-    1
+    #[cfg(target_os = "linux")]
+    {
+        return if resize_linux_gl_engine(handle, width, height) {
+            1
+        } else {
+            0
+        };
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let Some(entry) = lookup_engine(handle) else {
+            return 0;
+        };
+        let _ = entry.cmd_tx.send(EngineCommand::Resize { width, height });
+        1
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn next2_engine_reset_scene(handle: u64) -> u8 {
-    let Some(entry) = lookup_engine(handle) else {
-        return 0;
-    };
-    let _ = entry.cmd_tx.send(EngineCommand::ResetScene);
-    1
+    #[cfg(target_os = "linux")]
+    {
+        return if reset_linux_gl_engine(handle) { 1 } else { 0 };
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let Some(entry) = lookup_engine(handle) else {
+            return 0;
+        };
+        let _ = entry.cmd_tx.send(EngineCommand::ResetScene);
+        1
+    }
 }
 
 #[no_mangle]
@@ -146,38 +213,50 @@ pub extern "C" fn next2_engine_set_frame(
     custom_font_file_path: *const c_char,
 ) -> u8 {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let Some(entry) = lookup_engine(handle) else {
-            return 0;
-        };
         let Some(json) = parse_c_string(frame_json) else {
             return 0;
         };
 
         let custom_font_family = parse_c_string(custom_font_family).unwrap_or_default();
         let custom_font_file_path = parse_c_string(custom_font_file_path).unwrap_or_default();
+        let input = RenderFrameInput {
+            frame_json: json,
+            font_size,
+            outline_width,
+            shadow_style,
+            opacity,
+            custom_font_family,
+            custom_font_file_path,
+        };
 
-        let (reply_tx, reply_rx) = mpsc::channel();
-        if entry
-            .cmd_tx
-            .send(EngineCommand::SetFrame {
-                input: RenderFrameInput {
-                    frame_json: json,
-                    font_size,
-                    outline_width,
-                    shadow_style,
-                    opacity,
-                    custom_font_family,
-                    custom_font_file_path,
-                },
-                reply: reply_tx,
-            })
-            .is_err()
+        #[cfg(target_os = "linux")]
         {
-            return 0;
+            return if set_linux_gl_frame(handle, input) {
+                1
+            } else {
+                0
+            };
         }
-        match reply_rx.recv() {
-            Ok(true) => 1,
-            _ => 0,
+        #[cfg(not(target_os = "linux"))]
+        {
+            let Some(entry) = lookup_engine(handle) else {
+                return 0;
+            };
+            let (reply_tx, reply_rx) = mpsc::channel();
+            if entry
+                .cmd_tx
+                .send(EngineCommand::SetFrame {
+                    input,
+                    reply: reply_tx,
+                })
+                .is_err()
+            {
+                return 0;
+            }
+            match reply_rx.recv() {
+                Ok(true) => 1,
+                _ => 0,
+            }
         }
     }));
     match result {
@@ -192,4 +271,49 @@ pub extern "C" fn next2_engine_set_frame(
             0
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub extern "C" fn next2_engine_render_gl_texture(
+    handle: u64,
+    texture_name: u32,
+    width: u32,
+    height: u32,
+    loader: Option<GlProcLoader>,
+) -> u8 {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let Some(loader) = loader else {
+            return 0;
+        };
+        if render_linux_gl_texture(handle, texture_name, width, height, loader) {
+            1
+        } else {
+            0
+        }
+    }));
+    match result {
+        Ok(v) => v,
+        Err(e) => {
+            let msg = e
+                .downcast_ref::<String>()
+                .map(|s| s.as_str())
+                .or_else(|| e.downcast_ref::<&str>().copied())
+                .unwrap_or("unknown");
+            n2log(&format!("FFI render_gl_texture PANIC: {msg}"));
+            0
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+#[no_mangle]
+pub extern "C" fn next2_engine_render_gl_texture(
+    _handle: u64,
+    _texture_name: u32,
+    _width: u32,
+    _height: u32,
+    _loader: *const c_void,
+) -> u8 {
+    0
 }

--- a/rust/src/next2_engine/ffi.rs
+++ b/rust/src/next2_engine/ffi.rs
@@ -2,6 +2,8 @@ use std::ffi::{c_char, c_void, CStr};
 #[cfg(not(target_os = "linux"))]
 use std::sync::mpsc;
 
+#[cfg(target_os = "windows")]
+use super::engine::create_windows_dxgi_shared_texture;
 #[cfg(not(target_os = "linux"))]
 use super::engine::{
     create_engine, lookup_engine, n2log, remove_engine, EngineCommand, RenderFrameInput,
@@ -148,6 +150,46 @@ pub extern "C" fn next2_engine_attach_present_surface(
     _width: u32,
     _height: u32,
 ) {
+}
+
+#[cfg(target_os = "windows")]
+#[no_mangle]
+pub extern "C" fn next2_engine_create_dxgi_shared_texture(
+    handle: u64,
+    width: u32,
+    height: u32,
+    out_shared_handle: *mut usize,
+    out_width: *mut u32,
+    out_height: *mut u32,
+) -> u8 {
+    if out_shared_handle.is_null() || out_width.is_null() || out_height.is_null() {
+        return 0;
+    }
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        create_windows_dxgi_shared_texture(handle, width, height)
+    }));
+
+    match result {
+        Ok(Some(info)) => {
+            unsafe {
+                *out_shared_handle = info.shared_handle;
+                *out_width = info.width;
+                *out_height = info.height;
+            }
+            1
+        }
+        Ok(None) => 0,
+        Err(e) => {
+            let msg = e
+                .downcast_ref::<String>()
+                .map(|s| s.as_str())
+                .or_else(|| e.downcast_ref::<&str>().copied())
+                .unwrap_or("unknown");
+            n2log(&format!("FFI create_dxgi_shared_texture PANIC: {msg}"));
+            0
+        }
+    }
 }
 
 #[no_mangle]

--- a/rust/src/next2_engine/ffi.rs
+++ b/rust/src/next2_engine/ffi.rs
@@ -2,8 +2,7 @@ use std::ffi::{c_char, c_void, CStr};
 use std::sync::mpsc;
 
 use super::engine::{
-    create_engine, lookup_engine, n2log, readback_frame_bgra, remove_engine, EngineCommand,
-    RenderFrameInput,
+    create_engine, lookup_engine, n2log, remove_engine, EngineCommand, RenderFrameInput,
 };
 
 fn parse_c_string(ptr: *const c_char) -> Option<String> {
@@ -190,51 +189,6 @@ pub extern "C" fn next2_engine_set_frame(
                 .or_else(|| e.downcast_ref::<&str>().copied())
                 .unwrap_or("unknown");
             n2log(&format!("FFI set_frame PANIC: {msg}"));
-            0
-        }
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn next2_engine_copy_bgra_frame(
-    handle: u64,
-    out_pixels: *mut u8,
-    out_pixels_len: u32,
-    out_width: *mut u32,
-    out_height: *mut u32,
-) -> u8 {
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let Some(frame) = readback_frame_bgra(handle) else {
-            return 0;
-        };
-        let out_pixels_len = out_pixels_len as usize;
-        if out_pixels.is_null() || out_pixels_len < frame.pixels.len() {
-            return 0;
-        }
-        if !out_width.is_null() {
-            unsafe {
-                *out_width = frame.width;
-            }
-        }
-        if !out_height.is_null() {
-            unsafe {
-                *out_height = frame.height;
-            }
-        }
-        unsafe {
-            std::ptr::copy_nonoverlapping(frame.pixels.as_ptr(), out_pixels, frame.pixels.len());
-        }
-        1
-    }));
-    match result {
-        Ok(v) => v,
-        Err(e) => {
-            let msg = e
-                .downcast_ref::<String>()
-                .map(|s| s.as_str())
-                .or_else(|| e.downcast_ref::<&str>().copied())
-                .unwrap_or("unknown");
-            n2log(&format!("FFI copy_bgra_frame PANIC: {msg}"));
             0
         }
     }

--- a/rust/src/next2_engine/present.rs
+++ b/rust/src/next2_engine/present.rs
@@ -13,6 +13,27 @@ use std::num::NonZeroU32;
 #[cfg(target_os = "linux")]
 use wgpu_hal::api::Gles;
 
+#[cfg(target_os = "windows")]
+use wgpu_hal::api::Dx12;
+#[cfg(target_os = "windows")]
+use windows::{
+    core::PCWSTR,
+    Win32::{
+        Foundation::GENERIC_ALL,
+        Graphics::{
+            Direct3D12::{
+                ID3D12Resource, D3D12_CLEAR_VALUE, D3D12_CLEAR_VALUE_0,
+                D3D12_CPU_PAGE_PROPERTY_UNKNOWN, D3D12_HEAP_FLAG_SHARED, D3D12_HEAP_PROPERTIES,
+                D3D12_HEAP_TYPE_DEFAULT, D3D12_MEMORY_POOL_UNKNOWN, D3D12_RESOURCE_DESC,
+                D3D12_RESOURCE_DIMENSION_TEXTURE2D, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET,
+                D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS, D3D12_RESOURCE_STATE_COMMON,
+                D3D12_TEXTURE_LAYOUT_UNKNOWN,
+            },
+            Dxgi::Common::{DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_SAMPLE_DESC},
+        },
+    },
+};
+
 #[cfg(target_os = "android")]
 use std::{ffi::c_void, ptr::NonNull};
 #[cfg(target_os = "android")]
@@ -297,6 +318,116 @@ pub(crate) fn attach_present_texture(
         let _ = (device, mtl_texture_ptr, width, height, bytes_per_row);
         None
     }
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn create_dx12_shared_present_texture(
+    device: &wgpu::Device,
+    width: u32,
+    height: u32,
+) -> Option<(PresentTarget, usize)> {
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    let raw_device = unsafe {
+        device
+            .as_hal::<Dx12>()
+            .map(|hal_device| hal_device.raw_device().clone())
+    }?;
+
+    let heap_properties = D3D12_HEAP_PROPERTIES {
+        Type: D3D12_HEAP_TYPE_DEFAULT,
+        CPUPageProperty: D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+        MemoryPoolPreference: D3D12_MEMORY_POOL_UNKNOWN,
+        CreationNodeMask: 1,
+        VisibleNodeMask: 1,
+    };
+    let resource_desc = D3D12_RESOURCE_DESC {
+        Dimension: D3D12_RESOURCE_DIMENSION_TEXTURE2D,
+        Alignment: 0,
+        Width: width as u64,
+        Height: height,
+        DepthOrArraySize: 1,
+        MipLevels: 1,
+        Format: DXGI_FORMAT_B8G8R8A8_UNORM,
+        SampleDesc: DXGI_SAMPLE_DESC {
+            Count: 1,
+            Quality: 0,
+        },
+        Layout: D3D12_TEXTURE_LAYOUT_UNKNOWN,
+        Flags: D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET
+            | D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS,
+    };
+    let clear_value = D3D12_CLEAR_VALUE {
+        Format: DXGI_FORMAT_B8G8R8A8_UNORM,
+        Anonymous: D3D12_CLEAR_VALUE_0 {
+            Color: [0.0, 0.0, 0.0, 0.0],
+        },
+    };
+
+    let mut resource: Option<ID3D12Resource> = None;
+    unsafe {
+        raw_device
+            .CreateCommittedResource(
+                &heap_properties,
+                D3D12_HEAP_FLAG_SHARED,
+                &resource_desc,
+                D3D12_RESOURCE_STATE_COMMON,
+                Some(&clear_value as *const _),
+                &mut resource,
+            )
+            .ok()?;
+    }
+    let resource = resource?;
+    let shared_handle = unsafe {
+        raw_device
+            .CreateSharedHandle(&resource, None, GENERIC_ALL.0, PCWSTR::null())
+            .ok()?
+    };
+    if shared_handle.is_invalid() {
+        return None;
+    }
+
+    let size = wgpu::Extent3d {
+        width,
+        height,
+        depth_or_array_layers: 1,
+    };
+    let hal_texture = unsafe {
+        wgpu_hal::dx12::Device::texture_from_raw(
+            resource,
+            wgpu::TextureFormat::Bgra8Unorm,
+            wgpu::TextureDimension::D2,
+            size,
+            1,
+            1,
+        )
+    };
+    let desc = wgpu::TextureDescriptor {
+        label: Some("next2 present texture (DXGI shared D3D12 resource)"),
+        size,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Bgra8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::TEXTURE_BINDING
+            | wgpu::TextureUsages::COPY_SRC
+            | wgpu::TextureUsages::COPY_DST,
+        view_formats: BGRA8_UNORM_VIEW_FORMATS,
+    };
+    let texture = unsafe { device.create_texture_from_hal::<Dx12>(hal_texture, &desc) };
+    Some((
+        PresentTarget::Texture(PresentTextureTarget {
+            render_texture: texture,
+            width,
+            height,
+            format: wgpu::TextureFormat::Bgra8Unorm,
+            _bytes_per_row: 0,
+        }),
+        shared_handle.0 as usize,
+    ))
 }
 
 #[cfg(target_os = "linux")]

--- a/rust/src/next2_engine/present.rs
+++ b/rust/src/next2_engine/present.rs
@@ -8,6 +8,11 @@ use metal::MTLTextureType;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use wgpu_hal::{api::Metal, CopyExtent};
 
+#[cfg(target_os = "linux")]
+use std::num::NonZeroU32;
+#[cfg(target_os = "linux")]
+use wgpu_hal::api::Gles;
+
 #[cfg(target_os = "android")]
 use std::{ffi::c_void, ptr::NonNull};
 #[cfg(target_os = "android")]
@@ -37,12 +42,17 @@ pub(crate) struct PresentTextureTarget {
     render_texture: wgpu::Texture,
     pub(crate) width: u32,
     pub(crate) height: u32,
+    pub(crate) format: wgpu::TextureFormat,
     _bytes_per_row: u32,
 }
 
 impl PresentTextureTarget {
     pub(crate) fn render_texture(&self) -> &wgpu::Texture {
         &self.render_texture
+    }
+
+    pub(crate) fn format(&self) -> wgpu::TextureFormat {
+        self.format
     }
 }
 
@@ -278,6 +288,7 @@ pub(crate) fn attach_present_texture(
             render_texture: texture,
             width,
             height,
+            format: wgpu::TextureFormat::Bgra8Unorm,
             _bytes_per_row: bytes_per_row,
         }));
     }
@@ -286,4 +297,64 @@ pub(crate) fn attach_present_texture(
         let _ = (device, mtl_texture_ptr, width, height, bytes_per_row);
         None
     }
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn attach_present_gl_texture(
+    device: &wgpu::Device,
+    texture_name: u32,
+    width: u32,
+    height: u32,
+) -> Option<PresentTarget> {
+    let name = NonZeroU32::new(texture_name)?;
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    let format = wgpu::TextureFormat::Rgba8Unorm;
+    let hal_desc = wgpu_hal::TextureDescriptor {
+        label: Some("next2 present texture (external GL texture)"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage: wgpu::TextureUses::COLOR_TARGET | wgpu::TextureUses::RESOURCE,
+        memory_flags: wgpu_hal::MemoryFlags::empty(),
+        view_formats: vec![],
+    };
+
+    let hal_texture = unsafe {
+        device
+            .as_hal::<Gles>()
+            .map(|hal_device| hal_device.texture_from_raw(name, &hal_desc, Some(Box::new(|| {}))))
+    }?;
+
+    let desc = wgpu::TextureDescriptor {
+        label: Some("next2 present texture (external GL texture)"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    };
+
+    let texture = unsafe { device.create_texture_from_hal::<Gles>(hal_texture, &desc) };
+    Some(PresentTarget::Texture(PresentTextureTarget {
+        render_texture: texture,
+        width,
+        height,
+        format,
+        _bytes_per_row: 0,
+    }))
 }

--- a/rust_builder/linux/CMakeLists.txt
+++ b/rust_builder/linux/CMakeLists.txt
@@ -10,6 +10,7 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(EPOXY REQUIRED IMPORTED_TARGET epoxy)
 
 include("../cargokit/cmake/cargokit.cmake")
 set(_RUST_MANIFEST_REL "../../rust")
@@ -35,6 +36,7 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
 target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::EPOXY)
 target_link_libraries(${PLUGIN_NAME} PRIVATE "${${PROJECT_NAME}_cargokit_lib}")
 
 # List of absolute paths to libraries that should be bundled with the plugin.

--- a/rust_builder/linux/rust_lib_nipaplay_plugin.cc
+++ b/rust_builder/linux/rust_lib_nipaplay_plugin.cc
@@ -1,8 +1,11 @@
 #include "include/rust_lib_nipaplay/rust_lib_nipaplay_plugin.h"
 
 #include <flutter_linux/flutter_linux.h>
+#include <epoxy/egl.h>
+#include <epoxy/gl.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <new>
@@ -12,10 +15,17 @@
 #include <vector>
 
 extern "C" {
+typedef const void* (*Next2GlProcLoader)(const char* name);
+
 uint64_t next2_engine_create(uint32_t width, uint32_t height);
 uint8_t next2_engine_resize(uint64_t handle, uint32_t width, uint32_t height);
 void next2_engine_dispose(uint64_t handle);
 bool next2_engine_poll_frame_ready(uint64_t handle);
+uint8_t next2_engine_render_gl_texture(uint64_t handle,
+                                       uint32_t texture_name,
+                                       uint32_t width,
+                                       uint32_t height,
+                                       Next2GlProcLoader loader);
 uint8_t next2_engine_set_frame(uint64_t handle,
                                const char* frame_json,
                                float font_size,
@@ -41,31 +51,31 @@ using SurfaceMutex = std::mutex;
 
 struct SurfaceState {
   std::string surface_id;
-  FlPixelBufferTexture* texture = nullptr;
+  FlTextureGL* texture = nullptr;
   FlTexture* texture_base = nullptr;
   int64_t texture_id = -1;
   uint64_t engine_handle = 0;
   uint32_t width = 0;
   uint32_t height = 0;
-  std::vector<uint8_t> rgba;
   std::mutex lock;
 };
 
-typedef struct _Next2PixelBufferTexture Next2PixelBufferTexture;
-typedef struct _Next2PixelBufferTextureClass Next2PixelBufferTextureClass;
+typedef struct _Next2GLTexture Next2GLTexture;
+typedef struct _Next2GLTextureClass Next2GLTextureClass;
 
-struct _Next2PixelBufferTexture {
-  FlPixelBufferTexture parent_instance;
+struct _Next2GLTexture {
+  FlTextureGL parent_instance;
   SurfaceState* state = nullptr;
+  GLuint texture_name = 0;
+  uint32_t texture_width = 0;
+  uint32_t texture_height = 0;
 };
 
-struct _Next2PixelBufferTextureClass {
-  FlPixelBufferTextureClass parent_class;
+struct _Next2GLTextureClass {
+  FlTextureGLClass parent_class;
 };
 
-G_DEFINE_TYPE(Next2PixelBufferTexture,
-              next2_pixel_buffer_texture,
-              fl_pixel_buffer_texture_get_type())
+G_DEFINE_TYPE(Next2GLTexture, next2_gl_texture, fl_texture_gl_get_type())
 
 struct _RustLibNipaplayPlugin {
   GObject parent_instance;
@@ -169,41 +179,202 @@ static std::string ReadSurfaceId(FlValue* map) {
   return "default";
 }
 
-static gboolean next2_texture_copy_pixels(FlPixelBufferTexture* texture,
-                                          const guint8** out_buffer,
-                                          guint32* width,
-                                          guint32* height,
+struct GlStateSnapshot {
+  GLint active_texture = GL_TEXTURE0;
+  GLint texture_binding_2d = 0;
+  GLint framebuffer_binding = 0;
+  GLint renderbuffer_binding = 0;
+  GLint current_program = 0;
+  GLint array_buffer_binding = 0;
+  GLint element_array_buffer_binding = 0;
+  GLint vertex_array_binding = 0;
+  GLint viewport[4] = {0, 0, 0, 0};
+  GLboolean blend = GL_FALSE;
+  GLboolean scissor = GL_FALSE;
+  GLboolean depth = GL_FALSE;
+  GLboolean cull = GL_FALSE;
+};
+
+static void SetGlEnabled(GLenum capability, GLboolean enabled) {
+  if (enabled == GL_TRUE) {
+    glEnable(capability);
+  } else {
+    glDisable(capability);
+  }
+}
+
+static GlStateSnapshot SaveGlState() {
+  GlStateSnapshot state;
+  glGetIntegerv(GL_ACTIVE_TEXTURE, &state.active_texture);
+  glActiveTexture(GL_TEXTURE0);
+  glGetIntegerv(GL_TEXTURE_BINDING_2D, &state.texture_binding_2d);
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &state.framebuffer_binding);
+  glGetIntegerv(GL_RENDERBUFFER_BINDING, &state.renderbuffer_binding);
+  glGetIntegerv(GL_CURRENT_PROGRAM, &state.current_program);
+  glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &state.array_buffer_binding);
+  glGetIntegerv(GL_ELEMENT_ARRAY_BUFFER_BINDING, &state.element_array_buffer_binding);
+#ifdef GL_VERTEX_ARRAY_BINDING
+  glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &state.vertex_array_binding);
+#endif
+  glGetIntegerv(GL_VIEWPORT, state.viewport);
+  state.blend = glIsEnabled(GL_BLEND);
+  state.scissor = glIsEnabled(GL_SCISSOR_TEST);
+  state.depth = glIsEnabled(GL_DEPTH_TEST);
+  state.cull = glIsEnabled(GL_CULL_FACE);
+  return state;
+}
+
+static void RestoreGlState(const GlStateSnapshot& state) {
+  SetGlEnabled(GL_BLEND, state.blend);
+  SetGlEnabled(GL_SCISSOR_TEST, state.scissor);
+  SetGlEnabled(GL_DEPTH_TEST, state.depth);
+  SetGlEnabled(GL_CULL_FACE, state.cull);
+  glUseProgram(static_cast<GLuint>(state.current_program));
+#ifdef GL_VERTEX_ARRAY_BINDING
+  glBindVertexArray(static_cast<GLuint>(state.vertex_array_binding));
+#endif
+  glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(state.array_buffer_binding));
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, static_cast<GLuint>(state.element_array_buffer_binding));
+  glBindRenderbuffer(GL_RENDERBUFFER, static_cast<GLuint>(state.renderbuffer_binding));
+  glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(state.framebuffer_binding));
+  glViewport(state.viewport[0], state.viewport[1], state.viewport[2], state.viewport[3]);
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(state.texture_binding_2d));
+  glActiveTexture(static_cast<GLenum>(state.active_texture));
+}
+
+static const void* next2_gl_proc_loader(const char* name) {
+  if (name == nullptr) {
+    return nullptr;
+  }
+  return reinterpret_cast<const void*>(eglGetProcAddress(name));
+}
+
+static bool EnsureTextureStorage(Next2GLTexture* self,
+                                 uint32_t width,
+                                 uint32_t height) {
+  if (self->texture_name == 0) {
+    glGenTextures(1, &self->texture_name);
+  }
+  if (self->texture_name == 0) {
+    return false;
+  }
+
+  glBindTexture(GL_TEXTURE_2D, self->texture_name);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  const bool resized = self->texture_width != width || self->texture_height != height;
+  if (resized) {
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, static_cast<GLsizei>(width),
+                 static_cast<GLsizei>(height), 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 nullptr);
+    self->texture_width = width;
+    self->texture_height = height;
+  }
+  return true;
+}
+
+static void ClearTexture(GLuint texture_name, uint32_t width, uint32_t height) {
+  if (texture_name == 0 || width == 0 || height == 0) {
+    return;
+  }
+
+  GLuint framebuffer = 0;
+  glGenFramebuffers(1, &framebuffer);
+  if (framebuffer == 0) {
+    return;
+  }
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         texture_name, 0);
+  if (glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE) {
+    glViewport(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height));
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+  }
+  glDeleteFramebuffers(1, &framebuffer);
+}
+
+static gboolean next2_gl_texture_populate(FlTextureGL* texture,
+                                          uint32_t* target,
+                                          uint32_t* name,
+                                          uint32_t* width,
+                                          uint32_t* height,
                                           GError** error) {
   (void)error;
-  auto* next2_texture = reinterpret_cast<Next2PixelBufferTexture*>(texture);
+  auto* next2_texture = reinterpret_cast<Next2GLTexture*>(texture);
   SurfaceState* state = next2_texture->state;
-  if (!state) {
+  if (state == nullptr) {
     return FALSE;
   }
-  std::lock_guard<std::mutex> guard(state->lock);
-  if (state->rgba.empty() || state->width == 0 || state->height == 0) {
+
+  uint64_t engine_handle = 0;
+  uint32_t desired_width = 0;
+  uint32_t desired_height = 0;
+  {
+    std::lock_guard<std::mutex> guard(state->lock);
+    engine_handle = state->engine_handle;
+    desired_width = state->width;
+    desired_height = state->height;
+  }
+
+  if (engine_handle == 0 || desired_width == 0 || desired_height == 0) {
     return FALSE;
   }
-  *out_buffer = state->rgba.data();
-  *width = state->width;
-  *height = state->height;
+
+  const GlStateSnapshot gl_state = SaveGlState();
+  const bool has_storage = EnsureTextureStorage(next2_texture, desired_width, desired_height);
+  bool rendered = false;
+  if (has_storage) {
+    rendered = next2_engine_render_gl_texture(engine_handle, next2_texture->texture_name,
+                                              desired_width, desired_height,
+                                              next2_gl_proc_loader) != 0;
+    if (!rendered) {
+      ClearTexture(next2_texture->texture_name, desired_width, desired_height);
+    }
+  }
+  RestoreGlState(gl_state);
+
+  if (!has_storage) {
+    return FALSE;
+  }
+
+  *target = GL_TEXTURE_2D;
+  *name = next2_texture->texture_name;
+  *width = desired_width;
+  *height = desired_height;
   return TRUE;
 }
 
-static void next2_pixel_buffer_texture_class_init(
-    Next2PixelBufferTextureClass* klass) {
-  FL_PIXEL_BUFFER_TEXTURE_CLASS(klass)->copy_pixels = next2_texture_copy_pixels;
+static void next2_gl_texture_dispose(GObject* object) {
+  auto* self = reinterpret_cast<Next2GLTexture*>(object);
+  if (self->texture_name != 0) {
+    glDeleteTextures(1, &self->texture_name);
+    self->texture_name = 0;
+  }
+  G_OBJECT_CLASS(next2_gl_texture_parent_class)->dispose(object);
 }
 
-static void next2_pixel_buffer_texture_init(Next2PixelBufferTexture* self) {
+static void next2_gl_texture_class_init(Next2GLTextureClass* klass) {
+  FL_TEXTURE_GL_CLASS(klass)->populate = next2_gl_texture_populate;
+  G_OBJECT_CLASS(klass)->dispose = next2_gl_texture_dispose;
+}
+
+static void next2_gl_texture_init(Next2GLTexture* self) {
   self->state = nullptr;
+  self->texture_name = 0;
+  self->texture_width = 0;
+  self->texture_height = 0;
 }
 
-static FlPixelBufferTexture* create_pixel_texture(SurfaceState* state) {
-  auto* texture = reinterpret_cast<Next2PixelBufferTexture*>(
-      g_object_new(next2_pixel_buffer_texture_get_type(), nullptr));
+static FlTextureGL* create_gl_texture(SurfaceState* state) {
+  auto* texture = reinterpret_cast<Next2GLTexture*>(
+      g_object_new(next2_gl_texture_get_type(), nullptr));
   texture->state = state;
-  return FL_PIXEL_BUFFER_TEXTURE(texture);
+  return FL_TEXTURE_GL(texture);
 }
 
 static gboolean tick_cb(gpointer user_data) {
@@ -281,11 +452,12 @@ static void handle_method_call(RustLibNipaplayPlugin* self,
         fl_method_call_respond(method_call, response, nullptr);
         return;
       }
-      created->rgba.resize(static_cast<size_t>(width) * static_cast<size_t>(height) * 4);
-      created->texture = create_pixel_texture(created.get());
+      created->texture = create_gl_texture(created.get());
       created->texture_base = FL_TEXTURE(created->texture);
       if (!fl_texture_registrar_register_texture(self->texture_registrar,
                                                  created->texture_base)) {
+        next2_engine_dispose(created->engine_handle);
+        g_object_unref(created->texture);
         g_autoptr(FlMethodResponse) response = FL_METHOD_RESPONSE(
             fl_method_error_response_new("register_texture_failed",
                                          "Failed to register texture", nullptr));
@@ -310,10 +482,20 @@ static void handle_method_call(RustLibNipaplayPlugin* self,
           return;
         }
       }
-      state->width = width;
-      state->height = height;
-      state->rgba.assign(static_cast<size_t>(width) * static_cast<size_t>(height) * 4, 0);
+      {
+        std::lock_guard<std::mutex> state_guard(state->lock);
+        state->width = width;
+        state->height = height;
+      }
       is_new_engine = true;
+    }
+
+    uint32_t response_width = 0;
+    uint32_t response_height = 0;
+    {
+      std::lock_guard<std::mutex> state_guard(state->lock);
+      response_width = state->width;
+      response_height = state->height;
     }
 
     FlValue* response_map = fl_value_new_map();
@@ -322,9 +504,9 @@ static void handle_method_call(RustLibNipaplayPlugin* self,
     fl_value_set_string_take(response_map, "engineHandle",
                              fl_value_new_int(static_cast<int64_t>(state->engine_handle)));
     fl_value_set_string_take(response_map, "width",
-                             fl_value_new_int(static_cast<int32_t>(state->width)));
+                             fl_value_new_int(static_cast<int32_t>(response_width)));
     fl_value_set_string_take(response_map, "height",
-                             fl_value_new_int(static_cast<int32_t>(state->height)));
+                             fl_value_new_int(static_cast<int32_t>(response_height)));
     fl_value_set_string_take(response_map, "isNewEngine",
                              fl_value_new_bool(is_new_engine));
     g_autoptr(FlMethodResponse) response =

--- a/rust_builder/linux/rust_lib_nipaplay_plugin.cc
+++ b/rust_builder/linux/rust_lib_nipaplay_plugin.cc
@@ -25,11 +25,6 @@ uint8_t next2_engine_set_frame(uint64_t handle,
                                const char* custom_font_family,
                                const char* custom_font_file_path);
 uint8_t next2_engine_reset_scene(uint64_t handle);
-uint8_t next2_engine_copy_bgra_frame(uint64_t handle,
-                                     uint8_t* out_pixels,
-                                     uint32_t out_len,
-                                     uint32_t* out_width,
-                                     uint32_t* out_height);
 }
 
 #define RUST_LIB_NIPAPLAY_PLUGIN(obj)                                      \
@@ -222,20 +217,6 @@ static gboolean tick_cb(gpointer user_data) {
     if (!next2_engine_poll_frame_ready(state->engine_handle)) {
       continue;
     }
-    std::lock_guard<std::mutex> guard(state->lock);
-    if (state->rgba.empty() || state->width == 0 || state->height == 0) {
-      continue;
-    }
-    uint32_t out_w = 0;
-    uint32_t out_h = 0;
-    const uint8_t ok = next2_engine_copy_bgra_frame(
-        state->engine_handle, state->rgba.data(),
-        static_cast<uint32_t>(state->rgba.size()), &out_w, &out_h);
-    if (ok == 0 || out_w == 0 || out_h == 0) {
-      continue;
-    }
-    state->width = out_w;
-    state->height = out_h;
     fl_texture_registrar_mark_texture_frame_available(
         self->texture_registrar, state->texture_base);
   }

--- a/rust_builder/windows/rust_lib_nipaplay_plugin.cpp
+++ b/rust_builder/windows/rust_lib_nipaplay_plugin.cpp
@@ -15,6 +15,12 @@ uint64_t next2_engine_create(uint32_t width, uint32_t height);
 uint8_t next2_engine_resize(uint64_t handle, uint32_t width, uint32_t height);
 void next2_engine_dispose(uint64_t handle);
 bool next2_engine_poll_frame_ready(uint64_t handle);
+uint8_t next2_engine_create_dxgi_shared_texture(uint64_t handle,
+                                                uint32_t width,
+                                                uint32_t height,
+                                                uintptr_t* out_shared_handle,
+                                                uint32_t* out_width,
+                                                uint32_t* out_height);
 uint8_t next2_engine_set_frame(uint64_t handle,
                                const char* frame_json,
                                float font_size,
@@ -146,20 +152,31 @@ std::string ReadSurfaceId(const flutter::EncodableMap& args) {
 }  // namespace
 
 struct RustLibNipaplayPlugin::TextureBinding {
-  explicit TextureBinding(size_t size = 0) {
-    pixel_buffer.buffer = nullptr;
-    pixel_buffer.width = 0;
-    pixel_buffer.height = 0;
-    pixel_buffer.release_context = nullptr;
-    pixel_buffer.release_callback = nullptr;
-    if (size > 0) {
-      rgba.resize(size);
-      pixel_buffer.buffer = rgba.data();
+  TextureBinding(uintptr_t raw_shared_handle, uint32_t width, uint32_t height)
+      : shared_handle(reinterpret_cast<HANDLE>(raw_shared_handle)),
+        descriptor(std::make_unique<FlutterDesktopGpuSurfaceDescriptor>()) {
+    descriptor->struct_size = sizeof(FlutterDesktopGpuSurfaceDescriptor);
+    descriptor->handle = shared_handle;
+    descriptor->width = width;
+    descriptor->height = height;
+    descriptor->visible_width = width;
+    descriptor->visible_height = height;
+    descriptor->release_context = nullptr;
+    descriptor->release_callback = [](void*) {};
+    descriptor->format = kFlutterDesktopPixelFormatBGRA8888;
+  }
+
+  ~TextureBinding() {
+    if (shared_handle != nullptr && shared_handle != INVALID_HANDLE_VALUE) {
+      ::CloseHandle(shared_handle);
     }
   }
 
-  std::vector<uint8_t> rgba;
-  FlutterDesktopPixelBuffer pixel_buffer{};
+  TextureBinding(const TextureBinding&) = delete;
+  TextureBinding& operator=(const TextureBinding&) = delete;
+
+  HANDLE shared_handle = nullptr;
+  std::unique_ptr<FlutterDesktopGpuSurfaceDescriptor> descriptor;
 };
 
 struct RustLibNipaplayPlugin::SurfaceState {
@@ -195,25 +212,19 @@ RustLibNipaplayPlugin::RustLibNipaplayPlugin(
 RustLibNipaplayPlugin::~RustLibNipaplayPlugin() {
   StopTickThread();
 
-  std::vector<uint64_t> handles;
-  std::vector<int64_t> texture_ids;
+  std::vector<std::unique_ptr<SurfaceState>> removed_surfaces;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     for (auto& kv : surfaces_) {
-      if (kv.second->engine_handle != 0) {
-        handles.push_back(kv.second->engine_handle);
-      }
-      if (kv.second->texture_id >= 0) {
-        texture_ids.push_back(kv.second->texture_id);
-      }
+      removed_surfaces.push_back(std::move(kv.second));
     }
     surfaces_.clear();
   }
-  for (auto id : texture_ids) {
-    texture_registrar_->UnregisterTexture(id, []() {});
-  }
-  for (auto handle : handles) {
-    next2_engine_dispose(handle);
+  for (auto& surface : removed_surfaces) {
+    ReleaseTexture(surface.get());
+    if (surface->engine_handle != 0) {
+      next2_engine_dispose(surface->engine_handle);
+    }
   }
 }
 
@@ -272,27 +283,34 @@ void RustLibNipaplayPlugin::HandleMethodCall(
       is_new_engine = true;
       state->width = width;
       state->height = height;
-      state->binding.reset();
-      if (state->texture_id >= 0) {
-        texture_registrar_->UnregisterTexture(state->texture_id, []() {});
-        state->texture_id = -1;
-        state->texture_variant.reset();
-      }
+      ReleaseTexture(state);
     }
 
     if (state->texture_id < 0 || !state->binding || !state->texture_variant) {
-      const size_t size = static_cast<size_t>(state->width) *
-                          static_cast<size_t>(state->height) * 4;
-      state->binding = std::make_unique<TextureBinding>(size);
+      uintptr_t shared_handle = 0;
+      uint32_t out_width = state->width;
+      uint32_t out_height = state->height;
+      const uint8_t ok = next2_engine_create_dxgi_shared_texture(
+          state->engine_handle, state->width, state->height, &shared_handle,
+          &out_width, &out_height);
+      if (ok == 0 || shared_handle == 0) {
+        result->Error("texture_create_failed",
+                      "next2_engine_create_dxgi_shared_texture failed");
+        return;
+      }
+
+      state->width = out_width;
+      state->height = out_height;
+      state->binding =
+          std::make_unique<TextureBinding>(shared_handle, state->width, state->height);
       auto* binding = state->binding.get();
       state->texture_variant = std::make_unique<flutter::TextureVariant>(
-          flutter::PixelBufferTexture(
-              [binding](size_t, size_t) -> const FlutterDesktopPixelBuffer* {
-                return &binding->pixel_buffer;
+          flutter::GpuSurfaceTexture(
+              kFlutterDesktopGpuSurfaceTypeDxgiSharedHandle,
+              [binding](size_t, size_t)
+                  -> const FlutterDesktopGpuSurfaceDescriptor* {
+                return binding->descriptor.get();
               }));
-      state->binding->pixel_buffer.width = state->width;
-      state->binding->pixel_buffer.height = state->height;
-      state->binding->pixel_buffer.buffer = state->binding->rgba.data();
       state->texture_id =
           texture_registrar_->RegisterTexture(state->texture_variant.get());
       is_new_engine = true;
@@ -378,11 +396,34 @@ void RustLibNipaplayPlugin::DisposeSurface(const std::string& surface_id) {
     }
   }
   if (removed->texture_id >= 0) {
-    texture_registrar_->UnregisterTexture(removed->texture_id, []() {});
+    ReleaseTexture(removed.get());
   }
   if (removed->engine_handle != 0) {
     next2_engine_dispose(removed->engine_handle);
   }
+}
+
+void RustLibNipaplayPlugin::ReleaseTexture(SurfaceState* state) {
+  if (!state) {
+    return;
+  }
+  if (state->texture_id < 0) {
+    state->texture_variant.reset();
+    state->binding.reset();
+    return;
+  }
+
+  struct RetiredTexture {
+    std::unique_ptr<flutter::TextureVariant> texture_variant;
+    std::unique_ptr<TextureBinding> binding;
+  };
+
+  const int64_t texture_id = state->texture_id;
+  state->texture_id = -1;
+  auto retired = std::make_shared<RetiredTexture>();
+  retired->texture_variant = std::move(state->texture_variant);
+  retired->binding = std::move(state->binding);
+  texture_registrar_->UnregisterTexture(texture_id, [retired]() {});
 }
 
 void RustLibNipaplayPlugin::Tick() {

--- a/rust_builder/windows/rust_lib_nipaplay_plugin.cpp
+++ b/rust_builder/windows/rust_lib_nipaplay_plugin.cpp
@@ -24,11 +24,6 @@ uint8_t next2_engine_set_frame(uint64_t handle,
                                const char* custom_font_family,
                                const char* custom_font_file_path);
 uint8_t next2_engine_reset_scene(uint64_t handle);
-uint8_t next2_engine_copy_bgra_frame(uint64_t handle,
-                                     uint8_t* out_pixels,
-                                     uint32_t out_len,
-                                     uint32_t* out_width,
-                                     uint32_t* out_height);
 }
 
 namespace rust_lib_nipaplay {
@@ -400,17 +395,6 @@ void RustLibNipaplayPlugin::Tick() {
     if (!next2_engine_poll_frame_ready(state->engine_handle)) {
       continue;
     }
-    uint32_t out_w = 0;
-    uint32_t out_h = 0;
-    const uint32_t out_len =
-        static_cast<uint32_t>(state->binding->rgba.size());
-    const uint8_t ok = next2_engine_copy_bgra_frame(
-        state->engine_handle, state->binding->rgba.data(), out_len, &out_w, &out_h);
-    if (ok == 0 || out_w == 0 || out_h == 0) {
-      continue;
-    }
-    state->binding->pixel_buffer.width = out_w;
-    state->binding->pixel_buffer.height = out_h;
     texture_registrar_->MarkTextureFrameAvailable(state->texture_id);
   }
 }

--- a/rust_builder/windows/rust_lib_nipaplay_plugin.h
+++ b/rust_builder/windows/rust_lib_nipaplay_plugin.h
@@ -37,6 +37,7 @@ class RustLibNipaplayPlugin : public flutter::Plugin {
   void EnsureTickThreadRunning();
   void StopTickThread();
   void DisposeSurface(const std::string& surface_id);
+  void ReleaseTexture(SurfaceState* state);
   void Tick();
 
   flutter::PluginRegistrarWindows* registrar_;


### PR DESCRIPTION
## 主要内容

- 修复 Windows/Nipaplay 主题番剧详情页文本样式继承问题，移除正文、制作信息、其他标题等位置异常横线，并把普通正文恢复为正常字重。
- 保留现有主题字体链，只通过 `copyWith` 清理 `TextDecoration`，避免影响 ARM Linux 中文字体 fallback。
- 完善 next2/dfm+ 弹幕内核桌面端显存共享绘制路径：Linux 继续走 OpenGL 共享路径，Windows 新增 DXGI shared-handle / wgpu D3D 路径以避免 CPU 像素缓冲拷贝。
- 修复 Windows media-kit 子模块里 `mpv-dev*.7z` 下载完整性校验卡死/失败问题：改为临时文件下载、校验成功后 rename，并增加重试。

## 验证

- `cargo check` 通过。
- `flutter build windows --debug` 通过。
- `flutter build windows --release` 通过，并已启动 release 产物确认。
- `flutter analyze lib/pages/anime_detail_page.dart` 无解析/类型错误；该文件仍有既有 warning/info。