### PR TITLE
Fix/danmaku load fail

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,10 +56,10 @@ android {
             }
         }
         
-        // ──── cpp_native: C++ → Dart FFI ────
-        ndk {
-            abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86_64'
-        }
+        // 注释掉 ndk abiFilters，避免与 Flutter splits 配置冲突
+        // ndk {
+        //     abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86_64'
+        // }
 
         // CMake arguments/flags (path and version are set in android.externalNativeBuild below)
         externalNativeBuild {
@@ -69,9 +69,6 @@ android {
                 cppFlags "-std=c++20", "-fno-rtti", "-fvisibility=hidden"
             }
         }
-        
-        // 支持ARM和x86架构（包括模拟器）
-        // 注释掉 ndk abiFilters，避免与 splits 配置冲突
     }
 
     buildTypes {

--- a/lib/services/dandanplay_service_io.dart
+++ b/lib/services/dandanplay_service_io.dart
@@ -35,7 +35,7 @@ class DandanplayService {
   ];
   static const String _danmakuProxyEndpoint =
       'https://nipaplay.aimes-soft.com/danmaku_proxy.php';
-  static const Duration _danmakuRequestTimeout = Duration(seconds: 10);
+  static const Duration _danmakuRequestTimeout = Duration(seconds: 5);
   static const int _danmakuRequestMaxAttempts = 2;
   static const Duration _danmakuRetryDelay = Duration(milliseconds: 600);
   static bool get isLoggedIn => _isLoggedIn;

--- a/lib/services/dandanplay_service_io.dart
+++ b/lib/services/dandanplay_service_io.dart
@@ -1368,49 +1368,39 @@ class DandanplayService {
 
       // 获取当前配置的服务器
       final currentServer = await getApiBaseUrl();
-      final isPrimaryServer = currentServer == NetworkSettings.primaryServer;
-      final isBackupServer = currentServer == NetworkSettings.backupServer;
+      final isCustomServer = currentServer != NetworkSettings.primaryServer &&
+          currentServer != NetworkSettings.backupServer;
 
-      try {
-        return await _fetchDanmakuFromServer(episodeId, animeId, currentServer);
-      } catch (e) {
-        debugPrint('从当前服务器($currentServer)获取弹幕失败: $e');
-
-        // 统一回退链：主服务器 → 备用服务器 → 代理
-        if (isPrimaryServer) {
-          // 主服务器失败，尝试备用服务器
-          debugPrint('尝试回退到备用服务器获取弹幕...');
-          try {
-            return await _fetchDanmakuFromServer(
-              episodeId,
-              animeId,
-              NetworkSettings.backupServer,
-            );
-          } catch (backupError) {
-            debugPrint('从备用服务器获取弹幕也失败: $backupError');
-          }
-        } else if (isBackupServer) {
-          // 备用服务器失败，回退到主服务器
-          debugPrint('尝试回退到主服务器获取弹幕...');
-          try {
-            return await _fetchDanmakuFromServer(
-              episodeId,
-              animeId,
-              NetworkSettings.primaryServer,
-            );
-          } catch (fallbackError) {
-            debugPrint('从主服务器获取弹幕也失败: $fallbackError');
-          }
-        }
-
-        // 最后兜底：nipaplay 代理
-        debugPrint('尝试通过 nipaplay.aimes-soft.com 代理服务器获取弹幕...');
+      if (isCustomServer) {
+        // 第一层：用户自定义服务器
         try {
-          return await _fetchDanmakuViaProxy(episodeId, animeId);
-        } catch (proxyError) {
-          debugPrint('通过代理服务器获取弹幕失败: $proxyError');
-          throw Exception('所有服务器均无法获取弹幕，请稍后再试。（$proxyError）');
+          return await _fetchDanmakuFromServer(episodeId, animeId, currentServer);
+        } catch (e) {
+          debugPrint('从自定义服务器($currentServer)获取弹幕失败: $e');
         }
+      }
+
+      // 第二层：主副服务器并发竞速，谁先返回用谁
+      debugPrint('尝试主副服务器并发竞速获取弹幕...');
+      try {
+        final result = await Future.any([
+          _fetchDanmakuFromServer(
+              episodeId, animeId, NetworkSettings.primaryServer),
+          _fetchDanmakuFromServer(
+              episodeId, animeId, NetworkSettings.backupServer),
+        ]);
+        return result;
+      } catch (raceError) {
+        debugPrint('主副服务器竞速全部失败: $raceError');
+      }
+
+      // 第三层：nipaplay 代理兜底
+      debugPrint('尝试通过 nipaplay.aimes-soft.com 代理服务器获取弹幕...');
+      try {
+        return await _fetchDanmakuViaProxy(episodeId, animeId);
+      } catch (proxyError) {
+        debugPrint('通过代理服务器获取弹幕失败: $proxyError');
+        throw Exception('所有服务器均无法获取弹幕，请稍后再试。（$proxyError）');
       }
     } catch (e) {
       ////debugPrint('获取弹幕时出错: $e');

--- a/lib/services/dandanplay_service_io.dart
+++ b/lib/services/dandanplay_service_io.dart
@@ -35,7 +35,7 @@ class DandanplayService {
   ];
   static const String _danmakuProxyEndpoint =
       'https://nipaplay.aimes-soft.com/danmaku_proxy.php';
-  static const Duration _danmakuRequestTimeout = Duration(seconds: 5);
+  static const Duration _danmakuRequestTimeout = Duration(seconds: 10);
   static const int _danmakuRequestMaxAttempts = 2;
   static const Duration _danmakuRetryDelay = Duration(milliseconds: 600);
   static bool get isLoggedIn => _isLoggedIn;
@@ -1376,17 +1376,21 @@ class DandanplayService {
       } catch (e) {
         debugPrint('从当前服务器($currentServer)获取弹幕失败: $e');
 
+        // 统一回退链：主服务器 → 备用服务器 → 代理
         if (isPrimaryServer) {
-          debugPrint('尝试通过 nipaplay.aimes-soft.com 代理服务器获取弹幕...');
+          // 主服务器失败，尝试备用服务器
+          debugPrint('尝试回退到备用服务器获取弹幕...');
           try {
-            return await _fetchDanmakuViaProxy(episodeId, animeId);
-          } catch (proxyError) {
-            debugPrint('通过代理服务器获取弹幕失败: $proxyError');
-            throw Exception('主服务器与代理服务器均无法获取弹幕，请稍后再试。（$proxyError）');
+            return await _fetchDanmakuFromServer(
+              episodeId,
+              animeId,
+              NetworkSettings.backupServer,
+            );
+          } catch (backupError) {
+            debugPrint('从备用服务器获取弹幕也失败: $backupError');
           }
-        }
-
-        if (isBackupServer) {
+        } else if (isBackupServer) {
+          // 备用服务器失败，回退到主服务器
           debugPrint('尝试回退到主服务器获取弹幕...');
           try {
             return await _fetchDanmakuFromServer(
@@ -1396,17 +1400,17 @@ class DandanplayService {
             );
           } catch (fallbackError) {
             debugPrint('从主服务器获取弹幕也失败: $fallbackError');
-            debugPrint('尝试通过 nipaplay.aimes-soft.com 代理服务器获取弹幕...');
-            try {
-              return await _fetchDanmakuViaProxy(episodeId, animeId);
-            } catch (proxyError) {
-              debugPrint('通过代理服务器获取弹幕失败: $proxyError');
-              throw Exception('备用服务器、主服务器与代理服务器均无法获取弹幕，请检查网络连接。（$proxyError）');
-            }
           }
         }
 
-        rethrow;
+        // 最后兜底：nipaplay 代理
+        debugPrint('尝试通过 nipaplay.aimes-soft.com 代理服务器获取弹幕...');
+        try {
+          return await _fetchDanmakuViaProxy(episodeId, animeId);
+        } catch (proxyError) {
+          debugPrint('通过代理服务器获取弹幕失败: $proxyError');
+          throw Exception('所有服务器均无法获取弹幕，请稍后再试。（$proxyError）');
+        }
       }
     } catch (e) {
       ////debugPrint('获取弹幕时出错: $e');
@@ -1429,9 +1433,10 @@ class DandanplayService {
 
   static Future<http.Response> _getDanmakuResponseWithRetry(
     Uri uri,
-    Map<String, String> headers,
-  ) async {
-    for (var attempt = 1; attempt <= _danmakuRequestMaxAttempts; attempt++) {
+    Map<String, String> headers, {
+    int maxAttempts = _danmakuRequestMaxAttempts,
+  }) async {
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
         return await http
             .get(uri, headers: headers)
@@ -1439,12 +1444,12 @@ class DandanplayService {
       } catch (e, st) {
         final shouldRetry =
             _shouldRetryDanmakuRequest(e) &&
-            attempt < _danmakuRequestMaxAttempts;
+            attempt < maxAttempts;
         if (!shouldRetry) {
           Error.throwWithStackTrace(e, st);
         }
         final nextAttempt = attempt + 1;
-        debugPrint('弹幕请求失败，准备重试($nextAttempt/$_danmakuRequestMaxAttempts): $e');
+        debugPrint('弹幕请求失败，准备重试($nextAttempt/$maxAttempts): $e');
         await Future.delayed(
           Duration(milliseconds: _danmakuRetryDelay.inMilliseconds * attempt),
         );
@@ -1471,14 +1476,18 @@ class DandanplayService {
     debugPrint('发送弹幕请求到: $apiUrl');
     ////debugPrint('请求头: X-AppId: $appId, X-Timestamp: $timestamp, 是否包含token: ${_token != null}');
 
-    final response = await _getDanmakuResponseWithRetry(Uri.parse(apiUrl), {
-      'Accept': 'application/json',
-      'User-Agent': userAgent,
-      'X-AppId': appId,
-      'X-Signature': generateSignature(appId, timestamp, apiPath, appSecret),
-      'X-Timestamp': '$timestamp',
-      if (_token != null) 'Authorization': 'Bearer $_token',
-    });
+    final response = await _getDanmakuResponseWithRetry(
+      Uri.parse(apiUrl),
+      {
+        'Accept': 'application/json',
+        'User-Agent': userAgent,
+        'X-AppId': appId,
+        'X-Signature': generateSignature(appId, timestamp, apiPath, appSecret),
+        'X-Timestamp': '$timestamp',
+        if (_token != null) 'Authorization': 'Bearer $_token',
+      },
+      maxAttempts: 1,
+    );
 
     return _handleDanmakuResponse(response, episodeId, animeId);
   }

--- a/lib/services/dandanplay_service_io.dart
+++ b/lib/services/dandanplay_service_io.dart
@@ -1380,15 +1380,35 @@ class DandanplayService {
         }
       }
 
-      // 第二层：主副服务器并发竞速，谁先返回用谁
+      // 第二层：主副服务器并发竞速，只取第一个成功的，忽略错误
       debugPrint('尝试主副服务器并发竞速获取弹幕...');
+      final completer = Completer<Map<String, dynamic>>();
+      final servers = <String, String>{
+        NetworkSettings.primaryServer: '主服务器',
+        NetworkSettings.backupServer: '备用服务器',
+      };
+      var remaining = servers.length;
+
+      for (final entry in servers.entries) {
+        _fetchDanmakuFromServer(episodeId, animeId, entry.key).then((result) {
+          if (!completer.isCompleted) {
+            debugPrint('竞速成功: ${entry.value}(${entry.key}) 先返回');
+            completer.complete(result);
+          }
+        }).catchError((e) {
+          debugPrint('竞速: ${entry.value}(${entry.key}) 失败: $e');
+          remaining--;
+          if (remaining == 0 && !completer.isCompleted) {
+            completer.completeError(Exception('主副服务器竞速全部失败'));
+          }
+        });
+      }
+
       try {
-        final result = await Future.any([
-          _fetchDanmakuFromServer(
-              episodeId, animeId, NetworkSettings.primaryServer),
-          _fetchDanmakuFromServer(
-              episodeId, animeId, NetworkSettings.backupServer),
-        ]);
+        final result = await completer.future.timeout(
+          const Duration(seconds: 10),
+          onTimeout: () => throw TimeoutException('主副服务器竞速超时'),
+        );
         return result;
       } catch (raceError) {
         debugPrint('主副服务器竞速全部失败: $raceError');
@@ -1487,14 +1507,14 @@ class DandanplayService {
     String episodeId,
     int animeId,
   ) {
-    ////debugPrint('弹幕API响应: 状态码=${response.statusCode}, 内容长度=${response.body.length}');
+    debugPrint('弹幕API响应: 状态码=${response.statusCode}, 内容长度=${response.body.length}');
 
     if (response.statusCode == 200) {
       return _parseDanmakuBody(response.body, episodeId, animeId);
     }
 
     final errorMessage = response.headers['x-error-message'] ?? '请检查网络连接';
-    ////debugPrint('获取弹幕失败: 状态码=${response.statusCode}, 错误信息=$errorMessage');
+    debugPrint('获取弹幕失败: 状态码=${response.statusCode}, 错误信息=$errorMessage');
     throw Exception('获取弹幕失败: $errorMessage');
   }
 

--- a/lib/utils/video_player_state/video_player_state_danmaku.dart
+++ b/lib/utils/video_player_state/video_player_state_danmaku.dart
@@ -313,7 +313,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
       }
 
       final danmakuData = await DandanplayService.getDanmaku(episodeId, animeId)
-          .timeout(const Duration(seconds: 15), onTimeout: () {
+          .timeout(const Duration(seconds: 22), onTimeout: () {
         throw TimeoutException('加载弹幕超时');
       });
       if (!canContinue()) return;

--- a/lib/utils/video_player_state/video_player_state_danmaku.dart
+++ b/lib/utils/video_player_state/video_player_state_danmaku.dart
@@ -313,7 +313,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
       }
 
       final danmakuData = await DandanplayService.getDanmaku(episodeId, animeId)
-          .timeout(const Duration(seconds: 22), onTimeout: () {
+          .timeout(const Duration(seconds: 32), onTimeout: () {
         throw TimeoutException('加载弹幕超时');
       });
       if (!canContinue()) return;

--- a/lib/utils/video_player_state/video_player_state_metadata.dart
+++ b/lib/utils/video_player_state/video_player_state_metadata.dart
@@ -198,7 +198,7 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
                 // 从网络加载弹幕
                 final danmakuData =
                     await DandanplayService.getDanmaku(episodeId, animeId)
-                        .timeout(const Duration(seconds: 22), onTimeout: () {
+                        .timeout(const Duration(seconds: 32), onTimeout: () {
                   //debugPrint('加载弹幕超时');
                   throw TimeoutException('加载弹幕超时');
                 });

--- a/lib/utils/video_player_state/video_player_state_metadata.dart
+++ b/lib/utils/video_player_state/video_player_state_metadata.dart
@@ -198,7 +198,7 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
                 // 从网络加载弹幕
                 final danmakuData =
                     await DandanplayService.getDanmaku(episodeId, animeId)
-                        .timeout(const Duration(seconds: 15), onTimeout: () {
+                        .timeout(const Duration(seconds: 22), onTimeout: () {
                   //debugPrint('加载弹幕超时');
                   throw TimeoutException('加载弹幕超时');
                 });


### PR DESCRIPTION
## Summary

- 修复了因两次 弹弹play请 求和一次 nipaplay 代理的时序问题导致的播放后没有弹幕的问题
当前弹幕加载策略： 缓存命中0s → 用户自定义服务器 10s（没有则跳过） → 主服务器和备用服务器(139.224.252.88)并发竞速 10s → 代理(nipaplay.aimes-soft.com)10.6s
外层timeout：32s

## Bug Analysis

问题：弹幕三次兜底请求（dandanplay → dandanplay retry → nipaplay proxy）的总耗时超过 loadDanmaku 的 15s 外层超时，导致第三次 nipaplay 代理请求虽然成功（日志 13:24:18 返回 10559 条），但弹幕轨道已经在 13:24:12 以 0 条初始化完毕，视频在 13:24:13 开始播放，弹幕无法载入轨道。
