### PR TITLE
fix:plugin conf-interface scrolling freezed

### DIFF
--- a/lib/themes/nipaplay/pages/settings/plugin_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/plugin_settings_page.dart
@@ -540,9 +540,7 @@ class _PluginSettingsPageState extends State<PluginSettingsPage> {
             mainAxisSize: MainAxisSize.min,
             children: [
               Expanded(
-                child: SingleChildScrollView(
-                  child: listView,
-                ),
+                child: listView,
               ),
               Padding(
                 padding:

--- a/lib/themes/nipaplay/widgets/glass_bottom_sheet.dart
+++ b/lib/themes/nipaplay/widgets/glass_bottom_sheet.dart
@@ -53,36 +53,33 @@ class GlassBottomSheet extends StatelessWidget {
       maxWidth: dialogWidth,
       maxHeightFactor: (sheetHeight / screenSize.height).clamp(0.5, 0.9),
       onClose: () => Navigator.of(context).maybePop(),
-      child: SingleChildScrollView(
-        padding: EdgeInsets.only(bottom: keyboardHeight),
-        child: SizedBox(
-          height: sheetHeight,
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(20, 16, 20, 16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    title,
-                    locale: const Locale('zh', 'CN'),
-                    style: textTheme.titleLarge?.copyWith(
-                          fontWeight: FontWeight.bold,
-                          color: colorScheme.onSurface,
-                        ) ??
-                        TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                          color: colorScheme.onSurface,
-                        ),
-                    textAlign: TextAlign.left,
-                  ),
+      child: SizedBox(
+        height: sheetHeight,
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(20, 16, 20, 16 + keyboardHeight),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  title,
+                  locale: const Locale('zh', 'CN'),
+                  style: textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: colorScheme.onSurface,
+                      ) ??
+                      TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: colorScheme.onSurface,
+                      ),
+                  textAlign: TextAlign.left,
                 ),
-                const SizedBox(height: 16),
-                Expanded(child: child),
-              ],
-            ),
+              ),
+              const SizedBox(height: 16),
+              Expanded(child: child),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
## Summary

- 修复了插件配置页面无法滚动（反弹）的问题

## What Changed

- GlassBottomSheet：移除外层无用的 SingleChildScrollView，将键盘 padding 移到 SizedBox
- PluginSettingsPage：移除多余的内层 SingleChildScrollView，ListView(shrinkWrap: true) 直接放在 Column 中
