### PR TITLE
Fetch Erika through pub git dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,3 @@
 [submodule "third_party/libplacebo"]
 	path = third_party/libplacebo
 	url = https://github.com/AimesSoft/libplacebo.git
-[submodule "third_party/erika"]
-	path = third_party/erika
-	url = https://github.com/AimesSoft/Erika.git
-	branch = main

--- a/cpp_native/scripts/build_macos.sh
+++ b/cpp_native/scripts/build_macos.sh
@@ -3,7 +3,6 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CPP_NATIVE_DIR="$(dirname "$SCRIPT_DIR")"
 NIPAPLAY_ROOT="$(cd "${CPP_NATIVE_DIR}/.." && pwd)"
-ERIKA_ROOT="${ERIKA_ROOT:-${NIPAPLAY_ROOT}/third_party/erika}"
 ERIKA_NATIVE_PROFILE="${ERIKA_NATIVE_PROFILE:-lgpl}"
 HOST_JOBS="$(sysctl -n hw.ncpu)"
 ERIKA_RUST_TARGETS=("aarch64-apple-darwin" "x86_64-apple-darwin")
@@ -11,6 +10,70 @@ ERIKA_RUST_TARGETS=("aarch64-apple-darwin" "x86_64-apple-darwin")
 # Xcode Run Script 阶段的 PATH 不会继承 shell 配置，显式补上 Homebrew 路径
 # 让 Apple Silicon (/opt/homebrew) 和 Intel (/usr/local) 都能找到 cmake 等工具
 export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
+
+resolve_erika_root() {
+    if [ -n "${ERIKA_ROOT:-}" ]; then
+        if [ -f "${ERIKA_ROOT}/Cargo.toml" ]; then
+            (cd "${ERIKA_ROOT}" && pwd -P)
+            return
+        fi
+        echo "error: ERIKA_ROOT does not point to Erika source: ${ERIKA_ROOT}" >&2
+        return 1
+    fi
+
+    local vendored_root="${NIPAPLAY_ROOT}/third_party/erika"
+    if [ -f "${vendored_root}/Cargo.toml" ]; then
+        (cd "${vendored_root}" && pwd -P)
+        return
+    fi
+
+    local package_config="${NIPAPLAY_ROOT}/.dart_tool/package_config.json"
+    if [ ! -f "${package_config}" ]; then
+        echo "error: ${package_config} not found. Run flutter pub get first." >&2
+        return 1
+    fi
+
+    local erika_flutter_root
+    erika_flutter_root="$(python3 - "${package_config}" <<'PY'
+import json
+import pathlib
+import sys
+import urllib.parse
+
+package_config = pathlib.Path(sys.argv[1]).resolve()
+with package_config.open("r", encoding="utf-8") as handle:
+    data = json.load(handle)
+
+for package in data.get("packages", []):
+    if package.get("name") != "erika_flutter":
+        continue
+    root_uri = package.get("rootUri", "")
+    parsed = urllib.parse.urlparse(root_uri)
+    if parsed.scheme == "file":
+        root = pathlib.Path(urllib.parse.unquote(parsed.path))
+    elif parsed.scheme:
+        raise SystemExit(f"unsupported erika_flutter rootUri: {root_uri}")
+    else:
+        root = (package_config.parent / urllib.parse.unquote(root_uri)).resolve()
+    print(root)
+    break
+else:
+    raise SystemExit("erika_flutter not found in package_config.json")
+PY
+)"
+
+    local resolved_root
+    resolved_root="$(cd "${erika_flutter_root}/../.." && pwd -P)"
+    if [ -f "${resolved_root}/Cargo.toml" ]; then
+        echo "${resolved_root}"
+        return
+    fi
+
+    echo "error: Could not resolve Erika source root from erika_flutter package at ${erika_flutter_root}" >&2
+    return 1
+}
+
+ERIKA_ROOT="$(resolve_erika_root)"
 
 # Map Xcode configuration to CMake build type
 if [ "${CONFIGURATION}" = "Debug" ]; then
@@ -53,11 +116,6 @@ lipo -create \
     "${BUILD_DIR}/arm64/libnipaplay_native.dylib" \
     "${BUILD_DIR}/x86_64/libnipaplay_native.dylib" \
     -output "${BUILD_DIR}/libnipaplay_native.dylib"
-
-if [ ! -f "${ERIKA_ROOT}/Cargo.toml" ]; then
-    echo "error: Erika source not found at ${ERIKA_ROOT}. Run git submodule update --init third_party/erika." >&2
-    exit 1
-fi
 
 if [ "${CONFIGURATION}" = "Debug" ]; then
     ERIKA_CARGO_PROFILE="debug"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -282,9 +282,11 @@ packages:
   erika_flutter:
     dependency: "direct main"
     description:
-      path: "third_party/erika/packages/erika_flutter"
-      relative: true
-    source: path
+      path: "packages/erika_flutter"
+      ref: "403049af63cd104d7a99855d48069abc1169529b"
+      resolved-ref: "403049af63cd104d7a99855d48069abc1169529b"
+      url: "https://github.com/AimesSoft/Erika.git"
+    source: git
     version: "0.0.1"
   fake_async:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,7 +82,10 @@ dependencies:
   media_kit_libs_video:
     path: third_party/media-kit-upstream/libs/universal/media_kit_libs_video
   erika_flutter:
-    path: third_party/erika/packages/erika_flutter
+    git:
+      url: https://github.com/AimesSoft/Erika.git
+      ref: 403049af63cd104d7a99855d48069abc1169529b
+      path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   qr_code_scanner_plus: ^2.0.12
   flutter_svg: ^2.0.14  # 用于显示SVG图标


### PR DESCRIPTION
## Summary
- switch `erika_flutter` from a repository submodule path dependency to a pinned pub Git dependency
- remove the `third_party/erika` submodule so normal clones/forks can run `flutter pub get` without manual submodule setup for Erika
- resolve Erika source from `.dart_tool/package_config.json` in the macOS native build script, while still honoring `ERIKA_ROOT` and a vendored fallback

## GitHub Actions / build notes
- `flutter pub get` now fetches the public Erika repository through pub, so fork checkouts no longer need the Erika submodule for dependency resolution
- macOS native build still finds the full Erika repo because the git dependency is cached with the repository root around `packages/erika_flutter`
- existing workflows still checkout other vendored submodules recursively

## Tests
- `PUB_HOSTED_URL=https://pub.dev flutter pub get`
- `PUB_HOSTED_URL=https://pub.dev flutter pub get --enforce-lockfile`
- `flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings lib/player_abstraction/erika_player_adapter.dart lib/player_abstraction/player_abstraction.dart`
- `bash -n cpp_native/scripts/build_macos.sh`
- `git diff --check`