### PR TITLE
Sync Erika native danmaku offset

### DIFF
--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -1317,11 +1317,28 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   // Volume Getters
   double get currentSystemVolume => _currentVolume;
 
+  void _syncNativeDanmakuGlobalOffset() {
+    try {
+      if (!player.supportsNativeDanmaku) {
+        return;
+      }
+      final offsetMicros = ((_manualDanmakuOffset + _autoDanmakuOffset) *
+              Duration.microsecondsPerSecond)
+          .round();
+      unawaited(player.setNativeDanmakuGlobalOffset(
+        Duration(microseconds: offsetMicros),
+      ));
+    } catch (_) {
+      // The player is late-initialized; ignore calls made before it exists.
+    }
+  }
+
   void setManualDanmakuOffset(double offset) {
     if ((_manualDanmakuOffset - offset).abs() < 0.0001) {
       return;
     }
     _manualDanmakuOffset = offset;
+    _syncNativeDanmakuGlobalOffset();
     notifyListeners();
   }
 
@@ -1330,6 +1347,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
       return;
     }
     _autoDanmakuOffset = offset;
+    _syncNativeDanmakuGlobalOffset();
     notifyListeners();
   }
 

--- a/lib/utils/video_player_state/video_player_state_danmaku.dart
+++ b/lib/utils/video_player_state/video_player_state_danmaku.dart
@@ -72,6 +72,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
       customFontFamily: fontFamily,
       customFontFilePath: fontPath,
     ));
+    _syncNativeDanmakuGlobalOffset();
   }
 
   Future<void> _autoDetectAndLoadLocalDanmakuFromVideoDirectory(


### PR DESCRIPTION
## Summary
- forward manual + auto danmaku offset to Erika native danmaku renderer
- resync the offset when Erika native danmaku config is pushed, covering existing offsets during kernel/list reloads

## Tests
- flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings lib/utils/video_player_state.dart lib/utils/video_player_state/video_player_state_danmaku.dart