### PR TITLE
Fix/dfm overwriteinsert

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,10 +56,10 @@ android {
             }
         }
         
-        // ──── cpp_native: C++ → Dart FFI ────
-        ndk {
-            abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86_64'
-        }
+        // 注释掉 ndk abiFilters，避免与 Flutter splits 配置冲突
+        // ndk {
+        //     abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86_64'
+        // }
 
         // CMake arguments/flags (path and version are set in android.externalNativeBuild below)
         externalNativeBuild {
@@ -69,9 +69,6 @@ android {
                 cppFlags "-std=c++20", "-fno-rtti", "-fvisibility=hidden"
             }
         }
-        
-        // 支持ARM和x86架构（包括模拟器）
-        // 注释掉 ndk abiFilters，避免与 splits 配置冲突
     }
 
     buildTypes {

--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -44,4 +44,6 @@ class SettingsKeys {
       'downloader_auto_scanned_completed_task_keys';
 
   static const String githubProxyUrl = 'github_proxy_url';
+
+  static const String danmakuSupersample = 'danmaku_supersample';
 }

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -121,14 +121,16 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
         oldWidget.outlineWidth != widget.outlineWidth ||
         oldWidget.shadowStyle != widget.shadowStyle ||
         oldWidget.trackGapRatio != widget.trackGapRatio ||
-        oldWidget.opacity != widget.opacity ||
-        oldWidget.isVisible != widget.isVisible ||
         oldWidget.maxQuantity != widget.maxQuantity ||
         oldWidget.maxLinesPerType != widget.maxLinesPerType ||
         !listEquals(oldWidget.blockWords, widget.blockWords)) {
       _forceLayout = true;
       _queueUpdate();
+    } else if (oldWidget.isVisible != widget.isVisible) {
+      // Visibility only affects display layer, not layout — skip full reconfigure
+      _queueUpdate();
     }
+    // opacity changes are handled in build() via Opacity widget, no update needed
   }
 
   @override

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -181,8 +181,7 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
                 Next2TextureBridge.isSupported;
 
             final needsSupersample =
-                (globals.isTablet || (globals.isDesktop && dpr < 2.0)) &&
-                    context.watch<SettingsProvider>().danmakuSupersample;
+                context.watch<SettingsProvider>().danmakuSupersample;
             final filterQuality =
                 needsSupersample ? FilterQuality.low : FilterQuality.none;
             final Widget content = hasTexture
@@ -289,8 +288,7 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
         views.isNotEmpty ? views.first.devicePixelRatio : _lastDevicePixelRatio;
 
     final needsSupersample =
-        (globals.isTablet || (globals.isDesktop && dpr < 2.0)) &&
-            context.read<SettingsProvider>().danmakuSupersample;
+        context.read<SettingsProvider>().danmakuSupersample;
     final supersample = needsSupersample ? _supersampleMultiplier : 1.0;
     final double pixelRatio =
         (dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0) * supersample;

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -4,8 +4,10 @@ import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
 import 'package:nipaplay/danmaku_next/next2_emoji_pipeline.dart';
 import 'package:nipaplay/danmaku_next/next2_overlay_viewport.dart';
 import 'package:nipaplay/danmaku_next/next2_texture_bridge.dart';
+import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
+import 'package:provider/provider.dart';
 
 import 'dfm_plus_layout_bridge.dart';
 
@@ -177,7 +179,8 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
                 Next2TextureBridge.isSupported;
 
             final needsSupersample =
-                globals.isTablet || (globals.isDesktop && dpr < 2.0);
+                (globals.isTablet || (globals.isDesktop && dpr < 2.0)) &&
+                    context.watch<SettingsProvider>().danmakuSupersample;
             final filterQuality =
                 needsSupersample ? FilterQuality.low : FilterQuality.none;
             final Widget content = hasTexture
@@ -284,7 +287,8 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
         views.isNotEmpty ? views.first.devicePixelRatio : _lastDevicePixelRatio;
 
     final needsSupersample =
-        globals.isTablet || (globals.isDesktop && dpr < 2.0);
+        (globals.isTablet || (globals.isDesktop && dpr < 2.0)) &&
+            context.read<SettingsProvider>().danmakuSupersample;
     final supersample = needsSupersample ? _supersampleMultiplier : 1.0;
     final double pixelRatio =
         (dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0) * supersample;

--- a/lib/danmaku_next/nipaplay_next2_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next2_overlay.dart
@@ -152,8 +152,7 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
                 Next2TextureBridge.isSupported;
 
             final needsSupersample =
-                (globals.isTablet || (globals.isDesktop && dpr < 2.0)) &&
-                    context.watch<SettingsProvider>().danmakuSupersample;
+                context.watch<SettingsProvider>().danmakuSupersample;
             final filterQuality =
                 needsSupersample ? FilterQuality.low : FilterQuality.none;
             final Widget content = hasTexture
@@ -239,8 +238,7 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
         views.isNotEmpty ? views.first.devicePixelRatio : _lastDevicePixelRatio;
 
     final needsSupersample =
-        (globals.isTablet || (globals.isDesktop && dpr < 2.0)) &&
-            context.read<SettingsProvider>().danmakuSupersample;
+        context.read<SettingsProvider>().danmakuSupersample;
     final supersample = needsSupersample ? _supersampleMultiplier : 1.0;
     final double pixelRatio =
         (dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0) * supersample;

--- a/lib/danmaku_next/nipaplay_next2_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next2_overlay.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
+import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
+import 'package:provider/provider.dart';
 
 import 'next2_emoji_pipeline.dart';
 import 'next2_layout_bridge.dart';
@@ -150,7 +152,8 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
                 Next2TextureBridge.isSupported;
 
             final needsSupersample =
-                globals.isTablet || (globals.isDesktop && dpr < 2.0);
+                (globals.isTablet || (globals.isDesktop && dpr < 2.0)) &&
+                    context.watch<SettingsProvider>().danmakuSupersample;
             final filterQuality =
                 needsSupersample ? FilterQuality.low : FilterQuality.none;
             final Widget content = hasTexture
@@ -236,7 +239,8 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
         views.isNotEmpty ? views.first.devicePixelRatio : _lastDevicePixelRatio;
 
     final needsSupersample =
-        globals.isTablet || (globals.isDesktop && dpr < 2.0);
+        (globals.isTablet || (globals.isDesktop && dpr < 2.0)) &&
+            context.read<SettingsProvider>().danmakuSupersample;
     final supersample = needsSupersample ? _supersampleMultiplier : 1.0;
     final double pixelRatio =
         (dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0) * supersample;

