### PR TITLE
[codex] Improve downloader task UI and magnet preview flow

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -32,6 +32,12 @@ class SettingsKeys {
 
   static const String torrentDownloadDirectory = 'torrent_download_directory';
 
+  static const String torrentRecentDownloadDirectories =
+      'torrent_recent_download_directories';
+
+  static const String torrentRecentDownloadDirectoriesMigrated =
+      'torrent_recent_download_directories_migrated';
+
   static const String downloaderEnabled = 'downloader_enabled';
 
   static const String downloaderCreateFolderForTask =

--- a/lib/models/torrent_magnet_preview.dart
+++ b/lib/models/torrent_magnet_preview.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+
+import 'package:path/path.dart' as p;
+
+class TorrentMagnetPreviewFile {
+  const TorrentMagnetPreviewFile({
+    required this.index,
+    required this.path,
+    required this.length,
+  });
+
+  final int index;
+  final String path;
+  final int length;
+
+  String get name => p.basename(path);
+
+  factory TorrentMagnetPreviewFile.fromMap(Map<String, dynamic> map) {
+    return TorrentMagnetPreviewFile(
+      index: _asInt(map['index']),
+      path: _asString(map['path'], fallback: '未命名文件'),
+      length: _asInt(map['length']),
+    );
+  }
+}
+
+class TorrentMagnetPreview {
+  const TorrentMagnetPreview({
+    required this.name,
+    required this.suggestedFolderName,
+    required this.totalSize,
+    required this.files,
+  });
+
+  final String name;
+  final String suggestedFolderName;
+  final int totalSize;
+  final List<TorrentMagnetPreviewFile> files;
+
+  factory TorrentMagnetPreview.fromJson(String jsonText) {
+    final decoded = jsonDecode(jsonText);
+    if (decoded is! Map<String, dynamic>) {
+      return const TorrentMagnetPreview(
+        name: '未命名任务',
+        suggestedFolderName: '',
+        totalSize: 0,
+        files: <TorrentMagnetPreviewFile>[],
+      );
+    }
+
+    final rawFiles = decoded['files'];
+    return TorrentMagnetPreview(
+      name: _asString(decoded['name'], fallback: '未命名任务'),
+      suggestedFolderName: _asString(decoded['suggested_folder_name']),
+      totalSize: _asInt(decoded['total_size']),
+      files: rawFiles is List
+          ? rawFiles
+              .whereType<Map<String, dynamic>>()
+              .map(TorrentMagnetPreviewFile.fromMap)
+              .toList(growable: false)
+          : const <TorrentMagnetPreviewFile>[],
+    );
+  }
+}
+
+int _asInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value) ?? 0;
+  return 0;
+}
+
+String _asString(Object? value, {String fallback = ''}) {
+  final text = value?.toString().trim() ?? '';
+  return text.isEmpty ? fallback : text;
+}

--- a/lib/models/torrent_task_scan_summary.dart
+++ b/lib/models/torrent_task_scan_summary.dart
@@ -1,0 +1,64 @@
+import 'package:nipaplay/models/watch_history_model.dart';
+import 'package:path/path.dart' as p;
+
+class TorrentTaskScanSummary {
+  const TorrentTaskScanSummary({
+    required this.itemCount,
+    required this.labels,
+  });
+
+  final int itemCount;
+  final List<String> labels;
+
+  bool get hasItems => itemCount > 0;
+
+  String get displayText {
+    if (!hasItems) return '未匹配到番剧信息';
+    if (labels.isEmpty) return '';
+    final suffix = itemCount > labels.length ? ' 等' : '';
+    return '${labels.join('、')}$suffix';
+  }
+
+  factory TorrentTaskScanSummary.fromHistoryItems(
+    Iterable<WatchHistoryItem> items,
+  ) {
+    final matchedItems = items
+        .where(
+          _hasScanInfo,
+        )
+        .toList(growable: false);
+    final labels = <String>[];
+    final seen = <String>{};
+
+    for (final item in matchedItems) {
+      final label = _formatLabel(item);
+      if (label.isEmpty || !seen.add(label)) continue;
+      labels.add(label);
+      if (labels.length >= 3) break;
+    }
+
+    return TorrentTaskScanSummary(
+      itemCount: matchedItems.length,
+      labels: labels,
+    );
+  }
+
+  static String _formatLabel(WatchHistoryItem item) {
+    final animeName = item.animeName.trim();
+    final episodeTitle = item.episodeTitle?.trim() ?? '';
+    if (animeName.isEmpty) return episodeTitle;
+    if (episodeTitle.isEmpty) return animeName;
+    return '$animeName - $episodeTitle';
+  }
+
+  static bool _hasScanInfo(WatchHistoryItem item) {
+    final animeName = item.animeName.trim();
+    final fileName = p.basename(item.filePath).trim();
+    final baseName = p.basenameWithoutExtension(item.filePath).trim();
+    return item.animeId != null ||
+        item.episodeId != null ||
+        (animeName.isNotEmpty &&
+            animeName != fileName &&
+            animeName != baseName);
+  }
+}

--- a/lib/pages/torrent_download_page.dart
+++ b/lib/pages/torrent_download_page.dart
@@ -3,8 +3,10 @@ import 'dart:async';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/models/torrent_magnet_preview.dart';
 import 'package:nipaplay/models/torrent_task.dart';
 import 'package:nipaplay/models/playable_item.dart';
+import 'package:nipaplay/models/torrent_task_scan_summary.dart';
 import 'package:nipaplay/providers/downloader_settings_provider.dart';
 import 'package:nipaplay/providers/service_provider.dart';
 import 'package:nipaplay/services/file_picker_service.dart';
@@ -12,13 +14,27 @@ import 'package:nipaplay/services/folder_opener.dart';
 import 'package:nipaplay/services/playback_service.dart';
 import 'package:nipaplay/services/torrent_download_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/fluent_settings_switch.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/library_management_layout.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:nipaplay/utils/app_theme.dart';
 import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
+
+enum _TorrentTaskViewMode { cards, list }
+
+enum _TorrentTaskSort { latest, name, progress, status }
+
+const Map<_TorrentTaskSort, String> _torrentTaskSortLabels = {
+  _TorrentTaskSort.latest: '最近添加',
+  _TorrentTaskSort.name: '名称排序',
+  _TorrentTaskSort.progress: '进度排序',
+  _TorrentTaskSort.status: '状态排序',
+};
 
 class TorrentDownloadPage extends StatefulWidget {
   const TorrentDownloadPage({super.key});
@@ -30,16 +46,23 @@ class TorrentDownloadPage extends StatefulWidget {
 class _TorrentDownloadPageState extends State<TorrentDownloadPage>
     with WidgetsBindingObserver {
   final TorrentDownloadService _service = TorrentDownloadService.instance;
-  final TextEditingController _magnetController = TextEditingController();
+  final TextEditingController _searchController = TextEditingController();
+  final GlobalKey _sortDropdownKey = GlobalKey();
   Timer? _refreshTimer;
   List<TorrentTask> _tasks = const <TorrentTask>[];
   final Set<String> _autoScannedCompletedTaskKeys = <String>{};
   final Set<String> _autoScanningTaskKeys = <String>{};
   Future<void> _autoScanChain = Future<void>.value();
+  final Map<String, TorrentTaskScanSummary> _scanSummaries =
+      <String, TorrentTaskScanSummary>{};
+  final Set<String> _scanSummaryCheckedKeys = <String>{};
   String _downloadDirectory = '';
   bool _isLoading = true;
   bool _isBusy = false;
   bool _autoScanRegistryLoaded = false;
+  _TorrentTaskViewMode _viewMode = _TorrentTaskViewMode.cards;
+  _TorrentTaskSort _sort = _TorrentTaskSort.latest;
+  String _searchQuery = '';
 
   @override
   void initState() {
@@ -53,7 +76,7 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
   void dispose() {
     _refreshTimer?.cancel();
     WidgetsBinding.instance.removeObserver(this);
-    _magnetController.dispose();
+    _searchController.dispose();
     super.dispose();
   }
 
@@ -86,6 +109,7 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
         _tasks = tasks;
         _isLoading = false;
       });
+      unawaited(_loadScanSummariesForTasks(tasks));
       unawaited(_handleAutoScanCompletedTasks(tasks, silent: true));
     } catch (e) {
       if (!mounted) return;
@@ -104,6 +128,7 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
       setState(() {
         _tasks = tasks;
       });
+      unawaited(_loadScanSummariesForTasks(tasks));
       unawaited(_handleAutoScanCompletedTasks(tasks, silent: silent));
     } catch (e) {
       if (!mounted || silent) return;
@@ -111,45 +136,93 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
     }
   }
 
-  Future<void> _chooseDownloadDirectory() async {
-    final selected = await FilePickerService().pickDirectory(
-      initialDirectory: _downloadDirectory.isEmpty ? null : _downloadDirectory,
+  Future<void> _showAddMagnetDialog() async {
+    final downloaderSettings = context.read<DownloaderSettingsProvider>();
+    final initialDirectory = _downloadDirectory.isEmpty
+        ? await _service.getDownloadDirectory()
+        : _downloadDirectory;
+    final recentDirectories = await _service.loadRecentDownloadDirectories();
+    if (!mounted) return;
+    final result = await NipaplayWindow.show<_AddMagnetDialogResult>(
+      context: context,
+      barrierDismissible: false,
+      child: _AddMagnetDialog(
+        service: _service,
+        initialDirectory: initialDirectory,
+        initialRecentDirectories: recentDirectories,
+        initialCreateFolderForTask: downloaderSettings.createFolderForTask,
+      ),
     );
-    if (selected == null || selected.trim().isEmpty) return;
-
-    try {
-      await _service.setDownloadDirectory(selected);
-      final tasks = await _service.listTasks();
-      if (!mounted) return;
-      setState(() {
-        _downloadDirectory = selected;
-        _tasks = tasks;
-      });
-      BlurSnackBar.show(context, '默认下载位置已更新');
-    } catch (e) {
-      if (!mounted) return;
-      BlurSnackBar.show(context, '更新下载位置失败: $e');
-    }
-  }
-
-  Future<void> _addMagnet() async {
-    final magnet = _magnetController.text.trim();
-    if (magnet.isEmpty) {
-      BlurSnackBar.show(context, '请输入 magnet 链接');
-      return;
-    }
-    if (!magnet.startsWith('magnet:')) {
-      BlurSnackBar.show(context, '链接格式不是有效的 magnet 地址');
-      return;
-    }
+    if (result == null) return;
 
     await _runBusyAction(
-      action: () => _service.addMagnet(magnet),
+      action: () async {
+        await _service.setDownloadDirectory(result.downloadDirectory);
+        if (downloaderSettings.createFolderForTask !=
+            result.createFolderForTask) {
+          await downloaderSettings.setCreateFolderForTask(
+            result.createFolderForTask,
+          );
+        }
+        await _service.addMagnet(
+          result.magnetUri,
+          downloadDirectory: result.downloadDirectory,
+          createFolderForTask: result.createFolderForTask,
+        );
+      },
       successMessage: '已添加下载任务',
       afterSuccess: () {
-        _magnetController.clear();
+        if (mounted) {
+          setState(() {
+            _downloadDirectory = result.downloadDirectory;
+          });
+        }
       },
     );
+  }
+
+  void _updateSearchQuery(String value) {
+    setState(() {
+      _searchQuery = value.trim();
+    });
+  }
+
+  void _applySort(_TorrentTaskSort sort) {
+    if (_sort == sort) return;
+    setState(() {
+      _sort = sort;
+    });
+  }
+
+  List<TorrentTask> get _visibleTasks {
+    final query = _searchQuery.toLowerCase();
+    final filtered = query.isEmpty
+        ? List<TorrentTask>.from(_tasks)
+        : _tasks.where((task) {
+            final scanText =
+                _scanSummaries[task.autoScanKey]?.displayText ?? '';
+            final haystack = [
+              task.name,
+              task.outputFolder,
+              task.displayState,
+              scanText,
+            ].join('\n').toLowerCase();
+            return haystack.contains(query);
+          }).toList();
+
+    filtered.sort((a, b) {
+      switch (_sort) {
+        case _TorrentTaskSort.latest:
+          return b.id.compareTo(a.id);
+        case _TorrentTaskSort.name:
+          return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+        case _TorrentTaskSort.progress:
+          return b.progress.compareTo(a.progress);
+        case _TorrentTaskSort.status:
+          return a.displayState.compareTo(b.displayState);
+      }
+    });
+    return filtered;
   }
 
   Future<void> _pickTorrentFile() async {
@@ -249,13 +322,65 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
     }
   }
 
+  void _toggleViewMode() {
+    setState(() {
+      _viewMode = _viewMode == _TorrentTaskViewMode.cards
+          ? _TorrentTaskViewMode.list
+          : _TorrentTaskViewMode.cards;
+    });
+  }
+
   Future<void> _loadAutoScanRegistry() async {
     if (_autoScanRegistryLoaded) return;
     final keys = await _service.loadAutoScannedCompletedTaskKeys();
     _autoScannedCompletedTaskKeys
       ..clear()
       ..addAll(keys);
+    for (final key in keys) {
+      _scanSummaryCheckedKeys.remove(key);
+    }
     _autoScanRegistryLoaded = true;
+  }
+
+  Future<void> _loadScanSummariesForTasks(
+    List<TorrentTask> tasks, {
+    bool force = false,
+  }) async {
+    final targets = tasks.where((task) {
+      if (!task.finished || task.outputFolder.trim().isEmpty) return false;
+      return force || !_scanSummaryCheckedKeys.contains(task.autoScanKey);
+    }).toList(growable: false);
+    if (targets.isEmpty) return;
+
+    final summaries = <String, TorrentTaskScanSummary>{};
+    for (final task in targets) {
+      final summary = await _loadScanSummary(task);
+      if (summary != null) {
+        summaries[task.autoScanKey] = summary;
+      }
+    }
+    if (!mounted) return;
+
+    final activeKeys = tasks.map((task) => task.autoScanKey).toSet();
+    final checkedKeys = targets.map((task) => task.autoScanKey);
+    setState(() {
+      _scanSummaries
+        ..removeWhere((key, _) => !activeKeys.contains(key))
+        ..addAll(summaries);
+      _scanSummaryCheckedKeys
+        ..removeWhere((key) => !activeKeys.contains(key))
+        ..addAll(checkedKeys);
+    });
+  }
+
+  Future<TorrentTaskScanSummary?> _loadScanSummary(TorrentTask task) async {
+    final items = await _service.listCompletedFileScanHistoryItems(task);
+    final summary = TorrentTaskScanSummary.fromHistoryItems(items);
+    if (summary.hasItems ||
+        _autoScannedCompletedTaskKeys.contains(task.autoScanKey)) {
+      return summary;
+    }
+    return null;
   }
 
   Future<void> _handleAutoScanCompletedTasks(
@@ -269,6 +394,7 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
 
     await _loadAutoScanRegistry();
     if (!mounted) return;
+    unawaited(_loadScanSummariesForTasks(tasks));
 
     for (final task in tasks) {
       if (!task.finished || task.outputFolder.trim().isEmpty) continue;
@@ -306,6 +432,13 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
       await ServiceProvider.watchHistoryProvider.refresh();
       await _service.markAutoScannedCompletedTask(key);
       _autoScannedCompletedTaskKeys.add(key);
+      final summary = await _loadScanSummary(task);
+      if (mounted && summary != null) {
+        setState(() {
+          _scanSummaries[key] = summary;
+          _scanSummaryCheckedKeys.add(key);
+        });
+      }
 
       if (!mounted || silent) return;
       BlurSnackBar.show(context, '已自动扫描并加入媒体库: ${task.name}');
@@ -414,6 +547,7 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final visibleTasks = _visibleTasks;
 
     if (_isLoading) {
       return Center(
@@ -426,13 +560,15 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
         _buildTopBar(colorScheme),
         Divider(color: colorScheme.onSurface.withOpacity(0.10), height: 1),
         Expanded(
-          child: _tasks.isEmpty
-              ? const LibraryManagementEmptyState(
+          child: visibleTasks.isEmpty
+              ? LibraryManagementEmptyState(
                   icon: Ionicons.cloud_download_outline,
-                  title: '暂无下载任务',
-                  subtitle: '添加 magnet 链接或 .torrent 文件后，任务会显示在这里。',
+                  title: _tasks.isEmpty ? '暂无下载任务' : '没有匹配的下载任务',
+                  subtitle: _tasks.isEmpty
+                      ? '添加 magnet 链接或 .torrent 文件后，任务会显示在这里。'
+                      : '换一个关键词或清空搜索后再查看。',
                 )
-              : _buildTaskList(),
+              : _buildTaskList(visibleTasks),
         ),
       ],
     );
@@ -441,60 +577,112 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
   Widget _buildTopBar(ColorScheme colorScheme) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
-      child: Column(
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: _DownloadDirectoryRow(
-                  directory: _downloadDirectory,
-                  onChoose: _chooseDownloadDirectory,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final compact = constraints.maxWidth < 720;
+          final search = _SearchInput(
+            controller: _searchController,
+            onChanged: _updateSearchQuery,
+            onClear: () => _updateSearchQuery(''),
+          );
+          final sort = SizedBox(
+            width: 142,
+            child: BlurDropdown<_TorrentTaskSort>(
+              dropdownKey: _sortDropdownKey,
+              onItemSelected: _applySort,
+              items: _torrentTaskSortLabels.entries
+                  .map(
+                    (entry) => DropdownMenuItemData<_TorrentTaskSort>(
+                      title: entry.value,
+                      value: entry.key,
+                      isSelected: entry.key == _sort,
+                    ),
+                  )
+                  .toList(),
+            ),
+          );
+          final actions = <Widget>[
+            _TorrentHoverAction(
+              icon: Ionicons.refresh_outline,
+              label: '刷新',
+              onPressed: () => _refreshTasks(),
+            ),
+            const SizedBox(width: 8),
+            _TorrentHoverAction(
+              icon: _viewMode == _TorrentTaskViewMode.cards
+                  ? Ionicons.list_outline
+                  : Ionicons.grid_outline,
+              tooltip: _viewMode == _TorrentTaskViewMode.cards
+                  ? '切换为列表显示'
+                  : '切换为三列显示',
+              onPressed: _toggleViewMode,
+              padding: const EdgeInsets.all(8),
+              iconSize: 20,
+            ),
+            const SizedBox(width: 8),
+            _TorrentHoverAction(
+              icon: Ionicons.add_circle_outline,
+              label: '添加链接',
+              onPressed: _isBusy ? null : _showAddMagnetDialog,
+            ),
+            const SizedBox(width: 8),
+            _TorrentHoverAction(
+              icon: Ionicons.document_attach_outline,
+              label: '选择种子',
+              onPressed: _isBusy ? null : _pickTorrentFile,
+            ),
+          ];
+
+          if (compact) {
+            return Column(
+              children: [
+                Row(
+                  children: [
+                    Expanded(child: search),
+                    const SizedBox(width: 10),
+                    sort,
+                  ],
                 ),
-              ),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Row(children: actions),
+                  ),
+                ),
+              ],
+            );
+          }
+
+          return Row(
+            children: [
+              Expanded(child: search),
               const SizedBox(width: 12),
-              _TorrentHoverAction(
-                icon: Ionicons.refresh_outline,
-                label: '刷新',
-                onPressed: () => _refreshTasks(),
-              ),
-            ],
-          ),
-          const SizedBox(height: 10),
-          Row(
-            children: [
-              Expanded(
-                child: _MagnetInput(
-                  controller: _magnetController,
-                  enabled: !_isBusy,
-                  onSubmitted: (_) => _addMagnet(),
-                ),
-              ),
+              sort,
               const SizedBox(width: 10),
-              _TorrentHoverAction(
-                icon: Ionicons.add_circle_outline,
-                label: '添加链接',
-                onPressed: _isBusy ? null : _addMagnet,
-              ),
-              const SizedBox(width: 8),
-              _TorrentHoverAction(
-                icon: Ionicons.document_attach_outline,
-                label: '选择种子',
-                onPressed: _isBusy ? null : _pickTorrentFile,
-              ),
+              ...actions,
             ],
-          ),
-        ],
+          );
+        },
       ),
     );
   }
 
