### PR TITLE
fix:dfm+ optimize v6

### DIFF
--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -165,8 +165,8 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
           // layout size change is meaningful (>= 1 logical pixel) or this
           // is the initial layout.
           if (oldSize.isEmpty ||
-              (oldSize.width - layoutSize.width).abs() >= 1.0 ||
-              (oldSize.height - layoutSize.height).abs() >= 1.0) {
+              (oldSize.width - layoutSize.width).abs() >= 2.0 ||
+              (oldSize.height - layoutSize.height).abs() >= 2.0) {
             _forceLayout = true;
           }
         }
@@ -378,8 +378,13 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
         });
       }
 
+      // When isNewEngine is true, the Rust engine was recreated or resized.
+      // Do NOT call resetScene() here — it clears the glyph atlas, causing
+      // all characters to need re-rasterization (MSDF generation), which
+      // blocks the render thread and causes a visible black flash.
+      // Instead, just mark the emoji atlas dirty and let the next setFrame
+      // call naturally render new content on top of the fresh engine.
       if (info.isNewEngine) {
-        await _textureBridge.resetScene();
         _emojiPipeline.markAtlasDirty();
       }
     }

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -6,7 +6,6 @@ import 'package:nipaplay/danmaku_next/next2_overlay_viewport.dart';
 import 'package:nipaplay/danmaku_next/next2_texture_bridge.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
-import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:provider/provider.dart';
 
 import 'dfm_plus_layout_bridge.dart';
@@ -158,17 +157,33 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
         }
 
         if (_layoutSize != layoutSize) {
+          final oldSize = _layoutSize;
           _layoutSize = layoutSize;
-          _forceLayout = true;
           _queueUpdate();
+          // Sub-pixel jitter (e.g. Windows focus-loss) should not trigger
+          // the async configure() pipeline. Only force re-prepare when the
+          // layout size change is meaningful (>= 1 logical pixel) or this
+          // is the initial layout.
+          if (oldSize.isEmpty ||
+              (oldSize.width - layoutSize.width).abs() >= 1.0 ||
+              (oldSize.height - layoutSize.height).abs() >= 1.0) {
+            _forceLayout = true;
+          }
         }
 
         final dpr = MediaQuery.maybeOf(context)?.devicePixelRatio ??
             View.of(context).devicePixelRatio;
+        // DPR can micro-jitter on Windows when the window loses focus or the
+        // user clicks the taskbar (didChangeMetrics fires with a slightly
+        // different value). DPR only affects the texture's pixel size, not the
+        // danmaku layout (layout uses logical pixels). So we update the cached
+        // DPR for the next texture-acquire path, but we do NOT trigger
+        // _forceLayout — the texture path will pick up the new DPR on its own
+        // and re-acquire a different-sized texture if needed. Re-running
+        // prepareLayout here would re-execute overwriteInsert and cause
+        // visible flicker.
         if ((_lastDevicePixelRatio - dpr).abs() > 0.001) {
           _lastDevicePixelRatio = dpr;
-          _forceLayout = true;
-          _queueUpdate();
         }
 
         return ValueListenableBuilder<double>(
@@ -232,16 +247,19 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
           continue;
         }
 
-        final currentTime =
+        double currentTime =
             widget.playbackTimeMs.value / 1000.0 + widget.timeOffset;
 
         if (!_forceLayout && (currentTime - _lastTimeSeconds).abs() < 0.0001) {
           continue;
         }
 
-        _lastTimeSeconds = currentTime;
-
-        // If config changed, run async configure first
+        // If config changed, run async configure first. configure() takes
+        // tens to hundreds of milliseconds (Rust prepare + font load), and
+        // the player position may advance significantly during that time.
+        // The worst case: a resumed video where playbackTimeMs is briefly 0
+        // while the player is loading, then jumps to the saved position.
+        // Using the pre-configure currentTime would paint t=0 danmaku.
         if (_forceLayout || _configurePending) {
           _forceLayout = false;
           _configurePending = false;
@@ -262,6 +280,16 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
             customFontFilePath: widget.customFontFilePath,
             blockWords: widget.blockWords,
           );