--- a/lib/player_abstraction/media_kit_player_adapter.dart
+++ b/lib/player_abstraction/media_kit_player_adapter.dart
@@ -203,7 +203,10 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
   Ticker? _ticker;
   Duration _interpolatedPosition = Duration.zero;
   Duration _lastActualPosition = Duration.zero;
-  int _lastPositionTimestamp = 0;
+  /// 高精度时钟戳（微秒），用于播放位置插值的 delta 计算。
+  /// 使用 microsecond 精度替代原来的 millisecond 精度，
+  /// 消除 Windows 平台上时钟粒度过粗（~15.6ms）导致的位置跳变。
+  int _lastPositionTimestampUs = 0;
 
   final Map<PlayerMediaType, List<String>> _decoders = {
     PlayerMediaType.video: [],
@@ -515,7 +518,7 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
               : PlayerPlaybackState.stopped);
       if (playing) {
         _lastActualPosition = _player.state.position;
-        _lastPositionTimestamp = DateTime.now().millisecondsSinceEpoch;
+        _lastPositionTimestampUs = DateTime.now().microsecondsSinceEpoch;
         if (_ticker != null && !_ticker!.isActive) {
           _ticker!.start();
         }
@@ -1321,7 +1324,7 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
     final currentPosition = _interpolatedPosition;
     _lastActualPosition = currentPosition;
     _interpolatedPosition = currentPosition;
-    _lastPositionTimestamp = DateTime.now().millisecondsSinceEpoch;
+    _lastPositionTimestampUs = DateTime.now().microsecondsSinceEpoch;
 
     _playbackRate = value;
     try {
@@ -1840,7 +1843,7 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
     _player.seek(seekPosition);
     _interpolatedPosition = seekPosition;
     _lastActualPosition = seekPosition;
-    _lastPositionTimestamp = DateTime.now().millisecondsSinceEpoch;
+    _lastPositionTimestampUs = DateTime.now().microsecondsSinceEpoch;
   }
 
   @override
@@ -2361,13 +2364,17 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
 
   void _onTick(Duration elapsed) {
     if (_player.state.playing) {
-      final now = DateTime.now().millisecondsSinceEpoch;
-      if (_lastPositionTimestamp == 0) {
-        _lastPositionTimestamp = now;
+      // 使用微秒精度的 DateTime.now() 替代原来的毫秒精度。
+      // Windows 平台上毫秒级时钟默认粒度约 15.6ms，导致插值 delta
+      // 在连续帧之间跳变，造成弹幕可见的"抽帧"。微秒精度（~1µs）
+      // 远小于帧间隔（~16667µs @60fps），消除了量化噪声。
+      final nowUs = DateTime.now().microsecondsSinceEpoch;
+      if (_lastPositionTimestampUs == 0) {
+        _lastPositionTimestampUs = nowUs;
       }
-      final delta = now - _lastPositionTimestamp;
+      final deltaUs = nowUs - _lastPositionTimestampUs;
       _interpolatedPosition = _lastActualPosition +
-          Duration(milliseconds: (delta * _player.state.rate).toInt());
+          Duration(microseconds: (deltaUs * _player.state.rate).toInt());
 
       if (_player.state.duration > Duration.zero &&
           _interpolatedPosition > _player.state.duration) {

--- a/lib/player_abstraction/video_player_adapter.dart
+++ b/lib/player_abstraction/video_player_adapter.dart
@@ -29,7 +29,9 @@ class VideoPlayerAdapter implements AbstractPlayer, TickerProvider {
   Ticker? _ticker;
   Duration _interpolatedPosition = Duration.zero;
   Duration _lastActualPosition = Duration.zero;
-  int _lastPositionTimestamp = 0;
+  /// 高精度时钟戳（微秒），用于播放位置插值的 delta 计算。
+  /// 使用 microsecond 精度消除移动端时钟粒度过粗导致的位置跳变。
+  int _lastPositionTimestampUs = 0;
   bool _wasPlaying = false; // 新增状态跟踪标志
 
   final List<int> _activeSubtitleTracks = [];
@@ -70,12 +72,12 @@ class VideoPlayerAdapter implements AbstractPlayer, TickerProvider {
 
   void _onTick(Duration elapsed) {
     if (_controller?.value.isPlaying ?? false) {
-      final now = DateTime.now().millisecondsSinceEpoch;
-      if (_lastPositionTimestamp == 0) { // Safety check
-        _lastPositionTimestamp = now;
+      final nowUs = DateTime.now().microsecondsSinceEpoch;
+      if (_lastPositionTimestampUs == 0) { // Safety check
+        _lastPositionTimestampUs = nowUs;
       }
-      final delta = now - _lastPositionTimestamp;
-      _interpolatedPosition = _lastActualPosition + Duration(milliseconds: (delta * _playbackRate).toInt());
+      final deltaUs = nowUs - _lastPositionTimestampUs;
+      _interpolatedPosition = _lastActualPosition + Duration(microseconds: (deltaUs * _playbackRate).toInt());
 
       if (_controller!.value.duration > Duration.zero && _interpolatedPosition > _controller!.value.duration) {
         _interpolatedPosition = _controller!.value.duration;
@@ -101,7 +103,7 @@ class VideoPlayerAdapter implements AbstractPlayer, TickerProvider {
     final currentPosition = _interpolatedPosition;
     _lastActualPosition = currentPosition;
     _interpolatedPosition = currentPosition;
-    _lastPositionTimestamp = DateTime.now().millisecondsSinceEpoch;
+    _lastPositionTimestampUs = DateTime.now().microsecondsSinceEpoch;
 
     _playbackRate = value;
     try {
@@ -152,7 +154,7 @@ class VideoPlayerAdapter implements AbstractPlayer, TickerProvider {
           // 否则VideoPlayerState可能无法识别状态变化
           _controller!.play();
           // _lastActualPosition = _controller?.value.position ?? _lastActualPosition; // 移除这里的校准
-          // _lastPositionTimestamp = DateTime.now().millisecondsSinceEpoch; // 移除这里的校准
+          // _lastPositionTimestampUs = DateTime.now().microsecondsSinceEpoch; // 移除这里的校准
           // _ticker?.start(); // Ticker的启动交给监听器
           
           // 确保异步方法也被调用，以进行验证和重试
@@ -174,7 +176,7 @@ class VideoPlayerAdapter implements AbstractPlayer, TickerProvider {
           _controller!.seekTo(Duration.zero);
           _interpolatedPosition = Duration.zero;
           _lastActualPosition = Duration.zero;
-          _lastPositionTimestamp = 0;
+          _lastPositionTimestampUs = 0;
           break;
       }
     } catch (e) {
@@ -231,7 +233,7 @@ class VideoPlayerAdapter implements AbstractPlayer, TickerProvider {
         // 重置位置
         _interpolatedPosition = Duration.zero;
         _lastActualPosition = Duration.zero;
-        _lastPositionTimestamp = 0;
+        _lastPositionTimestampUs = 0;
         _mediaInfo = PlayerMediaInfo(duration: 0, specificErrorMessage: _mediaInfo.specificErrorMessage); // 保留可能已设置的错误信息
       }
     } catch (e) {
@@ -541,7 +543,7 @@ class VideoPlayerAdapter implements AbstractPlayer, TickerProvider {
     _controller!.seekTo(duration);
     _interpolatedPosition = duration;
     _lastActualPosition = duration;
-    _lastPositionTimestamp = DateTime.now().millisecondsSinceEpoch;
+    _lastPositionTimestampUs = DateTime.now().microsecondsSinceEpoch;
   }
 
   @override
@@ -971,7 +973,7 @@ class VideoPlayerAdapter implements AbstractPlayer, TickerProvider {
           // 状态从 暂停 -> 播放
           _lastActualPosition = value.position;
           _interpolatedPosition = value.position;
-          _lastPositionTimestamp = DateTime.now().millisecondsSinceEpoch;
+          _lastPositionTimestampUs = DateTime.now().microsecondsSinceEpoch;
           _ticker?.start();
         } else {
           // 状态从 播放 -> 暂停

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/l10n/app_locale_utils.dart';
+import 'package:nipaplay/utils/globals.dart' as globals;
 
 class SettingsProvider with ChangeNotifier {
   late SharedPreferences _prefs;
@@ -27,7 +28,10 @@ class SettingsProvider with ChangeNotifier {
 
   // GitHub 代理设置
   String _githubProxyUrl = '';
-  
+
+  // 弹幕超采样设置
+  bool _danmakuSupersample = true; // 默认值在 _loadSettings 中根据设备类型决定
+
   // --- Getters ---
   double get blurPower => _blurPower;
   bool get isBlurEnabled => _blurPower > 0;
@@ -38,6 +42,7 @@ class SettingsProvider with ChangeNotifier {
   bool get useExternalPlayer => _useExternalPlayer;
   String get externalPlayerPath => _externalPlayerPath;
   String get githubProxyUrl => _githubProxyUrl;
+  bool get danmakuSupersample => _danmakuSupersample;
 
   SettingsProvider() {
     _loadSettings();
@@ -72,10 +77,26 @@ class SettingsProvider with ChangeNotifier {
         _prefs.getString(SettingsKeys.externalPlayerPath) ?? '';
     _githubProxyUrl =
         _prefs.getString(SettingsKeys.githubProxyUrl) ?? '';
+    // 弹幕超采样：默认对平板和低 DPR 桌面设备开启
+    final defaultSupersample =
+        globals.isTablet || (globals.isDesktop && _defaultDprBelow2());
+    _danmakuSupersample =
+        _prefs.getBool(SettingsKeys.danmakuSupersample) ?? defaultSupersample;
     notifyListeners();
   }
 
   // --- Setters ---
+
+  /// 判断当前设备默认 DPR 是否低于 2.0
+  static bool _defaultDprBelow2() {
+    try {
+      final dpr = WidgetsBinding.instance.platformDispatcher.views.first
+          .devicePixelRatio;
+      return dpr < 2.0;
+    } catch (_) {
+      return false;
+    }
+  }
 
   /// Toggles the background blur effect.
   ///
@@ -144,6 +165,12 @@ class SettingsProvider with ChangeNotifier {
       SettingsKeys.githubProxyUrl,
       _githubProxyUrl,
     );
+    notifyListeners();
+  }
+
+  Future<void> setDanmakuSupersample(bool enable) async {
+    _danmakuSupersample = enable;
+    await _prefs.setBool(SettingsKeys.danmakuSupersample, enable);
     notifyListeners();
   }
 

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_danmaku_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_danmaku_settings_page.dart
@@ -336,6 +336,43 @@ class _CupertinoDanmakuSettingsPageState
             ),
             backgroundColor: tileBackground,
           ),
+          Consumer<SettingsProvider>(
+            builder: (context, settingsProvider, _) {
+              return CupertinoSettingsTile(
+                leading: Icon(
+                  CupertinoIcons.fullscreen,
+                  color: resolveSettingsIconColor(context),
+                ),
+                title: const Text('弹幕超采样渲染'),
+                subtitle: const Text('在部分设备上以更高像素密度渲染弹幕，使文字更清晰，但会增加 GPU 负担'),
+                trailing: AdaptiveSwitch(
+                  value: settingsProvider.danmakuSupersample,
+                  onChanged: (value) {
+                    settingsProvider.setDanmakuSupersample(value);
+                    if (mounted) {
+                      AdaptiveSnackBar.show(
+                        context,
+                        message: value ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
+                        type: AdaptiveSnackBarType.success,
+                      );
+                    }
+                  },
+                ),
+                onTap: () {
+                  final bool newValue = !settingsProvider.danmakuSupersample;
+                  settingsProvider.setDanmakuSupersample(newValue);
+                  if (mounted) {
+                    AdaptiveSnackBar.show(
+                      context,
+                      message: newValue ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
+                      type: AdaptiveSnackBarType.success,
+                    );
+                  }
+                },
+                backgroundColor: tileBackground,
+              );
+            },
+          ),
         ],
       ),
       const SizedBox(height: 16),
@@ -418,39 +455,6 @@ class _CupertinoDanmakuSettingsPageState
                       message: newValue
                           ? context.l10n.danmakuConvertToSimplifiedEnabled
                           : context.l10n.danmakuConvertToSimplifiedDisabled,
-                      type: AdaptiveSnackBarType.success,
-                    );
-                  }
-                },
-                backgroundColor: tileBackground,
-              ),
-              CupertinoSettingsTile(
-                leading: Icon(
-                  CupertinoIcons.fullscreen,
-                  color: resolveSettingsIconColor(context),
-                ),
-                title: const Text('弹幕超采样渲染'),
-                subtitle: const Text('在部分设备上以更高像素密度渲染弹幕，使文字更清晰，但会增加 GPU 负担'),
-                trailing: AdaptiveSwitch(
-                  value: settingsProvider.danmakuSupersample,
-                  onChanged: (value) {
-                    settingsProvider.setDanmakuSupersample(value);
-                    if (mounted) {
-                      AdaptiveSnackBar.show(
-                        context,
-                        message: value ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
-                        type: AdaptiveSnackBarType.success,
-                      );
-                    }
-                  },
-                ),
-                onTap: () {
-                  final bool newValue = !settingsProvider.danmakuSupersample;
-                  settingsProvider.setDanmakuSupersample(newValue);
-                  if (mounted) {
-                    AdaptiveSnackBar.show(
-                      context,
-                      message: newValue ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
                       type: AdaptiveSnackBarType.success,
                     );
                   }

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_danmaku_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_danmaku_settings_page.dart
@@ -336,43 +336,45 @@ class _CupertinoDanmakuSettingsPageState
             ),
             backgroundColor: tileBackground,
           ),
-          Consumer<SettingsProvider>(
-            builder: (context, settingsProvider, _) {
-              return CupertinoSettingsTile(
-                leading: Icon(
-                  CupertinoIcons.fullscreen,
-                  color: resolveSettingsIconColor(context),
-                ),
-                title: const Text('弹幕超采样渲染'),
-                subtitle: const Text('在部分设备上以更高像素密度渲染弹幕，使文字更清晰，但会增加 GPU 负担'),
-                trailing: AdaptiveSwitch(
-                  value: settingsProvider.danmakuSupersample,
-                  onChanged: (value) {
-                    settingsProvider.setDanmakuSupersample(value);
+          if (_selectedDanmakuRenderEngine == DanmakuRenderEngine.next2 ||
+              _selectedDanmakuRenderEngine == DanmakuRenderEngine.dfmPlus)
+            Consumer<SettingsProvider>(
+              builder: (context, settingsProvider, _) {
+                return CupertinoSettingsTile(
+                  leading: Icon(
+                    CupertinoIcons.fullscreen,
+                    color: resolveSettingsIconColor(context),
+                  ),
+                  title: const Text('弹幕超采样渲染'),
+                  subtitle: const Text('在部分设备上以更高像素密度渲染弹幕，使文字更清晰，但会增加 GPU 负担'),
+                  trailing: AdaptiveSwitch(
+                    value: settingsProvider.danmakuSupersample,
+                    onChanged: (value) {
+                      settingsProvider.setDanmakuSupersample(value);
+                      if (mounted) {
+                        AdaptiveSnackBar.show(
+                          context,
+                          message: value ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
+                          type: AdaptiveSnackBarType.success,
+                        );
+                      }
+                    },
+                  ),
+                  onTap: () {
+                    final bool newValue = !settingsProvider.danmakuSupersample;
+                    settingsProvider.setDanmakuSupersample(newValue);
                     if (mounted) {
                       AdaptiveSnackBar.show(
                         context,
-                        message: value ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
+                        message: newValue ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
                         type: AdaptiveSnackBarType.success,
                       );
                     }
                   },
-                ),
-                onTap: () {
-                  final bool newValue = !settingsProvider.danmakuSupersample;
-                  settingsProvider.setDanmakuSupersample(newValue);
-                  if (mounted) {
-                    AdaptiveSnackBar.show(
-                      context,
-                      message: newValue ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
-                      type: AdaptiveSnackBarType.success,
-                    );
-                  }
-                },
-                backgroundColor: tileBackground,
-              );
-            },
-          ),
+                  backgroundColor: tileBackground,
+                );
+              },
+            ),
         ],
       ),
       const SizedBox(height: 16),

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_danmaku_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_danmaku_settings_page.dart
@@ -424,6 +424,39 @@ class _CupertinoDanmakuSettingsPageState
                 },
                 backgroundColor: tileBackground,
               ),
+              CupertinoSettingsTile(
+                leading: Icon(
+                  CupertinoIcons.expand,
+                  color: resolveSettingsIconColor(context),
+                ),
+                title: const Text('弹幕超采样渲染'),
+                subtitle: const Text('在部分设备上以更高像素密度渲染弹幕，使文字更清晰，但会增加 GPU 负担'),
+                trailing: AdaptiveSwitch(
+                  value: settingsProvider.danmakuSupersample,
+                  onChanged: (value) {
+                    settingsProvider.setDanmakuSupersample(value);
+                    if (mounted) {
+                      AdaptiveSnackBar.show(
+                        context,
+                        message: value ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
+                        type: AdaptiveSnackBarType.success,
+                      );
+                    }
+                  },
+                ),
+                onTap: () {
+                  final bool newValue = !settingsProvider.danmakuSupersample;
+                  settingsProvider.setDanmakuSupersample(newValue);
+                  if (mounted) {
+                    AdaptiveSnackBar.show(
+                      context,
+                      message: newValue ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
+                      type: AdaptiveSnackBarType.success,
+                    );
+                  }
+                },
+                backgroundColor: tileBackground,
+              ),
               Consumer<VideoPlayerState>(
                 builder: (context, videoState, child) {
                   return CupertinoSettingsTile(

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_danmaku_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_danmaku_settings_page.dart
@@ -426,7 +426,7 @@ class _CupertinoDanmakuSettingsPageState
               ),
               CupertinoSettingsTile(
                 leading: Icon(
-                  CupertinoIcons.expand,
+                  CupertinoIcons.fullscreen,
                   color: resolveSettingsIconColor(context),
                 ),
                 title: const Text('弹幕超采样渲染'),

--- a/lib/themes/cupertino/widgets/cupertino_bangumi_comments_widget.dart
+++ b/lib/themes/cupertino/widgets/cupertino_bangumi_comments_widget.dart
@@ -36,6 +36,7 @@ class CupertinoBangumiCommentsWidget extends StatefulWidget {
 class CupertinoBangumiCommentsWidgetState
     extends State<CupertinoBangumiCommentsWidget> {
   final List<BangumiComment> _comments = [];
+  final ScrollController _scrollController = ScrollController();
   bool _isLoading = false;
   bool _hasMore = true;
   bool _usingFallback = false;
@@ -46,6 +47,7 @@ class CupertinoBangumiCommentsWidgetState
   @override
   void initState() {
     super.initState();
+    _scrollController.addListener(_onScroll);
     if (widget.subjectId != null || widget.dandanplayId != 0) {
       _loadComments();
     }
@@ -67,6 +69,22 @@ class CupertinoBangumiCommentsWidgetState
       if (widget.subjectId != null || widget.dandanplayId != 0) {
         _loadComments();
       }
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!_scrollController.hasClients) return;
+    final maxScroll = _scrollController.position.maxScrollExtent;
+    final currentScroll = _scrollController.position.pixels;
+    if (maxScroll > 0 && currentScroll >= maxScroll - 200) {
+      tryLoadMore();
     }
   }
 
@@ -375,115 +393,158 @@ class CupertinoBangumiCommentsWidgetState
 
     final int commentItemCount = _comments.length + (hasMyComment ? 1 : 0);
 
-    final List<Widget> items = [];
+    // 布局索引：
+    // 0: 标题行
+    // 1: 间距
+    // 2 (如果hasMyComment): 我的评论
+    // 2+myCommentOffset ~ 2+myCommentOffset+_comments.length-1: 评论列表
+    // 最后: 底部加载/错误
+    const int headerCount = 2;
+    final int myCommentCount = hasMyComment ? 1 : 0;
+    final bool hasFooter = _isLoading || (_error != null && _comments.isNotEmpty);
+    final int totalItems = headerCount + myCommentCount + _comments.length + (hasFooter ? 1 : 0);
 
-    // Header
-    items.add(
-      Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text('全部短评',
-              style: TextStyle(
-                  color: textColor,
-                  fontWeight: FontWeight.w600,
-                  fontSize: 14,
-                  height: 1.5)),
-          if (widget.onEditRating != null)
-            CupertinoButton(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              minSize: 0,
-              onPressed: widget.onEditRating,
+    return ListView.builder(
+      controller: _scrollController,
+      padding: EdgeInsets.zero,
+      itemCount: totalItems,
+      itemBuilder: (context, index) {
+        // 标题行
+        if (index == 0) {
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('全部短评',
+                  style: TextStyle(
+                      color: textColor,
+                      fontWeight: FontWeight.w600,
+                      fontSize: 14,
+                      height: 1.5)),
+              if (widget.onEditRating != null)
+                CupertinoButton(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  minSize: 0,
+                  onPressed: widget.onEditRating,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(CupertinoIcons.chat_bubble,
+                          size: 15, color: accentColor),
+                      const SizedBox(width: 4),
+                      Text(
+                        '评论',
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w500,
+                          color: accentColor,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          );
+        }
+
+        // 间距
+        if (index == 1) {
+          return const SizedBox(height: 12);
+        }
+
+        // 我的评论
+        if (hasMyComment && index == 2) {
+          final my = widget.myComment!;
+          return Padding(
+            padding: EdgeInsets.only(bottom: commentItemCount > 1 ? 8 : 0),
+            child: Container(
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: accentColor.withOpacity(isDark ? 0.12 : 0.08),
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(
+                    color: accentColor.withOpacity(0.3), width: 0.8),
+              ),
               child: Row(
-                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Icon(CupertinoIcons.chat_bubble,
-                      size: 15, color: accentColor),
-                  const SizedBox(width: 4),
-                  Text(
-                    '评论',
-                    style: TextStyle(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w500,
-                      color: accentColor,
+                  _buildAvatar(
+                      my.avatarUrl, systemFillColor, secondaryTextColor),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Flexible(
+                              child: Text(
+                                my.nickname.isNotEmpty ? my.nickname : '我',
+                                style: TextStyle(
+                                  color: textColor,
+                                  fontWeight: FontWeight.w600,
+                                  fontSize: 13,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            Text(
+                              _formatRelativeTime(my.updatedAt),
+                              style: TextStyle(
+                                  color: secondaryTextColor, fontSize: 11),
+                            ),
+                          ],
+                        ),
+                        if (my.rate > 0) ...[
+                          const SizedBox(height: 3),
+                          _buildMiniStars(my.rate, accentColor, mutedColor),
+                        ],
+                        if (my.comment.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(my.comment, style: valueStyle),
+                        ],
+                      ],
                     ),
                   ),
                 ],
               ),
             ),
-        ],
-      ),
-    );
-    items.add(const SizedBox(height: 12));
+          );
+        }
 
-    // My comment
-    if (hasMyComment) {
-      final my = widget.myComment!;
-      items.add(
-        Padding(
-          padding: EdgeInsets.only(bottom: commentItemCount > 1 ? 8 : 0),
-          child: Container(
-            padding: const EdgeInsets.all(10),
-            decoration: BoxDecoration(
-              color: accentColor.withOpacity(isDark ? 0.12 : 0.08),
-              borderRadius: BorderRadius.circular(10),
-              border: Border.all(
-                  color: accentColor.withOpacity(0.3), width: 0.8),
-            ),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _buildAvatar(
-                    my.avatarUrl, systemFillColor, secondaryTextColor),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Flexible(
-                            child: Text(
-                              my.nickname.isNotEmpty ? my.nickname : '我',
-                              style: TextStyle(
-                                color: textColor,
-                                fontWeight: FontWeight.w600,
-                                fontSize: 13,
-                              ),
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                          Text(
-                            _formatRelativeTime(my.updatedAt),
-                            style: TextStyle(
-                                color: secondaryTextColor, fontSize: 11),
-                          ),
-                        ],
-                      ),
-                      if (my.rate > 0) ...[
-                        const SizedBox(height: 3),
-                        _buildMiniStars(my.rate, accentColor, mutedColor),
-                      ],
-                      if (my.comment.isNotEmpty) ...[
-                        const SizedBox(height: 4),
-                        Text(my.comment, style: valueStyle),
-                      ],
-                    ],
-                  ),
+        // 底部加载/错误
+        if (index == totalItems - 1 && hasFooter) {
+          if (_isLoading) {
+            return const Padding(
+              padding: EdgeInsets.symmetric(vertical: 16),
+              child: Center(
+                child: SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CupertinoActivityIndicator(radius: 10),
                 ),
-              ],
+              ),
+            );
+          }
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Center(
+              child: CupertinoButton(
+                onPressed: _loadComments,
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 16, vertical: 8),
+                child: Text('加载失败，点击重试',
+                    style: TextStyle(color: accentColor, fontSize: 12)),
+              ),
             ),
-          ),
-        ),
-      );
-    }
+          );
+        }
 
-    // Comments list
-    for (int i = 0; i < _comments.length; i++) {
-      final comment = _comments[i];
-      final bool isLast = i == _comments.length - 1 && !_hasMore && _error == null;
-      items.add(
-        Padding(
+        // 评论列表项
+        final int commentIndex = index - headerCount - myCommentCount;
+        final comment = _comments[commentIndex];
+        final bool isLast = commentIndex == _comments.length - 1 && !_hasMore && _error == null;
+        return Padding(
           padding: EdgeInsets.only(bottom: isLast ? 0 : 8),
           child: Container(
             padding: const EdgeInsets.all(10),
@@ -541,45 +602,8 @@ class CupertinoBangumiCommentsWidgetState
               ],
             ),
           ),
-        ),
-      );
-    }
-
-    // Footer: loading or error
-    if (_isLoading) {
-      items.add(
-        const Padding(
-          padding: EdgeInsets.symmetric(vertical: 16),
-          child: Center(
-            child: SizedBox(
-              width: 20,
-              height: 20,
-              child: CupertinoActivityIndicator(radius: 10),
-            ),
-          ),
-        ),
-      );
-    } else if (_error != null && _comments.isNotEmpty) {
-      items.add(
-        Padding(
-          padding: const EdgeInsets.symmetric(vertical: 8),
-          child: Center(
-            child: CupertinoButton(
-              onPressed: _loadComments,
-              padding: const EdgeInsets.symmetric(
-                  horizontal: 16, vertical: 8),
-              child: Text('加载失败，点击重试',
-                  style: TextStyle(color: accentColor, fontSize: 12)),
-            ),
-          ),
-        ),
-      );
-    }
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: items,
+        );
+      },
     );
   }
 }