-  Widget _buildTaskList() {
+  Widget _buildTaskList(List<TorrentTask> tasks) {
+    if (_viewMode == _TorrentTaskViewMode.list) {
+      return _buildCompactTaskList(tasks);
+    }
+
     return LibraryManagementList<TorrentTask>(
-      items: _tasks,
+      items: tasks,
       minItemWidth: 420,
       padding: const EdgeInsets.all(16),
       itemBuilder: (context, task) => _TorrentTaskCard(
         task: task,
+        scanSummary: _scanSummaries[task.autoScanKey],
+        isAutoScanning: _autoScanningTaskKeys.contains(task.autoScanKey),
+        isAutoScanned: _autoScannedCompletedTaskKeys.contains(task.autoScanKey),
         onPlay: () => _playTask(task),
         onToggle: () => _toggleTask(task),
         onOpenFolder: () => _openTaskFolder(task),
@@ -503,72 +691,36 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
       ),
     );
   }
-}
 
-class _DownloadDirectoryRow extends StatelessWidget {
-  const _DownloadDirectoryRow({
-    required this.directory,
-    required this.onChoose,
-  });
-
-  final String directory;
-  final VoidCallback onChoose;
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final titleColor = colorScheme.onSurface;
-    final secondaryColor = colorScheme.onSurface.withOpacity(0.7);
-
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 6, 4, 6),
-      child: Row(
-        children: [
-          Icon(
-            Ionicons.folder_open_outline,
-            color: secondaryColor,
-            size: 22,
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  '默认下载位置',
-                  locale: const Locale("zh-Hans", "zh"),
-                  style: TextStyle(
-                    color: titleColor,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const SizedBox(height: 3),
-                Text(
-                  directory.isEmpty ? '使用应用下载目录' : directory,
-                  locale: const Locale("zh-Hans", "zh"),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(color: secondaryColor),
-                ),
-              ],
-            ),
-          ),
-          _TorrentHoverAction(
-            icon: Ionicons.chevron_forward_outline,
-            onPressed: onChoose,
-            tooltip: '更改默认下载位置',
-            padding: const EdgeInsets.all(8),
-            iconSize: 20,
-            hoverScale: 1.16,
-          ),
-        ],
+  Widget _buildCompactTaskList(List<TorrentTask> tasks) {
+    return Scrollbar(
+      radius: const Radius.circular(2),
+      thickness: 4,
+      child: ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemCount: tasks.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 10),
+        itemBuilder: (context, index) {
+          final task = tasks[index];
+          return _TorrentTaskListItem(
+            task: task,
+            scanSummary: _scanSummaries[task.autoScanKey],
+            isAutoScanning: _autoScanningTaskKeys.contains(task.autoScanKey),
+            isAutoScanned:
+                _autoScannedCompletedTaskKeys.contains(task.autoScanKey),
+            onPlay: () => _playTask(task),
+            onToggle: () => _toggleTask(task),
+            onOpenFolder: () => _openTaskFolder(task),
+            onForget: () => _forgetTask(task),
+            onDelete: () => _deleteTask(task),
+          );
+        },
       ),
     );
   }
 }
 
-class _TorrentHoverAction extends StatefulWidget {
+class _TorrentHoverAction extends StatelessWidget {
   const _TorrentHoverAction({
     required this.icon,
     required this.onPressed,
@@ -576,7 +728,6 @@ class _TorrentHoverAction extends StatefulWidget {
     this.tooltip,
     this.padding = const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
     this.iconSize = 16,
-    this.hoverScale = 1.08,
   });
 
   final IconData icon;
@@ -585,99 +736,64 @@ class _TorrentHoverAction extends StatefulWidget {
   final VoidCallback? onPressed;
   final EdgeInsetsGeometry padding;
   final double iconSize;
-  final double hoverScale;
-
-  @override
-  State<_TorrentHoverAction> createState() => _TorrentHoverActionState();
-}
-
-class _TorrentHoverActionState extends State<_TorrentHoverAction> {
-  bool _isHovered = false;
 
   @override
   Widget build(BuildContext context) {
-    final enabled = widget.onPressed != null;
+    final enabled = onPressed != null;
     final colorScheme = Theme.of(context).colorScheme;
     final baseColor = colorScheme.onSurface.withOpacity(enabled ? 0.72 : 0.36);
-    final activeColor =
-        enabled && _isHovered ? AppAccentColors.current : baseColor;
 
-    Widget content = MouseRegion(
-      cursor: enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
-      onEnter: (_) {
-        if (enabled) setState(() => _isHovered = true);
-      },
-      onExit: (_) {
-        if (enabled) setState(() => _isHovered = false);
-      },
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: widget.onPressed,
-        child: Padding(
-          padding: widget.padding,
-          child: AnimatedScale(
-            scale: enabled && _isHovered ? widget.hoverScale : 1.0,
-            duration: const Duration(milliseconds: 180),
-            curve: Curves.easeOutBack,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  widget.icon,
-                  color: activeColor,
-                  size: widget.iconSize,
-                ),
-                if (widget.label != null) ...[
-                  const SizedBox(width: 4),
-                  AnimatedDefaultTextStyle(
-                    duration: const Duration(milliseconds: 180),
-                    curve: Curves.easeOutCubic,
-                    style: TextStyle(
-                      color: activeColor,
-                      fontSize: 14,
-                      fontFamilyFallback: AppTheme.platformFontFamilyFallback,
-                      decoration: TextDecoration.none,
-                      decorationColor: Colors.transparent,
-                      fontWeight:
-                          enabled && _isHovered ? FontWeight.w500 : null,
-                    ),
-                    child: Text(
-                      widget.label!,
-                      locale: const Locale("zh-Hans", "zh"),
-                    ),
-                  ),
-                ],
-              ],
+    Widget content = HoverScaleTextButton(
+      onPressed: onPressed,
+      padding: padding,
+      hoverScale: 1.08,
+      idleColor: baseColor,
+      hoverColor: AppAccentColors.current,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: iconSize),
+          if (label != null) ...[
+            const SizedBox(width: 4),
+            Text(
+              label!,
+              locale: const Locale("zh-Hans", "zh"),
+              style: TextStyle(
+                fontSize: 14,
+                fontFamilyFallback: AppTheme.platformFontFamilyFallback,
+                decoration: TextDecoration.none,
+                decorationColor: Colors.transparent,
+              ),
             ),
-          ),
-        ),
+          ],
+        ],
       ),
     );
 
-    if (widget.tooltip != null) {
-      content = Tooltip(message: widget.tooltip!, child: content);
+    if (tooltip != null) {
+      content = Tooltip(message: tooltip!, child: content);
     }
 
     return content;
   }
 }
 