+          if (!mounted) {
+            return;
+          }
+          // Re-read playback position — it may have jumped from 0 to the
+          // saved resume point while configure was running.
+          currentTime =
+              widget.playbackTimeMs.value / 1000.0 + widget.timeOffset;
+          _lastTimeSeconds = currentTime;
+        } else {
+          _lastTimeSeconds = currentTime;
         }
 
         // Synchronous layout — no await, no microtask delay

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -184,6 +184,10 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
         // visible flicker.
         if ((_lastDevicePixelRatio - dpr).abs() > 0.001) {
           _lastDevicePixelRatio = dpr;
+          // DPR change may affect pixelWidth/pixelHeight → needsNewTexture.
+          // Queue an update so the texture size is re-evaluated, but do NOT
+          // set _forceLayout (that would re-run configure/overwriteInsert).
+          _queueUpdate();
         }
 
         return ValueListenableBuilder<double>(
@@ -311,9 +315,12 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
     }
 
     final locale = Localizations.maybeLocaleOf(context);
-    final views = WidgetsBinding.instance.platformDispatcher.views;
-    final dpr =
-        views.isNotEmpty ? views.first.devicePixelRatio : _lastDevicePixelRatio;
+
+    // Use cached DPR from build() instead of reading platformDispatcher.views
+    // directly. On Windows, DPR can micro-jitter when the window loses focus,
+    // causing pixelWidth/pixelHeight to oscillate by ±1 pixel, which triggers
+    // needsNewTexture → ensureTexture → isNewEngine → resetScene → flicker.
+    final dpr = _lastDevicePixelRatio;
 
     final needsSupersample =
         context.read<SettingsProvider>().danmakuSupersample;