--- a/lib/themes/cupertino/widgets/cupertino_shared_anime_detail_page.dart
+++ b/lib/themes/cupertino/widgets/cupertino_shared_anime_detail_page.dart
@@ -221,16 +221,7 @@ class _CupertinoSharedAnimeDetailPageState
   }
 
   void _onScroll() {
-    if (_currentSegment != _commentsSegment) return;
-    if (!_scrollController.hasClients) return;
-    final maxScroll = _scrollController.position.maxScrollExtent;
-    final currentScroll = _scrollController.position.pixels;
-    if (maxScroll > 0 && currentScroll >= maxScroll - 200) {
-      final state = _commentsWidgetKey.currentState;
-      if (state is CupertinoBangumiCommentsWidgetState) {
-        state.tryLoadMore();
-      }
-    }
+    // 评论段的滚动检测已移至 CupertinoBangumiCommentsWidget 内部
   }
 
   @override
@@ -1229,7 +1220,7 @@ class _CupertinoSharedAnimeDetailPageState
               )
             else if (_currentSegment == _commentsSegment)
               SliverFillRemaining(
-                hasScrollBody: false,
+                hasScrollBody: true,
                 child: Padding(
                   padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
                   child: _buildCommentsSection(context),

--- a/lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart
@@ -602,6 +602,26 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
         Consumer<SettingsProvider>(
           builder: (context, settingsProvider, child) {
             return SettingsItem.toggle(
+              title: '弹幕超采样渲染',
+              subtitle: '在部分设备上以更高像素密度渲染弹幕，使文字更清晰，但会增加 GPU 负担',
+              icon: Ionicons.expand_outline,
+              value: settingsProvider.danmakuSupersample,
+              onChanged: (bool value) {
+                settingsProvider.setDanmakuSupersample(value);
+                if (context.mounted) {
+                  BlurSnackBar.show(
+                    context,
+                    value ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
+                  );
+                }
+              },
+            );
+          },
+        ),
+        Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+        Consumer<SettingsProvider>(
+          builder: (context, settingsProvider, child) {
+            return SettingsItem.toggle(
               title: '哈希匹配失败自动匹配弹幕',
               subtitle: '哈希匹配失败时，默认使用文件名搜索的第一个结果自动匹配；关闭后将弹出搜索弹幕菜单',
               icon: Ionicons.search_outline,

--- a/lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart
@@ -269,26 +269,30 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
           dropdownKey: _danmakuRenderEngineDropdownKey,
         ),
         Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-        Consumer<SettingsProvider>(
-          builder: (context, settingsProvider, child) {
-            return SettingsItem.toggle(
-              title: '弹幕超采样渲染',
-              subtitle: '在部分设备上以更高像素密度渲染弹幕，使文字更清晰，但会增加 GPU 负担',
-              icon: Ionicons.expand_outline,
-              value: settingsProvider.danmakuSupersample,
-              onChanged: (bool value) {
-                settingsProvider.setDanmakuSupersample(value);
-                if (context.mounted) {
-                  BlurSnackBar.show(
-                    context,
-                    value ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
-                  );
-                }
-              },
-            );
-          },
-        ),
-        Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+        if (_selectedDanmakuRenderEngine == DanmakuRenderEngine.next2 ||
+            _selectedDanmakuRenderEngine == DanmakuRenderEngine.dfmPlus)
+          Consumer<SettingsProvider>(
+            builder: (context, settingsProvider, child) {
+              return SettingsItem.toggle(
+                title: '弹幕超采样渲染',
+                subtitle: '在部分设备上以更高像素密度渲染弹幕，使文字更清晰，但会增加 GPU 负担',
+                icon: Ionicons.expand_outline,
+                value: settingsProvider.danmakuSupersample,
+                onChanged: (bool value) {
+                  settingsProvider.setDanmakuSupersample(value);
+                  if (context.mounted) {
+                    BlurSnackBar.show(
+                      context,
+                      value ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
+                    );
+                  }
+                },
+              );
+            },
+          ),
+        if (_selectedDanmakuRenderEngine == DanmakuRenderEngine.next2 ||
+            _selectedDanmakuRenderEngine == DanmakuRenderEngine.dfmPlus)
+          Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
         Consumer<VideoPlayerState>(
           builder: (context, videoState, child) {
             return SettingsItem.toggle(

--- a/lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart
@@ -269,6 +269,26 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
           dropdownKey: _danmakuRenderEngineDropdownKey,
         ),
         Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+        Consumer<SettingsProvider>(
+          builder: (context, settingsProvider, child) {
+            return SettingsItem.toggle(
+              title: '弹幕超采样渲染',
+              subtitle: '在部分设备上以更高像素密度渲染弹幕，使文字更清晰，但会增加 GPU 负担',
+              icon: Ionicons.expand_outline,
+              value: settingsProvider.danmakuSupersample,
+              onChanged: (bool value) {
+                settingsProvider.setDanmakuSupersample(value);
+                if (context.mounted) {
+                  BlurSnackBar.show(
+                    context,
+                    value ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
+                  );
+                }
+              },
+            );
+          },
+        ),
+        Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
         Consumer<VideoPlayerState>(
           builder: (context, videoState, child) {
             return SettingsItem.toggle(
@@ -592,26 +612,6 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
                   BlurSnackBar.show(
                     context,
                     value ? '已开启播放时自动匹配弹幕' : '已关闭播放时自动匹配弹幕（可手动匹配）',
-                  );
-                }
-              },
-            );
-          },
-        ),
-        Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-        Consumer<SettingsProvider>(
-          builder: (context, settingsProvider, child) {
-            return SettingsItem.toggle(
-              title: '弹幕超采样渲染',
-              subtitle: '在部分设备上以更高像素密度渲染弹幕，使文字更清晰，但会增加 GPU 负担',
-              icon: Ionicons.expand_outline,
-              value: settingsProvider.danmakuSupersample,
-              onChanged: (bool value) {
-                settingsProvider.setDanmakuSupersample(value);
-                if (context.mounted) {
-                  BlurSnackBar.show(
-                    context,
-                    value ? '已开启弹幕超采样渲染' : '已关闭弹幕超采样渲染',
                   );
                 }
               },

--- a/lib/utils/video_player_state/video_player_state_navigation.dart
+++ b/lib/utils/video_player_state/video_player_state_navigation.dart
@@ -602,13 +602,23 @@ extension VideoPlayerStateNavigation on VideoPlayerState {
                 final smoothMs = _smoothAnchorMs + elapsedDeltaUs / 1000.0 * _playbackRate;
                 final drift = smoothMs - playerMs;
                 if (drift.abs() > 30.0) {
-                  // 大跳变：立即对齐
+                  // 大跳变（seek/暂停恢复后）：立即对齐
                   _smoothAnchorMs = playerMs;
+                  _smoothAnchorElapsedUs = currentElapsedUs;
                 } else {
-                  // 小漂移：渐进修正（每帧修正 5%），避免突变
-                  _smoothAnchorMs = smoothMs - drift * 0.05;
+                  // 小漂移：渐进修正锚点（每帧修正 5%）
+                  // 关键：同时按比例调整锚点时间，使当前帧输出完全连续（无阶跃），
+                  // 修正效果在后续帧中自然渐入。这消除了旧代码中 reset
+                  // _smoothAnchorElapsedUs 导致的周期性"抽帧"现象。
+                  final correctionMs = drift * 0.05;
+                  _smoothAnchorMs = smoothMs - correctionMs;
+                  // 锚点时间调整：锚点位置被修正了 correctionMs，
+                  // 锚点时间需设置为 currentElapsedUs - correctionMs*1000/rate，
+                  // 使得当前帧输出 = smoothMs（保持连续性），
+                  // 下一帧的插值从修正后的锚点自然推进。
+                  _smoothAnchorElapsedUs =
+                      currentElapsedUs - (correctionMs * 1000.0 / _playbackRate).round();
                 }
-                _smoothAnchorElapsedUs = currentElapsedUs;
                 _lastRawPlayerMs = playerPosition;
                 final newDeltaUs = currentElapsedUs - _smoothAnchorElapsedUs;
                 _playbackTimeMs.value = (_smoothAnchorMs + newDeltaUs / 1000.0 * _playbackRate)

--- a/rust/src/dfm_core/retainer.rs
+++ b/rust/src/dfm_core/retainer.rs
@@ -223,10 +223,30 @@ impl DanmakuRetainer {
 
 /// Select a track for a scroll danmaku.
 /// Returns (track_index, displaced_indices) or None if the item should be dropped.
-/// When all tracks collide, uses DFM's overwriteInsert strategy: pick the track
-/// whose items have the smallest right edge (furthest left), clear it, and place
-/// the new danmaku there. Returns indices of all cleared entries so the caller
-/// can mark them as filtered.
+///
+/// Track selection uses a two-phase strategy to implement overwriteInsert:
+///
+/// **Phase 1 — Stable zone** (upper 40% of tracks):
+///   Place danmaku in the first empty or non-colliding track in the top 40%.
+///   These tracks are NEVER overwritten, ensuring visual stability for the
+///   upper portion of the screen even under extreme density.
+///
+/// **Phase 2 — Overflow zone** (bottom 60% of tracks):
+///   When the stable zone is completely full (all tracks collide), overflow
+///   danmaku into the lower 60%. Within this zone, placement works the same
+///   way (empty track → non-colliding track), but also tracks the best
+///   overwrite candidate (track with minimum right edge — the danmaku furthest
+///   along its scroll path).
+///
+/// **Phase 3 — Overwrite** (all tracks full):
+///   Clear the best candidate track in the overflow zone and place the new
+///   danmaku there. The displaced (cleared) danmaku items are returned as
+///   indices so the caller can mark them filtered.
+///
+/// **Special: is_me** — user's own danmaku always forces placement on track 0.
+///
+/// Ported from DanmakuFlameMaster's DanmakusRetainer with the top-40%-stable
+/// extension to match Bilibili's overwriteInsert visual behavior.
 fn select_scroll_track(
     new_entry: &TrackEntry,
     track_data: &mut TrackData,
@@ -244,7 +264,30 @@ fn select_scroll_track(
     let mut best_track = overwrite_start;
     let mut min_right_edge = f32::MAX;
 
-    for i in 0..track_count {
+    // Phase 1: Place in stable zone (upper 40% of tracks)
+    // These tracks are never overwritten — danmaku here stay until they
+    // naturally exit the screen, providing visual stability.
+    for i in 0..overwrite_start {
+        if track_data.tracks[i].is_empty() {
+            track_data.tracks[i].push(new_entry.clone());
+            return Some((i, SmallVec::new()));
+        }
+        let mut collides = false;
+        for existing in &track_data.tracks[i] {
+            if scroll_entries_collide(new_entry, existing, view_width) {
+                collides = true;
+                break;
+            }
+        }
+        if !collides {
+            track_data.tracks[i].push(new_entry.clone());
+            return Some((i, SmallVec::new()));
+        }
+    }
+
+    // Phase 2: Stable zone full — overflow to sacrifice zone (bottom 60%)
+    // These tracks can be overwritten when capacity is exhausted.
+    for i in overwrite_start..track_count {
         if track_data.tracks[i].is_empty() {
             track_data.tracks[i].push(new_entry.clone());
             return Some((i, SmallVec::new()));
@@ -264,12 +307,16 @@ fn select_scroll_track(
             track_data.tracks[i].push(new_entry.clone());
             return Some((i, SmallVec::new()));
         }
-        if i >= overwrite_start && track_min_right < min_right_edge {
+        // Track best overwrite candidate in this zone
+        if track_min_right < min_right_edge {
             min_right_edge = track_min_right;
             best_track = i;
         }
     }
 
+    // Phase 3: All tracks collide — overwrite the best candidate in sacrifice zone.
+    // The overwrite picks the track whose danmaku has the smallest right edge
+    // (closest to exiting the screen), minimizing visual disruption.
     if is_me && track_count > 0 {
         let displaced: DisplacedIndices = track_data.tracks[0]
             .iter()
@@ -1080,6 +1127,123 @@ mod tests {
         assert!(
             scroll_entries_collide(&d1_fast, &d2_slow, 1920.0),
             "long fast danmaku should collide with short slow danmaku"
+        );
+    }
+
+    #[test]
+    fn test_overwrite_insert_overflow_to_lower_60_percent() {
+        // Verifies that when the upper 40% of tracks (stable zone) is full,
+        // danmaku overflow into the lower 60% (overflow zone), creating the
+        // expected visual pattern: stable upper region, dynamic lower region.
+        let flags = GlobalFlags::default();
+        // track_height = 30 + 30*0.5 = 45, effective_height = 1080 * 0.75 = 810
+        // track_count = floor(810 / 45) = 18
+        let mut retainer = DanmakuRetainer::new(2.0, 0.5);
+        let view_width = 1920.0f32;
+        let view_height = 1080.0f32;
+        let display_area = 1.0f32;
+
+        // Generate many same-time danmaku to force overflow
+        let mut items: Vec<DanmakuItem> = (0..30)
+            .map(|i| {
+                let mut item = make_scroll_item(
+                    0,
+                    &format!("dm{}", i),
+                    150.0,
+                    DanmakuType::ScrollRL,
+                    5000,
+                    view_width,
+                );
+                item.index = i;
+                item
+            })
+            .collect();
+
+        // Place all items through the retainer, collecting displaced indices
+        // to apply filtering afterwards (avoids borrow conflicts).
+        let mut displaced_all: Vec<usize> = Vec::new();
+        for item in &mut items {
+            let (placed, displaced) = retainer.fix(item, view_width, view_height, &flags, display_area, false);
+            if !placed {
+                item.is_filtered = true;
+                item.filter_param = 99;
+            }
+            displaced_all.extend(displaced.iter().copied());
+        }
+        for &displaced_idx in &displaced_all {
+            if displaced_idx < items.len() {
+                items[displaced_idx].is_filtered = true;
+                items[displaced_idx].filter_param = 99;
+            }
+        }
+
+        // Collect Y positions of non-filtered (visible) items
+        let visible: Vec<(&str, f32)> = items
+            .iter()
+            .filter(|i| !i.is_filtered)
+            .map(|i| (i.text.as_str(), i.y))
+            .collect();
+
+        eprintln!("Visible {} items out of {}", visible.len(), items.len());
+        for (text, y) in &visible {
+            eprintln!("  {}: y={}", text, y);
+        }
+
+        // Compute track properties for assertions
+        let track_height = 30.0 + 30.0 * 0.5; // 45.0
+        let effective_height = view_height * display_area.min(0.75); // 810.0
+        let track_count = (effective_height / track_height).floor() as usize; // 18
+        let overwrite_count = ((track_count as f32 * 0.6).ceil() as usize)
+            .max(1)
+            .min(track_count);
+        let overwrite_start = track_count - overwrite_count;
+        let stable_zone_max_y = 2.0 + (overwrite_start - 1) as f32 * track_height;
+        let overflow_zone_min_y = 2.0 + overwrite_start as f32 * track_height;
+
+        eprintln!(
+            "track_count={}, overwrite_start={}, overwrite_count={}, stable_max_y={:.0}, overflow_min_y={:.0}",
+            track_count, overwrite_start, overwrite_count, stable_zone_max_y, overflow_zone_min_y
+        );
+
+        // Verify overflow: at least one VISIBLE item should be placed in the overflow zone
+        // (y >= overflow_zone_min_y). This is the key behavior the fix enables:
+        // when the stable zone is full, danmaku must appear in the lower 60%.
+        let overflow_visible: Vec<_> = visible
+            .iter()
+            .filter(|(_, y)| *y >= overflow_zone_min_y)
+            .collect();
+
+        assert!(
+            !overflow_visible.is_empty(),
+            "Expected danmaku in overflow zone (y >= {:.0}), but all {} visible items are in stable zone only. \
+             This means the overwriteInsert overflow mechanism is not working correctly.",
+            overflow_zone_min_y,
+            visible.len(),
+        );
+
+        eprintln!(
+            "Overflow zone contains {} visible items (expected > 0)",
+            overflow_visible.len()
+        );
+
+        // Verify the stable zone still has items (protected from overwrite)
+        let stable_visible: Vec<_> = visible
+            .iter()
+            .filter(|(_, y)| *y <= stable_zone_max_y)
+            .collect();
+        eprintln!("Stable zone contains {} visible items", stable_visible.len());
+        assert!(
+            !stable_visible.is_empty(),
+            "Stable zone should also contain items"
+        );
+
+        // Verify no more items than tracks can be simultaneously visible
+        // (each track can host at most one visible item at a time with all-same-time danmaku)
+        assert!(
+            visible.len() <= track_count,
+            "Expected at most {} visible items (one per track), got {}",
+            track_count,
+            visible.len()
         );
     }
 }


### PR DESCRIPTION
## Summary

- 优化了DFM+引擎的overwriteinsert机制，修复了滚动弹幕始终在画面上40%，溢出和覆写策略无效的问题
- 弹幕超采样现在在全平台可手动开启或关闭（位于 设置- 弹幕 ，原先启用的平台默认开启）
- 进一步细化弹幕时间戳精度，大幅缓解弹幕抽帧问题
- 修复了 CupertinoUI 番剧评论页越往下滑越卡的问题
- 修复了 UI 交互导致的偶发 DFM+ 弹幕闪烁问题
