### PR TITLE
[codex] Gate Erika kernel and fix DEB libraries

### DIFF
--- a/.github/actions/build-linux/action.yml
+++ b/.github/actions/build-linux/action.yml
@@ -240,6 +240,20 @@ runs:
         # Copy app files
         echo "Copying application files to ${DEB_ROOT}/opt/${APP_NAME_LOWER}/"
         cp -r "${BUILD_OUTPUT_DIR}/"* "${DEB_ROOT}/opt/${APP_NAME_LOWER}/"
+
+        # Ensure the Rust FRB runtime library is present in the DEB even if the
+        # Flutter bundle omits native assets for this target.
+        RUST_LIB_DEST="${DEB_ROOT}/opt/${APP_NAME_LOWER}/lib/librust_lib_nipaplay.so"
+        if [ ! -f "${RUST_LIB_DEST}" ]; then
+          echo "Bundled Rust library missing; searching build outputs."
+          RUST_LIB_SOURCE=$(find build/linux rust/target -name "librust_lib_nipaplay.so" -type f -print -quit 2>/dev/null || true)
+          if [ -z "${RUST_LIB_SOURCE}" ]; then
+            echo "Error: librust_lib_nipaplay.so not found in build outputs."
+            exit 1
+          fi
+          mkdir -p "${DEB_ROOT}/opt/${APP_NAME_LOWER}/lib"
+          cp "${RUST_LIB_SOURCE}" "${RUST_LIB_DEST}"
+        fi
         
         # Copy system libmpv libraries only when not already bundled (avoid overwriting media_kit_libs_* shipped libs)
         mkdir -p "${DEB_ROOT}/opt/${APP_NAME_LOWER}/lib"

--- a/assets/linux/DEBIAN/control.template
+++ b/assets/linux/DEBIAN/control.template
@@ -10,5 +10,5 @@ Description: A cross platform danmaku video player.
  支持多种视频格式和弹幕显示的跨平台视频播放器。
  需要系统安装 libmpv 以支持视频播放功能。
 Homepage: https://github.com/AimesSoft/NipaPlay-Reload
-Depends: libgtk-3-0, libmpv1 | libmpv2, libmimalloc2.0, ffmpeg, libass9, libsqlite3-0, libcanberra-gtk3-module, gtk3-nocsd, libgtk3-nocsd0
+Depends: libgtk-3-0, libmpv1 | libmpv2, libmimalloc2.0, ffmpeg, libass9, libsqlite3-0, libcanberra-gtk3-module, gtk3-nocsd, libgtk3-nocsd0, libkeybinder-3.0-0
 Recommends: mpv