@@ -327,10 +334,16 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay> {
         (_layoutSize.height * pixelRatio).round().clamp(1, 16384).toInt();
 
     // Optimized: only re-acquire texture if size changed (avoids redundant
-    // ensureTexture await on every frame when texture ID is already stable)
+    // ensureTexture await on every frame when texture ID is already stable).
+    // Also apply a pixel threshold: Windows DPR micro-jitter on focus loss can
+    // cause pixelWidth/pixelHeight to oscillate by ±1 pixel, which would
+    // trigger a full texture/engine rebuild (isNewEngine → resetScene → flicker).
+    // Only rebuild when the pixel size change is significant (>=2 pixels).
+    final int pwDelta = (pixelWidth - _lastTextureWidth).abs();
+    final int phDelta = (pixelHeight - _lastTextureHeight).abs();
     bool needsNewTexture = _textureId == null ||
-        pixelWidth != _lastTextureWidth ||
-        pixelHeight != _lastTextureHeight ||
+        (pwDelta >= 2) ||
+        (phDelta >= 2) ||
         _surfaceId != _lastTextureSurfaceId;
 
     if (needsNewTexture) {

--- a/lib/danmaku_next/nipaplay_next2_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next2_overlay.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
-import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:provider/provider.dart';
 
 import 'next2_emoji_pipeline.dart';
@@ -137,9 +136,13 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
 
         final dpr = MediaQuery.maybeOf(context)?.devicePixelRatio ??
             View.of(context).devicePixelRatio;
+        // DPR can micro-jitter on Windows when the window loses focus.
+        // DPR only affects texture pixel size, not danmaku layout.
+        // Update the cached DPR silently — the texture path will pick up
+        // the new DPR on its own. Re-running configure here would cause
+        // visible flicker.
         if ((_lastDevicePixelRatio - dpr).abs() > 0.001) {
           _lastDevicePixelRatio = dpr;
-          _queueUpdate();
         }
 
         return ValueListenableBuilder<double>(

--- a/lib/danmaku_next/nipaplay_next2_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next2_overlay.dart
@@ -69,6 +69,9 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
   bool _textureReady = false;
   String _surfaceId = 'next2-default';
   double _lastDevicePixelRatio = 1.0;
+  int _lastTextureWidth = 0;
+  int _lastTextureHeight = 0;
+  String _lastTextureSurfaceId = '';
 
   /// Low-DPR screens render at 2x then downscale to fix aliasing.
   static const double _supersampleMultiplier = 2.0;
@@ -143,6 +146,7 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
         // visible flicker.
         if ((_lastDevicePixelRatio - dpr).abs() > 0.001) {
           _lastDevicePixelRatio = dpr;
+          _queueUpdate();
         }
 
         return ValueListenableBuilder<double>(
@@ -236,9 +240,12 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
     }
 
     final locale = Localizations.maybeLocaleOf(context);
-    final views = WidgetsBinding.instance.platformDispatcher.views;
-    final dpr =
-        views.isNotEmpty ? views.first.devicePixelRatio : _lastDevicePixelRatio;
+
+    // Use cached DPR from build() instead of reading platformDispatcher.views
+    // directly. On Windows, DPR can micro-jitter when the window loses focus,
+    // causing pixelWidth/pixelHeight to oscillate by ±1 pixel, which triggers
+    // ensureTexture → isNewEngine → resetScene → flicker.
+    final dpr = _lastDevicePixelRatio;
 
     final needsSupersample =
         context.read<SettingsProvider>().danmakuSupersample;
@@ -251,41 +258,57 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
     final int pixelHeight =
         (_layoutSize.height * pixelRatio).round().clamp(1, 16384).toInt();
 
-    final info = await _textureBridge.ensureTexture(
-      surfaceId: _surfaceId,
-      width: pixelWidth,
-      height: pixelHeight,
-    );
+    // Only re-acquire texture if pixel size changed significantly (>=2 pixels).
+    // Windows DPR micro-jitter on focus loss can cause ±1 pixel oscillation,
+    // which would trigger a full engine rebuild → resetScene → flicker.
+    final int pwDelta = (pixelWidth - _lastTextureWidth).abs();
+    final int phDelta = (pixelHeight - _lastTextureHeight).abs();
+    bool needsNewTexture = _textureId == null ||
+        (pwDelta >= 2) ||
+        (phDelta >= 2) ||
+        _surfaceId != _lastTextureSurfaceId;
 
-    if (info == null) {
-      if (_textureReady || _textureId != null) {
+    if (needsNewTexture) {
+      _lastTextureWidth = pixelWidth;
+      _lastTextureHeight = pixelHeight;
+      _lastTextureSurfaceId = _surfaceId;
+
+      final info = await _textureBridge.ensureTexture(
+        surfaceId: _surfaceId,
+        width: pixelWidth,
+        height: pixelHeight,
+      );
+
+      if (info == null) {
+        if (_textureReady || _textureId != null) {
+          setState(() {
+            _textureReady = false;
+            _textureId = null;
+          });
+        }
+        return false;
+      }
+
+      if (!mounted) {
+        return false;
+      }
+
+      if (_textureId != info.textureId || !_textureReady) {
         setState(() {
-          _textureReady = false;
-          _textureId = null;
+          _textureId = info.textureId;
+          _textureReady = true;
         });
       }
-      return false;
+
+      if (info.isNewEngine) {
+        await _textureBridge.resetScene();
+        _emojiPipeline.markAtlasDirty();
+      }
     }
 
-    if (!mounted) {
-      return false;
-    }
-
-    if (_textureId != info.textureId || !_textureReady) {
-      setState(() {
-        _textureId = info.textureId;
-        _textureReady = true;
-      });
-    }
-
-    if (info.isNewEngine) {
-      await _textureBridge.resetScene();
-      _emojiPipeline.markAtlasDirty();
-    }
-
-    final widthScale = info.width > 0 ? info.width / _layoutSize.width : 1.0;
+    final widthScale = pixelWidth > 0 ? pixelWidth / _layoutSize.width : 1.0;
     final heightScale =
-        info.height > 0 ? info.height / _layoutSize.height : 1.0;
+        pixelHeight > 0 ? pixelHeight / _layoutSize.height : 1.0;
     final fontScale =
         ((widthScale + heightScale) * 0.5).clamp(0.25, 8.0).toDouble();
 

--- a/lib/danmaku_next/nipaplay_next2_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next2_overlay.dart
@@ -301,7 +301,9 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
       }
 
       if (info.isNewEngine) {
-        await _textureBridge.resetScene();
+        // Don't call resetScene() — it clears the glyph atlas, causing
+        // all characters to need re-rasterization and a visible black flash.
+        // Let the next setFrame naturally render new content.
         _emojiPipeline.markAtlasDirty();
       }
     }

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -625,11 +625,20 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
         // 更新状态
         _position = Duration(milliseconds: lastPosition);
         _progress = lastPosition / _duration.inMilliseconds;
+        // 同步高频时间轴到恢复位置。否则在 Ticker 首次回调（仅 status=playing
+        // 之后启动）之前 _playbackTimeMs.value 停留在 0，依赖该值的弹幕引擎
+        // （DFM+）会把整集弹幕渲染成 t=0 时刻的画面，直到用户手动 seek。
+        _playbackTimeMs.value = lastPosition.toDouble();
+        _smoothAnchorMs = lastPosition.toDouble();
+        _anchorSetBySeek = true;
+        _seekTargetMs = lastPosition.toDouble();
       } else {
         _position = Duration.zero;
         _progress = 0.0;
         _bufferedPositionMs = 0;
         player.seek(position: 0);
+        _playbackTimeMs.value = 0;
+        _smoothAnchorMs = 0;
       }
 
       // debugPrint('9. 检查播放器实际状态...');


### PR DESCRIPTION
## Summary

- 修复了DFM+引擎续播视频情景下弹幕从头开始的问题
- 大幅减少了因DPR变化和布局微抖导致的失焦弹幕频闪现象（如播放器在副屏，用户在主屏上操作）

## Test

```
flutter build macos
flutter build windows
```

## What Changed

### Commit 1: `v6`

**`lib/danmaku_dfm/dfm_plus_overlay.dart`** — DPR 变化不再触发 `_forceLayout`/`_queueUpdate()`，改为静默更新缓存值；`_layoutSize` 变化增加 ≥1px 阈值才触发 `_forceLayout`，亚像素抖动只调 `_queueUpdate()`；`configure()` 后重新读取播放位置，防止恢复播放时弹幕渲染到 t=0；移除 `globals` 导入。

**`lib/danmaku_next/nipaplay_next2_overlay.dart`** — DPR 变化不再触发 `_queueUpdate()`，改为静默更新缓存值；移除 `globals` 导入。

**`lib/utils/video_player_state/video_player_state_player_setup.dart`** — 恢复播放时同步 `_playbackTimeMs`/`_smoothAnchorMs` 到实际位置，防止弹幕引擎在 Ticker 首次回调前使用 t=0 渲染。

---

### Commit 2: `DPR缓存`

**`lib/danmaku_dfm/dfm_plus_overlay.dart`** — `_tryUpdateTexture` 中 DPR 来源从 `platformDispatcher.views` 改为 `build()` 中缓存的 `_lastDevicePixelRatio`，避免 Windows 失焦时 DPR 微抖直接传入；`needsNewTexture` 增加 ≥2px 像素阈值，防止 ±1 像素振荡触发引擎重建；DPR 变化时恢复 `_queueUpdate()` 调用。

**`lib/danmaku_next/nipaplay_next2_overlay.dart`** — 同样将 DPR 来源改为缓存值；新增 `_lastTextureWidth`/`_lastTextureHeight`/`_lastTextureSurfaceId` 字段；`ensureTexture` 从每帧调用改为仅在像素尺寸变化 ≥2px 时调用（与 DFM+ 一致）；DPR 变化时恢复 `_queueUpdate()` 调用。

---

### Commit 3: `修复：失焦闪烁`

**`lib/danmaku_dfm/dfm_plus_overlay.dart`** — `isNewEngine` 时不再调用 `resetScene()`（会清空 glyph atlas 导致全量 MSDF 重建和黑闪），改为仅标记 emoji atlas dirty，让下一帧 `setFrame` 自然覆盖；`_forceLayout` 阈值从 1.0px 提高到 2.0px。

**`lib/danmaku_next/nipaplay_next2_overlay.dart`** — 同样移除 `isNewEngine` 时的 `resetScene()` 调用，仅标记 emoji atlas dirty。