-class _MagnetInput extends StatefulWidget {
-  const _MagnetInput({
+class _SearchInput extends StatefulWidget {
+  const _SearchInput({
     required this.controller,
-    required this.enabled,
-    required this.onSubmitted,
+    required this.onChanged,
+    required this.onClear,
   });
 
   final TextEditingController controller;
-  final bool enabled;
-  final ValueChanged<String> onSubmitted;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onClear;
 
   @override
-  State<_MagnetInput> createState() => _MagnetInputState();
+  State<_SearchInput> createState() => _SearchInputState();
 }
 
-class _MagnetInputState extends State<_MagnetInput> {
+class _SearchInputState extends State<_SearchInput> {
   final FocusNode _focusNode = FocusNode();
 
   @override
@@ -715,20 +831,40 @@ class _MagnetInputState extends State<_MagnetInput> {
         ),
       ),
       child: TextField(
-        enabled: widget.enabled,
         controller: widget.controller,
         focusNode: _focusNode,
-        onSubmitted: widget.onSubmitted,
+        onChanged: (value) {
+          widget.onChanged(value);
+          if (mounted) setState(() {});
+        },
         style: TextStyle(color: textColor, fontSize: 14),
         cursorColor: activeColor,
         decoration: InputDecoration(
-          hintText: 'magnet:?xt=urn:btih:...',
+          hintText: '搜索下载任务...',
           hintStyle: TextStyle(color: hintColor, fontSize: 14),
           prefixIcon: Icon(
-            Ionicons.magnet_outline,
+            Ionicons.search_outline,
             color: _focusNode.hasFocus ? activeColor : hintColor,
             size: 18,
           ),
+          suffixIcon: widget.controller.text.isEmpty
+              ? null
+              : Tooltip(
+                  message: '清空搜索',
+                  child: HoverScaleTextButton(
+                    onPressed: () {
+                      widget.controller.clear();
+                      widget.onClear();
+                      setState(() {});
+                    },
+                    padding: const EdgeInsets.all(8),
+                    idleColor: hintColor,
+                    child: const Icon(
+                      Ionicons.close_circle_outline,
+                      size: 18,
+                    ),
+                  ),
+                ),
           border: InputBorder.none,
           contentPadding: const EdgeInsets.symmetric(vertical: 8),
         ),
@@ -737,9 +873,657 @@ class _MagnetInputState extends State<_MagnetInput> {
   }
 }
 
+class _AddMagnetDialogResult {
+  const _AddMagnetDialogResult({
+    required this.magnetUri,
+    required this.downloadDirectory,
+    required this.createFolderForTask,
+  });
+
+  final String magnetUri;
+  final String downloadDirectory;
+  final bool createFolderForTask;
+}
+
+class _AddMagnetDialog extends StatefulWidget {
+  const _AddMagnetDialog({
+    required this.service,
+    required this.initialDirectory,
+    required this.initialRecentDirectories,
+    required this.initialCreateFolderForTask,
+  });
+
+  final TorrentDownloadService service;
+  final String initialDirectory;
+  final List<String> initialRecentDirectories;
+  final bool initialCreateFolderForTask;
+
+  @override
+  State<_AddMagnetDialog> createState() => _AddMagnetDialogState();
+}
+
+class _AddMagnetDialogState extends State<_AddMagnetDialog> {
+  late final TextEditingController _magnetController;
+  late String _downloadDirectory;
+  late bool _createFolderForTask;
+  late List<String> _recentDirectories;
+  TorrentMagnetPreview? _preview;
+  String? _error;
+  bool _isPreviewing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _magnetController = TextEditingController();
+    _downloadDirectory = widget.initialDirectory;
+    _createFolderForTask = widget.initialCreateFolderForTask;
+    _recentDirectories = List<String>.from(widget.initialRecentDirectories);
+  }
+
+  @override
+  void dispose() {
+    _magnetController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _chooseDirectory() async {
+    final selected = await FilePickerService().pickDirectory(
+      initialDirectory:
+          _downloadDirectory.trim().isEmpty ? null : _downloadDirectory,
+    );
+    if (selected == null || selected.trim().isEmpty) return;
+    await widget.service.rememberRecentDownloadDirectory(selected.trim());
+    _selectDirectory(selected.trim());
+  }
+
+  void _selectDirectory(String directory) {
+    setState(() {
+      _downloadDirectory = directory;
+      _recentDirectories = [
+        directory,
+        ..._recentDirectories.where((value) => value != directory),
+      ].take(8).toList(growable: false);
+      _preview = null;
+      _error = null;
+    });
+  }
+
+  Future<void> _removeRecentDirectory(String directory) async {
+    await widget.service.removeRecentDownloadDirectory(directory);
+    if (!mounted) return;
+    setState(() {
+      _recentDirectories.remove(directory);
+    });
+  }
+
+  Future<void> _previewMagnet() async {
+    final magnet = _magnetController.text.trim();
+    if (magnet.isEmpty) {
+      setState(() => _error = '请输入 magnet 链接');
+      return;
+    }
+    if (!magnet.startsWith('magnet:')) {
+      setState(() => _error = '链接格式不是有效的 magnet 地址');
+      return;
+    }
+    if (_downloadDirectory.trim().isEmpty) {
+      setState(() => _error = '请选择下载位置');
+      return;
+    }
+
+    setState(() {
+      _isPreviewing = true;
+      _error = null;
+      _preview = null;
+    });
+    try {
+      final preview = await widget.service.previewMagnet(
+        magnet,
+        downloadDirectory: _downloadDirectory,
+      );
+      if (!mounted) return;
+      setState(() {
+        _preview = preview;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _error = '解析失败: $error';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isPreviewing = false;
+        });
+      }
+    }
+  }
+
+  void _confirm() {
+    final magnet = _magnetController.text.trim();
+    if (_preview == null || magnet.isEmpty || _downloadDirectory.isEmpty) {
+      return;
+    }
+    Navigator.of(context).pop(
+      _AddMagnetDialogResult(
+        magnetUri: magnet,
+        downloadDirectory: _downloadDirectory,
+        createFolderForTask: _createFolderForTask,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return NipaplayWindowScaffold(
+      maxWidth: 980,
+      maxHeightFactor: 0.88,
+      onClose: () => Navigator.of(context).pop(),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 12, 24, 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '添加磁力链接',
+              locale: const Locale("zh-Hans", "zh"),
+              style: TextStyle(
+                color: colorScheme.onSurface,
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 14),
+            Divider(
+              height: 1,
+              color: colorScheme.onSurface.withValues(alpha: 0.12),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final useColumns = constraints.maxWidth >= 760;
+                  final settings = _buildDialogSettings(colorScheme);
+                  final files = _buildPreviewPane(colorScheme);
+                  if (!useColumns) {
+                    return ListView(
+                      children: [
+                        settings,
+                        const SizedBox(height: 16),
+                        SizedBox(height: 360, child: files),
+                      ],
+                    );
+                  }
+                  return Row(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      SizedBox(width: 360, child: settings),
+                      const SizedBox(width: 18),
+                      VerticalDivider(
+                        color: colorScheme.onSurface.withValues(alpha: 0.10),
+                        width: 1,
+                      ),
+                      const SizedBox(width: 18),
+                      Expanded(child: files),
+                    ],
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                if (_error != null)
+                  Expanded(
+                    child: Text(
+                      _error!,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: colorScheme.error,
+                        fontSize: 12,
+                      ),
+                    ),
+                  )
+                else
+                  const Spacer(),
+                const SizedBox(width: 12),
+                HoverScaleTextButton(
+                  text: '取消',
+                  onPressed:
+                      _isPreviewing ? null : () => Navigator.of(context).pop(),
+                  idleColor: colorScheme.onSurface.withValues(alpha: 0.62),
+                ),
+                const SizedBox(width: 8),
+                HoverScaleTextButton(
+                  onPressed: _isPreviewing ? null : _previewMagnet,
+                  idleColor: colorScheme.onSurface.withValues(alpha: 0.78),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (_isPreviewing)
+                        const SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      else
+                        const Icon(Ionicons.search_outline, size: 16),
+                      const SizedBox(width: 5),
+                      Text(_preview == null ? '预览' : '重新预览'),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                HoverScaleTextButton(
+                  onPressed:
+                      _preview == null || _isPreviewing ? null : _confirm,
+                  idleColor: colorScheme.onSurface.withValues(alpha: 0.88),
+                  hoverColor: AppAccentColors.current,
+                  child: const Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Ionicons.add_circle_outline, size: 16),
+                      SizedBox(width: 5),
+                      Text('添加任务'),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDialogSettings(ColorScheme colorScheme) {
+    final secondaryColor = colorScheme.onSurface.withOpacity(0.55);
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _DialogFieldLabel('磁力链接'),
+          const SizedBox(height: 8),
+          Container(
+            decoration: BoxDecoration(
+              color: colorScheme.onSurface.withOpacity(0.05),
+              borderRadius: BorderRadius.circular(8),
+              border:
+                  Border.all(color: colorScheme.onSurface.withOpacity(0.12)),
+            ),
+            child: TextField(
+              controller: _magnetController,
+              minLines: 3,
+              maxLines: 5,
+              onChanged: (_) {
+                if (_preview != null || _error != null) {
+                  setState(() {
+                    _preview = null;
+                    _error = null;
+                  });
+                }
+              },
+              onSubmitted: (_) => _previewMagnet(),
+              style: TextStyle(color: colorScheme.onSurface, fontSize: 13),
+              cursorColor: AppAccentColors.current,
+              decoration: InputDecoration(
+                hintText: 'magnet:?xt=urn:btih:...',
+                hintStyle: TextStyle(color: secondaryColor),
+                border: InputBorder.none,
+                enabledBorder: InputBorder.none,
+                focusedBorder: InputBorder.none,
+                contentPadding: const EdgeInsets.all(12),
+              ),
+            ),
+          ),
+          const SizedBox(height: 18),
+          _DialogFieldLabel('保存到'),
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: colorScheme.onSurface.withOpacity(0.05),
+              borderRadius: BorderRadius.circular(8),
+              border:
+                  Border.all(color: colorScheme.onSurface.withOpacity(0.12)),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    _downloadDirectory.isEmpty ? '请选择下载位置' : _downloadDirectory,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: _downloadDirectory.isEmpty
+                          ? secondaryColor
+                          : colorScheme.onSurface,
+                      fontSize: 13,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Tooltip(
+                  message: '选择下载位置',
+                  child: HoverScaleTextButton(
+                    onPressed: _chooseDirectory,
+                    padding: const EdgeInsets.all(6),
+                    child: const Icon(Ionicons.folder_open_outline, size: 20),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (_recentDirectories.isNotEmpty) ...[
+            const SizedBox(height: 14),
+            _buildQuickSelect(colorScheme),
+          ],
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  '为任务创建独立文件夹',
+                  locale: const Locale("zh-Hans", "zh"),
+                  style: TextStyle(
+                    color: colorScheme.onSurface,
+                    fontSize: 14,
+                  ),
+                ),
+              ),
+              FluentSettingsSwitch(
+                value: _createFolderForTask,
+                onChanged: (value) {
+                  setState(() {
+                    _createFolderForTask = value;
+                  });
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (_preview != null) _buildPreviewSummary(colorScheme, _preview!),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildQuickSelect(ColorScheme colorScheme) {
+    final secondaryColor = colorScheme.onSurface.withOpacity(0.55);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _DialogFieldLabel('快速选择'),
+        const SizedBox(height: 8),
+        Container(
+          decoration: BoxDecoration(
+            color: colorScheme.onSurface.withOpacity(0.04),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: colorScheme.onSurface.withOpacity(0.10)),
+          ),
+          child: Column(
+            children: [
+              for (var index = 0; index < _recentDirectories.length; index++)
+                Column(
+                  children: [
+                    if (index > 0)
+                      Divider(
+                        height: 1,
+                        color: colorScheme.onSurface.withOpacity(0.08),
+                      ),
+                    Padding(
+                      padding: const EdgeInsets.only(left: 10, right: 4),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: HoverScaleTextButton(
+                              onPressed: () =>
+                                  _selectDirectory(_recentDirectories[index]),
+                              padding: const EdgeInsets.symmetric(vertical: 9),
+                              hoverScale: 1.0,
+                              idleColor: _downloadDirectory ==
+                                      _recentDirectories[index]
+                                  ? AppAccentColors.current
+                                  : colorScheme.onSurface.withOpacity(0.72),
+                              child: Row(
+                                children: [
+                                  Icon(
+                                    _downloadDirectory ==
+                                            _recentDirectories[index]
+                                        ? Ionicons.checkmark_circle_outline
+                                        : Ionicons.folder_open_outline,
+                                    size: 16,
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Expanded(
+                                    child: Text(
+                                      _recentDirectories[index],
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: const TextStyle(fontSize: 12),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                          Tooltip(
+                            message: '从快速选择移除',
+                            child: HoverScaleTextButton(
+                              onPressed: () => _removeRecentDirectory(
+                                _recentDirectories[index],
+                              ),
+                              padding: const EdgeInsets.all(7),
+                              idleColor: secondaryColor,
+                              child: const Icon(
+                                Ionicons.close_circle_outline,
+                                size: 17,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPreviewSummary(
+    ColorScheme colorScheme,
+    TorrentMagnetPreview preview,
+  ) {
+    final secondaryColor = colorScheme.onSurface.withOpacity(0.55);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colorScheme.onSurface.withOpacity(0.04),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.onSurface.withOpacity(0.10)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            preview.name,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: colorScheme.onSurface,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '${preview.files.length} 个文件，${_TorrentTaskCard.formatBytes(preview.totalSize)}',
+            style: TextStyle(color: secondaryColor, fontSize: 12),
+          ),
+          if (preview.suggestedFolderName.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              '文件夹：${preview.suggestedFolderName}',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(color: secondaryColor, fontSize: 12),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPreviewPane(ColorScheme colorScheme) {
+    final preview = _preview;
+    if (_isPreviewing) {
+      return Center(
+        child: CircularProgressIndicator(color: AppAccentColors.current),
+      );
+    }
+    if (preview == null) {
+      return Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: colorScheme.onSurface.withOpacity(0.10)),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Center(
+          child: Text(
+            '输入 magnet 链接后预览文件',
+            style: TextStyle(
+              color: colorScheme.onSurface.withOpacity(0.55),
+              fontSize: 13,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: colorScheme.onSurface.withOpacity(0.10)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        children: [
+          Container(
+            height: 36,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            decoration: BoxDecoration(
+              color: colorScheme.onSurface.withOpacity(0.05),
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(8)),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    '名称',
+                    style: TextStyle(
+                      color: colorScheme.onSurface.withOpacity(0.7),
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                SizedBox(
+                  width: 90,
+                  child: Text(
+                    '大小',
+                    textAlign: TextAlign.right,
+                    style: TextStyle(
+                      color: colorScheme.onSurface.withOpacity(0.7),
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.separated(
+              itemCount: preview.files.length,
+              separatorBuilder: (_, __) => Divider(
+                height: 1,
+                color: colorScheme.onSurface.withOpacity(0.08),
+              ),
+              itemBuilder: (context, index) {
+                final file = preview.files[index];
+                return Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          child: Text(
+                            file.path,
+                            softWrap: false,
+                            style: TextStyle(
+                              color: colorScheme.onSurface,
+                              fontSize: 13,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      SizedBox(
+                        width: 90,
+                        child: Text(
+                          _TorrentTaskCard.formatBytes(file.length),
+                          textAlign: TextAlign.right,
+                          style: TextStyle(
+                            color: colorScheme.onSurface.withOpacity(0.55),
+                            fontSize: 12,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DialogFieldLabel extends StatelessWidget {
+  const _DialogFieldLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      locale: const Locale("zh-Hans", "zh"),
+      style: TextStyle(
+        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.75),
+        fontSize: 13,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+}
+
 class _TorrentTaskCard extends StatelessWidget {
   const _TorrentTaskCard({
     required this.task,
+    required this.scanSummary,
+    required this.isAutoScanning,
+    required this.isAutoScanned,
     required this.onPlay,
     required this.onToggle,
     required this.onOpenFolder,
@@ -748,6 +1532,9 @@ class _TorrentTaskCard extends StatelessWidget {
   });
 
   final TorrentTask task;
+  final TorrentTaskScanSummary? scanSummary;
+  final bool isAutoScanning;
+  final bool isAutoScanned;
   final VoidCallback onPlay;
   final VoidCallback onToggle;
   final VoidCallback onOpenFolder;
@@ -836,6 +1623,12 @@ class _TorrentTaskCard extends StatelessWidget {
                   label: '上传',
                   value: '${formatBytes(task.uploadSpeedBytesPerSecond)}/s',
                 ),
+                if (isAutoScanning || scanSummary != null || isAutoScanned)
+                  _TorrentTaskScanText(
+                    summary: scanSummary,
+                    isScanning: isAutoScanning,
+                    isScanned: isAutoScanned,
+                  ),
               ],
             ),
             if (task.error?.isNotEmpty ?? false) ...[
@@ -909,6 +1702,239 @@ class _TorrentTaskCard extends StatelessWidget {
             ? 1
             : 2;
     return '${value.toStringAsFixed(digits)} ${units[unit]}';
+  }
+}
+
+class _TorrentTaskListItem extends StatelessWidget {
+  const _TorrentTaskListItem({
+    required this.task,
+    required this.scanSummary,
+    required this.isAutoScanning,
+    required this.isAutoScanned,
+    required this.onPlay,
+    required this.onToggle,
+    required this.onOpenFolder,
+    required this.onForget,
+    required this.onDelete,
+  });
+
+  final TorrentTask task;
+  final TorrentTaskScanSummary? scanSummary;
+  final bool isAutoScanning;
+  final bool isAutoScanned;
+  final VoidCallback onPlay;
+  final VoidCallback onToggle;
+  final VoidCallback onOpenFolder;
+  final VoidCallback onForget;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final onSurface = colorScheme.onSurface;
+    final progress = task.progress;
+
+    return LibraryManagementCard(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(14, 12, 12, 12),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final compact = constraints.maxWidth < 720;
+            final actions = _buildActions();
+
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      Ionicons.cloud_download_outline,
+                      color: AppAccentColors.current,
+                      size: 22,
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            task.name,
+                            maxLines: compact ? 2 : 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: onSurface,
+                              fontSize: 15,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 3),
+                          Text(
+                            task.outputFolder,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: onSurface.withValues(alpha: 0.55),
+                              fontSize: 12,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    _StateBadge(task: task),
+                    if (!compact) ...[
+                      const SizedBox(width: 8),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: actions,
+                      ),
+                    ],
+                  ],
+                ),
+                const SizedBox(height: 10),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(99),
+                  child: LinearProgressIndicator(
+                    value: progress,
+                    minHeight: 5,
+                    color: task.hasError
+                        ? colorScheme.error
+                        : AppAccentColors.current,
+                    backgroundColor: onSurface.withValues(alpha: 0.10),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 16,
+                  runSpacing: 6,
+                  children: [
+                    _MetricText(
+                      label: '进度',
+                      value: _TorrentTaskCard._formatPercent(progress),
+                    ),
+                    _MetricText(
+                      label: '已下载',
+                      value:
+                          '${_TorrentTaskCard.formatBytes(task.progressBytes)} / ${_TorrentTaskCard.formatBytes(task.totalBytes)}',
+                    ),
+                    _MetricText(
+                      label: '下载',
+                      value:
+                          '${_TorrentTaskCard.formatBytes(task.downloadSpeedBytesPerSecond)}/s',
+                    ),
+                    _MetricText(
+                      label: '上传',
+                      value:
+                          '${_TorrentTaskCard.formatBytes(task.uploadSpeedBytesPerSecond)}/s',
+                    ),
+                    if (isAutoScanning || scanSummary != null || isAutoScanned)
+                      _TorrentTaskScanText(
+                        summary: scanSummary,
+                        isScanning: isAutoScanning,
+                        isScanned: isAutoScanned,
+                      ),
+                  ],
+                ),
+                if (task.error?.isNotEmpty ?? false) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    task.error!,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(color: colorScheme.error, fontSize: 12),
+                  ),
+                ],
+                if (compact) ...[
+                  const SizedBox(height: 8),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Wrap(
+                      spacing: 6,
+                      runSpacing: 4,
+                      children: actions,
+                    ),
+                  ),
+                ],
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildActions() {
+    return [
+      if (task.finished)
+        _TorrentHoverAction(
+          icon: Ionicons.play_circle_outline,
+          tooltip: '播放',
+          onPressed: onPlay,
+          padding: const EdgeInsets.all(8),
+          iconSize: 18,
+        ),
+      if (!task.finished)
+        _TorrentHoverAction(
+          icon: task.isPaused ? Ionicons.play_outline : Ionicons.pause_outline,
+          tooltip: task.isPaused ? '继续' : '暂停',
+          onPressed: onToggle,
+          padding: const EdgeInsets.all(8),
+          iconSize: 18,
+        ),
+      _TorrentHoverAction(
+        icon: Ionicons.folder_open_outline,
+        tooltip: '打开文件夹',
+        onPressed: onOpenFolder,
+        padding: const EdgeInsets.all(8),
+        iconSize: 18,
+      ),
+      _TorrentHoverAction(
+        icon: Ionicons.remove_circle_outline,
+        tooltip: '移除',
+        onPressed: onForget,
+        padding: const EdgeInsets.all(8),
+        iconSize: 18,
+      ),
+      _TorrentHoverAction(
+        icon: Ionicons.trash_outline,
+        tooltip: '删除任务和文件',
+        onPressed: onDelete,
+        padding: const EdgeInsets.all(8),
+        iconSize: 18,
+      ),
+    ];
+  }
+}
+
+class _TorrentTaskScanText extends StatelessWidget {
+  const _TorrentTaskScanText({
+    required this.summary,
+    required this.isScanning,
+    required this.isScanned,
+  });
+
+  final TorrentTaskScanSummary? summary;
+  final bool isScanning;
+  final bool isScanned;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final String text = isScanning
+        ? '正在扫描入库...'
+        : summary?.displayText ?? (isScanned ? '已扫描，正在读取结果...' : '');
+    if (text.isEmpty) return const SizedBox.shrink();
+
+    return Text(
+      text,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: TextStyle(
+        color: colorScheme.onSurface.withValues(alpha: 0.55),
+        fontSize: 12,
+      ),
+    );
   }
 }
 

--- a/lib/pages/torrent_download_page.dart
+++ b/lib/pages/torrent_download_page.dart
@@ -56,6 +56,9 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
   final Map<String, TorrentTaskScanSummary> _scanSummaries =
       <String, TorrentTaskScanSummary>{};
   final Set<String> _scanSummaryCheckedKeys = <String>{};
+  bool _isLoadingScanSummaries = false;
+  List<TorrentTask>? _pendingScanSummaryTasks;
+  bool _pendingScanSummaryForce = false;
   String _downloadDirectory = '';
   bool _isLoading = true;
   bool _isBusy = false;
@@ -237,9 +240,34 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
     );
     if (file == null) return;
 
+    final initialDirectory = _downloadDirectory.trim().isEmpty
+        ? await _service.getDownloadDirectory()
+        : _downloadDirectory;
+    if (!mounted) return;
+    final selectedDirectory = await FilePickerService().pickDirectory(
+      initialDirectory: initialDirectory,
+    );
+    if (selectedDirectory == null || selectedDirectory.trim().isEmpty) return;
+    if (!mounted) return;
+
+    final downloadDirectory = selectedDirectory.trim();
+    final downloaderSettings = context.read<DownloaderSettingsProvider>();
     await _runBusyAction(
-      action: () => _service.addTorrentFile(file.path),
+      action: () async {
+        await _service.setDownloadDirectory(downloadDirectory);
+        await _service.addTorrentFile(
+          file.path,
+          downloadDirectory: downloadDirectory,
+          createFolderForTask: downloaderSettings.createFolderForTask,
+        );
+      },
       successMessage: '已添加 ${p.basename(file.path)}',
+      afterSuccess: () {
+        if (!mounted) return;
+        setState(() {
+          _downloadDirectory = downloadDirectory;
+        });
+      },
     );
   }
 
@@ -345,6 +373,38 @@ class _TorrentDownloadPageState extends State<TorrentDownloadPage>
   Future<void> _loadScanSummariesForTasks(
     List<TorrentTask> tasks, {
     bool force = false,
+  }) async {
+    if (_isLoadingScanSummaries) {
+      _pendingScanSummaryTasks = tasks;
+      _pendingScanSummaryForce = _pendingScanSummaryForce || force;
+      return;
+    }
+
+    _isLoadingScanSummaries = true;
+    var currentTasks = tasks;
+    var currentForce = force;
+    try {
+      while (true) {
+        await _loadScanSummariesForTasksBatch(
+          currentTasks,
+          force: currentForce,
+        );
+
+        final pendingTasks = _pendingScanSummaryTasks;
+        if (pendingTasks == null) break;
+        currentTasks = pendingTasks;
+        currentForce = _pendingScanSummaryForce;
+        _pendingScanSummaryTasks = null;
+        _pendingScanSummaryForce = false;
+      }
+    } finally {
+      _isLoadingScanSummaries = false;
+    }
+  }
+
+  Future<void> _loadScanSummariesForTasksBatch(
+    List<TorrentTask> tasks, {
+    required bool force,
   }) async {
     final targets = tasks.where((task) {
       if (!task.finished || task.outputFolder.trim().isEmpty) return false;
@@ -910,6 +970,7 @@ class _AddMagnetDialogState extends State<_AddMagnetDialog> {
   TorrentMagnetPreview? _preview;
   String? _error;
   bool _isPreviewing = false;
+  int _previewRequestId = 0;
 
   @override
   void initState() {
@@ -958,6 +1019,7 @@ class _AddMagnetDialogState extends State<_AddMagnetDialog> {
 
   Future<void> _previewMagnet() async {
     final magnet = _magnetController.text.trim();
+    final downloadDirectory = _downloadDirectory.trim();
     if (magnet.isEmpty) {
       setState(() => _error = '请输入 magnet 链接');
       return;
@@ -966,11 +1028,12 @@ class _AddMagnetDialogState extends State<_AddMagnetDialog> {
       setState(() => _error = '链接格式不是有效的 magnet 地址');
       return;
     }
-    if (_downloadDirectory.trim().isEmpty) {
+    if (downloadDirectory.isEmpty) {
       setState(() => _error = '请选择下载位置');
       return;
     }
 
+    final requestId = ++_previewRequestId;
     setState(() {
       _isPreviewing = true;
       _error = null;
@@ -979,19 +1042,25 @@ class _AddMagnetDialogState extends State<_AddMagnetDialog> {
     try {
       final preview = await widget.service.previewMagnet(
         magnet,
-        downloadDirectory: _downloadDirectory,
+        downloadDirectory: downloadDirectory,
       );
       if (!mounted) return;
+      if (!_isCurrentPreviewRequest(requestId, magnet, downloadDirectory)) {
+        return;
+      }
       setState(() {
         _preview = preview;
       });
     } catch (error) {
       if (!mounted) return;
+      if (!_isCurrentPreviewRequest(requestId, magnet, downloadDirectory)) {
+        return;
+      }
       setState(() {
         _error = '解析失败: $error';
       });
     } finally {
-      if (mounted) {
+      if (mounted && requestId == _previewRequestId) {
         setState(() {
           _isPreviewing = false;
         });
@@ -999,15 +1068,26 @@ class _AddMagnetDialogState extends State<_AddMagnetDialog> {
     }
   }
 
+  bool _isCurrentPreviewRequest(
+    int requestId,
+    String magnet,
+    String downloadDirectory,
+  ) {
+    return requestId == _previewRequestId &&
+        _magnetController.text.trim() == magnet &&
+        _downloadDirectory.trim() == downloadDirectory;
+  }
+
   void _confirm() {
     final magnet = _magnetController.text.trim();
-    if (_preview == null || magnet.isEmpty || _downloadDirectory.isEmpty) {
+    final downloadDirectory = _downloadDirectory.trim();
+    if (_preview == null || magnet.isEmpty || downloadDirectory.isEmpty) {
       return;
     }
     Navigator.of(context).pop(
       _AddMagnetDialogResult(
         magnetUri: magnet,
-        downloadDirectory: _downloadDirectory,
+        downloadDirectory: downloadDirectory,
         createFolderForTask: _createFolderForTask,
       ),
     );

--- a/lib/services/torrent_download_service.dart
+++ b/lib/services/torrent_download_service.dart
@@ -235,9 +235,15 @@ class TorrentDownloadService {
     }
   }
 
-  Future<void> addTorrentFile(String torrentFilePath) async {
-    final downloadDir = await getDownloadDirectory();
-    final createFolder = await _createFolderForTask();
+  Future<void> addTorrentFile(
+    String torrentFilePath, {
+    String? downloadDirectory,
+    bool? createFolderForTask,
+  }) async {
+    final downloadDir = await _resolveDownloadDirectoryForAction(
+      downloadDirectory,
+    );
+    final createFolder = createFolderForTask ?? await _createFolderForTask();
     _log(
       'addTorrentFile start: path="$torrentFilePath", '
       'downloadDir="$downloadDir", createFolderForTask=$createFolder',

--- a/lib/services/torrent_download_service.dart
+++ b/lib/services/torrent_download_service.dart
@@ -2,6 +2,7 @@ import 'dart:io' as io;
 
 import 'package:flutter/foundation.dart';
 import 'package:nipaplay/constants/settings_keys.dart';
+import 'package:nipaplay/models/torrent_magnet_preview.dart';
 import 'package:nipaplay/models/torrent_task.dart';
 import 'package:nipaplay/models/watch_history_model.dart';
 import 'package:nipaplay/services/security_bookmark_service.dart';
@@ -15,6 +16,8 @@ class TorrentDownloadService {
   TorrentDownloadService._();
 
   static final TorrentDownloadService instance = TorrentDownloadService._();
+
+  static const int _maxRecentDownloadDirectories = 8;
 
   bool _sessionInitialized = false;
   String _sessionDownloadDir = '';
@@ -42,7 +45,72 @@ class TorrentDownloadService {
       SettingsKeys.torrentDownloadDirectory,
       resolved,
     );
+    await rememberRecentDownloadDirectory(resolved);
     _sessionDownloadDir = resolved;
+  }
+
+  Future<List<String>> loadRecentDownloadDirectories() async {
+    await _migrateRecentDownloadDirectoriesIfNeeded();
+    final saved = await SettingsStorage.loadStringList(
+      SettingsKeys.torrentRecentDownloadDirectories,
+    );
+    return _normalizeRecentDirectories(saved);
+  }
+
+  Future<void> rememberRecentDownloadDirectory(String directory) async {
+    final trimmed = directory.trim();
+    if (trimmed.isEmpty) return;
+    final existing = await loadRecentDownloadDirectories();
+    final updated = <String>[
+      trimmed,
+      ...existing.where((value) => value != trimmed),
+    ].take(_maxRecentDownloadDirectories).toList(growable: false);
+    await SettingsStorage.saveStringList(
+      SettingsKeys.torrentRecentDownloadDirectories,
+      updated,
+    );
+  }
+
+  Future<void> removeRecentDownloadDirectory(String directory) async {
+    final trimmed = directory.trim();
+    if (trimmed.isEmpty) return;
+    final existing = await loadRecentDownloadDirectories();
+    final updated = existing.where((value) => value != trimmed).toList();
+    await SettingsStorage.saveStringList(
+      SettingsKeys.torrentRecentDownloadDirectories,
+      updated,
+    );
+  }
+
+  Future<void> _migrateRecentDownloadDirectoriesIfNeeded() async {
+    final migrated = await SettingsStorage.loadBool(
+      SettingsKeys.torrentRecentDownloadDirectoriesMigrated,
+    );
+    if (migrated) return;
+
+    final saved = await SettingsStorage.loadString(
+      SettingsKeys.torrentDownloadDirectory,
+    );
+    final initial = saved.trim().isEmpty ? <String>[] : <String>[saved.trim()];
+    await SettingsStorage.saveStringList(
+      SettingsKeys.torrentRecentDownloadDirectories,
+      initial,
+    );
+    await SettingsStorage.saveBool(
+      SettingsKeys.torrentRecentDownloadDirectoriesMigrated,
+      true,
+    );
+  }
+
+  List<String> _normalizeRecentDirectories(List<String> directories) {
+    final normalized = <String>[];
+    for (final directory in directories) {
+      final trimmed = directory.trim();
+      if (trimmed.isEmpty || normalized.contains(trimmed)) continue;
+      normalized.add(trimmed);
+      if (normalized.length >= _maxRecentDownloadDirectories) break;
+    }
+    return normalized;
   }
 
   Future<void> initialize() async {
@@ -69,6 +137,25 @@ class TorrentDownloadService {
     return details.files
         .where((file) => file.included && file.isVideo)
         .toList(growable: false);
+  }
+
+  Future<List<WatchHistoryItem>> listCompletedFileScanHistoryItems(
+    TorrentTask task,
+  ) async {
+    if (!task.finished) return const <WatchHistoryItem>[];
+
+    final playableFiles = await listPlayableFiles(task);
+    final historyItems = <WatchHistoryItem>[];
+    for (final file in playableFiles) {
+      final filePath = await _findCompletedFilePath(task, file);
+      if (filePath == null) continue;
+
+      final historyItem = await WatchHistoryManager.getHistoryItem(filePath);
+      if (historyItem != null) {
+        historyItems.add(historyItem);
+      }
+    }
+    return historyItems;
   }
 
   Future<String> getStreamUrl(TorrentTask task, TorrentTaskFile file) async {
@@ -105,9 +192,30 @@ class TorrentDownloadService {
     );
   }
 
-  Future<void> addMagnet(String magnetUri) async {
-    final downloadDir = await getDownloadDirectory();
-    final createFolder = await _createFolderForTask();
+  Future<TorrentMagnetPreview> previewMagnet(
+    String magnetUri, {
+    String? downloadDirectory,
+  }) async {
+    final downloadDir = await _resolveDownloadDirectoryForAction(
+      downloadDirectory,
+    );
+    await _initSession(downloadDir);
+    final jsonText = await rust_torrent.torrentPreviewMagnet(
+      magnetUri: magnetUri,
+      downloadDir: downloadDir,
+    );
+    return TorrentMagnetPreview.fromJson(jsonText);
+  }
+
+  Future<void> addMagnet(
+    String magnetUri, {
+    String? downloadDirectory,
+    bool? createFolderForTask,
+  }) async {
+    final downloadDir = await _resolveDownloadDirectoryForAction(
+      downloadDirectory,
+    );
+    final createFolder = createFolderForTask ?? await _createFolderForTask();
     _log(
       'addMagnet start: ${_summarizeMagnetForLog(magnetUri)}, '
       'downloadDir="$downloadDir", createFolderForTask=$createFolder',
@@ -171,18 +279,20 @@ class TorrentDownloadService {
 
   Future<void> _initSession(String downloadDir) async {
     if (_sessionInitialized && _sessionDownloadDir == downloadDir) {
-      _log('initSession skipped: already initialized for "$downloadDir"');
       return;
     }
-    _log(
-      'initSession start: downloadDir="$downloadDir", '
-      'previousDir="$_sessionDownloadDir", initialized=$_sessionInitialized',
-    );
     await ensureRustInitialized();
     await rust_torrent.torrentInitSession(downloadDir: downloadDir);
     _sessionInitialized = true;
     _sessionDownloadDir = downloadDir;
-    _log('initSession success: downloadDir="$downloadDir"');
+  }
+
+  Future<String> _resolveDownloadDirectoryForAction(String? directory) async {
+    final trimmed = directory?.trim() ?? '';
+    if (trimmed.isEmpty) {
+      return getDownloadDirectory();
+    }
+    return _resolveDownloadDirectoryAccess(trimmed);
   }
 
   Future<bool> _createFolderForTask() {
@@ -283,18 +393,8 @@ class TorrentDownloadService {
     try {
       final resolved = await SecurityBookmarkService.resolveBookmark(directory);
       if (resolved != null && resolved.trim().isNotEmpty) {
-        if (resolved != directory) {
-          _log(
-            'download directory bookmark resolved: "$directory" -> "$resolved"',
-          );
-        } else {
-          _log('download directory bookmark restored: "$directory"');
-        }
         return resolved;
       }
-
-      _log(
-          'download directory has no bookmark, using path directly: "$directory"');
     } catch (error) {
       _log('download directory bookmark restore failed: "$directory", $error');
     }

--- a/lib/src/rust/api/torrent.dart
+++ b/lib/src/rust/api/torrent.dart
@@ -6,7 +6,7 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `add_torrent_options`, `current_api`, `current_session`, `default_session_dir`, `ensure_stream_server`, `file_stem_folder_name`, `file_stem_or_name`, `format_error_chain`, `handle_stream_request`, `magnet_log_summary`, `normalize_download_dir`, `normalize_torrent_id`, `parse_http_request`, `parse_range`, `parse_stream_path`, `parsed_magnet_log_summary`, `read_http_request`, `resolve_magnet_metadata_for_add`, `response_to_json`, `sanitize_folder_name`, `torrent_log`, `torrent_metadata_folder_name`, `torrent_runtime`, `truncate_for_log`, `url_path_segment_encode`, `write_simple_response`
+// These functions are ignored because they are not marked as `pub`: `add_torrent_options`, `current_api`, `current_session`, `default_session_dir`, `ensure_stream_server`, `file_stem_folder_name`, `file_stem_or_name`, `format_error_chain`, `handle_stream_request`, `magnet_log_summary`, `normalize_download_dir`, `normalize_torrent_id`, `parse_http_request`, `parse_range`, `parse_stream_path`, `parsed_magnet_log_summary`, `read_http_request`, `resolve_magnet_metadata_for_add`, `response_to_json`, `sanitize_folder_name`, `torrent_log`, `torrent_metadata_display_name`, `torrent_metadata_folder_name`, `torrent_preview_to_json`, `torrent_runtime`, `truncate_for_log`, `url_path_segment_encode`, `write_simple_response`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `HttpRange`, `TorrentRuntime`, `TorrentStreamServer`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`
 
@@ -31,6 +31,11 @@ Future<String> torrentAddFile(
         torrentFilePath: torrentFilePath,
         downloadDir: downloadDir,
         createFolderForTask: createFolderForTask);
+
+Future<String> torrentPreviewMagnet(
+        {required String magnetUri, required String downloadDir}) =>
+    RustLib.instance.api.crateApiTorrentTorrentPreviewMagnet(
+        magnetUri: magnetUri, downloadDir: downloadDir);
 
 Future<String> torrentList({required String downloadDir}) =>
     RustLib.instance.api.crateApiTorrentTorrentList(downloadDir: downloadDir);

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -74,7 +74,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 1494214116;
+  int get rustContentHash => 1429887362;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -173,6 +173,9 @@ abstract class RustLibApi extends BaseApi {
   Future<String> crateApiTorrentTorrentList({required String downloadDir});
 
   Future<void> crateApiTorrentTorrentPause({required int id});
+
+  Future<String> crateApiTorrentTorrentPreviewMagnet(
+      {required String magnetUri, required String downloadDir});
 
   Future<void> crateApiTorrentTorrentResume({required int id});
 
@@ -919,13 +922,40 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<String> crateApiTorrentTorrentPreviewMagnet(
+      {required String magnetUri, required String downloadDir}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(magnetUri, serializer);
+        sse_encode_String(downloadDir, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 27, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTorrentTorrentPreviewMagnetConstMeta,
+      argValues: [magnetUri, downloadDir],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTorrentTorrentPreviewMagnetConstMeta =>
+      const TaskConstMeta(
+        debugName: "torrent_preview_magnet",
+        argNames: ["magnetUri", "downloadDir"],
+      );
+
+  @override
   Future<void> crateApiTorrentTorrentResume({required int id}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_i_32(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 27, port: port_);
+            funcId: 28, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -953,7 +983,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_i_32(fileId, serializer);
         sse_encode_String(filename, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 28, port: port_);
+            funcId: 29, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,

--- a/lib/themes/cupertino/pages/cupertino_torrent_download_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_torrent_download_page.dart
@@ -52,6 +52,9 @@ class _CupertinoTorrentDownloadPageState
   final Map<String, TorrentTaskScanSummary> _scanSummaries =
       <String, TorrentTaskScanSummary>{};
   final Set<String> _scanSummaryCheckedKeys = <String>{};
+  bool _isLoadingScanSummaries = false;
+  List<TorrentTask>? _pendingScanSummaryTasks;
+  bool _pendingScanSummaryForce = false;
   String _downloadDirectory = '';
   bool _isLoading = true;
   bool _isBusy = false;
@@ -234,9 +237,34 @@ class _CupertinoTorrentDownloadPageState
     );
     if (file == null) return;
 
+    final initialDirectory = _downloadDirectory.trim().isEmpty
+        ? await _service.getDownloadDirectory()
+        : _downloadDirectory;
+    if (!mounted) return;
+    final selectedDirectory = await FilePickerService().pickDirectory(
+      initialDirectory: initialDirectory,
+    );
+    if (selectedDirectory == null || selectedDirectory.trim().isEmpty) return;
+    if (!mounted) return;
+
+    final downloadDirectory = selectedDirectory.trim();
+    final downloaderSettings = context.read<DownloaderSettingsProvider>();
     await _runBusyAction(
-      action: () => _service.addTorrentFile(file.path),
+      action: () async {
+        await _service.setDownloadDirectory(downloadDirectory);
+        await _service.addTorrentFile(
+          file.path,
+          downloadDirectory: downloadDirectory,
+          createFolderForTask: downloaderSettings.createFolderForTask,
+        );
+      },
       successMessage: '已添加 ${p.basename(file.path)}',
+      afterSuccess: () {
+        if (!mounted) return;
+        setState(() {
+          _downloadDirectory = downloadDirectory;
+        });
+      },
     );
   }
 
@@ -436,6 +464,38 @@ class _CupertinoTorrentDownloadPageState
   Future<void> _loadScanSummariesForTasks(
     List<TorrentTask> tasks, {
     bool force = false,
+  }) async {
+    if (_isLoadingScanSummaries) {
+      _pendingScanSummaryTasks = tasks;
+      _pendingScanSummaryForce = _pendingScanSummaryForce || force;
+      return;
+    }
+
+    _isLoadingScanSummaries = true;
+    var currentTasks = tasks;
+    var currentForce = force;
+    try {
+      while (true) {
+        await _loadScanSummariesForTasksBatch(
+          currentTasks,
+          force: currentForce,
+        );
+
+        final pendingTasks = _pendingScanSummaryTasks;
+        if (pendingTasks == null) break;
+        currentTasks = pendingTasks;
+        currentForce = _pendingScanSummaryForce;
+        _pendingScanSummaryTasks = null;
+        _pendingScanSummaryForce = false;
+      }
+    } finally {
+      _isLoadingScanSummaries = false;
+    }
+  }
+
+  Future<void> _loadScanSummariesForTasksBatch(
+    List<TorrentTask> tasks, {
+    required bool force,
   }) async {
     final targets = tasks.where((task) {
       if (!task.finished || task.outputFolder.trim().isEmpty) return false;
@@ -891,6 +951,7 @@ class _CupertinoAddMagnetSheetState extends State<_CupertinoAddMagnetSheet> {
   TorrentMagnetPreview? _preview;
   String? _error;
   bool _isPreviewing = false;
+  int _previewRequestId = 0;
 
   @override
   void initState() {
@@ -939,6 +1000,7 @@ class _CupertinoAddMagnetSheetState extends State<_CupertinoAddMagnetSheet> {
 
   Future<void> _previewMagnet() async {
     final magnet = _magnetController.text.trim();
+    final downloadDirectory = _downloadDirectory.trim();
     if (magnet.isEmpty) {
       setState(() => _error = '请输入 magnet 链接');
       return;
@@ -947,11 +1009,12 @@ class _CupertinoAddMagnetSheetState extends State<_CupertinoAddMagnetSheet> {
       setState(() => _error = '链接格式不是有效的 magnet 地址');
       return;
     }
-    if (_downloadDirectory.trim().isEmpty) {
+    if (downloadDirectory.isEmpty) {
       setState(() => _error = '请选择下载位置');
       return;
     }
 
+    final requestId = ++_previewRequestId;
     setState(() {
       _isPreviewing = true;
       _preview = null;
@@ -960,19 +1023,25 @@ class _CupertinoAddMagnetSheetState extends State<_CupertinoAddMagnetSheet> {
     try {
       final preview = await widget.service.previewMagnet(
         magnet,
-        downloadDirectory: _downloadDirectory,
+        downloadDirectory: downloadDirectory,
       );
       if (!mounted) return;
+      if (!_isCurrentPreviewRequest(requestId, magnet, downloadDirectory)) {
+        return;
+      }
       setState(() {
         _preview = preview;
       });
     } catch (error) {
       if (!mounted) return;
+      if (!_isCurrentPreviewRequest(requestId, magnet, downloadDirectory)) {
+        return;
+      }
       setState(() {
         _error = '解析失败: $error';
       });
     } finally {
-      if (mounted) {
+      if (mounted && requestId == _previewRequestId) {
         setState(() {
           _isPreviewing = false;
         });
@@ -980,15 +1049,26 @@ class _CupertinoAddMagnetSheetState extends State<_CupertinoAddMagnetSheet> {
     }
   }
 
+  bool _isCurrentPreviewRequest(
+    int requestId,
+    String magnet,
+    String downloadDirectory,
+  ) {
+    return requestId == _previewRequestId &&
+        _magnetController.text.trim() == magnet &&
+        _downloadDirectory.trim() == downloadDirectory;
+  }
+
   void _confirm() {
     final magnet = _magnetController.text.trim();
-    if (_preview == null || magnet.isEmpty || _downloadDirectory.isEmpty) {
+    final downloadDirectory = _downloadDirectory.trim();
+    if (_preview == null || magnet.isEmpty || downloadDirectory.isEmpty) {
       return;
     }
     Navigator.of(context).pop(
       _CupertinoAddMagnetResult(
         magnetUri: magnet,
-        downloadDirectory: _downloadDirectory,
+        downloadDirectory: downloadDirectory,
         createFolderForTask: _createFolderForTask,
       ),
     );

--- a/lib/themes/cupertino/pages/cupertino_torrent_download_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_torrent_download_page.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart' hide Text;
@@ -6,14 +7,30 @@ import 'package:nipaplay/themes/cupertino/cupertino_adaptive_platform_ui.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
 import 'package:nipaplay/models/torrent_task.dart';
 import 'package:nipaplay/models/playable_item.dart';
+import 'package:nipaplay/models/torrent_magnet_preview.dart';
+import 'package:nipaplay/models/torrent_task_scan_summary.dart';
 import 'package:nipaplay/providers/downloader_settings_provider.dart';
 import 'package:nipaplay/providers/service_provider.dart';
 import 'package:nipaplay/services/file_picker_service.dart';
 import 'package:nipaplay/services/playback_service.dart';
 import 'package:nipaplay/services/torrent_download_service.dart';
+import 'package:nipaplay/themes/cupertino/widgets/cupertino_modal_popup.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
+
+enum _CupertinoTorrentTaskViewMode { cards, list }
+
+enum _CupertinoTorrentTaskAction { play, toggle, openFolder, forget, delete }
+
+enum _CupertinoTorrentTaskSort { latest, name, progress, status }
+
+const Map<_CupertinoTorrentTaskSort, String> _cupertinoTorrentTaskSortLabels = {
+  _CupertinoTorrentTaskSort.latest: '最近添加',
+  _CupertinoTorrentTaskSort.name: '名称排序',
+  _CupertinoTorrentTaskSort.progress: '进度排序',
+  _CupertinoTorrentTaskSort.status: '状态排序',
+};
 
 class CupertinoTorrentDownloadPage extends StatefulWidget {
   const CupertinoTorrentDownloadPage({super.key});
@@ -24,19 +41,24 @@ class CupertinoTorrentDownloadPage extends StatefulWidget {
 }
 
 class _CupertinoTorrentDownloadPageState
-    extends State<CupertinoTorrentDownloadPage>
-    with WidgetsBindingObserver {
+    extends State<CupertinoTorrentDownloadPage> with WidgetsBindingObserver {
   final TorrentDownloadService _service = TorrentDownloadService.instance;
-  final TextEditingController _magnetController = TextEditingController();
+  final TextEditingController _searchController = TextEditingController();
   Timer? _refreshTimer;
   List<TorrentTask> _tasks = const <TorrentTask>[];
   final Set<String> _autoScannedCompletedTaskKeys = <String>{};
   final Set<String> _autoScanningTaskKeys = <String>{};
   Future<void> _autoScanChain = Future<void>.value();
+  final Map<String, TorrentTaskScanSummary> _scanSummaries =
+      <String, TorrentTaskScanSummary>{};
+  final Set<String> _scanSummaryCheckedKeys = <String>{};
   String _downloadDirectory = '';
   bool _isLoading = true;
   bool _isBusy = false;
   bool _autoScanRegistryLoaded = false;
+  _CupertinoTorrentTaskViewMode _viewMode = _CupertinoTorrentTaskViewMode.cards;
+  _CupertinoTorrentTaskSort _sort = _CupertinoTorrentTaskSort.latest;
+  String _searchQuery = '';
 
   @override
   void initState() {
@@ -50,7 +72,7 @@ class _CupertinoTorrentDownloadPageState
   void dispose() {
     _refreshTimer?.cancel();
     WidgetsBinding.instance.removeObserver(this);
-    _magnetController.dispose();
+    _searchController.dispose();
     super.dispose();
   }
 
@@ -82,6 +104,7 @@ class _CupertinoTorrentDownloadPageState
         _tasks = tasks;
         _isLoading = false;
       });
+      unawaited(_loadScanSummariesForTasks(tasks));
       unawaited(_handleAutoScanCompletedTasks(tasks, silent: true));
     } catch (e) {
       if (!mounted) return;
@@ -100,6 +123,7 @@ class _CupertinoTorrentDownloadPageState
       setState(() {
         _tasks = tasks;
       });
+      unawaited(_loadScanSummariesForTasks(tasks));
       unawaited(_handleAutoScanCompletedTasks(tasks, silent: silent));
     } catch (e) {
       if (!mounted || silent) return;
@@ -107,46 +131,95 @@ class _CupertinoTorrentDownloadPageState
     }
   }
 
-  Future<void> _chooseDownloadDirectory() async {
-    final selected = await FilePickerService().pickDirectory(
-      initialDirectory:
-          _downloadDirectory.isEmpty ? null : _downloadDirectory,
+  Future<void> _showAddMagnetDialog() async {
+    final downloaderSettings = context.read<DownloaderSettingsProvider>();
+    final initialDirectory = _downloadDirectory.isEmpty
+        ? await _service.getDownloadDirectory()
+        : _downloadDirectory;
+    final recentDirectories = await _service.loadRecentDownloadDirectories();
+    if (!mounted) return;
+    final result =
+        await showCupertinoModalPopupWithBottomBar<_CupertinoAddMagnetResult>(
+      context: context,
+      useRootNavigator: true,
+      barrierDismissible: false,
+      builder: (context) => _CupertinoAddMagnetSheet(
+        service: _service,
+        initialDirectory: initialDirectory,
+        initialRecentDirectories: recentDirectories,
+        initialCreateFolderForTask: downloaderSettings.createFolderForTask,
+      ),
     );
-    if (selected == null || selected.trim().isEmpty) return;
-
-    try {
-      await _service.setDownloadDirectory(selected);
-      final tasks = await _service.listTasks();
-      if (!mounted) return;
-      setState(() {
-        _downloadDirectory = selected;
-        _tasks = tasks;
-      });
-      _showToast('默认下载位置已更新');
-    } catch (e) {
-      if (!mounted) return;
-      _showToast('更新下载位置失败: $e');
-    }
-  }
-
-  Future<void> _addMagnet() async {
-    final magnet = _magnetController.text.trim();
-    if (magnet.isEmpty) {
-      _showToast('请输入 magnet 链接');
-      return;
-    }
-    if (!magnet.startsWith('magnet:')) {
-      _showToast('链接格式不是有效的 magnet 地址');
-      return;
-    }
+    if (result == null) return;
 
     await _runBusyAction(
-      action: () => _service.addMagnet(magnet),
+      action: () async {
+        await _service.setDownloadDirectory(result.downloadDirectory);
+        if (downloaderSettings.createFolderForTask !=
+            result.createFolderForTask) {
+          await downloaderSettings.setCreateFolderForTask(
+            result.createFolderForTask,
+          );
+        }
+        await _service.addMagnet(
+          result.magnetUri,
+          downloadDirectory: result.downloadDirectory,
+          createFolderForTask: result.createFolderForTask,
+        );
+      },
       successMessage: '已添加下载任务',
       afterSuccess: () {
-        _magnetController.clear();
+        if (mounted) {
+          setState(() {
+            _downloadDirectory = result.downloadDirectory;
+          });
+        }
       },
     );
+  }
+
+  void _updateSearchQuery(String value) {
+    setState(() {
+      _searchQuery = value.trim();
+    });
+  }
+
+  void _applySort(_CupertinoTorrentTaskSort sort) {
+    if (_sort == sort) return;
+    setState(() {
+      _sort = sort;
+    });
+  }
+
+  List<TorrentTask> get _visibleTasks {
+    final query = _searchQuery.toLowerCase();
+    final filtered = query.isEmpty
+        ? List<TorrentTask>.from(_tasks)
+        : _tasks.where((task) {
+            final scanText =
+                _scanSummaries[task.autoScanKey]?.displayText ?? '';
+            final haystack = [
+              task.name,
+              task.outputFolder,
+              task.displayState,
+              scanText,
+            ].join('\n').toLowerCase();
+            return haystack.contains(query);
+          }).toList();
+
+    filtered.sort((a, b) {
+      switch (_sort) {
+        case _CupertinoTorrentTaskSort.latest:
+          return b.id.compareTo(a.id);
+        case _CupertinoTorrentTaskSort.name:
+          return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+        case _CupertinoTorrentTaskSort.progress:
+          return b.progress.compareTo(a.progress);
+        case _CupertinoTorrentTaskSort.status:
+          return a.displayState.compareTo(b.displayState);
+      }
+    });
+    return filtered;
   }
 
   Future<void> _pickTorrentFile() async {
@@ -235,13 +308,170 @@ class _CupertinoTorrentDownloadPageState
     );
   }
 
+  void _toggleViewMode() {
+    setState(() {
+      _viewMode = _viewMode == _CupertinoTorrentTaskViewMode.cards
+          ? _CupertinoTorrentTaskViewMode.list
+          : _CupertinoTorrentTaskViewMode.cards;
+    });
+  }
+
+  Future<void> _showSortSheet() async {
+    final selected =
+        await showCupertinoModalPopupWithBottomBar<_CupertinoTorrentTaskSort>(
+      context: context,
+      builder: (sheetContext) => CupertinoActionSheet(
+        title: const Text('排序方式'),
+        actions: _cupertinoTorrentTaskSortLabels.entries
+            .map(
+              (entry) => CupertinoActionSheetAction(
+                onPressed: () => Navigator.of(sheetContext).pop(entry.key),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    if (entry.key == _sort) ...[
+                      const Icon(CupertinoIcons.check_mark, size: 18),
+                      const SizedBox(width: 8),
+                    ],
+                    Text(entry.value),
+                  ],
+                ),
+              ),
+            )
+            .toList(),
+        cancelButton: CupertinoActionSheetAction(
+          onPressed: () => Navigator.of(sheetContext).pop(),
+          child: const Text('取消'),
+        ),
+      ),
+    );
+    if (selected != null) {
+      _applySort(selected);
+    }
+  }
+
+  bool _usesMobileTaskActions(BuildContext context) {
+    return MediaQuery.of(context).size.width < 600;
+  }
+
+  Future<void> _showTaskActions(TorrentTask task) async {
+    final result =
+        await showCupertinoModalPopupWithBottomBar<_CupertinoTorrentTaskAction>(
+      context: context,
+      builder: (sheetContext) => CupertinoActionSheet(
+        title: Text(
+          task.name,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        actions: [
+          if (task.finished)
+            CupertinoActionSheetAction(
+              onPressed: () => Navigator.of(sheetContext)
+                  .pop(_CupertinoTorrentTaskAction.play),
+              child: const Text('播放'),
+            ),
+          if (!task.finished)
+            CupertinoActionSheetAction(
+              onPressed: () => Navigator.of(sheetContext)
+                  .pop(_CupertinoTorrentTaskAction.toggle),
+              child: Text(task.isPaused ? '继续下载' : '暂停下载'),
+            ),
+          CupertinoActionSheetAction(
+            onPressed: () => Navigator.of(sheetContext)
+                .pop(_CupertinoTorrentTaskAction.openFolder),
+            child: const Text('查看文件夹'),
+          ),
+          CupertinoActionSheetAction(
+            onPressed: () => Navigator.of(sheetContext)
+                .pop(_CupertinoTorrentTaskAction.forget),
+            child: const Text('移除任务'),
+          ),
+          CupertinoActionSheetAction(
+            isDestructiveAction: true,
+            onPressed: () => Navigator.of(sheetContext)
+                .pop(_CupertinoTorrentTaskAction.delete),
+            child: const Text('删除任务和文件'),
+          ),
+        ],
+        cancelButton: CupertinoActionSheetAction(
+          onPressed: () => Navigator.of(sheetContext).pop(),
+          child: const Text('取消'),
+        ),
+      ),
+    );
+
+    if (!mounted || result == null) return;
+    switch (result) {
+      case _CupertinoTorrentTaskAction.play:
+        await _playTask(task);
+        break;
+      case _CupertinoTorrentTaskAction.toggle:
+        await _toggleTask(task);
+        break;
+      case _CupertinoTorrentTaskAction.openFolder:
+        await _openTaskFolder(task);
+        break;
+      case _CupertinoTorrentTaskAction.forget:
+        await _forgetTask(task);
+        break;
+      case _CupertinoTorrentTaskAction.delete:
+        await _deleteTask(task);
+        break;
+    }
+  }
+
   Future<void> _loadAutoScanRegistry() async {
     if (_autoScanRegistryLoaded) return;
     final keys = await _service.loadAutoScannedCompletedTaskKeys();
     _autoScannedCompletedTaskKeys
       ..clear()
       ..addAll(keys);
+    for (final key in keys) {
+      _scanSummaryCheckedKeys.remove(key);
+    }
     _autoScanRegistryLoaded = true;
+  }
+
+  Future<void> _loadScanSummariesForTasks(
+    List<TorrentTask> tasks, {
+    bool force = false,
+  }) async {
+    final targets = tasks.where((task) {
+      if (!task.finished || task.outputFolder.trim().isEmpty) return false;
+      return force || !_scanSummaryCheckedKeys.contains(task.autoScanKey);
+    }).toList(growable: false);
+    if (targets.isEmpty) return;
+
+    final summaries = <String, TorrentTaskScanSummary>{};
+    for (final task in targets) {
+      final summary = await _loadScanSummary(task);
+      if (summary != null) {
+        summaries[task.autoScanKey] = summary;
+      }
+    }
+    if (!mounted) return;
+
+    final activeKeys = tasks.map((task) => task.autoScanKey).toSet();
+    final checkedKeys = targets.map((task) => task.autoScanKey);
+    setState(() {
+      _scanSummaries
+        ..removeWhere((key, _) => !activeKeys.contains(key))
+        ..addAll(summaries);
+      _scanSummaryCheckedKeys
+        ..removeWhere((key) => !activeKeys.contains(key))
+        ..addAll(checkedKeys);
+    });
+  }
+
+  Future<TorrentTaskScanSummary?> _loadScanSummary(TorrentTask task) async {
+    final items = await _service.listCompletedFileScanHistoryItems(task);
+    final summary = TorrentTaskScanSummary.fromHistoryItems(items);
+    if (summary.hasItems ||
+        _autoScannedCompletedTaskKeys.contains(task.autoScanKey)) {
+      return summary;
+    }
+    return null;
   }
 
   Future<void> _handleAutoScanCompletedTasks(
@@ -255,6 +485,7 @@ class _CupertinoTorrentDownloadPageState
 
     await _loadAutoScanRegistry();
     if (!mounted) return;
+    unawaited(_loadScanSummariesForTasks(tasks));
 
     for (final task in tasks) {
       if (!task.finished || task.outputFolder.trim().isEmpty) continue;
@@ -292,6 +523,13 @@ class _CupertinoTorrentDownloadPageState
       await ServiceProvider.watchHistoryProvider.refresh();
       await _service.markAutoScannedCompletedTask(key);
       _autoScannedCompletedTaskKeys.add(key);
+      final summary = await _loadScanSummary(task);
+      if (mounted && summary != null) {
+        setState(() {
+          _scanSummaries[key] = summary;
+          _scanSummaryCheckedKeys.add(key);
+        });
+      }
 
       if (!mounted || silent) return;
       _showToast('已自动扫描并加入媒体库: ${task.name}');
@@ -359,8 +597,7 @@ class _CupertinoTorrentDownloadPageState
             itemBuilder: (context, index) {
               final file = files[index];
               return CupertinoButton(
-                padding:
-                    const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+                padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
                 onPressed: () => Navigator.of(ctx).pop(file),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -409,11 +646,23 @@ class _CupertinoTorrentDownloadPageState
       CupertinoColors.systemGroupedBackground,
       context,
     );
+    final visibleTasks = _visibleTasks;
 
     return AdaptiveScaffold(
       appBar: AdaptiveAppBar(
         title: isZh ? '下载器' : 'Downloader',
         useNativeToolbar: true,
+        actions: [
+          AdaptiveAppBarAction(
+            iosSymbol: _viewMode == _CupertinoTorrentTaskViewMode.cards
+                ? 'list.bullet'
+                : 'square.grid.2x2',
+            icon: _viewMode == _CupertinoTorrentTaskViewMode.cards
+                ? CupertinoIcons.list_bullet
+                : CupertinoIcons.square_grid_2x2,
+            onPressed: _toggleViewMode,
+          ),
+        ],
       ),
       body: ColoredBox(
         color: backgroundColor,
@@ -427,9 +676,9 @@ class _CupertinoTorrentDownloadPageState
                     color: CupertinoColors.separator.resolveFrom(context),
                   ),
                   Expanded(
-                    child: _tasks.isEmpty
-                        ? _buildEmptyState()
-                        : _buildTaskList(),
+                    child: visibleTasks.isEmpty
+                        ? _buildEmptyState(isFiltered: _tasks.isNotEmpty)
+                        : _buildTaskList(visibleTasks),
                   ),
                 ],
               ),
@@ -437,7 +686,7 @@ class _CupertinoTorrentDownloadPageState
     );
   }
 
-  Widget _buildEmptyState() {
+  Widget _buildEmptyState({bool isFiltered = false}) {
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -449,7 +698,7 @@ class _CupertinoTorrentDownloadPageState
           ),
           const SizedBox(height: 16),
           Text(
-            '暂无下载任务',
+            isFiltered ? '没有匹配的下载任务' : '暂无下载任务',
             style: TextStyle(
               fontSize: 17,
               color: CupertinoColors.systemGrey.resolveFrom(context),
@@ -457,7 +706,9 @@ class _CupertinoTorrentDownloadPageState
           ),
           const SizedBox(height: 8),
           Text(
-            '添加 magnet 链接或 .torrent 文件后，任务会显示在这里。',
+            isFiltered
+                ? '换一个关键词或清空搜索后再查看。'
+                : '添加 magnet 链接或 .torrent 文件后，任务会显示在这里。',
             style: TextStyle(
               fontSize: 14,
               color: CupertinoColors.systemGrey2.resolveFrom(context),
@@ -471,138 +722,128 @@ class _CupertinoTorrentDownloadPageState
   Widget _buildTopBar() {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
-      child: Column(
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: _buildDirectoryRow(),
-              ),
-              CupertinoButton(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                minimumSize: Size.zero,
-                onPressed: () => _refreshTasks(),
-                child: const Icon(CupertinoIcons.refresh, size: 20),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          Row(
-            children: [
-              Expanded(
-                child: CupertinoTextField(
-                  controller: _magnetController,
-                  enabled: !_isBusy,
-                  onSubmitted: (_) => _addMagnet(),
-                  placeholder: 'magnet:?xt=urn:btih:...',
-                  prefix: Padding(
-                    padding: const EdgeInsets.only(left: 8),
-                    child: Icon(
-                      CupertinoIcons.link,
-                      size: 18,
-                      color: CupertinoColors.systemGrey3.resolveFrom(context),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final compact = constraints.maxWidth < 560;
+          final search = CupertinoSearchTextField(
+            controller: _searchController,
+            onChanged: _updateSearchQuery,
+            onSuffixTap: () {
+              _searchController.clear();
+              _updateSearchQuery('');
+            },
+            placeholder: '搜索下载任务',
+          );
+          final sortButton = CupertinoButton(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+            minimumSize: Size.zero,
+            onPressed: _showSortSheet,
+            child: Text(
+              _cupertinoTorrentTaskSortLabels[_sort] ?? '排序',
+              style: const TextStyle(fontSize: 14),
+            ),
+          );
+          final actions = <Widget>[
+            CupertinoButton(
+              padding: const EdgeInsets.all(7),
+              minimumSize: Size.zero,
+              onPressed: () => _refreshTasks(),
+              child: const Icon(CupertinoIcons.refresh, size: 20),
+            ),
+            const SizedBox(width: 4),
+            CupertinoButton(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+              color: AppAccentColors.current,
+              borderRadius: BorderRadius.circular(8),
+              minimumSize: Size.zero,
+              onPressed: _isBusy ? null : _showAddMagnetDialog,
+              child: const Text('添加', style: TextStyle(fontSize: 14)),
+            ),
+            const SizedBox(width: 4),
+            CupertinoButton(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+              minimumSize: Size.zero,
+              onPressed: _isBusy ? null : _pickTorrentFile,
+              child: const Text('种子', style: TextStyle(fontSize: 14)),
+            ),
+          ];
+
+          if (compact) {
+            return Column(
+              children: [
+                search,
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    sortButton,
+                    const SizedBox(width: 4),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        child: Row(children: actions),
+                      ),
                     ),
-                  ),
-                  style: const TextStyle(fontSize: 14),
-                  padding:
-                      const EdgeInsets.symmetric(vertical: 10, horizontal: 4),
-                  decoration: BoxDecoration(
-                    color: CupertinoColors.tertiarySystemFill
-                        .resolveFrom(context),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
+                  ],
                 ),
-              ),
+              ],
+            );
+          }
+
+          return Row(
+            children: [
+              Expanded(child: search),
               const SizedBox(width: 8),
-              CupertinoButton(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                color: AppAccentColors.current,
-                borderRadius: BorderRadius.circular(8),
-                onPressed: _isBusy ? null : _addMagnet,
-                child: const Text('添加', style: TextStyle(fontSize: 14)),
-              ),
+              sortButton,
               const SizedBox(width: 4),
-              CupertinoButton(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                onPressed: _isBusy ? null : _pickTorrentFile,
-                child:
-                    const Text('种子', style: TextStyle(fontSize: 14)),
-              ),
+              ...actions,
             ],
-          ),
-        ],
+          );
+        },
       ),
     );
   }
 
-  Widget _buildDirectoryRow() {
-    return GestureDetector(
-      onTap: _chooseDownloadDirectory,
-      behavior: HitTestBehavior.opaque,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 4),
-        child: Row(
-          children: [
-            Icon(
-              CupertinoIcons.folder,
-              size: 20,
-              color: CupertinoColors.systemGrey.resolveFrom(context),
-            ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    '默认下载位置',
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      color: CupertinoColors.label.resolveFrom(context),
-                    ),
-                  ),
-                  Text(
-                    _downloadDirectory.isEmpty
-                        ? '使用应用下载目录'
-                        : _downloadDirectory,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 12,
-                      color:
-                          CupertinoColors.systemGrey.resolveFrom(context),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Icon(
-              CupertinoIcons.chevron_right,
-              size: 16,
-              color: CupertinoColors.systemGrey2.resolveFrom(context),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
+  Widget _buildTaskList(List<TorrentTask> tasks) {
+    final useActionSheet = _usesMobileTaskActions(context);
+    if (_viewMode == _CupertinoTorrentTaskViewMode.list) {
+      return ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemCount: tasks.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 8),
+        itemBuilder: (context, index) {
+          final task = tasks[index];
+          return _CupertinoTorrentTaskListItem(
+            task: task,
+            scanSummary: _scanSummaries[task.autoScanKey],
+            isAutoScanning: _autoScanningTaskKeys.contains(task.autoScanKey),
+            isAutoScanned:
+                _autoScannedCompletedTaskKeys.contains(task.autoScanKey),
+            onShowActions: () => _showTaskActions(task),
+          );
+        },
+      );
+    }
 
-  Widget _buildTaskList() {
     return ListView.builder(
       padding: const EdgeInsets.all(16),
-      itemCount: _tasks.length,
-      itemBuilder: (context, index) =>
-          _CupertinoTorrentTaskCard(
-        task: _tasks[index],
-        onPlay: () => _playTask(_tasks[index]),
-        onToggle: () => _toggleTask(_tasks[index]),
-        onOpenFolder: () => _openTaskFolder(_tasks[index]),
-        onForget: () => _forgetTask(_tasks[index]),
-        onDelete: () => _deleteTask(_tasks[index]),
-      ),
+      itemCount: tasks.length,
+      itemBuilder: (context, index) {
+        final task = tasks[index];
+        return _CupertinoTorrentTaskCard(
+          task: task,
+          scanSummary: _scanSummaries[task.autoScanKey],
+          isAutoScanning: _autoScanningTaskKeys.contains(task.autoScanKey),
+          isAutoScanned:
+              _autoScannedCompletedTaskKeys.contains(task.autoScanKey),
+          useActionSheet: useActionSheet,
+          onShowActions: () => _showTaskActions(task),
+          onPlay: () => _playTask(task),
+          onToggle: () => _toggleTask(task),
+          onOpenFolder: () => _openTaskFolder(task),
+          onForget: () => _forgetTask(task),
+          onDelete: () => _deleteTask(task),
+        );
+      },
     );
   }
 
@@ -612,9 +853,655 @@ class _CupertinoTorrentDownloadPageState
   }
 }
 
+class _CupertinoAddMagnetResult {
+  const _CupertinoAddMagnetResult({
+    required this.magnetUri,
+    required this.downloadDirectory,
+    required this.createFolderForTask,
+  });
+
+  final String magnetUri;
+  final String downloadDirectory;
+  final bool createFolderForTask;
+}
+
+class _CupertinoAddMagnetSheet extends StatefulWidget {
+  const _CupertinoAddMagnetSheet({
+    required this.service,
+    required this.initialDirectory,
+    required this.initialRecentDirectories,
+    required this.initialCreateFolderForTask,
+  });
+
+  final TorrentDownloadService service;
+  final String initialDirectory;
+  final List<String> initialRecentDirectories;
+  final bool initialCreateFolderForTask;
+
+  @override
+  State<_CupertinoAddMagnetSheet> createState() =>
+      _CupertinoAddMagnetSheetState();
+}
+
+class _CupertinoAddMagnetSheetState extends State<_CupertinoAddMagnetSheet> {
+  late final TextEditingController _magnetController;
+  late String _downloadDirectory;
+  late bool _createFolderForTask;
+  late List<String> _recentDirectories;
+  TorrentMagnetPreview? _preview;
+  String? _error;
+  bool _isPreviewing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _magnetController = TextEditingController();
+    _downloadDirectory = widget.initialDirectory;
+    _createFolderForTask = widget.initialCreateFolderForTask;
+    _recentDirectories = List<String>.from(widget.initialRecentDirectories);
+  }
+
+  @override
+  void dispose() {
+    _magnetController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _chooseDirectory() async {
+    final selected = await FilePickerService().pickDirectory(
+      initialDirectory:
+          _downloadDirectory.trim().isEmpty ? null : _downloadDirectory,
+    );
+    if (selected == null || selected.trim().isEmpty) return;
+    await widget.service.rememberRecentDownloadDirectory(selected.trim());
+    _selectDirectory(selected.trim());
+  }
+
+  void _selectDirectory(String directory) {
+    setState(() {
+      _downloadDirectory = directory;
+      _recentDirectories = [
+        directory,
+        ..._recentDirectories.where((value) => value != directory),
+      ].take(8).toList(growable: false);
+      _preview = null;
+      _error = null;
+    });
+  }
+
+  Future<void> _removeRecentDirectory(String directory) async {
+    await widget.service.removeRecentDownloadDirectory(directory);
+    if (!mounted) return;
+    setState(() {
+      _recentDirectories.remove(directory);
+    });
+  }
+
+  Future<void> _previewMagnet() async {
+    final magnet = _magnetController.text.trim();
+    if (magnet.isEmpty) {
+      setState(() => _error = '请输入 magnet 链接');
+      return;
+    }
+    if (!magnet.startsWith('magnet:')) {
+      setState(() => _error = '链接格式不是有效的 magnet 地址');
+      return;
+    }
+    if (_downloadDirectory.trim().isEmpty) {
+      setState(() => _error = '请选择下载位置');
+      return;
+    }
+
+    setState(() {
+      _isPreviewing = true;
+      _preview = null;
+      _error = null;
+    });
+    try {
+      final preview = await widget.service.previewMagnet(
+        magnet,
+        downloadDirectory: _downloadDirectory,
+      );
+      if (!mounted) return;
+      setState(() {
+        _preview = preview;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _error = '解析失败: $error';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isPreviewing = false;
+        });
+      }
+    }
+  }
+
+  void _confirm() {
+    final magnet = _magnetController.text.trim();
+    if (_preview == null || magnet.isEmpty || _downloadDirectory.isEmpty) {
+      return;
+    }
+    Navigator.of(context).pop(
+      _CupertinoAddMagnetResult(
+        magnetUri: magnet,
+        downloadDirectory: _downloadDirectory,
+        createFolderForTask: _createFolderForTask,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaSize = MediaQuery.of(context).size;
+    final sheetWidth = math.min(mediaSize.width - 16, 980.0);
+    final sheetHeight = mediaSize.width < 600
+        ? mediaSize.height * 0.88
+        : math.min(mediaSize.height - 80, 680.0);
+    final backgroundColor =
+        CupertinoColors.secondarySystemBackground.resolveFrom(context);
+    final labelColor = CupertinoColors.label.resolveFrom(context);
+    final separatorColor = CupertinoColors.separator.resolveFrom(context);
+
+    return SafeArea(
+      top: false,
+      child: Align(
+        alignment: Alignment.bottomCenter,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+          child: CupertinoPopupSurface(
+            isSurfacePainted: true,
+            child: Container(
+              width: sheetWidth,
+              height: sheetHeight,
+              decoration: BoxDecoration(
+                color: backgroundColor,
+                borderRadius: BorderRadius.circular(18),
+              ),
+              padding: const EdgeInsets.fromLTRB(18, 16, 18, 14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          '添加磁力链接',
+                          style: TextStyle(
+                            color: labelColor,
+                            fontSize: 18,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                      CupertinoButton(
+                        padding: EdgeInsets.zero,
+                        minimumSize: Size.zero,
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: const Icon(
+                          CupertinoIcons.xmark_circle,
+                          size: 24,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 14),
+                  Expanded(
+                    child: LayoutBuilder(
+                      builder: (context, constraints) {
+                        final useColumns = constraints.maxWidth >= 760;
+                        final settings = _buildSettingsPane();
+                        final preview = _buildPreviewPane();
+                        if (!useColumns) {
+                          return ListView(
+                            children: [
+                              settings,
+                              const SizedBox(height: 16),
+                              SizedBox(height: 330, child: preview),
+                            ],
+                          );
+                        }
+                        return Row(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            SizedBox(width: 360, child: settings),
+                            const SizedBox(width: 18),
+                            Container(width: 0.5, color: separatorColor),
+                            const SizedBox(width: 18),
+                            Expanded(child: preview),
+                          ],
+                        );
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 14),
+                  Row(
+                    children: [
+                      if (_error != null)
+                        Expanded(
+                          child: Text(
+                            _error!,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: CupertinoColors.destructiveRed.resolveFrom(
+                                context,
+                              ),
+                              fontSize: 12,
+                            ),
+                          ),
+                        )
+                      else
+                        const Spacer(),
+                      const SizedBox(width: 10),
+                      CupertinoButton(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 7,
+                        ),
+                        minimumSize: Size.zero,
+                        onPressed: _isPreviewing
+                            ? null
+                            : () => Navigator.of(context).pop(),
+                        child: const Text('取消'),
+                      ),
+                      const SizedBox(width: 6),
+                      CupertinoButton(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 7,
+                        ),
+                        minimumSize: Size.zero,
+                        onPressed: _isPreviewing ? null : _previewMagnet,
+                        child: _isPreviewing
+                            ? const CupertinoActivityIndicator()
+                            : Text(_preview == null ? '预览' : '重新预览'),
+                      ),
+                      const SizedBox(width: 6),
+                      CupertinoButton(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 7,
+                        ),
+                        minimumSize: Size.zero,
+                        color: _preview == null || _isPreviewing
+                            ? CupertinoColors.systemGrey4.resolveFrom(context)
+                            : AppAccentColors.current,
+                        onPressed:
+                            _preview == null || _isPreviewing ? null : _confirm,
+                        child: const Text('添加任务'),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSettingsPane() {
+    final fillColor = CupertinoColors.tertiarySystemFill.resolveFrom(context);
+    final labelColor = CupertinoColors.label.resolveFrom(context);
+    final secondaryColor = CupertinoColors.secondaryLabel.resolveFrom(context);
+
+    return ListView(
+      children: [
+        const _CupertinoDialogLabel('磁力链接'),
+        const SizedBox(height: 8),
+        CupertinoTextField(
+          controller: _magnetController,
+          minLines: 3,
+          maxLines: 5,
+          placeholder: 'magnet:?xt=urn:btih:...',
+          padding: const EdgeInsets.all(12),
+          onChanged: (_) {
+            if (_preview != null || _error != null) {
+              setState(() {
+                _preview = null;
+                _error = null;
+              });
+            }
+          },
+          decoration: BoxDecoration(
+            color: fillColor,
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ),
+        const SizedBox(height: 18),
+        const _CupertinoDialogLabel('保存到'),
+        const SizedBox(height: 8),
+        Container(
+          padding: const EdgeInsets.fromLTRB(12, 10, 6, 10),
+          decoration: BoxDecoration(
+            color: fillColor,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  _downloadDirectory.isEmpty ? '请选择下载位置' : _downloadDirectory,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: _downloadDirectory.isEmpty
+                        ? secondaryColor
+                        : labelColor,
+                    fontSize: 13,
+                  ),
+                ),
+              ),
+              CupertinoButton(
+                padding: const EdgeInsets.all(6),
+                minimumSize: Size.zero,
+                onPressed: _chooseDirectory,
+                child: const Icon(CupertinoIcons.folder, size: 20),
+              ),
+            ],
+          ),
+        ),
+        if (_recentDirectories.isNotEmpty) ...[
+          const SizedBox(height: 14),
+          _buildQuickSelect(),
+        ],
+        const SizedBox(height: 14),
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                '为任务创建独立文件夹',
+                style: TextStyle(color: labelColor, fontSize: 14),
+              ),
+            ),
+            CupertinoSwitch(
+              value: _createFolderForTask,
+              onChanged: (value) {
+                setState(() {
+                  _createFolderForTask = value;
+                });
+              },
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        if (_preview != null) _buildPreviewSummary(_preview!),
+      ],
+    );
+  }
+
+  Widget _buildQuickSelect() {
+    final fillColor = CupertinoColors.tertiarySystemFill.resolveFrom(context);
+    final labelColor = CupertinoColors.label.resolveFrom(context);
+    final secondaryColor = CupertinoColors.secondaryLabel.resolveFrom(context);
+    final separatorColor = CupertinoColors.separator.resolveFrom(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _CupertinoDialogLabel('快速选择'),
+        const SizedBox(height: 8),
+        Container(
+          decoration: BoxDecoration(
+            color: fillColor,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            children: [
+              for (var index = 0; index < _recentDirectories.length; index++)
+                Column(
+                  children: [
+                    if (index > 0)
+                      Container(height: 0.5, color: separatorColor),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: CupertinoButton(
+                            padding: const EdgeInsets.fromLTRB(12, 9, 6, 9),
+                            minimumSize: Size.zero,
+                            alignment: Alignment.centerLeft,
+                            onPressed: () =>
+                                _selectDirectory(_recentDirectories[index]),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  _downloadDirectory ==
+                                          _recentDirectories[index]
+                                      ? CupertinoIcons.check_mark_circled
+                                      : CupertinoIcons.folder,
+                                  size: 17,
+                                  color: _downloadDirectory ==
+                                          _recentDirectories[index]
+                                      ? AppAccentColors.current
+                                      : secondaryColor,
+                                ),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    _recentDirectories[index],
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TextStyle(
+                                      color: _downloadDirectory ==
+                                              _recentDirectories[index]
+                                          ? AppAccentColors.current
+                                          : labelColor,
+                                      fontSize: 13,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                        CupertinoButton(
+                          padding: const EdgeInsets.all(8),
+                          minimumSize: Size.zero,
+                          onPressed: () => _removeRecentDirectory(
+                            _recentDirectories[index],
+                          ),
+                          child: Icon(
+                            CupertinoIcons.xmark_circle,
+                            size: 18,
+                            color: secondaryColor,
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                      ],
+                    ),
+                  ],
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPreviewSummary(TorrentMagnetPreview preview) {
+    final secondaryColor = CupertinoColors.secondaryLabel.resolveFrom(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: CupertinoColors.tertiarySystemFill.resolveFrom(context),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            preview.name,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: CupertinoColors.label.resolveFrom(context),
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '${preview.files.length} 个文件，${_CupertinoTorrentTaskCard._formatBytes(preview.totalSize)}',
+            style: TextStyle(color: secondaryColor, fontSize: 12),
+          ),
+          if (preview.suggestedFolderName.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              '文件夹：${preview.suggestedFolderName}',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(color: secondaryColor, fontSize: 12),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPreviewPane() {
+    final labelColor = CupertinoColors.label.resolveFrom(context);
+    final secondaryColor = CupertinoColors.secondaryLabel.resolveFrom(context);
+    final separatorColor = CupertinoColors.separator.resolveFrom(context);
+    final preview = _preview;
+
+    if (_isPreviewing) {
+      return const Center(child: CupertinoActivityIndicator());
+    }
+    if (preview == null) {
+      return Container(
+        decoration: BoxDecoration(
+          color: CupertinoColors.systemBackground.resolveFrom(context),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Center(
+          child: Text(
+            '输入 magnet 链接后预览文件',
+            style: TextStyle(color: secondaryColor, fontSize: 13),
+          ),
+        ),
+      );
+    }
+
+    return Container(
+      decoration: BoxDecoration(
+        color: CupertinoColors.systemBackground.resolveFrom(context),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        children: [
+          Container(
+            height: 36,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            decoration: BoxDecoration(
+              color: CupertinoColors.tertiarySystemFill.resolveFrom(context),
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(8)),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    '名称',
+                    style: TextStyle(
+                      color: secondaryColor,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                SizedBox(
+                  width: 88,
+                  child: Text(
+                    '大小',
+                    textAlign: TextAlign.right,
+                    style: TextStyle(
+                      color: secondaryColor,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.separated(
+              itemCount: preview.files.length,
+              separatorBuilder: (_, __) =>
+                  Container(height: 0.5, color: separatorColor),
+              itemBuilder: (context, index) {
+                final file = preview.files[index];
+                return Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          child: Text(
+                            file.path,
+                            softWrap: false,
+                            style: TextStyle(color: labelColor, fontSize: 13),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      SizedBox(
+                        width: 88,
+                        child: Text(
+                          _CupertinoTorrentTaskCard._formatBytes(file.length),
+                          textAlign: TextAlign.right,
+                          style: TextStyle(
+                            color: secondaryColor,
+                            fontSize: 12,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CupertinoDialogLabel extends StatelessWidget {
+  const _CupertinoDialogLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: TextStyle(
+        color: CupertinoColors.secondaryLabel.resolveFrom(context),
+        fontSize: 13,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+}
+
 class _CupertinoTorrentTaskCard extends StatelessWidget {
   const _CupertinoTorrentTaskCard({
     required this.task,
+    required this.scanSummary,
+    required this.isAutoScanning,
+    required this.isAutoScanned,
+    required this.useActionSheet,
+    required this.onShowActions,
     required this.onPlay,
     required this.onToggle,
     required this.onOpenFolder,
@@ -623,6 +1510,11 @@ class _CupertinoTorrentTaskCard extends StatelessWidget {
   });
 
   final TorrentTask task;
+  final TorrentTaskScanSummary? scanSummary;
+  final bool isAutoScanning;
+  final bool isAutoScanned;
+  final bool useActionSheet;
+  final VoidCallback onShowActions;
   final VoidCallback onPlay;
   final VoidCallback onToggle;
   final VoidCallback onOpenFolder;
@@ -682,6 +1574,10 @@ class _CupertinoTorrentTaskCard extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               _CupertinoStateBadge(task: task),
+              if (useActionSheet) ...[
+                const SizedBox(width: 4),
+                _CupertinoTaskMoreButton(onPressed: onShowActions),
+              ],
             ],
           ),
           const SizedBox(height: 14),
@@ -693,8 +1589,7 @@ class _CupertinoTorrentTaskCard extends StatelessWidget {
               color: task.hasError
                   ? CupertinoColors.destructiveRed.resolveFrom(context)
                   : AppAccentColors.current,
-              backgroundColor:
-                  CupertinoColors.systemGrey5.resolveFrom(context),
+              backgroundColor: CupertinoColors.systemGrey5.resolveFrom(context),
             ),
           ),
           const SizedBox(height: 10),
@@ -709,6 +1604,12 @@ class _CupertinoTorrentTaskCard extends StatelessWidget {
                   '${_formatBytes(task.downloadSpeedBytesPerSecond)}/s'),
               _metricText(context, '上传',
                   '${_formatBytes(task.uploadSpeedBytesPerSecond)}/s'),
+              if (isAutoScanning || scanSummary != null || isAutoScanned)
+                _CupertinoTaskScanText(
+                  summary: scanSummary,
+                  isScanning: isAutoScanning,
+                  isScanned: isAutoScanned,
+                ),
             ],
           ),
           if (task.error?.isNotEmpty ?? false) ...[
@@ -723,8 +1624,10 @@ class _CupertinoTorrentTaskCard extends StatelessWidget {
               ),
             ),
           ],
-          const SizedBox(height: 12),
-          _buildActionButtons(context),
+          if (!useActionSheet) ...[
+            const SizedBox(height: 12),
+            _buildActionButtons(context),
+          ],
         ],
       ),
     );
@@ -733,7 +1636,8 @@ class _CupertinoTorrentTaskCard extends StatelessWidget {
   Widget _buildActionButtons(BuildContext context) {
     final actions = <Widget>[];
     if (task.finished) {
-      actions.add(_actionButton(context, CupertinoIcons.play_circle, '播放', onPlay));
+      actions.add(
+          _actionButton(context, CupertinoIcons.play_circle, '播放', onPlay));
     } else {
       actions.add(_actionButton(
         context,
@@ -777,8 +1681,7 @@ class _CupertinoTorrentTaskCard extends StatelessWidget {
   }
 
   Widget _metricText(BuildContext context, String label, String value) {
-    final secondaryColor =
-        CupertinoColors.secondaryLabel.resolveFrom(context);
+    final secondaryColor = CupertinoColors.secondaryLabel.resolveFrom(context);
     return Text.rich(
       TextSpan(
         children: [
@@ -812,6 +1715,190 @@ class _CupertinoTorrentTaskCard extends StatelessWidget {
             ? 1
             : 2;
     return '${value.toStringAsFixed(digits)} ${units[unit]}';
+  }
+}
+
+class _CupertinoTorrentTaskListItem extends StatelessWidget {
+  const _CupertinoTorrentTaskListItem({
+    required this.task,
+    required this.scanSummary,
+    required this.isAutoScanning,
+    required this.isAutoScanned,
+    required this.onShowActions,
+  });
+
+  final TorrentTask task;
+  final TorrentTaskScanSummary? scanSummary;
+  final bool isAutoScanning;
+  final bool isAutoScanned;
+  final VoidCallback onShowActions;
+
+  @override
+  Widget build(BuildContext context) {
+    final accentColor = AppAccentColors.current;
+    final progress = task.progress;
+    final labelColor = CupertinoColors.label.resolveFrom(context);
+    final secondaryColor = CupertinoColors.secondaryLabel.resolveFrom(context);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: CupertinoColors.secondarySystemGroupedBackground
+            .resolveFrom(context),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      padding: const EdgeInsets.fromLTRB(12, 10, 8, 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                CupertinoIcons.cloud_download,
+                color: accentColor,
+                size: 21,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      task.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: labelColor,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      task.outputFolder,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(color: secondaryColor, fontSize: 12),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              _CupertinoStateBadge(task: task),
+              const SizedBox(width: 4),
+              _CupertinoTaskMoreButton(onPressed: onShowActions),
+            ],
+          ),
+          const SizedBox(height: 10),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(99),
+            child: LinearProgressIndicator(
+              value: progress,
+              minHeight: 5,
+              color: task.hasError
+                  ? CupertinoColors.destructiveRed.resolveFrom(context)
+                  : AppAccentColors.current,
+              backgroundColor: CupertinoColors.systemGrey5.resolveFrom(context),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 12,
+            runSpacing: 5,
+            children: [
+              _metricText(context, '进度',
+                  _CupertinoTorrentTaskCard._formatPercent(progress)),
+              _metricText(context, '已下载',
+                  '${_CupertinoTorrentTaskCard._formatBytes(task.progressBytes)} / ${_CupertinoTorrentTaskCard._formatBytes(task.totalBytes)}'),
+              _metricText(context, '下载',
+                  '${_CupertinoTorrentTaskCard._formatBytes(task.downloadSpeedBytesPerSecond)}/s'),
+              _metricText(context, '上传',
+                  '${_CupertinoTorrentTaskCard._formatBytes(task.uploadSpeedBytesPerSecond)}/s'),
+              if (isAutoScanning || scanSummary != null || isAutoScanned)
+                _CupertinoTaskScanText(
+                  summary: scanSummary,
+                  isScanning: isAutoScanning,
+                  isScanned: isAutoScanned,
+                ),
+            ],
+          ),
+          if (task.error?.isNotEmpty ?? false) ...[
+            const SizedBox(height: 8),
+            Text(
+              task.error!,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: CupertinoColors.destructiveRed.resolveFrom(context),
+                fontSize: 12,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _metricText(BuildContext context, String label, String value) {
+    final secondaryColor = CupertinoColors.secondaryLabel.resolveFrom(context);
+    return Text.rich(
+      TextSpan(
+        children: [
+          TextSpan(
+            text: '$label ',
+            style: TextStyle(color: secondaryColor),
+          ),
+          TextSpan(text: value),
+        ],
+      ),
+      style: const TextStyle(fontSize: 12),
+    );
+  }
+}
+
+class _CupertinoTaskMoreButton extends StatelessWidget {
+  const _CupertinoTaskMoreButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoButton(
+      padding: const EdgeInsets.all(6),
+      minimumSize: Size.zero,
+      onPressed: onPressed,
+      child: const Icon(CupertinoIcons.ellipsis_circle, size: 22),
+    );
+  }
+}
+
+class _CupertinoTaskScanText extends StatelessWidget {
+  const _CupertinoTaskScanText({
+    required this.summary,
+    required this.isScanning,
+    required this.isScanned,
+  });
+
+  final TorrentTaskScanSummary? summary;
+  final bool isScanning;
+  final bool isScanned;
+
+  @override
+  Widget build(BuildContext context) {
+    final String text = isScanning
+        ? '正在扫描入库...'
+        : summary?.displayText ?? (isScanned ? '已扫描，正在读取结果...' : '');
+    if (text.isEmpty) return const SizedBox.shrink();
+
+    return Text(
+      text,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: TextStyle(
+        color: CupertinoColors.secondaryLabel.resolveFrom(context),
+        fontSize: 12,
+      ),
+    );
   }
 }
 

--- a/rust/src/api/torrent.rs
+++ b/rust/src/api/torrent.rs
@@ -49,9 +49,6 @@ fn torrent_runtime() -> &'static TorrentRuntime {
 pub fn torrent_init_session(download_dir: String) -> Result<(), String> {
     let normalized_dir = normalize_download_dir(download_dir)?;
     let state = torrent_runtime();
-    torrent_log(format_args!(
-        "init_session start: download_dir={normalized_dir:?}"
-    ));
     std::fs::create_dir_all(&normalized_dir)
         .map_err(|error| format!("failed to create download directory: {error}"))?;
 
@@ -65,9 +62,6 @@ pub fn torrent_init_session(download_dir: String) -> Result<(), String> {
             .lock()
             .map_err(|_| "torrent API lock poisoned".to_string())?;
         if api_slot.is_some() {
-            torrent_log(format_args!(
-                "init_session reuse existing session: download_dir={normalized_dir:?}"
-            ));
             let mut current_dir = state
                 .download_dir
                 .lock()
@@ -116,7 +110,6 @@ pub fn torrent_init_session(download_dir: String) -> Result<(), String> {
         .map_err(|_| "torrent download directory lock poisoned".to_string())?;
     *current_dir = Some(normalized_dir);
 
-    torrent_log(format_args!("init_session success"));
     Ok(())
 }
 
@@ -298,6 +291,20 @@ pub fn torrent_add_file(
             }
         }
     })
+}
+
+pub fn torrent_preview_magnet(magnet_uri: String, download_dir: String) -> Result<String, String> {
+    let magnet_uri = magnet_uri.trim().to_string();
+    if magnet_uri.is_empty() {
+        return Err("magnet URI is empty".to_string());
+    }
+    Magnet::parse(&magnet_uri).map_err(|error| format!("invalid magnet URI: {error:#}"))?;
+
+    let normalized_dir = normalize_download_dir(download_dir)?;
+    torrent_init_session(normalized_dir)?;
+    let state = torrent_runtime();
+    let metadata = resolve_magnet_metadata_for_add(state, &magnet_uri)?;
+    torrent_preview_to_json(&metadata)
 }
 
 pub fn torrent_list(download_dir: String) -> Result<String, String> {
@@ -801,6 +808,58 @@ fn torrent_metadata_folder_name(metadata: &ListOnlyResponse) -> Option<String> {
     }
 
     largest_file.map(|(_, folder_name)| folder_name)
+}
+
+fn torrent_metadata_display_name(metadata: &ListOnlyResponse) -> Option<String> {
+    metadata.info.name.as_ref().and_then(|name| {
+        let name = String::from_utf8_lossy(name.as_slice()).trim().to_string();
+        if name.is_empty() {
+            None
+        } else {
+            Some(name)
+        }
+    })
+}
+
+fn torrent_preview_to_json(metadata: &ListOnlyResponse) -> Result<String, String> {
+    let files = metadata
+        .info
+        .iter_file_details()
+        .map_err(|error| format!("failed to list torrent files: {error:#}"))?;
+    let mut total_size = 0_u64;
+    let files_json = files
+        .enumerate()
+        .map(|(index, file)| {
+            total_size = total_size.saturating_add(file.len);
+            let path = file
+                .filename
+                .to_string()
+                .unwrap_or_else(|_| format!("file-{}", index + 1));
+            serde_json::json!({
+                "index": index,
+                "path": path,
+                "length": file.len,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let suggested_folder_name = torrent_metadata_folder_name(metadata).unwrap_or_default();
+    let name = torrent_metadata_display_name(metadata)
+        .or_else(|| {
+            if suggested_folder_name.is_empty() {
+                None
+            } else {
+                Some(suggested_folder_name.clone())
+            }
+        })
+        .unwrap_or_else(|| "未命名任务".to_string());
+
+    response_to_json(&serde_json::json!({
+        "name": name,
+        "suggested_folder_name": suggested_folder_name,
+        "total_size": total_size,
+        "files": files_json,
+    }))
 }
 
 fn url_path_segment_encode(input: &str) -> String {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1494214116;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1429887362;
 
 // Section: executor
 
@@ -969,6 +969,43 @@ fn wire__crate__api__torrent__torrent_pause_impl(
         },
     )
 }
+fn wire__crate__api__torrent__torrent_preview_magnet_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "torrent_preview_magnet",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_magnet_uri = <String>::sse_decode(&mut deserializer);
+            let api_download_dir = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::torrent::torrent_preview_magnet(
+                        api_magnet_uri,
+                        api_download_dir,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__torrent__torrent_resume_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -1844,8 +1881,14 @@ fn pde_ffi_dispatcher_primary_impl(
         }
         25 => wire__crate__api__torrent__torrent_list_impl(port, ptr, rust_vec_len, data_len),
         26 => wire__crate__api__torrent__torrent_pause_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__torrent__torrent_resume_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__torrent__torrent_stream_url_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__torrent__torrent_preview_magnet_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        28 => wire__crate__api__torrent__torrent_resume_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__torrent__torrent_stream_url_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
## What changed

- Added downloader card/list view switching and compact list rendering.
- Added search and sort controls to the downloader toolbar.
- Reworked magnet adding into a preview-and-confirm flow with torrent file metadata preview.
- Moved download location selection into the add flow, with shared recent folder quick selection and removable entries.
- Added completed-download scan summary display using exact completed file history lookups.
- Updated Cupertino downloader behavior to use the project bottom sheet pattern for mobile actions and magnet adding.
- Reduced noisy torrent initialization and download-directory logs.

## Why

The downloader page had wasted vertical space, inconsistent scan-result display, and a direct magnet input flow that did not let users confirm contents or choose location at the right point. The Cupertino path also needed mobile-native interaction patterns.

## Validation

- /Library/Afolder/FlutterProject/flutter/bin/dart format ...
- /Library/Afolder/FlutterProject/flutter/bin/dart analyze ... (no errors or warnings; existing info-level lints remain)
- cargo check (passes; existing Rust warnings remain)
- git diff --check