### PR TITLE
[codex] Show build target on about page

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:intl/intl.dart' as intl;
 
+import 'app_localizations_en.dart';
 import 'app_localizations_zh.dart';
 
 // ignore_for_file: type=lint
@@ -94,7 +95,8 @@ abstract class AppLocalizations {
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('zh'),
-    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant')
+    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'),
+    Locale('en')
   ];
 
   /// No description provided for @appTitle.
@@ -193,6 +195,12 @@ abstract class AppLocalizations {
   /// **'繁體中文'**
   String get languageTraditionalChinese;
 
+  /// No description provided for @languageEnglish.
+  ///
+  /// In zh, this message translates to:
+  /// **'English'**
+  String get languageEnglish;
+
   /// No description provided for @currentLanguage.
   ///
   /// In zh, this message translates to:
@@ -214,7 +222,7 @@ abstract class AppLocalizations {
   /// No description provided for @languageTileSubtitle.
   ///
   /// In zh, this message translates to:
-  /// **'切换简体中文或繁體中文'**
+  /// **'切换简体中文、繁體中文或English'**
   String get languageTileSubtitle;
 
   /// No description provided for @settingsBasicSection.
@@ -3184,7 +3192,7 @@ class _AppLocalizationsDelegate
 
   @override
   bool isSupported(Locale locale) =>
-      <String>['zh'].contains(locale.languageCode);
+      <String>['en', 'zh'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -3205,6 +3213,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
 
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
+    case 'en':
+      return AppLocalizationsEn();
     case 'zh':
       return AppLocalizationsZh();
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1,0 +1,1821 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class AppLocalizationsEn extends AppLocalizations {
+  AppLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get appTitle => 'NipaPlay';
+
+  @override
+  String get tabHome => 'Home';
+
+  @override
+  String get tabVideoPlay => 'Video Player';
+
+  @override
+  String get tabMediaLibrary => 'Media Library';
+
+  @override
+  String get tabTorrentDownload => 'Downloader';
+
+  @override
+  String get tabAccount => 'Account';
+
+  @override
+  String get tabSettings => 'Settings';
+
+  @override
+  String get settingsLabel => 'Settings';
+
+  @override
+  String get toggleToLightMode => 'Switch to Light Mode';
+
+  @override
+  String get toggleToDarkMode => 'Switch to Dark Mode';
+
+  @override
+  String get language => 'Language';
+
+  @override
+  String get languageSettingsTitle => 'Language Settings';
+
+  @override
+  String get languageSettingsSubtitle => 'Choose the display language';
+
+  @override
+  String get languageAuto => 'Auto (Follow System)';
+
+  @override
+  String get languageSimplifiedChinese => '简体中文';
+
+  @override
+  String get languageTraditionalChinese => '繁體中文';
+
+  @override
+  String get languageEnglish => 'English';
+
+  @override
+  String currentLanguage(Object language) {
+    return 'Current: $language';
+  }
+
+  @override
+  String currentServer(Object server) {
+    return 'Current: $server';
+  }
+
+  @override
+  String currentTheme(Object theme) {
+    return 'Current: $theme';
+  }
+
+  @override
+  String get languageTileSubtitle =>
+      'Switch between Simplified Chinese, Traditional Chinese, or English';
+
+  @override
+  String get settingsBasicSection => 'Basic Settings';
+
+  @override
+  String get settingsAboutSection => 'About';
+
+  @override
+  String get appearance => 'Appearance';
+
+  @override
+  String get lightMode => 'Light Mode';
+
+  @override
+  String get appearanceLightModeSubtitle =>
+      'Bright interface with good contrast.';
+
+  @override
+  String get darkMode => 'Dark Mode';
+
+  @override
+  String get appearanceDarkModeSubtitle =>
+      'Reduces brightness, protects eyes and saves battery.';
+
+  @override
+  String get followSystem => 'Follow System';
+
+  @override
+  String get appearanceFollowSystemSubtitle =>
+      'Automatically switch appearance based on system settings.';
+
+  @override
+  String get appearancePreviewTitle => 'Preview';
+
+  @override
+  String get appearancePreviewFollowSystemDescription =>
+      'Automatically switch between light and dark mode based on system appearance.';
+
+  @override
+  String get appearancePreviewDarkDescription =>
+      'Uses a dark color scheme, suitable for nighttime or low-light environments.';
+
+  @override
+  String get appearancePreviewLightDescription =>
+      'Uses a bright color scheme, suitable for daytime or bright environments.';
+
+  @override
+  String get appearanceAnimeDetailStyle => 'Anime Detail Style';
+
+  @override
+  String get appearanceDetailSimple => 'Simple';
+
+  @override
+  String get appearanceDetailSimpleSubtitle =>
+      'Classic layout with information in separate columns.';
+
+  @override
+  String get appearanceDetailVivid => 'Vivid';
+
+  @override
+  String get appearanceDetailVividSubtitle =>
+      'Poster-driven visuals with horizontal episode cards.';
+
+  @override
+  String get appearanceRecentWatchingStyle => 'Recently Watched Style';
+
+  @override
+  String get appearanceRecentSimple => 'Simple';
+
+  @override
+  String get appearanceRecentSimpleSubtitle => 'Plain text list, saves space.';
+
+  @override
+  String get appearanceRecentDetailed => 'Detailed';
+
+  @override
+  String get appearanceRecentDetailedSubtitle =>
+      'Horizontal scrolling cards with screenshots.';
+
+  @override
+  String get appearanceHomeSections => 'Home Sections';
+
+  @override
+  String get restoreDefaults => 'Restore Defaults';
+
+  @override
+  String get restoreDefaultsSubtitle =>
+      'Restore default sorting and display states';
+
+  @override
+  String get uiThemeExperimental => 'Theme (Experimental)';
+
+  @override
+  String get uiThemeRestartHint =>
+      'Tip: Restart the app after switching themes for full effect.';
+
+  @override
+  String get uiThemeSwitchDialogTitle => 'Theme Switch Notice';
+
+  @override
+  String uiThemeSwitchDialogMessage(Object theme) {
+    return 'Switching to the $theme theme requires a restart to take full effect.\n\nWould you like to restart the app now?';
+  }
+
+  @override
+  String get restartApp => 'Restart App';
+
+  @override
+  String get refreshPageApplyTheme =>
+      'Please manually refresh the page to apply the new theme';
+
+  @override
+  String get player => 'Player';
+
+  @override
+  String get playerKernel => 'Player Kernel';
+
+  @override
+  String get playerKernelCurrentMdk => 'Current: MDK';
+
+  @override
+  String get playerKernelCurrentVideoPlayer => 'Current: Video Player';
+
+  @override
+  String get playerKernelCurrentLibmpv => 'Current: Libmpv';
+
+  @override
+  String get playerKernelSwitched => 'Player kernel switched';
+
+  @override
+  String get playerKernelDescriptionMdk =>
+      'MDK Multimedia Development Kit, supports hardware decoding (default priority; falls back to software decoding when unsupported).';
+
+  @override
+  String get playerKernelDescriptionVideoPlayer =>
+      'Flutter official Video Player, with good compatibility.';
+
+  @override
+  String get playerKernelDescriptionLibmpv =>
+      'MediaKit (Libmpv) player, supports hardware decoding and advanced features.';
+
+  @override
+  String get externalCall => 'External Player';
+
+  @override
+  String get externalPlayerEnabled => 'External player enabled';
+
+  @override
+  String get externalPlayerDisabled => 'External player disabled';
+
+  @override
+  String get externalPlayerIntroDesktop =>
+      'When enabled, all playback will be opened through an external player.';
+
+  @override
+  String get externalPlayerIntroUnsupported =>
+      'External player is only supported on desktop.';
+
+  @override
+  String get externalPlayerEnableTitle => 'Enable External Player';
+
+  @override
+  String get externalPlayerEnableSubtitle =>
+      'Use an external player for video playback';
+
+  @override
+  String get externalPlayerSelectTitle => 'Select External Player';
+
+  @override
+  String get externalPlayerNotSelected => 'No external player selected';
+
+  @override
+  String get externalPlayerSelectionCanceled =>
+      'External player selection canceled';
+
+  @override
+  String get externalPlayerUpdated => 'External player updated';
+
+  @override
+  String get desktopOnlySupported => 'Desktop only';
+
+  @override
+  String get networkSettings => 'Network Settings';
+
+  @override
+  String get networkSettingsSubtitle =>
+      'DanDanPlay server and custom addresses';
+
+  @override
+  String get storage => 'Storage';
+
+  @override
+  String get storageSettingsSubtitle =>
+      'Manage danmaku cache and cleanup policies';
+
+  @override
+  String get networkMediaLibrary => 'Network Media Library';
+
+  @override
+  String get mediaServerStatusConnected => 'Connected';
+
+  @override
+  String get mediaServerStatusDisconnected => 'Disconnected';
+
+  @override
+  String get mediaServerInfoServerUrl => 'Server URL';
+
+  @override
+  String get mediaServerInfoUsername => 'Logged in as';
+
+  @override
+  String get mediaServerInfoItemCount => 'Media items';
+
+  @override
+  String get mediaServerInfoSelectedLibraries => 'Selected libraries';
+
+  @override
+  String get mediaServerUnknown => 'Unknown';
+
+  @override
+  String get mediaServerAnonymous => 'Anonymous';
+
+  @override
+  String get mediaServerViewLibrary => 'View Library';
+
+  @override
+  String get mediaServerRefresh => 'Refresh';
+
+  @override
+  String get mediaServerManageServer => 'Manage Server';
+
+  @override
+  String get mediaServerConnectServer => 'Connect to Server';
+
+  @override
+  String get mediaServerDisconnectedHint =>
+      'Not connected to this media server yet. Tap the button below to log in.';
+
+  @override
+  String get retry => 'Retry';
+
+  @override
+  String get save => 'Save';
+
+  @override
+  String get disconnect => 'Disconnect';
+
+  @override
+  String get loadFailed => 'Load failed';
+
+  @override
+  String loadFailedWithError(Object error) {
+    return 'Load failed: $error';
+  }
+
+  @override
+  String operationFailed(Object error) {
+    return 'Operation failed: $error';
+  }
+
+  @override
+  String saveFailedWithError(Object error) {
+    return 'Save failed: $error';
+  }
+
+  @override
+  String connectFailedWithError(Object error) {
+    return 'Connection failed: $error';
+  }
+
+  @override
+  String refreshFailedWithError(Object error) {
+    return 'Refresh failed: $error';
+  }
+
+  @override
+  String disconnectFailedWithError(Object error) {
+    return 'Disconnect failed: $error';
+  }
+
+  @override
+  String get deviceIdTitle => 'Device ID (DeviceId)';
+
+  @override
+  String get deviceIdDescription =>
+      'Used by Jellyfin / Emby to distinguish different devices and avoid being kicked out.';
+
+  @override
+  String get deviceIdCurrent => 'Current DeviceId';
+
+  @override
+  String get deviceIdGenerated => 'Auto-generated ID';
+
+  @override
+  String get deviceIdCustom => 'Custom DeviceId';
+
+  @override
+  String deviceIdCustomSet(Object deviceId) {
+    return 'Set to: $deviceId';
+  }
+
+  @override
+  String get deviceIdCustomUnset => 'Not set (using auto-generated)';
+
+  @override
+  String get deviceIdRestoreAuto => 'Restore Auto-Generated';
+
+  @override
+  String get deviceIdRestoreAutoSubtitle => 'Clear custom DeviceId';
+
+  @override
+  String get deviceIdRestoreSuccess => 'Restored auto-generated device ID';
+
+  @override
+  String get deviceIdDialogTitle => 'Custom DeviceId';
+
+  @override
+  String get deviceIdDialogHint =>
+      'Leave empty to use the auto-generated device ID.';
+
+  @override
+  String get deviceIdDialogPlaceholder => 'e.g. My-iPhone-01';
+
+  @override
+  String get deviceIdDialogValidationHint =>
+      'Do not include double quotes or newlines; max length 128.';
+
+  @override
+  String get deviceIdUpdatedHint =>
+      'Device ID updated. It is recommended to disconnect and reconnect to the server.';
+
+  @override
+  String get deviceIdInvalid =>
+      'Invalid DeviceId: avoid double quotes/newlines and keep length ≤ 128';
+
+  @override
+  String networkServerConnected(Object server) {
+    return '$server server connected';
+  }
+
+  @override
+  String networkServerSettingsUpdated(Object server) {
+    return '$server server settings updated';
+  }
+
+  @override
+  String disconnectServerConfirm(Object server) {
+    return 'Are you sure you want to disconnect from the $server server?';
+  }
+
+  @override
+  String networkServerDisconnected(Object server) {
+    return '$server disconnected';
+  }
+
+  @override
+  String disconnectServerFailed(Object server, Object error) {
+    return 'Failed to disconnect from $server: $error';
+  }
+
+  @override
+  String networkServerNotConnected(Object server) {
+    return 'Not connected to $server server yet';
+  }
+
+  @override
+  String networkLibraryRefreshed(Object server) {
+    return '$server library refreshed';
+  }
+
+  @override
+  String connectServerDialogTitle(Object server) {
+    return 'Connect to $server Server';
+  }
+
+  @override
+  String get serverUrlInputPlaceholder => 'e.g. http://192.168.1.100:8096';
+
+  @override
+  String get inputUsernamePlaceholder => 'Enter username';
+
+  @override
+  String get inputPasswordPlaceholder => 'Enter password';
+
+  @override
+  String get nextStep => 'Next';
+
+  @override
+  String get connectAction => 'Connect';
+
+  @override
+  String get testConnection => 'Test Connection';
+
+  @override
+  String get canBeEmpty => 'Can be empty';
+
+  @override
+  String get leaveEmptyAutoGenerate => 'Leave empty to auto-generate';
+
+  @override
+  String get usernameOptional => 'Username (optional)';
+
+  @override
+  String get passwordOptional => 'Password (optional)';
+
+  @override
+  String get connectFailedCheckCredentials =>
+      'Connection failed. Please check the server address and credentials.';
+
+  @override
+  String get webdavAddServer => 'Add WebDAV Server';
+
+  @override
+  String get webdavEditServer => 'Edit WebDAV Server';
+
+  @override
+  String get webdavEnterAddress => 'Enter WebDAV address';
+
+  @override
+  String get webdavInvalidUrl => 'Please enter a valid URL (http/https)';
+
+  @override
+  String get webdavConnection => 'WebDAV Connection';
+
+  @override
+  String webdavTestFailedWithError(Object error) {
+    return 'Test failed: $error';
+  }
+
+  @override
+  String get webdavTestFailedCheckInfo =>
+      'Connection test failed. Please check the address and credentials.';
+
+  @override
+  String get webdavTestSuccess => 'Connection test successful';
+
+  @override
+  String get webdavTestFailed => 'Connection test failed';
+
+  @override
+  String get webdavSaveFailedCheckInfo =>
+      'Save failed. Please check the address and credentials.';
+
+  @override
+  String get webdavConnectHint =>
+      'After connecting to a WebDAV server, you can browse directories and select media folders.';
+
+  @override
+  String get webdavConnectionNameOptional => 'Connection name (optional)';
+
+  @override
+  String get webdavAddress => 'WebDAV Address';
+
+  @override
+  String get smbAddServer => 'Add SMB Server';
+
+  @override
+  String get smbEditServer => 'Edit SMB Server';
+
+  @override
+  String get smbEnterHostOrIp => 'Enter hostname or IP address';
+
+  @override
+  String get smbInvalidPortRange =>
+      'Invalid port. Please enter a value between 1 and 65535.';
+
+  @override
+  String get smbAnonymousHint =>
+      'Leave username/password empty for anonymous access. Domain name is supported.';
+
+  @override
+  String get smbHostOrIp => 'Host / IP';
+
+  @override
+  String get smbHostOrIpPlaceholder => 'e.g. 192.168.1.10 or nas.local';
+
+  @override
+  String get smbPort => 'Port';
+
+  @override
+  String get smbDefaultPort445 => 'Default: 445';
+
+  @override
+  String get smbDomainOptional => 'Domain (optional)';
+
+  @override
+  String get smbDomainPlaceholder => 'e.g. WORKGROUP';
+
+  @override
+  String get connectJellyfinOrEmbyFirst =>
+      'Please connect to a Jellyfin or Emby server first';
+
+  @override
+  String get networkMediaLibraryIntro =>
+      'Manage Jellyfin / Emby server connections and set up DanDanPlay remote libraries here.';
+
+  @override
+  String get currentServerNotConnectedHint =>
+      'Current server is not connected. Please go back and select again.';
+
+  @override
+  String get loadingRemoteMediaLibrary => 'Loading remote media library...';
+
+  @override
+  String get noRemoteMediaItems => 'No remote media items found';
+
+  @override
+  String recordedAtDate(Object date) {
+    return 'Added on $date';
+  }
+
+  @override
+  String get jellyfinMediaServerTitle => 'Jellyfin Media Server';
+
+  @override
+  String get jellyfinDisconnectedDescription =>
+      'Connect to a Jellyfin server to sync your media library and playback history.';
+
+  @override
+  String get embyMediaServerTitle => 'Emby Media Server';
+
+  @override
+  String get embyDisconnectedDescription =>
+      'Connect to an Emby server to browse your media library and play remotely.';
+
+  @override
+  String get dandanRemoteCardTitle => 'DanDanPlay Remote Access';
+
+  @override
+  String get dandanRemoteManageAccessTitle => 'Manage DanDanPlay Remote Access';
+
+  @override
+  String get dandanRemoteConnectAccessTitle =>
+      'Connect to DanDanPlay Remote Access';
+
+  @override
+  String get dandanRemoteAddressPrompt =>
+      'Enter the remote service address shown on your desktop.';
+
+  @override
+  String get dandanRemoteAddressPlaceholder => 'e.g. http://192.168.1.2:23333';
+
+  @override
+  String get dandanRemoteApiTokenOptionalTitle => 'API Key (optional)';
+
+  @override
+  String dandanRemoteApiTokenPrompt(Object actionLabel) {
+    return 'If you have enabled API authentication in the DanDanPlay desktop app, enter the corresponding key. Otherwise, just tap $actionLabel.';
+  }
+
+  @override
+  String get enterApiToken => 'Enter API key';
+
+  @override
+  String get optionalApiTokenHint => 'Optional, fill in if needed';
+
+  @override
+  String get dandanRemoteStatusSynced => 'Synced';
+
+  @override
+  String get dandanRemoteStatusConnectFailed => 'Connection failed';
+
+  @override
+  String get dandanRemoteStatusNotConfigured => 'Not configured';
+
+  @override
+  String get unknownErrorOccurred => 'An unknown error occurred';
+
+  @override
+  String get dandanRemoteServerAddressLabel => 'Server address';
+
+  @override
+  String get dandanRemoteLastSyncedLabel => 'Last synced';
+
+  @override
+  String get dandanRemoteAnimeEntries => 'Anime entries';
+
+  @override
+  String get dandanRemoteVideoFiles => 'Video files';
+
+  @override
+  String get dandanRemoteNoRecordsHint =>
+      'No remote media records found. Try refreshing or check your remote access settings.';
+
+  @override
+  String get dandanRemoteRecentUpdates => 'Recent Updates';
+
+  @override
+  String dandanRemoteEpisodeCount(int count) {
+    return '$count episodes total';
+  }
+
+  @override
+  String get dandanRemoteManageConnection => 'Manage Connection';
+
+  @override
+  String get dandanRemoteSyncing => 'Syncing...';
+
+  @override
+  String get dandanRemoteRefreshLibrary => 'Refresh Library';
+
+  @override
+  String get dandanRemoteDisconnectedHintLong =>
+      'Enable remote access in the DanDanPlay desktop app to sync anime records from your home PC or NAS and play directly here.';
+
+  @override
+  String get pleaseWait => 'Please wait...';
+
+  @override
+  String get connectDandanRemoteService =>
+      'Connect to DanDanPlay Remote Service';
+
+  @override
+  String get noRecordYet => 'No records yet';
+
+  @override
+  String get justNow => 'Just now';
+
+  @override
+  String minutesAgo(int minutes) {
+    return '$minutes min ago';
+  }
+
+  @override
+  String hoursAgo(int hours) {
+    return '$hours hr ago';
+  }
+
+  @override
+  String daysAgo(int days) {
+    return '$days days ago';
+  }
+
+  @override
+  String get dandanRemoteConfigUpdated =>
+      'DanDanPlay remote service configuration updated';
+
+  @override
+  String get dandanRemoteConnected => 'DanDanPlay remote service connected';
+
+  @override
+  String get dandanRemoteDisconnected =>
+      'Disconnected from DanDanPlay remote service';
+
+  @override
+  String get disconnectDandanRemoteTitle =>
+      'Disconnect DanDanPlay Remote Service';
+
+  @override
+  String get disconnectDandanRemoteContent =>
+      'Are you sure you want to disconnect from the DanDanPlay remote service?\n\nThis will clear the saved server address and API key.';
+
+  @override
+  String get remoteLibraryRefreshed => 'Remote library refreshed';
+
+  @override
+  String get noConnectedServer => 'No server connected';
+
+  @override
+  String get mediaLibraryNotSelected => 'No library selected';
+
+  @override
+  String get mediaLibraryNotMatched => 'No library matched';
+
+  @override
+  String mediaLibraryAndCount(Object first, int count) {
+    return '$first and $count others';
+  }
+
+  @override
+  String mediaServerSummary(Object server, Object summary) {
+    return '$server · $summary';
+  }
+
+  @override
+  String serverMediaLibraryTitle(Object server) {
+    return '$server Library';
+  }
+
+  @override
+  String get serverLabel => 'Server';
+
+  @override
+  String get accountLabel => 'Account';
+
+  @override
+  String get mediaLibrary => 'Media Library';
+
+  @override
+  String get noMediaLibrary => 'No libraries available';
+
+  @override
+  String get checkServerConnection => 'Please check the server connection';
+
+  @override
+  String get transcodeSettings => 'Transcoding Settings';
+
+  @override
+  String currentDefaultQuality(Object quality) {
+    return 'Current default quality: $quality';
+  }
+
+  @override
+  String get enableTranscode => 'Enable Transcoding';
+
+  @override
+  String get defaultQuality => 'Default Quality';
+
+  @override
+  String get tvShowsLibrary => 'TV Shows';
+
+  @override
+  String get moviesLibrary => 'Movies';
+
+  @override
+  String get boxsetsLibrary => 'Collections';
+
+  @override
+  String get folderLibrary => 'Folders';
+
+  @override
+  String get mixedLibrary => 'Mixed Library';
+
+  @override
+  String get userActivityTitle => 'My Activity';
+
+  @override
+  String get userActivityTabWatched => 'Watched';
+
+  @override
+  String get userActivityTabFavorites => 'Favorites';
+
+  @override
+  String get userActivityTabRated => 'Rated';
+
+  @override
+  String userActivityTabWatchedCount(int count) {
+    return 'Watched ($count)';
+  }
+
+  @override
+  String userActivityTabFavoritesCount(int count) {
+    return 'Favorites ($count)';
+  }
+
+  @override
+  String userActivityTabRatedCount(int count) {
+    return 'Rated ($count)';
+  }
+
+  @override
+  String get userActivityNoWatchedRecords => 'No watch history';
+
+  @override
+  String get userActivityNoFavorites => 'No favorites';
+
+  @override
+  String get userActivityNoRatings => 'No ratings yet';
+
+  @override
+  String get userActivityNotLoggedIn => 'Not logged in to DanDanPlay';
+
+  @override
+  String userActivityWatchedEpisode(Object episode) {
+    return 'Watched: $episode';
+  }
+
+  @override
+  String userActivityWatchedUpdatedTime(Object time) {
+    return 'Updated: $time';
+  }
+
+  @override
+  String get userActivityWatchedOnly => 'Watched';
+
+  @override
+  String userActivityStatusWithValue(Object status) {
+    return 'Status: $status';
+  }
+
+  @override
+  String userActivityRatingWithValue(int rating) {
+    return 'Rating: $rating';
+  }
+
+  @override
+  String get userActivityUnknownTitle => 'Unknown Title';
+
+  @override
+  String get ratingLevelMasterpiece => 'Masterpiece';
+
+  @override
+  String get ratingLevelGreat => 'Great';
+
+  @override
+  String get ratingLevelGood => 'Good';
+
+  @override
+  String get ratingLevelAverage => 'Average';
+
+  @override
+  String get ratingLevelOkay => 'Okay';
+
+  @override
+  String get ratingLevelPoor => 'Poor';
+
+  @override
+  String get ratingLevelVeryPoor => 'Very Poor';
+
+  @override
+  String get ratingLevelTerrible => 'Terrible';
+
+  @override
+  String get favoriteStatusFollowing => 'Following';
+
+  @override
+  String get favoriteStatusFinished => 'Finished';
+
+  @override
+  String get favoriteStatusAbandoned => 'Dropped';
+
+  @override
+  String get favoriteStatusFavorited => 'Favorited';
+
+  @override
+  String get weekdaySunday => 'Sun';
+
+  @override
+  String get weekdayMonday => 'Mon';
+
+  @override
+  String get weekdayTuesday => 'Tue';
+
+  @override
+  String get weekdayWednesday => 'Wed';
+
+  @override
+  String get weekdayThursday => 'Thu';
+
+  @override
+  String get weekdayFriday => 'Fri';
+
+  @override
+  String get weekdaySaturday => 'Sat';
+
+  @override
+  String get newSeriesNoTodayAnime => 'No new anime today';
+
+  @override
+  String get newSeriesUpdateTimeTbd => 'Update time TBD';
+
+  @override
+  String get newSeriesSearchDescription =>
+      'Search new anime\nFilter by tags and genres\nFind anime you\'re interested in';
+
+  @override
+  String get newSeriesSortDescriptionAscending =>
+      'Switch to ascending order\nToday\'s new anime shown first';
+
+  @override
+  String get newSeriesSortDescriptionDescending =>
+      'Switch to descending order\nToday\'s new anime shown last';
+
+  @override
+  String get newSeriesInitializingPlayer => 'Initializing player...';
+
+  @override
+  String newSeriesPlayerLoadFailedWithError(Object error) {
+    return 'Player load failed: $error';
+  }
+
+  @override
+  String newSeriesErrorOccurredWithError(Object error) {
+    return 'Error occurred: $error';
+  }
+
+  @override
+  String newSeriesHandlePlayRequestFailedWithError(Object error) {
+    return 'Error handling play request: $error';
+  }
+
+  @override
+  String newSeriesAnimeCount(int count) {
+    return '$count anime';
+  }
+
+  @override
+  String get newSeriesRemoteAddressNotConfigured =>
+      'Remote access address not configured';
+
+  @override
+  String get newSeriesNetworkTimeout =>
+      'Network request timed out. Please check your connection and try again.';
+
+  @override
+  String get newSeriesNetworkConnectionFailed =>
+      'Network connection failed. Please check your network settings.';
+
+  @override
+  String get newSeriesServerUnavailableRetryLater =>
+      'Server is unavailable. Please try again later.';
+
+  @override
+  String get newSeriesServerDataFormatError =>
+      'Invalid data format received from server';
+
+  @override
+  String get developerOptions => 'Developer Options';
+
+  @override
+  String get developerOptionsSubtitle =>
+      'Terminal output, dependency versions, build info';
+
+  @override
+  String get terminalOutput => 'Terminal Output';
+
+  @override
+  String get terminalOutputSubtitle =>
+      'View logs, copy content, or generate QR code to share';
+
+  @override
+  String get dependencyVersions => 'Dependency Versions';
+
+  @override
+  String get dependencyVersionsSubtitle =>
+      'View dependencies and version numbers (with GitHub links)';
+
+  @override
+  String get invalidLink => 'Invalid link';
+
+  @override
+  String get unknown => 'Unknown';
+
+  @override
+  String get localSource => 'Local';
+
+  @override
+  String get dependencyTypeDirectMain => 'Direct dependency';
+
+  @override
+  String get dependencyTypeDirectDev => 'Dev dependency';
+
+  @override
+  String get dependencyTypeTransitive => 'Transitive dependency';
+
+  @override
+  String get dependencyTypeUnknown => 'Unknown source';
+
+  @override
+  String get parsingDependencyInfo => 'Parsing dependency info...';
+
+  @override
+  String get readDependencyListFailed => 'Failed to read dependency list';
+
+  @override
+  String dependencySummaryWithOther(
+      int total, int directMain, int directDev, int transitive, int other) {
+    return '$total total · Direct $directMain / Dev $directDev / Transitive $transitive / Other $other';
+  }
+
+  @override
+  String dependencySummaryNoOther(
+      int total, int directMain, int directDev, int transitive) {
+    return '$total total · Direct $directMain / Dev $directDev / Transitive $transitive';
+  }
+
+  @override
+  String dependencyEntrySubtitle(
+      Object version, Object dependencyType, Object sourceType) {
+    return 'Version: $version · $dependencyType · $sourceType';
+  }
+
+  @override
+  String get buildInfo => 'Build Info';
+
+  @override
+  String get buildInfoSubtitle =>
+      'View build time, processor, memory, and system architecture';
+
+  @override
+  String get fileLogWriteTitle => 'Write Logs to File';
+
+  @override
+  String get fileLogWriteSubtitle =>
+      'Writes to disk every 1 second, keeps the last 5 log files';
+
+  @override
+  String get fileLogWriteEnabled => 'Log file writing enabled';
+
+  @override
+  String get fileLogWriteDisabled => 'Log file writing disabled';
+
+  @override
+  String get openLogDirectoryTitle => 'Open Log Directory';
+
+  @override
+  String get openLogDirectorySubtitle =>
+      'Open the log directory in file manager';
+
+  @override
+  String get logDirectoryOpened => 'Log directory opened';
+
+  @override
+  String get openLogDirectoryFailed => 'Failed to open log directory';
+
+  @override
+  String get spoilerAiDebugPrintTitle => 'Debug: Print AI Response';
+
+  @override
+  String get spoilerAiDebugPrintEnabledHint =>
+      'When enabled, raw AI response text and matched danmaku will be printed to logs.';
+
+  @override
+  String get spoilerAiDebugPrintNeedSpoilerMode =>
+      'Enable spoiler prevention mode first';
+
+  @override
+  String get spoilerAiDebugPrintEnabled => 'AI debug printing enabled';
+
+  @override
+  String get spoilerAiDebugPrintDisabled => 'AI debug printing disabled';
+
+  @override
+  String get playerUnavailableOnWeb =>
+      'Player settings are not available on the web platform';
+
+  @override
+  String get danmakuRenderEngine => 'Danmaku Render Engine';
+
+  @override
+  String get danmakuRenderEngineSwitched => 'Danmaku render engine switched';
+
+  @override
+  String get danmakuRenderEngineDescriptionCpu =>
+      'CPU Rendering: Best compatibility, suitable for most scenarios.';
+
+  @override
+  String get danmakuRenderEngineDescriptionGpuExperimental =>
+      'GPU Rendering (Experimental): Higher performance, still under development.';
+
+  @override
+  String get danmakuRenderEngineDescriptionCanvasExperimental =>
+      'Canvas Danmaku (Experimental): High performance, low power consumption.';
+
+  @override
+  String get danmakuRenderEngineDescriptionNipaplayNext =>
+      'NipaPlay Next: Combines the strengths of both CPU and Canvas danmaku, featuring all advantages of both.';
+
+  @override
+  String get danmakuRenderEngineTitleCpu => 'CPU Rendering';
+
+  @override
+  String get danmakuRenderEngineTitleGpuExperimental =>
+      'GPU Rendering (Experimental)';
+
+  @override
+  String get danmakuRenderEngineTitleCanvasExperimental =>
+      'Canvas Danmaku (Experimental)';
+
+  @override
+  String get danmakuRenderEngineTitleNipaplayNext => 'NipaPlay Next';
+
+  @override
+  String get qualityProfileOff => 'Off';
+
+  @override
+  String get qualityProfileLite => 'Lite';
+
+  @override
+  String get qualityProfileStandard => 'Standard';
+
+  @override
+  String get qualityProfileHigh => 'High Quality';
+
+  @override
+  String get doubleResolutionPlaybackTitle => 'Double Resolution Playback';
+
+  @override
+  String get doubleResolutionPlaybackSubtitle =>
+      'Render at 2x resolution for sharper embedded subtitles (Libmpv only, not combinable with Anime4K)';
+
+  @override
+  String get settingSavedReopenVideoToApply =>
+      'Saved. Reopen the video to apply.';
+
+  @override
+  String get doubleResolutionPlaybackEnabled =>
+      'Double resolution playback enabled';
+
+  @override
+  String get doubleResolutionPlaybackDisabled =>
+      'Double resolution playback disabled';
+
+  @override
+  String get anime4kSuperResolutionTitle =>
+      'Anime4K Super Resolution (Experimental)';
+
+  @override
+  String get anime4kProfileDescriptionOff =>
+      'Keep original image, no super resolution processing.';
+
+  @override
+  String get anime4kProfileDescriptionLite =>
+      'Moderate super resolution and denoising with low performance impact.';
+
+  @override
+  String get anime4kProfileDescriptionStandard =>
+      'Balanced quality and performance.';
+
+  @override
+  String get anime4kProfileDescriptionHigh =>
+      'Best image quality, highest performance requirements.';
+
+  @override
+  String get anime4kDisabled => 'Anime4K disabled';
+
+  @override
+  String anime4kSwitchedTo(Object option) {
+    return 'Anime4K switched to $option';
+  }
+
+  @override
+  String get crtDisplayEffectTitle => 'CRT Display Effect';
+
+  @override
+  String get crtProfileDescriptionOff => 'Keep original image, no CRT effect.';
+
+  @override
+  String get crtProfileDescriptionLite =>
+      'Scanlines + vignette, minimal performance impact.';
+
+  @override
+  String get crtProfileDescriptionStandard =>
+      'Adds curvature and grid for a more authentic CRT look.';
+
+  @override
+  String get crtProfileDescriptionHigh =>
+      'Adds glow and color fringing, best effect but higher performance cost.';
+
+  @override
+  String get crtDisabled => 'CRT disabled';
+
+  @override
+  String crtSwitchedTo(Object option) {
+    return 'CRT switched to $option';
+  }
+
+  @override
+  String get enterAiApiUrl => 'Enter AI API URL';
+
+  @override
+  String get enterModelName => 'Enter model name';
+
+  @override
+  String get enterApiKey => 'Enter API Key';
+
+  @override
+  String get spoilerAiSettingsSaved => 'Spoiler prevention AI settings saved';
+
+  @override
+  String get spoilerPreventionMode => 'Spoiler Prevention';
+
+  @override
+  String get spoilerPreventionModeSubtitle =>
+      'When enabled, AI will identify and filter suspected spoiler danmaku after loading.';
+
+  @override
+  String get fillAndSaveAiConfigFirst =>
+      'Please fill in and save the AI API configuration first';
+
+  @override
+  String get spoilerPreventionModeEnabled => 'Spoiler prevention enabled';
+
+  @override
+  String get spoilerPreventionModeDisabled => 'Spoiler prevention disabled';
+
+  @override
+  String get autoMatchDanmakuOnPlayTitle => 'Auto-Match Danmaku on Play';
+
+  @override
+  String get autoMatchDanmakuOnPlaySubtitle =>
+      'When disabled, danmaku won\'t be auto-matched on playback. You can manually match in danmaku settings.';
+
+  @override
+  String get autoMatchDanmakuOnPlayEnabled =>
+      'Auto-match danmaku on play enabled';
+
+  @override
+  String get autoMatchDanmakuOnPlayDisabledManual =>
+      'Auto-match on play disabled (manual matching available)';
+
+  @override
+  String get autoMatchOnHashFailTitle => 'Auto-Match on Hash Failure';
+
+  @override
+  String get autoMatchOnHashFailSubtitle =>
+      'When hash matching fails, automatically use the first filename search result. When disabled, the search danmaku menu will be shown instead.';
+
+  @override
+  String get autoMatchOnHashFailEnabled => 'Auto-match on hash failure enabled';
+
+  @override
+  String get autoMatchOnHashFailDisabledShowSearch =>
+      'Auto-match on hash failure disabled (search menu will be shown)';
+
+  @override
+  String get hardwareDecoding => 'Hardware Decoding';
+
+  @override
+  String get hardwareDecodingSubtitle => 'Only applies to MDK / Libmpv kernels';
+
+  @override
+  String get hardwareDecodingEnabled => 'Hardware decoding enabled';
+
+  @override
+  String get hardwareDecodingDisabled => 'Hardware decoding disabled';
+
+  @override
+  String get pauseOnBackgroundTitle => 'Pause on Background';
+
+  @override
+  String get pauseOnBackgroundSubtitle =>
+      'Automatically pause playback when switching to background or locking screen';
+
+  @override
+  String get pauseOnBackgroundEnabled => 'Pause on background enabled';
+
+  @override
+  String get pauseOnBackgroundDisabled => 'Pause on background disabled';
+
+  @override
+  String get playbackEndActionTitle => 'Action After Playback';
+
+  @override
+  String get playbackEndActionAutoNextMessage =>
+      'Automatically play the next episode after playback ends';
+
+  @override
+  String get playbackEndActionLoopMessage =>
+      'Loop from the beginning after playback ends';
+
+  @override
+  String get playbackEndActionPauseMessage =>
+      'Stay on the current page after playback ends';
+
+  @override
+  String get playbackEndActionExitMessage =>
+      'Return to the previous page after playback ends';
+
+  @override
+  String get autoNextCountdownTitle => 'Auto-Next Countdown';
+
+  @override
+  String autoNextCountdownWaitSeconds(int seconds) {
+    return 'Wait $seconds seconds before auto-playing next episode';
+  }
+
+  @override
+  String get autoNextCountdownNeedAutoNext =>
+      'Enable auto-play next episode first';
+
+  @override
+  String get timelinePreviewTitle => 'Timeline Preview Thumbnails';
+
+  @override
+  String get timelinePreviewSubtitle =>
+      'Show thumbnails when hovering over the progress bar (works for local/WebDAV/SMB/shared libraries)';
+
+  @override
+  String get enableWarning => 'Warning';
+
+  @override
+  String get timelinePreviewEnableWarningContent =>
+      'Enabling timeline preview will generate screenshots in real-time during playback, which may cause stuttering or performance degradation. Continue?';
+
+  @override
+  String get timelinePreviewEnabled => 'Timeline preview enabled';
+
+  @override
+  String get timelinePreviewDisabled => 'Timeline preview disabled';
+
+  @override
+  String get playPrecacheDuration => 'Pre-cache Duration';
+
+  @override
+  String get playPrecacheSize => 'Pre-cache Size';
+
+  @override
+  String currentPrecacheDurationSeconds(int seconds) {
+    return 'Current: $seconds seconds. Changes take effect immediately.';
+  }
+
+  @override
+  String currentPrecacheSizeMb(int mb) {
+    return 'Current: $mb MB. Reopen the video to apply changes.';
+  }
+
+  @override
+  String get libmpvKernelOnly => 'Only applies to Libmpv kernel';
+
+  @override
+  String get spoilerAiSettingsTitle => 'Spoiler Prevention AI Settings';
+
+  @override
+  String get spoilerAiSettingsDescription =>
+      'Fill in and save the configuration before enabling spoiler prevention (API URL / Key / Model are required).';
+
+  @override
+  String get spoilerAiGeminiUrlNote =>
+      'Gemini: URL can end at /v1beta/models. The request path /<model>:generateContent will be appended automatically.';
+
+  @override
+  String get spoilerAiOpenAiUrlNote =>
+      'OpenAI: URL should be /v1/chat/completions (compatible endpoints also work).';
+
+  @override
+  String get apiFormatLabel => 'API Format';
+
+  @override
+  String get openAiCompatible => 'OpenAI Compatible';
+
+  @override
+  String get enterYourApiKey => 'Enter your API Key';
+
+  @override
+  String temperatureLabel(Object value) {
+    return 'Temperature: $value';
+  }
+
+  @override
+  String get saveConfiguration => 'Save Configuration';
+
+  @override
+  String get about => 'About';
+
+  @override
+  String get loading => 'Loading…';
+
+  @override
+  String currentVersion(Object version) {
+    return 'Current version: $version';
+  }
+
+  @override
+  String get versionLoadFailed => 'Failed to load version info';
+
+  @override
+  String get general => 'General';
+
+  @override
+  String get backupAndRestore => 'Backup & Restore';
+
+  @override
+  String get shortcuts => 'Shortcuts';
+
+  @override
+  String get remoteAccess => 'Remote Access';
+
+  @override
+  String get remoteMediaLibrary => 'Remote Media Library';
+
+  @override
+  String get appearanceSettings => 'Appearance Settings';
+
+  @override
+  String get generalSettings => 'General Settings';
+
+  @override
+  String get storageSettings => 'Storage Settings';
+
+  @override
+  String get playerSettings => 'Player Settings';
+
+  @override
+  String get shortcutsSettings => 'Shortcuts Settings';
+
+  @override
+  String get rememberDanmakuOffset => 'Remember Danmaku Offset';
+
+  @override
+  String get rememberDanmakuOffsetSubtitle =>
+      'Keep the current manual offset when switching videos (auto-matched offset will still reset).';
+
+  @override
+  String get rememberDanmakuOffsetEnabled => 'Danmaku offset memory enabled';
+
+  @override
+  String get rememberDanmakuOffsetDisabled => 'Danmaku offset memory disabled';
+
+  @override
+  String get danmakuConvertToSimplified =>
+      'Convert Danmaku to Simplified Chinese';
+
+  @override
+  String get danmakuConvertToSimplifiedSubtitle =>
+      'When enabled, Traditional Chinese danmaku will be displayed in Simplified Chinese.';
+
+  @override
+  String get danmakuConvertToSimplifiedEnabled =>
+      'Danmaku conversion to Simplified Chinese enabled';
+
+  @override
+  String get danmakuConvertToSimplifiedDisabled =>
+      'Danmaku conversion to Simplified Chinese disabled';
+
+  @override
+  String get cancel => 'Cancel';
+
+  @override
+  String get confirm => 'Confirm';
+
+  @override
+  String get close => 'Close';
+
+  @override
+  String get saving => 'Saving...';
+
+  @override
+  String networkServerSwitchedTo(Object server) {
+    return 'DanDanPlay server switched to $server';
+  }
+
+  @override
+  String get enterServerAddress => 'Enter server address';
+
+  @override
+  String get invalidServerAddress =>
+      'Invalid server address. Must start with http/https.';
+
+  @override
+  String get switchedToCustomServer => 'Switched to custom server';
+
+  @override
+  String get networkPrimaryServerRecommended => 'Primary Server (Recommended)';
+
+  @override
+  String get networkBackupServer => 'Backup Server';
+
+  @override
+  String get networkCurrentCustomServer => 'Current Custom Server';
+
+  @override
+  String get networkSelectServer => 'Select DanDanPlay Server';
+
+  @override
+  String get primaryServer => 'Primary Server';
+
+  @override
+  String get backupServer => 'Backup Server';
+
+  @override
+  String get dandanplayServer => 'DanDanPlay Server';
+
+  @override
+  String get customServer => 'Custom Server';
+
+  @override
+  String get customServerInputHint =>
+      'Enter a danmaku server address compatible with DanDanPlay API, e.g. https://example.com';
+
+  @override
+  String get customServerPlaceholder => 'https://your-danmaku-server.com';
+
+  @override
+  String get useThisServer => 'Use This Server';
+
+  @override
+  String get currentServerInfo => 'Current Server Info';
+
+  @override
+  String get serverDescriptionTitle => 'Server Description';
+
+  @override
+  String serverField(Object server) {
+    return 'Server: $server';
+  }
+
+  @override
+  String urlField(Object url) {
+    return 'URL: $url';
+  }
+
+  @override
+  String serverBullet(Object name, Object description) {
+    return '• $name: $description';
+  }
+
+  @override
+  String get networkServerDescriptionPrimary =>
+      'api.dandanplay.net (Official server, recommended)';
+
+  @override
+  String get networkServerDescriptionBackup =>
+      '139.224.252.88:16001 (Mirror server, use when the primary server is unavailable)';
+
+  @override
+  String get networkServerSelectSubtitle =>
+      'Select a DanDanPlay danmaku server. The backup server can be used when the primary server is unavailable.';
+
+  @override
+  String customServerWithValue(Object server) {
+    return 'Custom: $server';
+  }
+
+  @override
+  String get enabledClearOnLaunchSnack =>
+      'Danmaku cache cleanup on launch enabled';
+
+  @override
+  String get danmakuCacheCleared => 'Danmaku cache cleared';
+
+  @override
+  String clearFailed(Object error) {
+    return 'Clear failed: $error';
+  }
+
+  @override
+  String get imageCacheCleared => 'Image cache cleared';
+
+  @override
+  String get confirmClearCacheTitle => 'Confirm Cache Clear';
+
+  @override
+  String get confirmClearImageCacheContent =>
+      'Are you sure you want to clear the cover and thumbnail image cache?';
+
+  @override
+  String get clearDanmakuCacheOnLaunchTitle => 'Clear Danmaku Cache on Launch';
+
+  @override
+  String get clearDanmakuCacheOnLaunchSubtitle =>
+      'Automatically delete danmaku cache in the cache/danmaku/ directory';
+
+  @override
+  String get screenshotSaveLocation => 'Screenshot Save Location';
+
+  @override
+  String get defaultDownloadDir => 'Default: Downloads';
+
+  @override
+  String get screenshotSaveLocationUpdated =>
+      'Screenshot save location updated';
+
+  @override
+  String get screenshotDefaultSaveTarget => 'Default Screenshot Save Target';
+
+  @override
+  String get screenshotDefaultSaveTargetMessage =>
+      'Choose how screenshots are saved by default';
+
+  @override
+  String get clearDanmakuCacheNow => 'Clear Danmaku Cache Now';
+
+  @override
+  String get clearingInProgress => 'Clearing...';
+
+  @override
+  String get clearDanmakuCacheManualHint =>
+      'Manually clear when danmaku is abnormal or using too much space';
+
+  @override
+  String get clearImageCache => 'Clear Image Cache';
+
+  @override
+  String get clearImageCacheHint => 'Clear cover and thumbnail image cache';
+
+  @override
+  String get danmakuCacheDescription =>
+      'Danmaku cache is stored in the app cache directory cache/danmaku/. Enable auto-cleanup to reduce storage usage.';
+
+  @override
+  String get imageCacheDescription =>
+      'Image cache includes covers and playback thumbnails, stored in the app cache directory. Can be cleared as needed.';
+
+  @override
+  String get clearDanmakuCacheOnLaunchSubtitleNipaplay =>
+      'Automatically delete all cached danmaku files when restarting the app to ensure fresh data';
+
+  @override
+  String get clearDanmakuCacheManualHintNipaplay =>
+      'Manually clear when cache is deleted or abnormal';
+
+  @override
+  String get danmakuCacheDescriptionNipaplay =>
+      'Danmaku cache files are stored in the cache/danmaku/ directory. Clear anytime if taking up too much space.';
+
+  @override
+  String get imageCacheDescriptionNipaplay =>
+      'Image cache includes covers and playback thumbnails, stored in the app cache directory. Can be cleared periodically.';
+
+  @override
+  String clearDanmakuCacheFailed(Object error) {
+    return 'Failed to clear danmaku cache: $error';
+  }
+
+  @override
+  String clearImageCacheFailed(Object error) {
+    return 'Failed to clear image cache: $error';
+  }
+
+  @override
+  String get screenshotSaveAskDescription =>
+      'Show save dialog each time you take a screenshot';
+
+  @override
+  String get screenshotSavePhotosDescription =>
+      'Save screenshots directly to the photo gallery';
+
+  @override
+  String get screenshotSaveFileDescription =>
+      'Save screenshots directly as files';
+
+  @override
+  String get aboutNoReleaseNotes => 'No release notes available';
+
+  @override
+  String aboutFoundNewVersion(Object version) {
+    return 'New version $version available';
+  }
+
+  @override
+  String get aboutCurrentIsLatest => 'You are on the latest version';
+
+  @override
+  String aboutCurrentVersionLabel(Object version) {
+    return 'Current version: $version';
+  }
+
+  @override
+  String aboutLatestVersionLabel(Object version) {
+    return 'Latest version: $version';
+  }
+
+  @override
+  String aboutReleaseNameLabel(Object name) {
+    return 'Release name: $name';
+  }
+
+  @override
+  String aboutPublishedAtLabel(Object publishedAt) {
+    return 'Published: $publishedAt';
+  }
+
+  @override
+  String get aboutReleaseNotesTitle => 'Release Notes';
+
+  @override
+  String get aboutOpenReleasePage => 'View Release Page';
+
+  @override
+  String get updateCheckFailed => 'Update check failed';
+
+  @override
+  String get pleaseTryAgainLater => 'Please try again later';
+
+  @override
+  String cannotOpenLink(Object url) {
+    return 'Cannot open link: $url';
+  }
+
+  @override
+  String get appreciationCode => 'Tip Jar';
+
+  @override
+  String get appreciationImageLoadFailed => 'Failed to load tip jar image';
+
+  @override
+  String get acknowledgements => 'Acknowledgements';
+
+  @override
+  String get aboutStoryPrefix =>
+      'NipaPlay\'s name comes from Furude Rika\'s catchphrase \"';
+
+  @override
+  String get aboutStorySuffix =>
+      '\" from Higurashi: When They Cry. I created NipaPlay to solve the inconvenience of watching anime on macOS, Linux, and iOS.';
+
+  @override
+  String get aboutThanksDandanplayPrefix =>
+      'Thanks to DanDanPlay and developer ';
+
+  @override
+  String get aboutThanksDandanplaySuffix =>
+      ' for providing the API and development support.';
+
+  @override
+  String get aboutThanksSakikoPrefix => 'Thanks to developer ';
+
+  @override
+  String get aboutThanksSakikoSuffix =>
+      ' for helping implement Emby and Jellyfin media library support.';
+
+  @override
+  String get thanksSponsorUsers =>
+      'Thanks to the following users for their sponsorship:';
+
+  @override
+  String aboutVersionBanner(Object version) {
+    return 'NipaPlay Reload Version: $version';
+  }
+
+  @override
+  String get aboutCheckingUpdates => 'Checking…';
+
+  @override
+  String get aboutCheckUpdates => 'Check for Updates';
+
+  @override
+  String get aboutAutoCheckUpdates => 'Auto-check for Updates';
+
+  @override
+  String get aboutManualOnlyWhenDisabled => 'Manual check only when disabled';
+
+  @override
+  String aboutQqGroup(Object id) {
+    return 'QQ Group: $id';
+  }
+
+  @override
+  String get aboutOfficialWebsite => 'NipaPlay Official Website';
+
+  @override
+  String get openSourceCommunity => 'Open Source & Community';
+
+  @override
+  String get aboutCommunityHint =>
+      'Contributions are welcome! Feel free to port the app to more platforms. No Dart experience needed — AI-assisted programming works too.';
+
+  @override
+  String get sponsorSupport => 'Sponsor Support';
+
+  @override
+  String get aboutSponsorParagraph1 =>
+      'If you enjoy NipaPlay and want to support its continued development, consider sponsoring via Afdian.';
+
+  @override
+  String get aboutSponsorParagraph2 =>
+      'Sponsors\' names will appear in the project\'s README file and the About page after each update.';
+
+  @override
+  String get aboutAfdianSponsorPage => 'Afdian Sponsorship Page';
+}

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -57,6 +57,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get languageTraditionalChinese => '繁體中文';
 
   @override
+  String get languageEnglish => 'English';
+
+  @override
   String currentLanguage(Object language) {
     return '当前：$language';
   }
@@ -72,7 +75,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get languageTileSubtitle => '切换简体中文或繁體中文';
+  String get languageTileSubtitle => '切换简体中文、繁體中文或English';
 
   @override
   String get settingsBasicSection => '基础设置';
@@ -1762,6 +1765,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get languageTraditionalChinese => '繁體中文';
 
   @override
+  String get languageEnglish => 'English';
+
+  @override
   String currentLanguage(Object language) {
     return '目前：$language';
   }
@@ -1777,7 +1783,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   }
 
   @override
-  String get languageTileSubtitle => '切換簡體中文或繁體中文';
+  String get languageTileSubtitle => '切換簡體中文、繁體中文或English';
 
   @override
   String get settingsBasicSection => '基礎設定';

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_about_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_about_page.dart
@@ -527,7 +527,7 @@ class _CupertinoAboutPageState extends State<CupertinoAboutPage> {
           ),
           const SizedBox(height: 12),
           CupertinoButton.filled(
-            padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
+            padding: const EdgeInsets.fromLTRB(0, 10, 18, 10),
             onPressed: _isCheckingUpdate ? null : _manualCheckForUpdates,
             child: _isCheckingUpdate
                 ? Row(

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_about_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_about_page.dart
@@ -454,90 +454,94 @@ class _CupertinoAboutPageState extends State<CupertinoAboutPage> {
   ) {
     final hasUpdate = _updateInfo?.hasUpdate ?? false;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        Image.asset(
-          'assets/logo.png',
-          height: 110,
-          errorBuilder: (_, __, ___) => Icon(
-            Ionicons.image_outline,
-            size: 96,
-            color: secondaryColor,
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Image.asset(
+            'assets/logo.png',
+            height: 110,
+            errorBuilder: (_, __, ___) => Icon(
+              Ionicons.image_outline,
+              size: 96,
+              color: secondaryColor,
+            ),
           ),
-        ),
-        const SizedBox(height: 18),
-        GestureDetector(
-          onTap: hasUpdate ? () => _launchURL(_updateInfo!.releaseUrl) : null,
-          child: MouseRegion(
-            cursor:
-                hasUpdate ? SystemMouseCursors.click : SystemMouseCursors.basic,
-            child: Stack(
-              clipBehavior: Clip.none,
-              children: [
-                AboutVersionBannerText(
-                  text: context.l10n.aboutVersionBanner(
-                    _displayVersionText(context),
+          const SizedBox(height: 18),
+          GestureDetector(
+            onTap: hasUpdate ? () => _launchURL(_updateInfo!.releaseUrl) : null,
+            child: MouseRegion(
+              cursor: hasUpdate
+                  ? SystemMouseCursors.click
+                  : SystemMouseCursors.basic,
+              child: Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  AboutVersionBannerText(
+                    text: context.l10n.aboutVersionBanner(
+                      _displayVersionText(context),
+                    ),
+                    targetLabel: _buildTargetLabel,
+                    style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.w600,
+                      color: labelColor,
+                    ),
+                    textAlign: TextAlign.start,
                   ),
-                  targetLabel: _buildTargetLabel,
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.w600,
-                    color: labelColor,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-                if (hasUpdate)
-                  Positioned(
-                    top: -10,
-                    right: -12,
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 8,
-                        vertical: 3,
-                      ),
-                      decoration: BoxDecoration(
-                        color: CupertinoColors.systemRed,
-                        borderRadius: BorderRadius.circular(10),
-                        boxShadow: const [
-                          BoxShadow(
-                            color: Color(0x33999999),
-                            blurRadius: 6,
-                            offset: Offset(0, 3),
+                  if (hasUpdate)
+                    Positioned(
+                      top: -10,
+                      right: -12,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 3,
+                        ),
+                        decoration: BoxDecoration(
+                          color: CupertinoColors.systemRed,
+                          borderRadius: BorderRadius.circular(10),
+                          boxShadow: const [
+                            BoxShadow(
+                              color: Color(0x33999999),
+                              blurRadius: 6,
+                              offset: Offset(0, 3),
+                            ),
+                          ],
+                        ),
+                        child: const Text(
+                          'NEW',
+                          style: TextStyle(
+                            color: CupertinoColors.white,
+                            fontSize: 11,
+                            fontWeight: FontWeight.bold,
+                            letterSpacing: 0.6,
                           ),
-                        ],
-                      ),
-                      child: const Text(
-                        'NEW',
-                        style: TextStyle(
-                          color: CupertinoColors.white,
-                          fontSize: 11,
-                          fontWeight: FontWeight.bold,
-                          letterSpacing: 0.6,
                         ),
                       ),
                     ),
-                  ),
-              ],
+                ],
+              ),
             ),
           ),
-        ),
-        const SizedBox(height: 12),
-        CupertinoButton.filled(
-          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
-          onPressed: _isCheckingUpdate ? null : _manualCheckForUpdates,
-          child: _isCheckingUpdate
-              ? Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const CupertinoActivityIndicator(radius: 8),
-                    const SizedBox(width: 8),
-                    Text(context.l10n.aboutCheckingUpdates),
-                  ],
-                )
-              : Text(context.l10n.aboutCheckUpdates),
-        ),
-      ],
+          const SizedBox(height: 12),
+          CupertinoButton.filled(
+            padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
+            onPressed: _isCheckingUpdate ? null : _manualCheckForUpdates,
+            child: _isCheckingUpdate
+                ? Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const CupertinoActivityIndicator(radius: 8),
+                      const SizedBox(width: 8),
+                      Text(context.l10n.aboutCheckingUpdates),
+                    ],
+                  )
+                : Text(context.l10n.aboutCheckUpdates),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_about_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_about_page.dart
@@ -17,6 +17,8 @@ import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_group_card.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_tile.dart';
 import 'package:nipaplay/widgets/adaptive_markdown.dart';
+import 'package:nipaplay/utils/build_target_label.dart';
+import 'package:nipaplay/widgets/about_version_banner_text.dart';
 
 class CupertinoAboutPage extends StatefulWidget {
   const CupertinoAboutPage({super.key});
@@ -26,6 +28,7 @@ class CupertinoAboutPage extends StatefulWidget {
 }
 
 class _CupertinoAboutPageState extends State<CupertinoAboutPage> {
+  late final String _buildTargetLabel = getBuildTargetLabel();
   String _version = '';
   bool _versionLoadFailed = false;
   UpdateInfo? _updateInfo;
@@ -472,8 +475,11 @@ class _CupertinoAboutPageState extends State<CupertinoAboutPage> {
             child: Stack(
               clipBehavior: Clip.none,
               children: [
-                Text(
-                  context.l10n.aboutVersionBanner(_displayVersionText(context)),
+                AboutVersionBannerText(
+                  text: context.l10n.aboutVersionBanner(
+                    _displayVersionText(context),
+                  ),
+                  targetLabel: _buildTargetLabel,
                   style: TextStyle(
                     fontSize: 24,
                     fontWeight: FontWeight.w600,

--- a/lib/themes/nipaplay/pages/settings/about_page.dart
+++ b/lib/themes/nipaplay/pages/settings/about_page.dart
@@ -333,124 +333,135 @@ class _AboutPageState extends State<AboutPage> {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           SizedBox(height: 40), // Add some space at the top
-          Image.asset(
-            'assets/logo.png', // Ensure this path is correct
-            height: 120, // Adjust size as needed
-            errorBuilder: (context, error, stackTrace) {
-              return Icon(Ionicons.image_outline,
-                  size: 100,
-                  color: colorScheme.onSurface
-                      .withOpacity(0.7)); // Placeholder if logo fails
-            },
-          ),
-          SizedBox(height: 24),
-          // 版本信息，点击跳转到releases页面（如果有更新）
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            child: Stack(
-              clipBehavior: Clip.none,
-              children: [
-                GestureDetector(
-                  onTap: _updateInfo?.hasUpdate == true
-                      ? () => _launchURL(_updateInfo!.releaseUrl)
-                      : null,
-                  child: MouseRegion(
-                    cursor: _updateInfo?.hasUpdate == true
+          SizedBox(
+            width: double.infinity,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Image.asset(
+                    'assets/logo.png', // Ensure this path is correct
+                    height: 120, // Adjust size as needed
+                    errorBuilder: (context, error, stackTrace) {
+                      return Icon(Ionicons.image_outline,
+                          size: 100,
+                          color: colorScheme.onSurface
+                              .withOpacity(0.7)); // Placeholder if logo fails
+                    },
+                  ),
+                  SizedBox(height: 24),
+                  // 版本信息，点击跳转到releases页面（如果有更新）
+                  Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      GestureDetector(
+                        onTap: _updateInfo?.hasUpdate == true
+                            ? () => _launchURL(_updateInfo!.releaseUrl)
+                            : null,
+                        child: MouseRegion(
+                          cursor: _updateInfo?.hasUpdate == true
+                              ? SystemMouseCursors.click
+                              : SystemMouseCursors.basic,
+                          child: AboutVersionBannerText(
+                            text: l10n.aboutVersionBanner(
+                                _displayVersionText(context)),
+                            targetLabel: _buildTargetLabel,
+                            style: textTheme.headlineMedium?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                  color: colorScheme.onSurface,
+                                ) ??
+                                TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  color: colorScheme.onSurface,
+                                ),
+                            textAlign: TextAlign.start,
+                          ),
+                        ),
+                      ),
+                      // NEW 标识 - 独立定位
+                      if (_updateInfo?.hasUpdate == true)
+                        Positioned(
+                          top: -8,
+                          right: -8,
+                          child: const Text(
+                            'NEW',
+                            locale: Locale("zh-Hans", "zh"),
+                            style: TextStyle(
+                              color: Colors.red,
+                              fontSize: 10,
+                              fontWeight: FontWeight.bold,
+                              letterSpacing: 0.5,
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                  SizedBox(height: 20),
+                  MouseRegion(
+                    onEnter: (_) => isUpdateButtonEnabled
+                        ? setState(() => _isUpdateButtonHovered = true)
+                        : null,
+                    onExit: (_) => isUpdateButtonEnabled
+                        ? setState(() => _isUpdateButtonHovered = false)
+                        : null,
+                    cursor: isUpdateButtonEnabled
                         ? SystemMouseCursors.click
                         : SystemMouseCursors.basic,
-                    child: AboutVersionBannerText(
-                      text:
-                          l10n.aboutVersionBanner(_displayVersionText(context)),
-                      targetLabel: _buildTargetLabel,
-                      style: textTheme.headlineMedium?.copyWith(
-                            fontWeight: FontWeight.bold,
-                            color: colorScheme.onSurface,
-                          ) ??
-                          TextStyle(
-                            fontWeight: FontWeight.bold,
-                            color: colorScheme.onSurface,
+                    child: Material(
+                      type: MaterialType.transparency,
+                      child: InkWell(
+                        onTap: isUpdateButtonEnabled
+                            ? _manualCheckForUpdates
+                            : null,
+                        hoverColor: Colors.transparent,
+                        splashColor: Colors.transparent,
+                        highlightColor: Colors.transparent,
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 16, vertical: 10),
+                          child: AnimatedScale(
+                            scale: showUpdateButtonHover ? 1.1 : 1.0,
+                            alignment: Alignment.centerLeft,
+                            duration: const Duration(milliseconds: 200),
+                            curve: Curves.easeOutBack,
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                if (_isCheckingUpdate)
+                                  SizedBox(
+                                    width: 16,
+                                    height: 16,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      valueColor: AlwaysStoppedAnimation<Color>(
+                                          updateButtonColor),
+                                    ),
+                                  )
+                                else
+                                  Icon(
+                                    Icons.system_update_alt,
+                                    size: 18,
+                                    color: updateButtonColor,
+                                  ),
+                                SizedBox(width: 6),
+                                Text(
+                                  _isCheckingUpdate
+                                      ? l10n.aboutCheckingUpdates
+                                      : l10n.aboutCheckUpdates,
+                                  style: textTheme.labelLarge?.copyWith(
+                                        color: updateButtonColor,
+                                      ) ??
+                                      TextStyle(color: updateButtonColor),
+                                ),
+                              ],
+                            ),
                           ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                ),
-                // NEW 标识 - 独立定位
-                if (_updateInfo?.hasUpdate == true)
-                  Positioned(
-                    top: -8,
-                    right: -8,
-                    child: const Text(
-                      'NEW',
-                      locale: Locale("zh-Hans", "zh"),
-                      style: TextStyle(
-                        color: Colors.red,
-                        fontSize: 10,
-                        fontWeight: FontWeight.bold,
-                        letterSpacing: 0.5,
+                        ),
                       ),
                     ),
                   ),
-              ],
-            ),
-          ),
-          SizedBox(height: 20),
-          MouseRegion(
-            onEnter: (_) => isUpdateButtonEnabled
-                ? setState(() => _isUpdateButtonHovered = true)
-                : null,
-            onExit: (_) => isUpdateButtonEnabled
-                ? setState(() => _isUpdateButtonHovered = false)
-                : null,
-            cursor: isUpdateButtonEnabled
-                ? SystemMouseCursors.click
-                : SystemMouseCursors.basic,
-            child: Material(
-              type: MaterialType.transparency,
-              child: InkWell(
-                onTap: isUpdateButtonEnabled ? _manualCheckForUpdates : null,
-                hoverColor: Colors.transparent,
-                splashColor: Colors.transparent,
-                highlightColor: Colors.transparent,
-                child: Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-                  child: AnimatedScale(
-                    scale: showUpdateButtonHover ? 1.1 : 1.0,
-                    duration: const Duration(milliseconds: 200),
-                    curve: Curves.easeOutBack,
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (_isCheckingUpdate)
-                          SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              valueColor: AlwaysStoppedAnimation<Color>(
-                                  updateButtonColor),
-                            ),
-                          )
-                        else
-                          Icon(
-                            Icons.system_update_alt,
-                            size: 18,
-                            color: updateButtonColor,
-                          ),
-                        SizedBox(width: 6),
-                        Text(
-                          _isCheckingUpdate
-                              ? l10n.aboutCheckingUpdates
-                              : l10n.aboutCheckUpdates,
-                          style: textTheme.labelLarge?.copyWith(
-                                color: updateButtonColor,
-                              ) ??
-                              TextStyle(color: updateButtonColor),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
+                ],
               ),
             ),
           ),

--- a/lib/themes/nipaplay/pages/settings/about_page.dart
+++ b/lib/themes/nipaplay/pages/settings/about_page.dart
@@ -418,8 +418,7 @@ class _AboutPageState extends State<AboutPage> {
                         splashColor: Colors.transparent,
                         highlightColor: Colors.transparent,
                         child: Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 16, vertical: 10),
+                          padding: const EdgeInsets.fromLTRB(0, 10, 16, 10),
                           child: AnimatedScale(
                             scale: showUpdateButtonHover ? 1.1 : 1.0,
                             alignment: Alignment.centerLeft,

--- a/lib/themes/nipaplay/pages/settings/about_page.dart
+++ b/lib/themes/nipaplay/pages/settings/about_page.dart
@@ -11,6 +11,8 @@ import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/services/update_service.dart';
 import 'package:nipaplay/widgets/adaptive_markdown.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
+import 'package:nipaplay/utils/build_target_label.dart';
+import 'package:nipaplay/widgets/about_version_banner_text.dart';
 
 class AboutPage extends StatefulWidget {
   const AboutPage({super.key});
@@ -20,6 +22,7 @@ class AboutPage extends StatefulWidget {
 }
 
 class _AboutPageState extends State<AboutPage> {
+  late final String _buildTargetLabel = getBuildTargetLabel();
   String _version = '';
   bool _versionLoadFailed = false;
   UpdateInfo? _updateInfo;
@@ -355,12 +358,18 @@ class _AboutPageState extends State<AboutPage> {
                     cursor: _updateInfo?.hasUpdate == true
                         ? SystemMouseCursors.click
                         : SystemMouseCursors.basic,
-                    child: Text(
-                      l10n.aboutVersionBanner(_displayVersionText(context)),
+                    child: AboutVersionBannerText(
+                      text:
+                          l10n.aboutVersionBanner(_displayVersionText(context)),
+                      targetLabel: _buildTargetLabel,
                       style: textTheme.headlineMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: colorScheme.onSurface,
-                      ),
+                            fontWeight: FontWeight.bold,
+                            color: colorScheme.onSurface,
+                          ) ??
+                          TextStyle(
+                            fontWeight: FontWeight.bold,
+                            color: colorScheme.onSurface,
+                          ),
                       textAlign: TextAlign.center,
                     ),
                   ),

--- a/lib/themes/nipaplay/widgets/nipaplay_window.dart
+++ b/lib/themes/nipaplay/widgets/nipaplay_window.dart
@@ -230,6 +230,7 @@ class _NipaplayWindowScaffoldState extends State<NipaplayWindowScaffold> {
         : screenSize.height * widget.maxHeightFactor;
     final double windowControlPadding =
         globals.isTablet ? _windowControlPadding + 3 : _windowControlPadding;
+    final BorderRadius windowBorderRadius = BorderRadius.circular(15);
 
     final baseTheme = Theme.of(context);
     final windowTheme = baseTheme.copyWith(
@@ -270,10 +271,8 @@ class _NipaplayWindowScaffoldState extends State<NipaplayWindowScaffold> {
                           bottomMargin,
                         ),
                         child: Container(
-                          clipBehavior: Clip.antiAlias,
                           decoration: BoxDecoration(
-                            color: bgColor,
-                            borderRadius: BorderRadius.circular(15),
+                            borderRadius: windowBorderRadius,
                             boxShadow: [
                               BoxShadow(
                                 color: Colors.black.withValues(alpha: 0.2),
@@ -282,100 +281,105 @@ class _NipaplayWindowScaffoldState extends State<NipaplayWindowScaffold> {
                               ),
                             ],
                           ),
-                          child: Stack(
-                            children: [
-                              if (widget.backgroundImageUrl != null &&
-                                  widget.backgroundImageUrl!.isNotEmpty)
+                          child: Material(
+                            color: bgColor,
+                            borderRadius: windowBorderRadius,
+                            clipBehavior: Clip.antiAlias,
+                            child: Stack(
+                              children: [
+                                if (widget.backgroundImageUrl != null &&
+                                    widget.backgroundImageUrl!.isNotEmpty)
+                                  Positioned.fill(
+                                    child: ImageFiltered(
+                                      imageFilter: widget.blurBackground
+                                          ? ui.ImageFilter.blur(
+                                              sigmaX: 40, sigmaY: 40)
+                                          : ui.ImageFilter.blur(
+                                              sigmaX: 0, sigmaY: 0),
+                                      child: Opacity(
+                                        opacity: isDark ? 0.25 : 0.35,
+                                        child: CachedNetworkImageWidget(
+                                          imageUrl: widget.backgroundImageUrl!,
+                                          fit: BoxFit.cover,
+                                          shouldCompress: false,
+                                          loadMode: CachedImageLoadMode.hybrid,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
                                 Positioned.fill(
-                                  child: ImageFiltered(
-                                    imageFilter: widget.blurBackground
-                                        ? ui.ImageFilter.blur(
-                                            sigmaX: 40, sigmaY: 40)
-                                        : ui.ImageFilter.blur(
-                                            sigmaX: 0, sigmaY: 0),
-                                    child: Opacity(
-                                      opacity: isDark ? 0.25 : 0.35,
-                                      child: CachedNetworkImageWidget(
-                                        imageUrl: widget.backgroundImageUrl!,
-                                        fit: BoxFit.cover,
-                                        shouldCompress: false,
-                                        loadMode: CachedImageLoadMode.hybrid,
+                                  child: Container(
+                                    decoration: BoxDecoration(
+                                      gradient: LinearGradient(
+                                        begin: Alignment.topCenter,
+                                        end: Alignment.bottomCenter,
+                                        colors: [
+                                          bgColor.withValues(alpha: 0.1),
+                                          bgColor.withValues(alpha: 0.4),
+                                        ],
                                       ),
                                     ),
                                   ),
                                 ),
-                              Positioned.fill(
-                                child: Container(
-                                  decoration: BoxDecoration(
-                                    gradient: LinearGradient(
-                                      begin: Alignment.topCenter,
-                                      end: Alignment.bottomCenter,
-                                      colors: [
-                                        bgColor.withValues(alpha: 0.1),
-                                        bgColor.withValues(alpha: 0.4),
-                                      ],
+                                DefaultTextStyle(
+                                  style: windowTextStyle,
+                                  child: NipaplayWindowPositionProvider(
+                                    onMove: _applyWindowOffset,
+                                    child: Padding(
+                                      padding: const EdgeInsets.only(
+                                        top: _contentTopPadding,
+                                      ),
+                                      child: widget.child,
                                     ),
                                   ),
                                 ),
-                              ),
-                              DefaultTextStyle(
-                                style: windowTextStyle,
-                                child: NipaplayWindowPositionProvider(
-                                  onMove: _applyWindowOffset,
-                                  child: Padding(
-                                    padding: const EdgeInsets.only(
-                                      top: _contentTopPadding,
-                                    ),
-                                    child: widget.child,
-                                  ),
-                                ),
-                              ),
-                              Positioned(
-                                top: 0,
-                                left: 0,
-                                right: 0,
-                                height: _contentTopPadding,
-                                child: GestureDetector(
-                                  behavior: HitTestBehavior.translucent,
-                                  onPanUpdate: (details) =>
-                                      _applyWindowOffset(details.delta),
-                                ),
-                              ),
-                              if (showCloseButton && useMacStyleCloseButton)
                                 Positioned(
                                   top: 0,
                                   left: 0,
-                                  child: _buildMacCloseButton(context),
-                                )
-                              else if (showCloseButton &&
-                                  topRightAction == null)
-                                Positioned(
-                                  top: windowControlPadding,
-                                  right: windowControlPadding,
-                                  child: _buildFluentCloseButton(context),
+                                  right: 0,
+                                  height: _contentTopPadding,
+                                  child: GestureDetector(
+                                    behavior: HitTestBehavior.translucent,
+                                    onPanUpdate: (details) =>
+                                        _applyWindowOffset(details.delta),
+                                  ),
                                 ),
-                              if (topRightAction != null)
-                                Positioned(
-                                  top: windowControlPadding,
-                                  right: windowControlPadding,
-                                  child: showCloseButton
-                                      ? (useMacStyleCloseButton
-                                          ? topRightAction
-                                          : Row(
-                                              mainAxisSize: MainAxisSize.min,
-                                              children: [
-                                                topRightAction,
-                                                const SizedBox(
-                                                  width: _windowControlGap,
-                                                ),
-                                                _buildFluentCloseButton(
-                                                  context,
-                                                ),
-                                              ],
-                                            ))
-                                      : topRightAction,
-                                ),
-                            ],
+                                if (showCloseButton && useMacStyleCloseButton)
+                                  Positioned(
+                                    top: 0,
+                                    left: 0,
+                                    child: _buildMacCloseButton(context),
+                                  )
+                                else if (showCloseButton &&
+                                    topRightAction == null)
+                                  Positioned(
+                                    top: windowControlPadding,
+                                    right: windowControlPadding,
+                                    child: _buildFluentCloseButton(context),
+                                  ),
+                                if (topRightAction != null)
+                                  Positioned(
+                                    top: windowControlPadding,
+                                    right: windowControlPadding,
+                                    child: showCloseButton
+                                        ? (useMacStyleCloseButton
+                                            ? topRightAction
+                                            : Row(
+                                                mainAxisSize: MainAxisSize.min,
+                                                children: [
+                                                  topRightAction,
+                                                  const SizedBox(
+                                                    width: _windowControlGap,
+                                                  ),
+                                                  _buildFluentCloseButton(
+                                                    context,
+                                                  ),
+                                                ],
+                                              ))
+                                        : topRightAction,
+                                  ),
+                              ],
+                            ),
                           ),
                         ),
                       ),

--- a/lib/utils/build_target_label.dart
+++ b/lib/utils/build_target_label.dart
@@ -1,0 +1,2 @@
+export 'build_target_label_stub.dart'
+    if (dart.library.io) 'build_target_label_io.dart';

--- a/lib/utils/build_target_label_common.dart
+++ b/lib/utils/build_target_label_common.dart
@@ -1,0 +1,81 @@
+String buildTargetLabelFromParts({
+  required String architecture,
+  required String platform,
+}) {
+  final formattedArchitecture = _formatArchitecture(architecture);
+  final formattedPlatform = _formatPlatform(platform);
+
+  if (formattedArchitecture.isEmpty) {
+    return formattedPlatform;
+  }
+  if (formattedPlatform.isEmpty) {
+    return formattedArchitecture;
+  }
+  return '$formattedArchitecture $formattedPlatform';
+}
+
+String _formatArchitecture(String rawValue) {
+  final value =
+      rawValue.trim().toLowerCase().replaceAll(RegExp(r'[\s_\-]'), '');
+  if (value.isEmpty) {
+    return '';
+  }
+  if (value.contains('riscv64')) {
+    return 'RISC-V 64';
+  }
+  if (value.contains('riscv32')) {
+    return 'RISC-V 32';
+  }
+  if (value.contains('arm64') ||
+      value.contains('aarch64') ||
+      value.contains('armv8')) {
+    return 'Arm64';
+  }
+  if (value.contains('armv7') || value.contains('armeabiv7')) {
+    return 'Armv7';
+  }
+  if (value == 'arm' || value.contains('armv6')) {
+    return 'Arm';
+  }
+  if (value.contains('x8664') || value.contains('amd64') || value == 'x64') {
+    return 'X64';
+  }
+  if (value.contains('ia32') ||
+      value == 'x86' ||
+      value.contains('i386') ||
+      value.contains('i686')) {
+    return 'X86';
+  }
+  return '';
+}
+
+String _formatPlatform(String rawValue) {
+  final value = rawValue.trim().toLowerCase();
+  if (value.isEmpty) {
+    return '';
+  }
+  if (value.contains('ios')) {
+    return 'iOS';
+  }
+  if (value.contains('android')) {
+    return 'Android';
+  }
+  if (value.contains('macos') ||
+      value.contains('mac os') ||
+      value.contains('darwin')) {
+    return 'macOS';
+  }
+  if (value.contains('windows')) {
+    return 'Windows';
+  }
+  if (value.contains('linux')) {
+    return 'Linux';
+  }
+  if (value.contains('web') || value.contains('browser')) {
+    return 'Web';
+  }
+  if (value.contains('fuchsia')) {
+    return 'Fuchsia';
+  }
+  return '';
+}

--- a/lib/utils/build_target_label_io.dart
+++ b/lib/utils/build_target_label_io.dart
@@ -1,0 +1,12 @@
+import 'dart:ffi' as ffi;
+import 'dart:io' show Platform;
+
+import 'build_target_label_common.dart';
+
+String getBuildTargetLabel() {
+  final abi = ffi.Abi.current().toString().split('.').last;
+  return buildTargetLabelFromParts(
+    architecture: abi,
+    platform: Platform.operatingSystem,
+  );
+}

--- a/lib/utils/build_target_label_stub.dart
+++ b/lib/utils/build_target_label_stub.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/foundation.dart';
+
+import 'build_target_label_common.dart';
+
+String getBuildTargetLabel() {
+  return buildTargetLabelFromParts(
+    architecture: '',
+    platform: kIsWeb ? 'web' : defaultTargetPlatform.name,
+  );
+}

--- a/lib/widgets/about_version_banner_text.dart
+++ b/lib/widgets/about_version_banner_text.dart
@@ -39,7 +39,7 @@ class AboutVersionBannerText extends StatelessWidget {
         children: [
           const TextSpan(text: _productName),
           TextSpan(
-            text: ' $detailText',
+            text: '\n$detailText',
             style: style.copyWith(
               fontSize: baseFontSize * 0.58,
               fontWeight: FontWeight.w600,
@@ -47,7 +47,7 @@ class AboutVersionBannerText extends StatelessWidget {
           ),
         ],
       ),
-      textAlign: textAlign,
+      textAlign: TextAlign.start,
     );
   }
 

--- a/lib/widgets/about_version_banner_text.dart
+++ b/lib/widgets/about_version_banner_text.dart
@@ -29,6 +29,7 @@ class AboutVersionBannerText extends StatelessWidget {
 
     final defaultFontSize = DefaultTextStyle.of(context).style.fontSize ?? 24;
     final baseFontSize = style.fontSize ?? defaultFontSize;
+    final versionText = text.substring(_productName.length).trimLeft();
 
     return Text.rich(
       TextSpan(
@@ -36,14 +37,15 @@ class AboutVersionBannerText extends StatelessWidget {
         children: [
           const TextSpan(text: _productName),
           TextSpan(
-            text: ' for $label',
+            text: '\nfor $label',
             style: style.copyWith(
               color: _mutedColor(style.color),
               fontSize: baseFontSize * 0.58,
               fontWeight: FontWeight.w600,
+              height: 1.2,
             ),
           ),
-          TextSpan(text: text.substring(_productName.length)),
+          if (versionText.isNotEmpty) TextSpan(text: '\n$versionText'),
         ],
       ),
       textAlign: textAlign,

--- a/lib/widgets/about_version_banner_text.dart
+++ b/lib/widgets/about_version_banner_text.dart
@@ -29,7 +29,9 @@ class AboutVersionBannerText extends StatelessWidget {
 
     final defaultFontSize = DefaultTextStyle.of(context).style.fontSize ?? 24;
     final baseFontSize = style.fontSize ?? defaultFontSize;
-    final versionText = text.substring(_productName.length).trimLeft();
+    final versionText = _extractVersionText(text);
+    final detailText =
+        ['for $label', if (versionText.isNotEmpty) versionText].join(' ');
 
     return Text.rich(
       TextSpan(
@@ -37,7 +39,7 @@ class AboutVersionBannerText extends StatelessWidget {
         children: [
           const TextSpan(text: _productName),
           TextSpan(
-            text: '\nfor $label',
+            text: '\n$detailText',
             style: style.copyWith(
               color: _mutedColor(style.color),
               fontSize: baseFontSize * 0.58,
@@ -45,7 +47,6 @@ class AboutVersionBannerText extends StatelessWidget {
               height: 1.2,
             ),
           ),
-          if (versionText.isNotEmpty) TextSpan(text: '\n$versionText'),
         ],
       ),
       textAlign: textAlign,
@@ -57,5 +58,14 @@ class AboutVersionBannerText extends StatelessWidget {
       return null;
     }
     return color.withValues(alpha: color.a * 0.72);
+  }
+
+  String _extractVersionText(String bannerText) {
+    final tail = bannerText.substring(_productName.length).trim();
+    if (tail.isEmpty) {
+      return '';
+    }
+    final match = RegExp(r'[:：]\s*(.+)$').firstMatch(tail);
+    return (match?.group(1) ?? tail).trim();
   }
 }

--- a/lib/widgets/about_version_banner_text.dart
+++ b/lib/widgets/about_version_banner_text.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/widgets.dart';
+
+class AboutVersionBannerText extends StatelessWidget {
+  const AboutVersionBannerText({
+    super.key,
+    required this.text,
+    required this.targetLabel,
+    required this.style,
+    this.textAlign = TextAlign.center,
+  });
+
+  static const String _productName = 'NipaPlay Reload';
+
+  final String text;
+  final String targetLabel;
+  final TextStyle style;
+  final TextAlign textAlign;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = targetLabel.trim();
+    if (label.isEmpty || !text.startsWith(_productName)) {
+      return Text(
+        text,
+        style: style,
+        textAlign: textAlign,
+      );
+    }
+
+    final defaultFontSize = DefaultTextStyle.of(context).style.fontSize ?? 24;
+    final baseFontSize = style.fontSize ?? defaultFontSize;
+
+    return Text.rich(
+      TextSpan(
+        style: style,
+        children: [
+          const TextSpan(text: _productName),
+          TextSpan(
+            text: ' for $label',
+            style: style.copyWith(
+              color: _mutedColor(style.color),
+              fontSize: baseFontSize * 0.58,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          TextSpan(text: text.substring(_productName.length)),
+        ],
+      ),
+      textAlign: textAlign,
+    );
+  }
+
+  Color? _mutedColor(Color? color) {
+    if (color == null) {
+      return null;
+    }
+    return color.withValues(alpha: color.a * 0.72);
+  }
+}

--- a/lib/widgets/about_version_banner_text.dart
+++ b/lib/widgets/about_version_banner_text.dart
@@ -39,25 +39,16 @@ class AboutVersionBannerText extends StatelessWidget {
         children: [
           const TextSpan(text: _productName),
           TextSpan(
-            text: '\n$detailText',
+            text: ' $detailText',
             style: style.copyWith(
-              color: _mutedColor(style.color),
               fontSize: baseFontSize * 0.58,
               fontWeight: FontWeight.w600,
-              height: 1.2,
             ),
           ),
         ],
       ),
       textAlign: textAlign,
     );
-  }
-
-  Color? _mutedColor(Color? color) {
-    if (color == null) {
-      return null;
-    }
-    return color.withValues(alpha: color.a * 0.72);
   }
 
   String _extractVersionText(String bannerText) {


### PR DESCRIPTION
## Summary
- Add a small `for <architecture> <platform>` suffix after `NipaPlay Reload` on the About page version banner.
- Share the banner rendering between the Material and Cupertino About pages.
- Detect runtime target labels such as `Arm64 iOS`, `X64 Windows`, and `Web` with conditional imports.

## Validation
- `/Library/Afolder/FlutterProject/flutter/bin/dart format ...`
- `flutter analyze --no-fatal-infos lib/utils/build_target_label_common.dart lib/utils/build_target_label.dart lib/utils/build_target_label_io.dart lib/utils/build_target_label_stub.dart lib/widgets/about_version_banner_text.dart lib/themes/nipaplay/pages/settings/about_page.dart lib/themes/cupertino/pages/settings/pages/cupertino_about_page.dart`

Note: Full `flutter analyze` still reports existing issues in generated build assets and third-party code that are unrelated to this change.