--- a/build-arm64.sh
+++ b/build-arm64.sh
@@ -15,6 +15,17 @@ cp -r assets/linux/DEBIAN/* "${PACKAGE_DIR}/DEBIAN/"
 chmod 0755 "${PACKAGE_DIR}/DEBIAN/postinst"
 chmod 0755 "${PACKAGE_DIR}/DEBIAN/postrm"
 
+RUST_LIB_DEST="${PACKAGE_DIR}/opt/nipaplay/lib/librust_lib_nipaplay.so"
+if [ ! -f "${RUST_LIB_DEST}" ]; then
+  RUST_LIB_SOURCE=$(find build/linux rust/target -name "librust_lib_nipaplay.so" -type f -print -quit 2>/dev/null || true)
+  if [ -z "${RUST_LIB_SOURCE}" ]; then
+    echo "Error: librust_lib_nipaplay.so not found in build outputs."
+    exit 1
+  fi
+  mkdir -p "${PACKAGE_DIR}/opt/nipaplay/lib"
+  cp "${RUST_LIB_SOURCE}" "${RUST_LIB_DEST}"
+fi
+
 cat > "${PACKAGE_DIR}/DEBIAN/control" << EOF
 Package: NipaPlay
 Version: ${VERSION}
@@ -26,7 +37,7 @@ Installed-Size: 34648
 Maintainer: madoka773 <valigarmanda55@gmail.com>
 Description: A cross platform danmaku video player.
 Homepage: https://github.com/AimesSoft/NipaPlay-Reload
-Depends: ffmpeg, libass9
+Depends: ffmpeg, libass9, libkeybinder-3.0-0
 EOF
 
 cp assets/linux/io.github.MCDFsteve.NipaPlay-Reload.desktop "${PACKAGE_DIR}/usr/share/applications/"

--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -30,6 +30,9 @@ class SettingsKeys {
   static const String labsEnableNext2DanmakuKernel =
       'labs_enable_next2_danmaku_kernel';
 
+  static const String labsEnableErikaPlayerKernel =
+      'labs_enable_erika_player_kernel';
+
   static const String labsEnableNextPlusPlusEngine =
       'labs_enable_next_plus_plus_engine';
 

--- a/lib/providers/labs_settings_provider.dart
+++ b/lib/providers/labs_settings_provider.dart
@@ -11,12 +11,14 @@ class LabsSettingsProvider extends ChangeNotifier {
   bool _enableLargeScreenMode = false;
   bool _showRemoteAccessQrCode = false;
   bool _enableNext2DanmakuKernel = false;
+  bool _enableErikaPlayerKernel = false;
   bool _enableNextPlusPlusEngine = true; // 默认打开：Next++ 激进优化引擎
   bool _isLoaded = false;
 
   bool get enableLargeScreenMode => _enableLargeScreenMode;
   bool get showRemoteAccessQrCode => _showRemoteAccessQrCode;
   bool get enableNext2DanmakuKernel => _enableNext2DanmakuKernel;
+  bool get enableErikaPlayerKernel => _enableErikaPlayerKernel;
   bool get enableNextPlusPlusEngine => _enableNextPlusPlusEngine;
   bool get isLoaded => _isLoaded;
 
@@ -31,6 +33,10 @@ class LabsSettingsProvider extends ChangeNotifier {
     );
     _enableNext2DanmakuKernel = await SettingsStorage.loadBool(
       SettingsKeys.labsEnableNext2DanmakuKernel,
+      defaultValue: false,
+    );
+    _enableErikaPlayerKernel = await SettingsStorage.loadBool(
+      SettingsKeys.labsEnableErikaPlayerKernel,
       defaultValue: false,
     );
     _enableNextPlusPlusEngine = await SettingsStorage.loadBool(
@@ -68,6 +74,16 @@ class LabsSettingsProvider extends ChangeNotifier {
     notifyListeners();
     await SettingsStorage.saveBool(
       SettingsKeys.labsEnableNext2DanmakuKernel,
+      enabled,
+    );
+  }
+
+  Future<void> setEnableErikaPlayerKernel(bool enabled) async {
+    if (_enableErikaPlayerKernel == enabled) return;
+    _enableErikaPlayerKernel = enabled;
+    notifyListeners();
+    await SettingsStorage.saveBool(
+      SettingsKeys.labsEnableErikaPlayerKernel,
       enabled,
     );
   }

--- a/lib/services/web_server_service.dart
+++ b/lib/services/web_server_service.dart
@@ -13,6 +13,7 @@ class WebServerService {
   // 兼容旧版本：历史上使用 web_server_enabled 来表示“自动启动”
   static const String _legacyAutoStartKey = 'web_server_enabled';
   static const String _autoStartKey = 'web_server_auto_start';
+  static const String _ipv6EnabledKey = 'web_server_ipv6_enabled';
   static const String _portKey = 'web_server_port';
   static const String _webAssetsRelativePath = 'assets/web';
 
@@ -20,6 +21,8 @@ class WebServerService {
   int _port = 1180;
   bool _isRunning = false;
   bool _autoStart = false;
+  bool _ipv6Enabled = false;
+  bool _isIpv6Listening = false;
   String? _lastStartErrorMessage;
   final WebApiService _webApiService = WebApiService();
   final NipaPlayLanDiscoveryResponder _lanDiscoveryResponder =
@@ -30,6 +33,7 @@ class WebServerService {
   bool get isRunning => _isRunning;
   int get port => _port;
   bool get autoStart => _autoStart;
+  bool get ipv6Enabled => _ipv6Enabled;
   String? get lastStartErrorMessage => _lastStartErrorMessage;
 
   String _buildHttpUrlForHost(String host, int port) {
@@ -297,6 +301,7 @@ class WebServerService {
   Future<void> loadSettings() async {
     final prefs = await SharedPreferences.getInstance();
     _port = prefs.getInt(_portKey) ?? 1180;
+    _ipv6Enabled = prefs.getBool(_ipv6EnabledKey) ?? false;
     if (prefs.containsKey(_autoStartKey)) {
       _autoStart = prefs.getBool(_autoStartKey) ?? false;
     } else {
@@ -396,15 +401,24 @@ class WebServerService {
           .addMiddleware(logRequests())
           .addHandler(rootHandler);
 
-      try {
-        final v6Server = await HttpServer.bind(
-          InternetAddress.anyIPv6,
-          _port,
-          v6Only: false,
-        );
-        shelf_io.serveRequests(v6Server, handler);
-        _server = v6Server;
-      } on SocketException {
+      _isIpv6Listening = false;
+      if (_ipv6Enabled) {
+        try {
+          final v6Server = await HttpServer.bind(
+            InternetAddress.anyIPv6,
+            _port,
+            v6Only: false,
+          );
+          shelf_io.serveRequests(v6Server, handler);
+          _server = v6Server;
+          _isIpv6Listening = true;
+        } on SocketException {
+          final v4Server =
+              await HttpServer.bind(InternetAddress.anyIPv4, _port);
+          shelf_io.serveRequests(v4Server, handler);
+          _server = v4Server;
+        }
+      } else {
         final v4Server = await HttpServer.bind(InternetAddress.anyIPv4, _port);
         shelf_io.serveRequests(v4Server, handler);
         _server = v4Server;
@@ -418,6 +432,7 @@ class WebServerService {
     } catch (e) {
       _isRunning = false;
       _server = null;
+      _isIpv6Listening = false;
       _lastStartErrorMessage = _formatStartError(e);
       await _lanDiscoveryResponder.stop();
       return false;
@@ -429,6 +444,7 @@ class WebServerService {
       await _server!.close(force: true);
       _server = null;
       _isRunning = false;
+      _isIpv6Listening = false;
       await _lanDiscoveryResponder.stop();
       print('Remote access server stopped.');
       await saveSettings();
@@ -485,6 +501,7 @@ class WebServerService {
     if (!_isRunning || _server == null) return [];
 
     final urls = <String>{};
+    final includeIpv6 = _ipv6Enabled && _isIpv6Listening;
 
     void addUrl(String host) {
       if (host.trim().isEmpty) return;
@@ -495,7 +512,7 @@ class WebServerService {
       for (var interface in await NetworkInterface.list(
         includeLoopback: true,
         includeLinkLocal: true,
-        type: InternetAddressType.any,
+        type: includeIpv6 ? InternetAddressType.any : InternetAddressType.IPv4,
       )) {
         for (var addr in interface.addresses) {
           if (addr.type == InternetAddressType.IPv4) {
@@ -504,6 +521,10 @@ class WebServerService {
           }
 
           if (addr.type != InternetAddressType.IPv6) {
+            continue;
+          }
+
+          if (!includeIpv6) {
             continue;
           }
 
@@ -524,7 +545,9 @@ class WebServerService {
     }
     addUrl('localhost');
     addUrl('127.0.0.1');
-    addUrl('::1');
+    if (includeIpv6) {
+      addUrl('::1');
+    }
     final urlList = urls.toList();
     urlList.sort((a, b) {
       final weightCompare =
@@ -552,5 +575,21 @@ class WebServerService {
     await prefs.setBool(_autoStartKey, enabled);
     // 写回旧Key，便于降级/旧版本读取
     await prefs.setBool(_legacyAutoStartKey, enabled);
+  }
+
+  Future<bool> setIpv6Enabled(bool enabled) async {
+    if (_ipv6Enabled == enabled) return true;
+
+    _ipv6Enabled = enabled;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_ipv6EnabledKey, enabled);
+
+    if (_isRunning) {
+      final currentPort = _port;
+      await stopServer();
+      return startServer(port: currentPort);
+    }
+
+    return true;
   }
 }

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:nipaplay/themes/cupertino/cupertino_adaptive_platform_ui.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
+import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/providers/labs_settings_provider.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_group_card.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_tile.dart';
@@ -102,6 +103,28 @@ class CupertinoLabsSettingsPage extends StatelessWidget {
                         },
                         backgroundColor: resolveSettingsTileBackground(context),
                       ),
+                      if (PlayerFactory.isErikaKernelSupported)
+                        CupertinoSettingsTile(
+                          leading: Icon(
+                            CupertinoIcons.lab_flask,
+                            color: resolveSettingsIconColor(context),
+                          ),
+                          title: const Text('显示 Erika 播放内核'),
+                          subtitle: const Text('开启后，播放器内核菜单显示 Erika'),
+                          trailing: AdaptiveSwitch(
+                            value: labsSettings.enableErikaPlayerKernel,
+                            onChanged: (value) {
+                              labsSettings.setEnableErikaPlayerKernel(value);
+                            },
+                          ),
+                          onTap: () {
+                            labsSettings.setEnableErikaPlayerKernel(
+                              !labsSettings.enableErikaPlayerKernel,
+                            );
+                          },
+                          backgroundColor:
+                              resolveSettingsTileBackground(context),
+                        ),
                       CupertinoSettingsTile(
                         leading: Icon(
                           CupertinoIcons.bolt,

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_player_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_player_settings_page.dart
@@ -11,6 +11,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 import 'package:nipaplay/danmaku_next/next2_platform_support.dart';
 import 'package:nipaplay/player_abstraction/player_factory.dart';
+import 'package:nipaplay/providers/labs_settings_provider.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/utils/decoder_manager.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
@@ -396,12 +397,13 @@ class _CupertinoPlayerSettingsPageState
     }
   }
 
-  List<AdaptivePopupMenuEntry> _kernelMenuItems() {
+  List<AdaptivePopupMenuEntry> _kernelMenuItems({
+    required bool showErikaKernel,
+  }) {
     return PlayerKernelType.values
         .where(
           (kernel) =>
-              kernel != PlayerKernelType.erika ||
-              PlayerFactory.isErikaKernelSupported,
+              kernel != PlayerKernelType.erika || showErikaKernel,
         )
         .map(
           (kernel) => AdaptivePopupMenuItem<PlayerKernelType>(
@@ -651,6 +653,12 @@ class _CupertinoPlayerSettingsPageState
 
     final Color tileBackground = resolveSettingsTileBackground(context);
     final bool externalSupported = globals.isDesktop;
+    final bool showErikaKernel = PlayerFactory.isErikaKernelSupported &&
+        context.watch<LabsSettingsProvider>().enableErikaPlayerKernel;
+    final PlayerKernelType visibleKernelType =
+        _selectedKernelType == PlayerKernelType.erika && !showErikaKernel
+            ? PlayerKernelType.mdk
+            : _selectedKernelType;
 
     final List<Widget> sections = [
       CupertinoSettingsGroupCard(
@@ -665,12 +673,12 @@ class _CupertinoPlayerSettingsPageState
               color: resolveSettingsIconColor(context),
             ),
             title: Text(context.l10n.playerKernel),
-            subtitle: Text(_getPlayerKernelDescription(_selectedKernelType)),
+            subtitle: Text(_getPlayerKernelDescription(visibleKernelType)),
             trailing: AdaptivePopupMenuButton.widget<PlayerKernelType>(
-              items: _kernelMenuItems(),
+              items: _kernelMenuItems(showErikaKernel: showErikaKernel),
               buttonStyle: PopupButtonStyle.gray,
               child: _buildMenuChip(
-                  context, _kernelDisplayName(_selectedKernelType)),
+                  context, _kernelDisplayName(visibleKernelType)),
               onSelected: (index, entry) {
                 final kernel = entry.value ?? PlayerKernelType.values[index];
                 if (kernel != _selectedKernelType) {
@@ -787,8 +795,8 @@ class _CupertinoPlayerSettingsPageState
             ),
           ],
         ),
-      if (_selectedKernelType == PlayerKernelType.mdk ||
-          _selectedKernelType == PlayerKernelType.mediaKit) ...[
+      if (visibleKernelType == PlayerKernelType.mdk ||
+          visibleKernelType == PlayerKernelType.mediaKit) ...[
         const SizedBox(height: 16),
         Consumer<VideoPlayerState>(
           builder: (context, videoState, child) {
@@ -840,7 +848,7 @@ class _CupertinoPlayerSettingsPageState
       ],
       if (!kIsWeb &&
           Platform.isAndroid &&
-          _selectedKernelType == PlayerKernelType.mediaKit) ...[
+          visibleKernelType == PlayerKernelType.mediaKit) ...[
         const SizedBox(height: 16),
         CupertinoSettingsGroupCard(
           margin: EdgeInsets.zero,
@@ -1013,7 +1021,7 @@ class _CupertinoPlayerSettingsPageState
           );
         },
       ),
-      if (_selectedKernelType == PlayerKernelType.mdk) ...[
+      if (visibleKernelType == PlayerKernelType.mdk) ...[
         const SizedBox(height: 16),
         Consumer<VideoPlayerState>(
           builder: (context, videoState, child) {
@@ -1079,9 +1087,9 @@ class _CupertinoPlayerSettingsPageState
       const SizedBox(height: 16),
       Consumer<VideoPlayerState>(
         builder: (context, videoState, child) {
-          final bool isMdk = _selectedKernelType == PlayerKernelType.mdk;
+          final bool isMdk = visibleKernelType == PlayerKernelType.mdk;
           final bool enableSetting =
-              isMdk || _selectedKernelType == PlayerKernelType.mediaKit;
+              isMdk || visibleKernelType == PlayerKernelType.mediaKit;
           return CupertinoSettingsGroupCard(
             margin: EdgeInsets.zero,
             backgroundColor: sectionBackground,
@@ -1138,7 +1146,7 @@ class _CupertinoPlayerSettingsPageState
           );
         },
       ),
-      if (_selectedKernelType == PlayerKernelType.mediaKit)
+      if (visibleKernelType == PlayerKernelType.mediaKit)
         Consumer<VideoPlayerState>(
           builder: (context, videoState, child) {
             final bool supportsUpscale = videoState.isDoubleResolutionSupported;
@@ -1209,7 +1217,7 @@ class _CupertinoPlayerSettingsPageState
             );
           },
         ),
-      if (_selectedKernelType == PlayerKernelType.mediaKit)
+      if (visibleKernelType == PlayerKernelType.mediaKit)
         Consumer<VideoPlayerState>(
           builder: (context, videoState, child) {
             final bool supportsAnime4K = videoState.isAnime4KSupported;
@@ -1285,7 +1293,7 @@ class _CupertinoPlayerSettingsPageState
             );
           },
         ),
-      if (_selectedKernelType == PlayerKernelType.mediaKit)
+      if (visibleKernelType == PlayerKernelType.mediaKit)
         Consumer<VideoPlayerState>(
           builder: (context, videoState, child) {
             final bool supportsCrt = videoState.isCrtSupported;

--- a/lib/themes/nipaplay/pages/settings/labs_page.dart
+++ b/lib/themes/nipaplay/pages/settings/labs_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/providers/labs_settings_provider.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_item.dart';
 import 'package:nipaplay/themes/nipaplay/pages/settings/webdav_quick_settings_page.dart';
@@ -55,6 +56,21 @@ class LabsPage extends StatelessWidget {
               color: colorScheme.onSurface.withValues(alpha: 0.12),
               height: 1,
             ),
+            if (PlayerFactory.isErikaKernelSupported) ...[
+              SettingsItem.toggle(
+                title: '显示 Erika 播放内核',
+                subtitle: '开启后，播放器内核下拉菜单显示 Erika',
+                icon: Ionicons.flask_outline,
+                value: labsSettings.enableErikaPlayerKernel,
+                onChanged: (bool value) {
+                  labsSettings.setEnableErikaPlayerKernel(value);
+                },
+              ),
+              Divider(
+                color: colorScheme.onSurface.withValues(alpha: 0.12),
+                height: 1,
+              ),
+            ],
             SettingsItem.toggle(
               title: 'Next++ 激进优化引擎',
               subtitle: '激进优化，推荐。关闭则回退至 Next 原始引擎路径',

--- a/lib/themes/nipaplay/pages/settings/player_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/player_settings_page.dart
@@ -19,6 +19,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/blur_button.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_card.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_item.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
+import 'package:nipaplay/providers/labs_settings_provider.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/utils/player_kernel_manager.dart';
 import 'package:nipaplay/utils/anime4k_shader_manager.dart';
@@ -499,6 +500,12 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final showErikaKernel = PlayerFactory.isErikaKernelSupported &&
+        context.watch<LabsSettingsProvider>().enableErikaPlayerKernel;
+    final visibleKernelType =
+        _selectedKernelType == PlayerKernelType.erika && !showErikaKernel
+            ? PlayerKernelType.mdk
+            : _selectedKernelType;
     // Web 平台现在允许访问此页面，但部分功能受限
     return ListView(
       children: [
@@ -511,28 +518,28 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
               DropdownMenuItemData(
                 title: "MDK",
                 value: PlayerKernelType.mdk,
-                isSelected: _selectedKernelType == PlayerKernelType.mdk,
+                isSelected: visibleKernelType == PlayerKernelType.mdk,
                 description: _getPlayerKernelDescription(PlayerKernelType.mdk),
               ),
               DropdownMenuItemData(
                 title: "Video Player",
                 value: PlayerKernelType.videoPlayer,
-                isSelected: _selectedKernelType == PlayerKernelType.videoPlayer,
+                isSelected: visibleKernelType == PlayerKernelType.videoPlayer,
                 description:
                     _getPlayerKernelDescription(PlayerKernelType.videoPlayer),
               ),
               DropdownMenuItemData(
                 title: "Libmpv",
                 value: PlayerKernelType.mediaKit,
-                isSelected: _selectedKernelType == PlayerKernelType.mediaKit,
+                isSelected: visibleKernelType == PlayerKernelType.mediaKit,
                 description:
                     _getPlayerKernelDescription(PlayerKernelType.mediaKit),
               ),
-              if (PlayerFactory.isErikaKernelSupported)
+              if (showErikaKernel)
                 DropdownMenuItemData(
                   title: "Erika",
                   value: PlayerKernelType.erika,
-                  isSelected: _selectedKernelType == PlayerKernelType.erika,
+                  isSelected: visibleKernelType == PlayerKernelType.erika,
                   description:
                       _getPlayerKernelDescription(PlayerKernelType.erika),
                 ),
@@ -544,8 +551,8 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
           ),
           Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
         ],
-        if (_selectedKernelType == PlayerKernelType.mdk ||
-            _selectedKernelType == PlayerKernelType.mediaKit) ...[
+        if (visibleKernelType == PlayerKernelType.mdk ||
+            visibleKernelType == PlayerKernelType.mediaKit) ...[
           Consumer<VideoPlayerState>(
             builder: (context, videoState, child) {
               return SettingsItem.toggle(
@@ -568,7 +575,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
         ],
         if (!kIsWeb &&
             Platform.isAndroid &&
-            _selectedKernelType == PlayerKernelType.mediaKit) ...[
+            visibleKernelType == PlayerKernelType.mediaKit) ...[
           SettingsItem.dropdown(
             title: 'Android 音频后端',
             subtitle:
@@ -599,7 +606,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
         ],
         if (!kIsWeb &&
             Platform.isMacOS &&
-            _selectedKernelType == PlayerKernelType.mediaKit) ...[
+            visibleKernelType == PlayerKernelType.mediaKit) ...[
           SettingsItem.toggle(
             title: '实验性 HDR 原生视频输出',
             subtitle: '开启后使用 macOS 原生视频层；关闭后回退到 Flutter 纹理路径',
@@ -709,7 +716,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
             );
           },
         ),
-        if (_selectedKernelType == PlayerKernelType.mdk) ...[
+        if (visibleKernelType == PlayerKernelType.mdk) ...[
           Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
           Consumer<VideoPlayerState>(
             builder: (context, videoState, child) {
@@ -754,7 +761,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
         Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
         Consumer<VideoPlayerState>(
           builder: (context, videoState, child) {
-            if (_selectedKernelType == PlayerKernelType.mdk) {
+            if (visibleKernelType == PlayerKernelType.mdk) {
               const int minSeconds = 1;
               const int maxSeconds = 120;
               return SettingsItem.slider(
@@ -773,7 +780,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
               );
             }
             final bool enableSetting =
-                _selectedKernelType == PlayerKernelType.mediaKit;
+                visibleKernelType == PlayerKernelType.mediaKit;
             const int stepSize = 4;
             final int minValue = PlayerFactory.minPrecacheBufferSizeMb;
             final int maxValue = PlayerFactory.maxPrecacheBufferSizeMb;
@@ -859,7 +866,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
         ],
         Consumer<VideoPlayerState>(
           builder: (context, videoState, child) {
-            if (_selectedKernelType != PlayerKernelType.mediaKit) {
+            if (visibleKernelType != PlayerKernelType.mediaKit) {
               return const SizedBox.shrink();
             }
             final bool supportsUpscale = videoState.isDoubleResolutionSupported;
@@ -903,7 +910,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
                 )
                 .toList();
 
-            if (_selectedKernelType != PlayerKernelType.mediaKit) {
+            if (visibleKernelType != PlayerKernelType.mediaKit) {
               return const SizedBox.shrink();
             }
 
@@ -938,7 +945,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
             final CrtProfile currentProfile = videoState.crtProfile;
             final bool supportsCrt = videoState.isCrtSupported;
 
-            if (_selectedKernelType != PlayerKernelType.mediaKit) {
+            if (visibleKernelType != PlayerKernelType.mediaKit) {
               return const SizedBox.shrink();
             }
 
@@ -974,7 +981,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
             );
           },
         ),
-        if (_selectedKernelType == PlayerKernelType.mdk) ...[
+        if (visibleKernelType == PlayerKernelType.mdk) ...[
           // 这里可以添加解码器相关设置
         ],
       ],

--- a/lib/themes/nipaplay/pages/settings/remote_access_page.dart
+++ b/lib/themes/nipaplay/pages/settings/remote_access_page.dart
@@ -29,6 +29,7 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
   bool _webServerEnabled = false;
   bool _receiverEnabled = true;
   bool _autoStartEnabled = false;
+  bool _ipv6Enabled = false;
   List<String> _accessUrls = [];
   String? _publicIpUrl;
   bool _isLoadingPublicIp = false;
@@ -58,6 +59,7 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
         _webServerEnabled = server.isRunning;
         _receiverEnabled = receiverEnabled;
         _autoStartEnabled = server.autoStart;
+        _ipv6Enabled = server.ipv6Enabled;
         _currentPort = server.port;
       });
       if (shouldUpdateUrls) {
@@ -213,6 +215,40 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
         BlurSnackBar.show(context, '已关闭自动开启');
       }
     }
+  }
+
+  Future<void> _toggleIpv6(bool enabled) async {
+    final previousValue = _ipv6Enabled;
+    setState(() {
+      _ipv6Enabled = enabled;
+    });
+
+    final server = ServiceProvider.webServer;
+    final success = await server.setIpv6Enabled(enabled);
+    if (!mounted) return;
+
+    if (success) {
+      setState(() {
+        _webServerEnabled = server.isRunning;
+      });
+      if (server.isRunning) {
+        await _updateAccessUrls();
+      }
+      if (!mounted) return;
+      BlurSnackBar.show(
+        context,
+        enabled ? '已开启 IPv6 访问地址' : '已关闭 IPv6 访问地址',
+      );
+      return;
+    }
+
+    setState(() {
+      _ipv6Enabled = previousValue;
+      _webServerEnabled = server.isRunning;
+      _accessUrls = [];
+      _publicIpUrl = null;
+    });
+    _showStartServerErrorDialog(server.lastStartErrorMessage ?? '未知原因');
   }
 
   Future<void> _toggleReceiver(bool enabled) async {
@@ -456,6 +492,16 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
             trailing: FluentSettingsSwitch(
               value: _autoStartEnabled,
               onChanged: _toggleAutoStart,
+            ),
+          ),
+
+          _buildSettingItem(
+            icon: Icons.router,
+            title: '启用 IPv6 访问地址',
+            subtitle: '默认关闭。开启后地址列表和扫码二维码会包含 IPv6 地址（服务运行中切换会自动重启）',
+            trailing: FluentSettingsSwitch(
+              value: _ipv6Enabled,
+              onChanged: _toggleIpv6,
             ),
           ),
 


### PR DESCRIPTION
## Summary
- Gate the Erika player kernel behind a Labs switch in both Material and Cupertino settings.
- Add libkeybinder-3.0-0 to the DEB runtime dependencies.
- Ensure librust_lib_nipaplay.so is copied into the DEB package when the Flutter bundle omits it.
- Add a Remote Access IPv6 toggle that defaults off, so the service uses IPv4-only access by default and keeps IPv6 addresses out of the address list and QR payload until enabled.

## Validation
- flutter pub get
- flutter analyze <changed Dart files> (existing warnings/infos remain; no new type errors found)
- bash -n build-arm64.sh
- git diff --check
- flutter test test/remote_access_qr_service_test.dart

Closes #626
