### PR TITLE
[Security] Update openssl to fix Dependabot alerts

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2439,9 +2439,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2471,9 +2471,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary

Updated  to fix multiple high-severity Dependabot alerts for the  crate.

### Changes:
- : 0.10.73 → 0.10.80
- : 0.9.109 → 0.9.114

### Fixed vulnerabilities:
- **#11** (High): Undefined behavior in X509Ref::ocsp_responders
- **#10** (High): Buffer overflow in Deriver::derive
- **#8** (High): Incorrect bounds assertion in AES key wrap
- **#13** (Medium): Out-of-bounds write in CipherCtxRef::cipher_update_inplace
- **#12** (Medium): Heap buffer overflow in AES key-wrap-with-padding

Closes #8, #10, #11, #12, #13