### PR TITLE
[codex] reduce dandanplay search calls

### DIFF
--- a/lib/services/dandanplay_service_io.dart
+++ b/lib/services/dandanplay_service_io.dart
@@ -56,6 +56,7 @@ class DandanplayService {
   static final Map<int, DateTime> _bangumiDetailsMemoryCacheTime = {};
   static final Map<int, Future<Map<String, dynamic>>> _bangumiDetailsInFlight =
       {};
+  static int _bangumiDetailsCacheEpoch = 0;
   static bool get isLoggedIn => _isLoggedIn;
   static String? get userName => _userName;
   static String? get screenName => _screenName;
@@ -223,6 +224,7 @@ class DandanplayService {
     String username,
     String screenName,
   ) async {
+    _clearBangumiDetailsCache();
     _token = token;
     _userName = username;
     _screenName = screenName;
@@ -240,6 +242,7 @@ class DandanplayService {
   }
 
   static Future<void> clearLoginInfo() async {
+    _clearBangumiDetailsCache();
     _token = null;
     _userName = null;
     _screenName = null;
@@ -323,6 +326,9 @@ class DandanplayService {
   }
 
   static Future<void> saveToken(String token) async {
+    if (_token != token) {
+      _clearBangumiDetailsCache();
+    }
     _token = token;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('dandanplay_token', token);
@@ -334,6 +340,7 @@ class DandanplayService {
   }
 
   static Future<void> clearToken() async {
+    _clearBangumiDetailsCache();
     _token = null;
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('dandanplay_token');
@@ -1071,6 +1078,7 @@ class DandanplayService {
         final data = json.decode(response.body);
         if (data['success'] == true) {
           debugPrint('[弹弹play服务] 观看状态更新成功');
+          _clearBangumiDetailsCache();
         } else {
           throw Exception(data['errorMessage'] ?? '更新观看状态失败');
         }
@@ -1964,6 +1972,7 @@ class DandanplayService {
         final data = json.decode(response.body);
         if (data['success'] == true) {
           debugPrint('[弹弹play服务] 播放历史提交成功');
+          _clearBangumiDetailsCache();
           return data;
         } else {
           throw Exception(data['errorMessage'] ?? '提交播放历史失败');
@@ -1982,6 +1991,20 @@ class DandanplayService {
     return _isLoggedIn && _token != null
         ? _authorizedBangumiDetailsCacheDuration
         : _bangumiDetailsCacheDuration;
+  }
+
+  static void _clearBangumiDetailsCache([int? animeId]) {
+    _bangumiDetailsCacheEpoch++;
+    if (animeId == null) {
+      _bangumiDetailsMemoryCache.clear();
+      _bangumiDetailsMemoryCacheTime.clear();
+      _bangumiDetailsInFlight.clear();
+      return;
+    }
+
+    _bangumiDetailsMemoryCache.remove(animeId);
+    _bangumiDetailsMemoryCacheTime.remove(animeId);
+    _bangumiDetailsInFlight.remove(animeId);
   }
 
   // 获取番剧详情（包含用户观看状态）
@@ -2005,6 +2028,7 @@ class DandanplayService {
       }
     }
 
+    final requestEpoch = _bangumiDetailsCacheEpoch;
     final request = _fetchBangumiDetailsFromApi(bangumiId);
     if (useCache) {
       _bangumiDetailsInFlight[bangumiId] = request;
@@ -2012,13 +2036,15 @@ class DandanplayService {
 
     try {
       final data = await request;
-      if (useCache && data['success'] == true) {
+      if (useCache &&
+          data['success'] == true &&
+          requestEpoch == _bangumiDetailsCacheEpoch) {
         _bangumiDetailsMemoryCache[bangumiId] = Map<String, dynamic>.from(data);
         _bangumiDetailsMemoryCacheTime[bangumiId] = DateTime.now();
       }
       return data;
     } finally {
-      if (useCache) {
+      if (useCache && identical(_bangumiDetailsInFlight[bangumiId], request)) {
         _bangumiDetailsInFlight.remove(bangumiId);
       }
     }
@@ -2402,6 +2428,7 @@ class DandanplayService {
         final data = json.decode(response.body);
         if (data['success'] == true) {
           debugPrint('[弹弹play服务] 收藏添加成功');
+          _clearBangumiDetailsCache(animeId);
           return data;
         } else {
           throw Exception(data['errorMessage'] ?? '添加收藏失败');
@@ -2453,6 +2480,7 @@ class DandanplayService {
         final data = json.decode(response.body);
         if (data['success'] == true) {
           debugPrint('[弹弹play服务] 收藏取消成功');
+          _clearBangumiDetailsCache(animeId);
           return data;
         } else {
           throw Exception(data['errorMessage'] ?? '取消收藏失败');

--- a/lib/services/dandanplay_service_io.dart
+++ b/lib/services/dandanplay_service_io.dart
@@ -23,6 +23,14 @@ class DandanplayService {
   static String? _token;
   static String? _appSecret;
   static const String _videoCacheKey = 'video_recognition_cache';
+  static const String _animeSearchCacheKey = 'dandanplay_anime_search_cache';
+  static const Duration _animeSearchCacheDuration = Duration(days: 7);
+  static const Duration _emptyAnimeSearchCacheDuration = Duration(hours: 12);
+  static const Duration _bangumiDetailsCacheDuration = Duration(hours: 6);
+  static const Duration _authorizedBangumiDetailsCacheDuration =
+      Duration(minutes: 15);
+  static const Duration _unmatchedVideoCacheDuration = Duration(days: 3);
+  static const int _animeSearchCacheMaxEntries = 300;
   static const String _lastTokenRenewKey = 'last_token_renew_time';
   static const int _tokenRenewInterval = 21 * 24 * 60 * 60 * 1000; // 21天（毫秒）
   static bool _isLoggedIn = false;
@@ -39,6 +47,15 @@ class DandanplayService {
   static const Duration _danmakuRequestTimeout = Duration(seconds: 10);
   static const int _danmakuRequestMaxAttempts = 2;
   static const Duration _danmakuRetryDelay = Duration(milliseconds: 600);
+  static final Map<String, List<Map<String, dynamic>>> _animeSearchMemoryCache =
+      {};
+  static final Map<String, DateTime> _animeSearchMemoryCacheTime = {};
+  static final Map<String, Future<List<Map<String, dynamic>>?>>
+      _animeSearchInFlight = {};
+  static final Map<int, Map<String, dynamic>> _bangumiDetailsMemoryCache = {};
+  static final Map<int, DateTime> _bangumiDetailsMemoryCacheTime = {};
+  static final Map<int, Future<Map<String, dynamic>>> _bangumiDetailsInFlight =
+      {};
   static bool get isLoggedIn => _isLoggedIn;
   static String? get userName => _userName;
   static String? get screenName => _screenName;
@@ -335,7 +352,22 @@ class DandanplayService {
       //////debugPrint('查找哈希: $fileHash');
       //////debugPrint('缓存中是否有该哈希: ${cacheMap.containsKey(fileHash)}');
       if (cacheMap.containsKey(fileHash)) {
-        final videoInfo = cacheMap[fileHash];
+        final rawVideoInfo = cacheMap[fileHash];
+        if (rawVideoInfo is! Map) return null;
+        final videoInfo = Map<String, dynamic>.from(rawVideoInfo);
+        if (videoInfo['isMatched'] == false) {
+          final cachedAt = _tryParsePositiveInt(videoInfo['cachedAt']);
+          if (cachedAt != null) {
+            final age = DateTime.now().difference(
+              DateTime.fromMillisecondsSinceEpoch(cachedAt),
+            );
+            if (age > _unmatchedVideoCacheDuration) {
+              cacheMap.remove(fileHash);
+              await prefs.setString(_videoCacheKey, json.encode(cacheMap));
+              return null;
+            }
+          }
+        }
         //////debugPrint('视频信息: ${json.encode(videoInfo)}');
         return videoInfo;
       }
@@ -358,6 +390,154 @@ class DandanplayService {
 
     cacheMap[fileHash] = videoInfo;
     await prefs.setString(_videoCacheKey, json.encode(cacheMap));
+  }
+
+  static String _normalizeAnimeSearchKeyword(String keyword) {
+    return keyword.trim().replaceAll(RegExp(r'\s+'), ' ');
+  }
+
+  static String _animeSearchCacheKeyFor(String baseUrl, String keyword) {
+    return '${baseUrl.trim()}|${_normalizeAnimeSearchKeyword(keyword).toLowerCase()}';
+  }
+
+  static bool _isAnimeSearchCacheFresh(DateTime cachedAt, int resultCount) {
+    final duration = resultCount == 0
+        ? _emptyAnimeSearchCacheDuration
+        : _animeSearchCacheDuration;
+    return DateTime.now().difference(cachedAt) < duration;
+  }
+
+  static Future<List<Map<String, dynamic>>?> _getCachedAnimeSearch(
+    String cacheKey,
+  ) async {
+    final memoryTime = _animeSearchMemoryCacheTime[cacheKey];
+    final memoryResults = _animeSearchMemoryCache[cacheKey];
+    if (memoryTime != null &&
+        memoryResults != null &&
+        _isAnimeSearchCacheFresh(memoryTime, memoryResults.length)) {
+      return memoryResults
+          .map((item) => Map<String, dynamic>.from(item))
+          .toList();
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    final rawCache = prefs.getString(_animeSearchCacheKey);
+    if (rawCache == null || rawCache.isEmpty) return null;
+
+    try {
+      final decoded = json.decode(rawCache);
+      if (decoded is! Map<String, dynamic>) return null;
+      final rawEntry = decoded[cacheKey];
+      if (rawEntry is! Map<String, dynamic>) return null;
+      final timestamp = _tryParsePositiveInt(rawEntry['timestamp']);
+      final rawResults = rawEntry['results'];
+      if (timestamp == null || rawResults is! List) return null;
+
+      final results = rawResults
+          .whereType<Map>()
+          .map((item) => Map<String, dynamic>.from(item))
+          .toList();
+      final cachedAt = DateTime.fromMillisecondsSinceEpoch(timestamp);
+      if (!_isAnimeSearchCacheFresh(cachedAt, results.length)) {
+        return null;
+      }
+
+      _animeSearchMemoryCache[cacheKey] = results;
+      _animeSearchMemoryCacheTime[cacheKey] = cachedAt;
+      return results.map((item) => Map<String, dynamic>.from(item)).toList();
+    } catch (e) {
+      debugPrint('[弹弹play服务] 读取搜索缓存失败: $e');
+      return null;
+    }
+  }
+
+  static Future<void> _saveAnimeSearchCache(
+    String cacheKey,
+    List<Map<String, dynamic>> results,
+  ) async {
+    final now = DateTime.now();
+    _animeSearchMemoryCache[cacheKey] =
+        results.map((item) => Map<String, dynamic>.from(item)).toList();
+    _animeSearchMemoryCacheTime[cacheKey] = now;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final rawCache = prefs.getString(_animeSearchCacheKey);
+      Map<String, dynamic> cacheMap = {};
+      if (rawCache != null && rawCache.isNotEmpty) {
+        final decoded = json.decode(rawCache);
+        if (decoded is Map<String, dynamic>) {
+          cacheMap = Map<String, dynamic>.from(decoded);
+        }
+      }
+
+      cacheMap[cacheKey] = {
+        'timestamp': now.millisecondsSinceEpoch,
+        'results': results,
+      };
+
+      if (cacheMap.length > _animeSearchCacheMaxEntries) {
+        final entries = cacheMap.entries.toList()
+          ..sort((a, b) {
+            final aValue = a.value;
+            final bValue = b.value;
+            final aTimestamp = aValue is Map<String, dynamic>
+                ? (_tryParsePositiveInt(aValue['timestamp']) ?? 0)
+                : 0;
+            final bTimestamp = bValue is Map<String, dynamic>
+                ? (_tryParsePositiveInt(bValue['timestamp']) ?? 0)
+                : 0;
+            return bTimestamp.compareTo(aTimestamp);
+          });
+        cacheMap = Map<String, dynamic>.fromEntries(
+          entries.take(_animeSearchCacheMaxEntries),
+        );
+      }
+
+      await prefs.setString(_animeSearchCacheKey, json.encode(cacheMap));
+    } catch (e) {
+      debugPrint('[弹弹play服务] 保存搜索缓存失败: $e');
+    }
+  }
+
+  static Future<List<Map<String, dynamic>>> searchAnime(
+    String keyword, {
+    bool useCache = true,
+  }) async {
+    final normalizedKeyword = _normalizeAnimeSearchKeyword(keyword);
+    if (normalizedKeyword.isEmpty) return [];
+
+    final baseUrl = await getApiBaseUrl();
+    final cacheKey = _animeSearchCacheKeyFor(baseUrl, normalizedKeyword);
+
+    if (useCache) {
+      final cached = await _getCachedAnimeSearch(cacheKey);
+      if (cached != null) {
+        return cached;
+      }
+    }
+
+    final inFlight = _animeSearchInFlight[cacheKey];
+    if (inFlight != null) {
+      return await inFlight ?? [];
+    }
+
+    final future = _fetchAnimeSearchResults(
+      normalizedKeyword,
+      baseUrl: baseUrl,
+    );
+    _animeSearchInFlight[cacheKey] = future;
+
+    try {
+      final results = await future;
+      if (results != null && useCache) {
+        await _saveAnimeSearchCache(cacheKey, results);
+      }
+      return results?.map((item) => Map<String, dynamic>.from(item)).toList() ??
+          [];
+    } finally {
+      _animeSearchInFlight.remove(cacheKey);
+    }
   }
 
   // 获取appSecret
@@ -1089,13 +1269,18 @@ class DandanplayService {
           }
         }
 
-        return {
+        final unmatchedResult = {
           'isMatched': false,
           'fileName': fileName,
           'fileHash': fileHash,
           'fileSize': fileSize,
+          'cachedAt': DateTime.now().millisecondsSinceEpoch,
           'matches': [],
         };
+        if (fileHash.isNotEmpty) {
+          await saveVideoInfoToCache(fileHash, unmatchedResult);
+        }
+        return unmatchedResult;
       }
     } else {
       final errorMessage = response.headers['x-error-message'] ?? '请检查网络连接';
@@ -1172,21 +1357,19 @@ class DandanplayService {
     return candidate;
   }
 
-  static Future<List<Map<String, dynamic>>> _searchAnimeByKeyword(
-    String keyword,
-  ) async {
-    if (keyword.trim().isEmpty) return [];
-
+  static Future<List<Map<String, dynamic>>?> _fetchAnimeSearchResults(
+    String keyword, {
+    required String baseUrl,
+  }) async {
     final appSecret = await getAppSecret();
     final timestamp =
         (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
     const apiPath = '/api/v2/search/anime';
-    final baseUrl = await getApiBaseUrl();
     final url =
         '$baseUrl$apiPath?keyword=${Uri.encodeComponent(keyword.trim())}';
 
     final response = await http.get(
-      Uri.parse(url),
+      WebRemoteAccessService.proxyUri(Uri.parse(url)),
       headers: {
         'Accept': 'application/json',
         'User-Agent': userAgent,
@@ -1198,13 +1381,13 @@ class DandanplayService {
     );
 
     if (response.statusCode != 200) {
-      return [];
+      return null;
     }
 
     final data = json.decode(response.body);
-    if (data is! Map<String, dynamic>) return [];
+    if (data is! Map<String, dynamic>) return null;
     final animes = data['animes'];
-    if (animes is! List) return [];
+    if (animes is! List) return null;
 
     return animes
         .whereType<Map>()
@@ -1212,34 +1395,16 @@ class DandanplayService {
         .toList();
   }
 
+  static Future<List<Map<String, dynamic>>> _searchAnimeByKeyword(
+    String keyword,
+  ) {
+    return searchAnime(keyword);
+  }
+
   static Future<List<Map<String, dynamic>>> _getBangumiEpisodes(
     int animeId,
   ) async {
-    final appSecret = await getAppSecret();
-    final timestamp =
-        (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
-    final apiPath = '/api/v2/bangumi/$animeId';
-    final baseUrl = await getApiBaseUrl();
-    final url = '$baseUrl$apiPath';
-
-    final response = await http.get(
-      Uri.parse(url),
-      headers: {
-        'Accept': 'application/json',
-        'User-Agent': userAgent,
-        'X-AppId': appId,
-        'X-Signature': generateSignature(appId, timestamp, apiPath, appSecret),
-        'X-Timestamp': '$timestamp',
-        if (_token != null) 'Authorization': 'Bearer $_token',
-      },
-    );
-
-    if (response.statusCode != 200) {
-      return [];
-    }
-
-    final data = json.decode(response.body);
-    if (data is! Map<String, dynamic>) return [];
+    final data = await getBangumiDetails(animeId);
 
     final dynamic rawEpisodes = (data['bangumi'] is Map<String, dynamic>)
         ? (data['bangumi'] as Map<String, dynamic>)['episodes']
@@ -1506,7 +1671,8 @@ class DandanplayService {
     String episodeId,
     int animeId,
   ) {
-    debugPrint('弹幕API响应: 状态码=${response.statusCode}, 内容长度=${response.body.length}');
+    debugPrint(
+        '弹幕API响应: 状态码=${response.statusCode}, 内容长度=${response.body.length}');
 
     if (response.statusCode == 200) {
       return _parseDanmakuBody(response.body, episodeId, animeId);
@@ -1812,8 +1978,55 @@ class DandanplayService {
     }
   }
 
+  static Duration get _currentBangumiDetailsCacheDuration {
+    return _isLoggedIn && _token != null
+        ? _authorizedBangumiDetailsCacheDuration
+        : _bangumiDetailsCacheDuration;
+  }
+
   // 获取番剧详情（包含用户观看状态）
-  static Future<Map<String, dynamic>> getBangumiDetails(int bangumiId) async {
+  static Future<Map<String, dynamic>> getBangumiDetails(
+    int bangumiId, {
+    bool useCache = true,
+  }) async {
+    if (useCache) {
+      final cachedAt = _bangumiDetailsMemoryCacheTime[bangumiId];
+      final cached = _bangumiDetailsMemoryCache[bangumiId];
+      if (cachedAt != null &&
+          cached != null &&
+          DateTime.now().difference(cachedAt) <
+              _currentBangumiDetailsCacheDuration) {
+        return Map<String, dynamic>.from(cached);
+      }
+
+      final inFlight = _bangumiDetailsInFlight[bangumiId];
+      if (inFlight != null) {
+        return Map<String, dynamic>.from(await inFlight);
+      }
+    }
+
+    final request = _fetchBangumiDetailsFromApi(bangumiId);
+    if (useCache) {
+      _bangumiDetailsInFlight[bangumiId] = request;
+    }
+
+    try {
+      final data = await request;
+      if (useCache && data['success'] == true) {
+        _bangumiDetailsMemoryCache[bangumiId] = Map<String, dynamic>.from(data);
+        _bangumiDetailsMemoryCacheTime[bangumiId] = DateTime.now();
+      }
+      return data;
+    } finally {
+      if (useCache) {
+        _bangumiDetailsInFlight.remove(bangumiId);
+      }
+    }
+  }
+
+  static Future<Map<String, dynamic>> _fetchBangumiDetailsFromApi(
+    int bangumiId,
+  ) async {
     try {
       final appSecret = await getAppSecret();
       final timestamp =

--- a/lib/services/dandanplay_service_stub.dart
+++ b/lib/services/dandanplay_service_stub.dart
@@ -45,6 +45,7 @@ class DandanplayService {
   static final Map<int, DateTime> _bangumiDetailsMemoryCacheTime = {};
   static final Map<int, Future<Map<String, dynamic>>> _bangumiDetailsInFlight =
       {};
+  static int _bangumiDetailsCacheEpoch = 0;
 
   static bool get isLoggedIn => _isLoggedIn;
   static String? get userName => _userName;
@@ -255,6 +256,7 @@ class DandanplayService {
 
   static Future<void> saveLoginInfo(
       String token, String username, String screenName) async {
+    _clearBangumiDetailsCache();
     _token = token;
     await _updateLoginStatus(
       isLoggedIn: true,
@@ -265,6 +267,7 @@ class DandanplayService {
   }
 
   static Future<void> clearLoginInfo() async {
+    _clearBangumiDetailsCache();
     final webApiBaseUrl = await _getWebApiBaseUrl();
     if (webApiBaseUrl != null) {
       // 调用API登出，然后清除本地状态
@@ -282,11 +285,15 @@ class DandanplayService {
 
   static Future<void> saveToken(String token) async {
     if (token.isEmpty) return;
+    if (_token != token) {
+      _clearBangumiDetailsCache();
+    }
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('dandanplay_token', token);
   }
 
   static Future<void> clearToken() async {
+    _clearBangumiDetailsCache();
     _token = null;
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('dandanplay_token');
@@ -1039,7 +1046,9 @@ class DandanplayService {
           }),
         );
 
-        if (response.statusCode != 200) {
+        if (response.statusCode == 200) {
+          _clearBangumiDetailsCache();
+        } else {
           debugPrint('[弹弹play服务-Web] 更新观看状态失败: HTTP ${response.statusCode}');
         }
       } catch (e) {
@@ -1079,7 +1088,9 @@ class DandanplayService {
 
       if (response.statusCode == 200) {
         final data = json.decode(response.body);
-        if (data['success'] != true) {
+        if (data['success'] == true) {
+          _clearBangumiDetailsCache();
+        } else {
           throw Exception(data['errorMessage'] ?? '更新观看状态失败');
         }
       } else {
@@ -1347,7 +1358,11 @@ class DandanplayService {
         );
 
         if (response.statusCode == 200) {
-          return json.decode(response.body);
+          final data = json.decode(response.body);
+          if (data is Map<String, dynamic> && data['success'] == true) {
+            _clearBangumiDetailsCache();
+          }
+          return data;
         } else {
           throw Exception('提交播放历史失败: HTTP ${response.statusCode}');
         }
@@ -1399,6 +1414,7 @@ class DandanplayService {
       if (response.statusCode == 200) {
         final data = json.decode(response.body);
         if (data['success'] == true) {
+          _clearBangumiDetailsCache();
           return data;
         } else {
           throw Exception(data['errorMessage'] ?? '提交播放历史失败');
@@ -1417,6 +1433,20 @@ class DandanplayService {
     return _isLoggedIn && _token != null
         ? _authorizedBangumiDetailsCacheDuration
         : _bangumiDetailsCacheDuration;
+  }
+
+  static void _clearBangumiDetailsCache([int? animeId]) {
+    _bangumiDetailsCacheEpoch++;
+    if (animeId == null) {
+      _bangumiDetailsMemoryCache.clear();
+      _bangumiDetailsMemoryCacheTime.clear();
+      _bangumiDetailsInFlight.clear();
+      return;
+    }
+
+    _bangumiDetailsMemoryCache.remove(animeId);
+    _bangumiDetailsMemoryCacheTime.remove(animeId);
+    _bangumiDetailsInFlight.remove(animeId);
   }
 
   static Future<Map<String, dynamic>> getBangumiDetails(
@@ -1439,6 +1469,7 @@ class DandanplayService {
       }
     }
 
+    final requestEpoch = _bangumiDetailsCacheEpoch;
     final request = _fetchBangumiDetailsFromApi(bangumiId);
     if (useCache) {
       _bangumiDetailsInFlight[bangumiId] = request;
@@ -1446,13 +1477,15 @@ class DandanplayService {
 
     try {
       final data = await request;
-      if (useCache && data['success'] == true) {
+      if (useCache &&
+          data['success'] == true &&
+          requestEpoch == _bangumiDetailsCacheEpoch) {
         _bangumiDetailsMemoryCache[bangumiId] = Map<String, dynamic>.from(data);
         _bangumiDetailsMemoryCacheTime[bangumiId] = DateTime.now();
       }
       return data;
     } finally {
-      if (useCache) {
+      if (useCache && identical(_bangumiDetailsInFlight[bangumiId], request)) {
         _bangumiDetailsInFlight.remove(bangumiId);
       }
     }
@@ -1695,7 +1728,11 @@ class DandanplayService {
         );
 
         if (response.statusCode == 200) {
-          return json.decode(response.body);
+          final data = json.decode(response.body);
+          if (data is Map<String, dynamic> && data['success'] == true) {
+            _clearBangumiDetailsCache(animeId);
+          }
+          return data;
         } else {
           throw Exception('添加收藏失败: HTTP ${response.statusCode}');
         }
@@ -1740,6 +1777,7 @@ class DandanplayService {
       if (response.statusCode == 200) {
         final data = json.decode(response.body);
         if (data['success'] == true) {
+          _clearBangumiDetailsCache(animeId);
           return data;
         } else {
           throw Exception(data['errorMessage'] ?? '添加收藏失败');
@@ -1763,7 +1801,11 @@ class DandanplayService {
         );
 
         if (response.statusCode == 200) {
-          return json.decode(response.body);
+          final data = json.decode(response.body);
+          if (data is Map<String, dynamic> && data['success'] == true) {
+            _clearBangumiDetailsCache(animeId);
+          }
+          return data;
         } else {
           throw Exception('取消收藏失败: HTTP ${response.statusCode}');
         }
@@ -1799,6 +1841,7 @@ class DandanplayService {
       if (response.statusCode == 200) {
         final data = json.decode(response.body);
         if (data['success'] == true) {
+          _clearBangumiDetailsCache(animeId);
           return data;
         } else {
           throw Exception(data['errorMessage'] ?? '取消收藏失败');

--- a/lib/services/dandanplay_service_stub.dart
+++ b/lib/services/dandanplay_service_stub.dart
@@ -28,6 +28,23 @@ class DandanplayService {
   static String? _appSecret;
   static Map<String, dynamic>? _linkedBangumiAccount;
   static int? _loginTimestamp;
+  static const String _animeSearchCacheKey = 'dandanplay_anime_search_cache';
+  static const Duration _animeSearchCacheDuration = Duration(days: 7);
+  static const Duration _emptyAnimeSearchCacheDuration = Duration(hours: 12);
+  static const Duration _unmatchedVideoCacheDuration = Duration(days: 3);
+  static const int _animeSearchCacheMaxEntries = 300;
+  static const Duration _bangumiDetailsCacheDuration = Duration(hours: 6);
+  static const Duration _authorizedBangumiDetailsCacheDuration =
+      Duration(minutes: 15);
+  static final Map<String, List<Map<String, dynamic>>> _animeSearchMemoryCache =
+      {};
+  static final Map<String, DateTime> _animeSearchMemoryCacheTime = {};
+  static final Map<String, Future<List<Map<String, dynamic>>?>>
+      _animeSearchInFlight = {};
+  static final Map<int, Map<String, dynamic>> _bangumiDetailsMemoryCache = {};
+  static final Map<int, DateTime> _bangumiDetailsMemoryCacheTime = {};
+  static final Map<int, Future<Map<String, dynamic>>> _bangumiDetailsInFlight =
+      {};
 
   static bool get isLoggedIn => _isLoggedIn;
   static String? get userName => _userName;
@@ -285,6 +302,19 @@ class DandanplayService {
       if (!cacheMap.containsKey(fileHash)) return null;
       final videoInfo = cacheMap[fileHash];
       if (videoInfo is Map<String, dynamic>) {
+        if (videoInfo['isMatched'] == false) {
+          final cachedAt = _tryParsePositiveInt(videoInfo['cachedAt']);
+          if (cachedAt != null) {
+            final age = DateTime.now().difference(
+              DateTime.fromMillisecondsSinceEpoch(cachedAt),
+            );
+            if (age > _unmatchedVideoCacheDuration) {
+              cacheMap.remove(fileHash);
+              await prefs.setString(_videoCacheKey, json.encode(cacheMap));
+              return null;
+            }
+          }
+        }
         return Map<String, dynamic>.from(videoInfo);
       }
       return null;
@@ -305,6 +335,151 @@ class DandanplayService {
       cacheMap[fileHash] = videoInfo;
       await prefs.setString(_videoCacheKey, json.encode(cacheMap));
     } catch (_) {}
+  }
+
+  static String _normalizeAnimeSearchKeyword(String keyword) {
+    return keyword.trim().replaceAll(RegExp(r'\s+'), ' ');
+  }
+
+  static String _animeSearchCacheKeyFor(String baseUrl, String keyword) {
+    return '${baseUrl.trim()}|${_normalizeAnimeSearchKeyword(keyword).toLowerCase()}';
+  }
+
+  static bool _isAnimeSearchCacheFresh(DateTime cachedAt, int resultCount) {
+    final duration = resultCount == 0
+        ? _emptyAnimeSearchCacheDuration
+        : _animeSearchCacheDuration;
+    return DateTime.now().difference(cachedAt) < duration;
+  }
+
+  static Future<List<Map<String, dynamic>>?> _getCachedAnimeSearch(
+    String cacheKey,
+  ) async {
+    final memoryTime = _animeSearchMemoryCacheTime[cacheKey];
+    final memoryResults = _animeSearchMemoryCache[cacheKey];
+    if (memoryTime != null &&
+        memoryResults != null &&
+        _isAnimeSearchCacheFresh(memoryTime, memoryResults.length)) {
+      return memoryResults
+          .map((item) => Map<String, dynamic>.from(item))
+          .toList();
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    final rawCache = prefs.getString(_animeSearchCacheKey);
+    if (rawCache == null || rawCache.isEmpty) return null;
+
+    try {
+      final decoded = json.decode(rawCache);
+      if (decoded is! Map<String, dynamic>) return null;
+      final rawEntry = decoded[cacheKey];
+      if (rawEntry is! Map<String, dynamic>) return null;
+      final timestamp = _tryParsePositiveInt(rawEntry['timestamp']);
+      final rawResults = rawEntry['results'];
+      if (timestamp == null || rawResults is! List) return null;
+
+      final results = rawResults
+          .whereType<Map>()
+          .map((item) => Map<String, dynamic>.from(item))
+          .toList();
+      final cachedAt = DateTime.fromMillisecondsSinceEpoch(timestamp);
+      if (!_isAnimeSearchCacheFresh(cachedAt, results.length)) {
+        return null;
+      }
+
+      _animeSearchMemoryCache[cacheKey] = results;
+      _animeSearchMemoryCacheTime[cacheKey] = cachedAt;
+      return results.map((item) => Map<String, dynamic>.from(item)).toList();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static Future<void> _saveAnimeSearchCache(
+    String cacheKey,
+    List<Map<String, dynamic>> results,
+  ) async {
+    final now = DateTime.now();
+    _animeSearchMemoryCache[cacheKey] =
+        results.map((item) => Map<String, dynamic>.from(item)).toList();
+    _animeSearchMemoryCacheTime[cacheKey] = now;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final rawCache = prefs.getString(_animeSearchCacheKey);
+      Map<String, dynamic> cacheMap = {};
+      if (rawCache != null && rawCache.isNotEmpty) {
+        final decoded = json.decode(rawCache);
+        if (decoded is Map<String, dynamic>) {
+          cacheMap = Map<String, dynamic>.from(decoded);
+        }
+      }
+
+      cacheMap[cacheKey] = {
+        'timestamp': now.millisecondsSinceEpoch,
+        'results': results,
+      };
+
+      if (cacheMap.length > _animeSearchCacheMaxEntries) {
+        final entries = cacheMap.entries.toList()
+          ..sort((a, b) {
+            final aValue = a.value;
+            final bValue = b.value;
+            final aTimestamp = aValue is Map<String, dynamic>
+                ? (_tryParsePositiveInt(aValue['timestamp']) ?? 0)
+                : 0;
+            final bTimestamp = bValue is Map<String, dynamic>
+                ? (_tryParsePositiveInt(bValue['timestamp']) ?? 0)
+                : 0;
+            return bTimestamp.compareTo(aTimestamp);
+          });
+        cacheMap = Map<String, dynamic>.fromEntries(
+          entries.take(_animeSearchCacheMaxEntries),
+        );
+      }
+
+      await prefs.setString(_animeSearchCacheKey, json.encode(cacheMap));
+    } catch (_) {}
+  }
+
+  static Future<List<Map<String, dynamic>>> searchAnime(
+    String keyword, {
+    bool useCache = true,
+  }) async {
+    final normalizedKeyword = _normalizeAnimeSearchKeyword(keyword);
+    if (normalizedKeyword.isEmpty) return [];
+
+    final baseUrl = await getApiBaseUrl();
+    final cacheKey = _animeSearchCacheKeyFor(baseUrl, normalizedKeyword);
+
+    if (useCache) {
+      final cached = await _getCachedAnimeSearch(cacheKey);
+      if (cached != null) {
+        return cached;
+      }
+    }
+
+    final inFlight = _animeSearchInFlight[cacheKey];
+    if (inFlight != null) {
+      return await inFlight ?? [];
+    }
+
+    final future = _fetchAnimeSearchResults(
+      normalizedKeyword,
+      baseUrl: baseUrl,
+    );
+    _animeSearchInFlight[cacheKey] = future;
+
+    try {
+      final results = await future;
+      if (results != null && useCache) {
+        await _saveAnimeSearchCache(cacheKey, results);
+      }
+      return results?.map((item) => Map<String, dynamic>.from(item)).toList() ??
+          [];
+    } finally {
+      _animeSearchInFlight.remove(cacheKey);
+    }
   }
 
   static Future<String> getAppSecret() async {
@@ -1238,7 +1413,54 @@ class DandanplayService {
     }
   }
 
-  static Future<Map<String, dynamic>> getBangumiDetails(int bangumiId) async {
+  static Duration get _currentBangumiDetailsCacheDuration {
+    return _isLoggedIn && _token != null
+        ? _authorizedBangumiDetailsCacheDuration
+        : _bangumiDetailsCacheDuration;
+  }
+
+  static Future<Map<String, dynamic>> getBangumiDetails(
+    int bangumiId, {
+    bool useCache = true,
+  }) async {
+    if (useCache) {
+      final cachedAt = _bangumiDetailsMemoryCacheTime[bangumiId];
+      final cached = _bangumiDetailsMemoryCache[bangumiId];
+      if (cachedAt != null &&
+          cached != null &&
+          DateTime.now().difference(cachedAt) <
+              _currentBangumiDetailsCacheDuration) {
+        return Map<String, dynamic>.from(cached);
+      }
+
+      final inFlight = _bangumiDetailsInFlight[bangumiId];
+      if (inFlight != null) {
+        return Map<String, dynamic>.from(await inFlight);
+      }
+    }
+
+    final request = _fetchBangumiDetailsFromApi(bangumiId);
+    if (useCache) {
+      _bangumiDetailsInFlight[bangumiId] = request;
+    }
+
+    try {
+      final data = await request;
+      if (useCache && data['success'] == true) {
+        _bangumiDetailsMemoryCache[bangumiId] = Map<String, dynamic>.from(data);
+        _bangumiDetailsMemoryCacheTime[bangumiId] = DateTime.now();
+      }
+      return data;
+    } finally {
+      if (useCache) {
+        _bangumiDetailsInFlight.remove(bangumiId);
+      }
+    }
+  }
+
+  static Future<Map<String, dynamic>> _fetchBangumiDetailsFromApi(
+    int bangumiId,
+  ) async {
     final webApiBaseUrl = await _getWebApiBaseUrl();
     if (webApiBaseUrl != null) {
       try {
@@ -1302,13 +1524,15 @@ class DandanplayService {
   }
 
   /// 通过 Bangumi.tv subjectId 获取番剧详情（Web stub — 不支持）
-  static Future<Map<String, dynamic>?> getBangumiByBgmId(int bgmtvSubjectId) async {
+  static Future<Map<String, dynamic>?> getBangumiByBgmId(
+      int bgmtvSubjectId) async {
     debugPrint('[弹弹play服务-Web] getBangumiByBgmId not supported on web');
     return null;
   }
 
   /// 通过 TMDB ID 获取番剧详情（Web stub — 不支持）
-  static Future<Map<String, dynamic>?> getBangumiByTmdbId(int tmdbId, {int? seasonNumber}) async {
+  static Future<Map<String, dynamic>?> getBangumiByTmdbId(int tmdbId,
+      {int? seasonNumber}) async {
     debugPrint('[弹弹play服务-Web] getBangumiByTmdbId not supported on web');
     return null;
   }
@@ -1874,13 +2098,18 @@ class DandanplayService {
       }
     }
 
-    return {
+    final unmatchedResult = {
       'isMatched': false,
       'fileName': fileName,
       'fileHash': fileHash,
       'fileSize': fileSize,
+      'cachedAt': DateTime.now().millisecondsSinceEpoch,
       'matches': [],
     };
+    if (fileHash.isNotEmpty) {
+      await saveVideoInfoToCache(fileHash, unmatchedResult);
+    }
+    return unmatchedResult;
   }
 
   static void _ensureVideoInfoTitles(Map<String, dynamic> videoInfo) {
@@ -1986,20 +2215,19 @@ class DandanplayService {
     return candidate;
   }
 
-  static Future<List<Map<String, dynamic>>> _searchAnimeByKeyword(
-      String keyword) async {
-    if (keyword.trim().isEmpty) return [];
-
+  static Future<List<Map<String, dynamic>>?> _fetchAnimeSearchResults(
+    String keyword, {
+    required String baseUrl,
+  }) async {
     final appSecret = await getAppSecret();
     final timestamp =
         (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
     const apiPath = '/api/v2/search/anime';
-    final baseUrl = await getApiBaseUrl();
     final url =
         '$baseUrl$apiPath?keyword=${Uri.encodeComponent(keyword.trim())}';
 
     final response = await http.get(
-      Uri.parse(url),
+      WebRemoteAccessService.proxyUri(Uri.parse(url)),
       headers: {
         'Accept': 'application/json',
         'User-Agent': userAgent,
@@ -2011,13 +2239,13 @@ class DandanplayService {
     );
 
     if (response.statusCode != 200) {
-      return [];
+      return null;
     }
 
     final data = json.decode(response.body);
-    if (data is! Map<String, dynamic>) return [];
+    if (data is! Map<String, dynamic>) return null;
     final animes = data['animes'];
-    if (animes is! List) return [];
+    if (animes is! List) return null;
 
     return animes
         .whereType<Map>()
@@ -2025,33 +2253,14 @@ class DandanplayService {
         .toList();
   }
 
+  static Future<List<Map<String, dynamic>>> _searchAnimeByKeyword(
+      String keyword) {
+    return searchAnime(keyword);
+  }
+
   static Future<List<Map<String, dynamic>>> _getBangumiEpisodes(
       int animeId) async {
-    final appSecret = await getAppSecret();
-    final timestamp =
-        (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
-    final apiPath = '/api/v2/bangumi/$animeId';
-    final baseUrl = await getApiBaseUrl();
-    final url = '$baseUrl$apiPath';
-
-    final response = await http.get(
-      Uri.parse(url),
-      headers: {
-        'Accept': 'application/json',
-        'User-Agent': userAgent,
-        'X-AppId': appId,
-        'X-Signature': generateSignature(appId, timestamp, apiPath, appSecret),
-        'X-Timestamp': '$timestamp',
-        if (_token != null) 'Authorization': 'Bearer $_token',
-      },
-    );
-
-    if (response.statusCode != 200) {
-      return [];
-    }
-
-    final data = json.decode(response.body);
-    if (data is! Map<String, dynamic>) return [];
+    final data = await getBangumiDetails(animeId);
 
     final dynamic rawEpisodes = (data['bangumi'] is Map<String, dynamic>)
         ? (data['bangumi'] as Map<String, dynamic>)['episodes']

--- a/lib/services/emby_dandanplay_matcher.dart
+++ b/lib/services/emby_dandanplay_matcher.dart
@@ -756,68 +756,13 @@ class EmbyDandanplayMatcher {
       }
 
       debugPrint('搜索动画关键词: "$cleanedKeyword"');
-
-      final appSecret = await DandanplayService.getAppSecret();
-      final timestamp =
-          (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
-      const apiPath = '/api/v2/search/anime';
-
-      final baseUrl = await DandanplayService.getApiBaseUrl();
-      final url =
-          '$baseUrl/api/v2/search/anime?keyword=${Uri.encodeComponent(cleanedKeyword)}';
-      debugPrint('请求URL: $url');
-
-      final uri = WebRemoteAccessService.proxyUri(Uri.parse(url));
-
-      final headers = {
-        'Accept': 'application/json',
-        'X-AppId': DandanplayService.appId,
-        'X-Signature': DandanplayService.generateSignature(
-            DandanplayService.appId, timestamp, apiPath, appSecret),
-        'X-Timestamp': '$timestamp',
-      };
-
-      debugPrint('发送搜索请求: ${uri.toString()}');
-      final response = await http.get(uri, headers: headers);
-
-      debugPrint('搜索结果状态码: ${response.statusCode}');
-
-      if (response.statusCode == 200) {
-        final data = json.decode(response.body);
-
-        // 打印前100个字符，避免日志过长
-        final previewText = response.body.length > 100
-            ? '${response.body.substring(0, 100)}...(总长度: ${response.body.length})'
-            : response.body;
-        debugPrint('搜索结果预览: $previewText');
-
-        // 检查是否有'animes'字段且不为空
-        if (data['animes'] != null &&
-            data['animes'] is List &&
-            data['animes'].isNotEmpty) {
-          final results = List<Map<String, dynamic>>.from(data['animes']);
-          debugPrint('找到 ${results.length} 个匹配动画');
-
-          // 检查返回的结果是否包含所需字段
-          bool hasValidResults = false;
-          for (var anime in results) {
-            if (anime.containsKey('animeId') &&
-                anime.containsKey('animeTitle')) {
-              hasValidResults = true;
-              break;
-            }
-          }
-
-          if (hasValidResults) {
-            return results;
-          } else {
-            debugPrint('警告: 搜索结果不包含必要字段 (animeId, animeTitle)');
-          }
-        } else {
-          debugPrint('搜索结果为空或格式不正确');
-        }
+      final results = await DandanplayService.searchAnime(cleanedKeyword);
+      if (results.any((anime) =>
+          anime.containsKey('animeId') && anime.containsKey('animeTitle'))) {
+        debugPrint('找到 ${results.length} 个匹配动画');
+        return results;
       } else {
-        debugPrint('搜索请求失败: HTTP ${response.statusCode}');
+        debugPrint('搜索结果为空或格式不正确');
       }
     } catch (e) {
       debugPrint('搜索动画时出错: $e');
@@ -942,8 +887,7 @@ class EmbyDandanplayMatcher {
   /// 返回包含哈希值、原始文件名和文件大小的Map
   ///
   /// 优先通过直连流+WebDAV首段策略自动计算哈希，失败时回退到手动匹配
-  Future<Map<String, dynamic>> calculateVideoHash(
-      EmbyEpisodeInfo episode) {
+  Future<Map<String, dynamic>> calculateVideoHash(EmbyEpisodeInfo episode) {
     final cached = _videoInfoCache[episode.id];
     if (cached != null) {
       debugPrint('命中Emby视频哈希缓存: ${episode.id}');
@@ -1620,8 +1564,8 @@ class _AnimeMatchDialogState extends State<AnimeMatchDialog> {
                                     child: ListTile(
                                       title: Text(
                                         match['animeTitle'] ?? '未知动画',
-                                        style:
-                                            const TextStyle(color: Colors.white),
+                                        style: const TextStyle(
+                                            color: Colors.white),
                                       ),
                                       subtitle: match['typeDescription'] != null
                                           ? Text(
@@ -1691,8 +1635,8 @@ class _AnimeMatchDialogState extends State<AnimeMatchDialog> {
                                     child: ListTile(
                                       title: Text(
                                         '第${episode['episodeIndex'] ?? '?'}集: ${episode['episodeTitle'] ?? '未知剧集'}',
-                                        style:
-                                            const TextStyle(color: Colors.white),
+                                        style: const TextStyle(
+                                            color: Colors.white),
                                       ),
                                       trailing: isSelected
                                           ? const Icon(Icons.check_circle,

--- a/lib/services/jellyfin_dandanplay_matcher.dart
+++ b/lib/services/jellyfin_dandanplay_matcher.dart
@@ -301,9 +301,7 @@ class JellyfinDandanplayMatcher {
         }
         hashMatchFailed = true;
       } else {
-        final reason = hasVideoInfo && hasBasicInfo
-            ? '缺少有效哈希值'
-            : '没有可用的精确信息';
+        final reason = hasVideoInfo && hasBasicInfo ? '缺少有效哈希值' : '没有可用的精确信息';
         debugPrint('$reason，使用标题搜索匹配');
       }
 
@@ -749,8 +747,7 @@ class JellyfinDandanplayMatcher {
       final episodeTitle = bestMatch['episodeTitle'] ?? raw['episodeTitle'];
 
       if (animeId == null || episodeId == null) {
-        debugPrint(
-            '警告: 精确匹配返回的首条记录缺少animeId或episodeId，可能导致弹幕无法加载');
+        debugPrint('警告: 精确匹配返回的首条记录缺少animeId或episodeId，可能导致弹幕无法加载');
       }
 
       return {
@@ -782,85 +779,15 @@ class JellyfinDandanplayMatcher {
 
     try {
       debugPrint('开始搜索动画: "$title"');
-
-      // 获取DandanPlay的appSecret
-      final appSecret = await DandanplayService.getAppSecret();
-      final timestamp =
-          (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
-      const apiPath = '/api/v2/search/anime';
-
-      final baseUrl = await DandanplayService.getApiBaseUrl();
-      final url =
-          '$baseUrl/api/v2/search/anime?keyword=${Uri.encodeComponent(title)}';
-      debugPrint('请求URL: $url');
-
-      final response = await http.get(
-        WebRemoteAccessService.proxyUri(Uri.parse(url)),
-        headers: {
-          'Accept': 'application/json',
-          'X-AppId': DandanplayService.appId,
-          'X-Signature': DandanplayService.generateSignature(
-              DandanplayService.appId, timestamp, apiPath, appSecret),
-          'X-Timestamp': '$timestamp',
-        },
-      );
-
-      debugPrint('搜索结果状态码: ${response.statusCode}');
-
-      if (response.statusCode == 200) {
-        final data = json.decode(response.body);
-
-        // 打印前100个字符，避免日志过长
-        final previewText = response.body.length > 100
-            ? '${response.body.substring(0, 100)}...(总长度: ${response.body.length})'
-            : response.body;
-        debugPrint('搜索结果预览: $previewText');
-
-        // 检查是否有'animes'字段且不为空
-        if (data['animes'] != null &&
-            data['animes'] is List &&
-            data['animes'].isNotEmpty) {
-          final results = List<Map<String, dynamic>>.from(data['animes']);
-          debugPrint('找到 ${results.length} 个匹配动画');
-
-          // 检查返回的结果是否包含所需字段
-          bool hasValidResults = false;
-          for (var anime in results) {
-            if (anime['animeId'] != null && anime['animeTitle'] != null) {
-              hasValidResults = true;
-              break;
-            }
-          }
-
-          if (!hasValidResults) {
-            debugPrint('警告: 所有结果都不包含必要的animeId或animeTitle字段');
-          } else {
-            // 打印第一个结果的基本信息
-            if (results.isNotEmpty) {
-              final first = results.first;
-              debugPrint(
-                  '第一个结果: ID=${first['animeId']}, 标题=${first['animeTitle']}, 类型=${first['typeDescription']}');
-            }
-          }
-
-          return results;
-        } else {
-          debugPrint('没有匹配的动画: animes=${data['animes'] ?? "null"}');
-
-          // 检查是否有错误信息
-          if (data.containsKey('errorMessage') &&
-              data['errorMessage'] != null) {
-            debugPrint('API返回错误: ${data['errorMessage']}');
-          }
-
-          if (data.containsKey('success') && data['success'] == false) {
-            debugPrint('API调用失败: success=false');
-          }
-        }
-      } else {
+      final results = await DandanplayService.searchAnime(title);
+      if (results.isNotEmpty) {
+        debugPrint('找到 ${results.length} 个匹配动画');
+        final first = results.first;
         debugPrint(
-            'API调用失败，状态码: ${response.statusCode}, 响应内容: ${response.body}');
+            '第一个结果: ID=${first['animeId']}, 标题=${first['animeTitle']}, 类型=${first['typeDescription']}');
+        return results;
       }
+      debugPrint('没有匹配的动画');
     } catch (e, stackTrace) {
       debugPrint('搜索动画时出错: $e');
       debugPrint('错误堆栈: $stackTrace');
@@ -879,6 +806,55 @@ class JellyfinDandanplayMatcher {
     if (animeTitle.isEmpty) {
       debugPrint('动画标题为空 (ID: $animeId)，无法继续搜索剧集。');
       return [];
+    }
+
+    List<Map<String, dynamic>> normalizeEpisodes(List<dynamic> rawEpisodes) {
+      final episodes = rawEpisodes
+          .whereType<Map>()
+          .map((episode) => Map<String, dynamic>.from(episode))
+          .toList();
+
+      for (var i = 0; i < episodes.length; i++) {
+        final ep = episodes[i];
+        final episodeNumber = ep['episodeNumber'];
+        if (episodeNumber is int && episodeNumber > 0) {
+          ep['episodeIndex'] = episodeNumber;
+          continue;
+        }
+        final episodeTitle = ep['episodeTitle'] as String? ?? '';
+        final indexMatch = RegExp(
+                r'第\s*(\d+)\s*[集话期]|\s(\d+)(?:\s|$)|EP\s*(\d+)|\((\d+)\)|\【(\d+)\】|\s(\d+)$')
+            .firstMatch(episodeTitle);
+        if (indexMatch != null) {
+          String? numStr;
+          for (int j = 1; j <= indexMatch.groupCount; j++) {
+            if (indexMatch.group(j) != null) {
+              numStr = indexMatch.group(j);
+              break;
+            }
+          }
+          ep['episodeIndex'] = int.tryParse(numStr ?? '') ?? i + 1;
+        } else {
+          ep['episodeIndex'] = i + 1;
+        }
+      }
+
+      return episodes;
+    }
+
+    try {
+      final bangumiData = await DandanplayService.getBangumiDetails(animeId);
+      final bangumi = bangumiData['bangumi'];
+      final rawEpisodes = bangumi is Map<String, dynamic>
+          ? bangumi['episodes']
+          : bangumiData['episodes'];
+      if (rawEpisodes is List && rawEpisodes.isNotEmpty) {
+        final episodes = normalizeEpisodes(rawEpisodes);
+        debugPrint('通过番剧详情获取 ${episodes.length} 个剧集，跳过标题搜索剧集');
+        return episodes;
+      }
+    } catch (e) {
+      debugPrint('通过番剧详情获取剧集失败，回退标题搜索剧集: $e');
     }
 
     try {
@@ -1133,8 +1109,7 @@ class JellyfinDandanplayMatcher {
   ///
   /// 优先通过直连流+WebDAV首段策略自动计算哈希，失败时回退到手动匹配
   /// 内部复用同一任务，确保不会重复下载前16MB数据
-  Future<Map<String, dynamic>> calculateVideoHash(
-      JellyfinEpisodeInfo episode) {
+  Future<Map<String, dynamic>> calculateVideoHash(JellyfinEpisodeInfo episode) {
     final cached = _videoInfoCache[episode.id];
     if (cached != null) {
       debugPrint('命中Jellyfin视频哈希缓存: ${episode.id}');
@@ -1221,7 +1196,8 @@ class JellyfinDandanplayMatcher {
       return trimmedRemote;
     }
 
-    final metadataName = (mediaInfo['fileName'] ?? mediaInfo['Name'])?.toString();
+    final metadataName =
+        (mediaInfo['fileName'] ?? mediaInfo['Name'])?.toString();
     if (metadataName != null && metadataName.trim().isNotEmpty) {
       return metadataName.trim();
     }
@@ -1780,8 +1756,8 @@ class _AnimeMatchDialogState extends State<AnimeMatchDialog> {
                                     child: ListTile(
                                       title: Text(
                                         match['animeTitle'] ?? '未知动画',
-                                        style:
-                                            const TextStyle(color: Colors.white),
+                                        style: const TextStyle(
+                                            color: Colors.white),
                                       ),
                                       subtitle: match['typeDescription'] != null
                                           ? Text(
@@ -1851,8 +1827,8 @@ class _AnimeMatchDialogState extends State<AnimeMatchDialog> {
                                     child: ListTile(
                                       title: Text(
                                         '第${episode['episodeIndex'] ?? '?'}集: ${episode['episodeTitle'] ?? '未知剧集'}',
-                                        style:
-                                            const TextStyle(color: Colors.white),
+                                        style: const TextStyle(
+                                            color: Colors.white),
                                       ),
                                       trailing: isSelected
                                           ? const Icon(Icons.check_circle,

--- a/lib/services/manual_danmaku_matcher.dart
+++ b/lib/services/manual_danmaku_matcher.dart
@@ -28,33 +28,7 @@ class ManualDanmakuMatcher {
     }
 
     try {
-      final appSecret = await DandanplayService.getAppSecret();
-      final timestamp =
-          (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
-      const apiPath = '/api/v2/search/anime';
-      final baseUrl = await DandanplayService.getApiBaseUrl();
-      final url = '$baseUrl$apiPath?keyword=${Uri.encodeComponent(keyword)}';
-
-      final response = await http.get(
-        WebRemoteAccessService.proxyUri(Uri.parse(url)),
-        headers: {
-          'Accept': 'application/json',
-          'X-AppId': DandanplayService.appId,
-          'X-Signature': DandanplayService.generateSignature(
-              DandanplayService.appId, timestamp, apiPath, appSecret),
-          'X-Timestamp': '$timestamp',
-        },
-      );
-
-      if (response.statusCode == 200) {
-        final data = json.decode(response.body);
-
-        if (data['animes'] != null && data['animes'] is List) {
-          return List<Map<String, dynamic>>.from(data['animes']);
-        }
-      }
-
-      return [];
+      return DandanplayService.searchAnime(keyword);
     } catch (e) {
       debugPrint('搜索动画时出错: $e');
       rethrow;
@@ -106,7 +80,8 @@ class ManualDanmakuMatcher {
     BuildContext context, {
     String? initialVideoTitle,
   }) async {
-    final uiThemeProvider = Provider.of<UIThemeProvider>(context, listen: false);
+    final uiThemeProvider =
+        Provider.of<UIThemeProvider>(context, listen: false);
     if (uiThemeProvider.isCupertinoTheme) {
       return CupertinoBottomSheet.show<Map<String, dynamic>>(
         context: context,

--- a/lib/themes/cupertino/widgets/cupertino_manual_danmaku_sheet.dart
+++ b/lib/themes/cupertino/widgets/cupertino_manual_danmaku_sheet.dart
@@ -92,33 +92,7 @@ class _CupertinoManualDanmakuSheetState
     }
 
     try {
-      final appSecret = await DandanplayService.getAppSecret();
-      final timestamp =
-          (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
-      const apiPath = '/api/v2/search/anime';
-      final baseUrl = await DandanplayService.getApiBaseUrl();
-      final url = '$baseUrl$apiPath?keyword=${Uri.encodeComponent(keyword)}';
-
-      final response = await http.get(
-        WebRemoteAccessService.proxyUri(Uri.parse(url)),
-        headers: {
-          'Accept': 'application/json',
-          'X-AppId': DandanplayService.appId,
-          'X-Signature': DandanplayService.generateSignature(
-              DandanplayService.appId, timestamp, apiPath, appSecret),
-          'X-Timestamp': '$timestamp',
-        },
-      );
-
-      if (response.statusCode == 200) {
-        final data = json.decode(response.body);
-
-        if (data['animes'] != null && data['animes'] is List) {
-          return List<Map<String, dynamic>>.from(data['animes']);
-        }
-      }
-
-      return [];
+      return DandanplayService.searchAnime(keyword);
     } catch (e) {
       debugPrint('搜索动画时出错: $e');
       rethrow;
@@ -209,8 +183,7 @@ class _CupertinoManualDanmakuSheetState
           }
         } else {
           setState(() {
-            _episodesMessage =
-                '获取动画信息失败: ${data['errorMessage'] ?? '未知错误'}';
+            _episodesMessage = '获取动画信息失败: ${data['errorMessage'] ?? '未知错误'}';
           });
         }
       } else {
@@ -268,8 +241,7 @@ class _CupertinoManualDanmakuSheetState
       context,
     );
     final title = _showEpisodesView ? '选择剧集' : '搜索动画';
-    final subtitle =
-        _showEpisodesView ? '选择对应剧集以匹配弹幕' : '输入动画名称搜索弹幕';
+    final subtitle = _showEpisodesView ? '选择对应剧集以匹配弹幕' : '输入动画名称搜索弹幕';
 
     final List<Widget> children = [];
     if (_showEpisodesView) {
@@ -432,8 +404,7 @@ class _CupertinoManualDanmakuSheetState
     return CupertinoListSection.insetGrouped(
       children: _currentMatches.map((match) {
         final title = match['animeTitle']?.toString() ?? '未知动画';
-        final typeDescription =
-            match['typeDescription']?.toString() ?? '未知类型';
+        final typeDescription = match['typeDescription']?.toString() ?? '未知类型';
         final episodeCount = match['episodeCount'] ?? 0;
 
         return CupertinoListTile(
@@ -497,9 +468,8 @@ class _CupertinoManualDanmakuSheetState
       CupertinoColors.secondaryLabel,
       context,
     );
-    final String text = _selectedEpisode == null
-        ? '请选择一个剧集来匹配弹幕'
-        : '已选择剧集，可确认匹配';
+    final String text =
+        _selectedEpisode == null ? '请选择一个剧集来匹配弹幕' : '已选择剧集，可确认匹配';
     final Color textColor =
         _selectedEpisode == null ? secondaryColor : accentColor;
 

--- a/lib/themes/nipaplay/widgets/batch_danmaku_dialog.dart
+++ b/lib/themes/nipaplay/widgets/batch_danmaku_dialog.dart
@@ -85,7 +85,8 @@ class _BatchDanmakuMatchDialogState extends State<BatchDanmakuMatchDialog>
         final smbPath = uri.queryParameters['path'];
         if (smbPath != null && smbPath.isNotEmpty) {
           final lastSlash = smbPath.lastIndexOf('/');
-          final tail = lastSlash >= 0 ? smbPath.substring(lastSlash + 1) : smbPath;
+          final tail =
+              lastSlash >= 0 ? smbPath.substring(lastSlash + 1) : smbPath;
           if (tail.isNotEmpty) return tail;
         }
         // 一般 HTTP URL：取 pathSegments 最后一段
@@ -209,43 +210,10 @@ class _BatchDanmakuMatchDialogState extends State<BatchDanmakuMatchDialog>
     });
 
     try {
-      final appSecret = await DandanplayService.getAppSecret();
-      final timestamp =
-          (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
-      const apiPath = '/api/v2/search/anime';
-      final baseUrl = await DandanplayService.getApiBaseUrl();
-      final url = '$baseUrl$apiPath?keyword=${Uri.encodeComponent(keyword)}';
-
-      final response = await http.get(
-        WebRemoteAccessService.proxyUri(Uri.parse(url)),
-        headers: {
-          'Accept': 'application/json',
-          'X-AppId': DandanplayService.appId,
-          'X-Signature': DandanplayService.generateSignature(
-            DandanplayService.appId,
-            timestamp,
-            apiPath,
-            appSecret,
-          ),
-          'X-Timestamp': '$timestamp',
-        },
-      );
-
       if (!mounted) return;
 
-      if (response.statusCode != 200) {
-        setState(() {
-          _isSearching = false;
-          _searchMessage = '搜索失败: HTTP ${response.statusCode}';
-          _searchResults = [];
-        });
-        return;
-      }
-
-      final data = json.decode(response.body);
-      final results = (data is Map<String, dynamic> && data['animes'] is List)
-          ? List<Map<String, dynamic>>.from(data['animes'] as List)
-          : <Map<String, dynamic>>[];
+      final results = await DandanplayService.searchAnime(keyword);
+      if (!mounted) return;
 
       // 对搜索结果进行简繁转换
       final isTraditional =

--- a/lib/themes/nipaplay/widgets/manual_danmaku_dialog.dart
+++ b/lib/themes/nipaplay/widgets/manual_danmaku_dialog.dart
@@ -189,33 +189,7 @@ class _ManualDanmakuMatchDialogState extends State<ManualDanmakuMatchDialog>
     }
 
     try {
-      final appSecret = await DandanplayService.getAppSecret();
-      final timestamp =
-          (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).round();
-      const apiPath = '/api/v2/search/anime';
-      final baseUrl = await DandanplayService.getApiBaseUrl();
-      final url = '$baseUrl$apiPath?keyword=${Uri.encodeComponent(keyword)}';
-
-      final response = await http.get(
-        WebRemoteAccessService.proxyUri(Uri.parse(url)),
-        headers: {
-          'Accept': 'application/json',
-          'X-AppId': DandanplayService.appId,
-          'X-Signature': DandanplayService.generateSignature(
-              DandanplayService.appId, timestamp, apiPath, appSecret),
-          'X-Timestamp': '$timestamp',
-        },
-      );
-
-      if (response.statusCode == 200) {
-        final data = json.decode(response.body);
-
-        if (data['animes'] != null && data['animes'] is List) {
-          return List<Map<String, dynamic>>.from(data['animes']);
-        }
-      }
-
-      return [];
+      return DandanplayService.searchAnime(keyword);
     } catch (e) {
       debugPrint('搜索动画时出错: $e');
       rethrow;


### PR DESCRIPTION
## Summary

This reduces repeated Dandanplay search API usage across local, manual, Jellyfin, and Emby matching flows.

## Changes

- Add a shared DandanplayService.searchAnime() path with memory cache, persisted cache, and in-flight request coalescing.
- Cache unmatched video recognition results by non-empty file hash for a short TTL so repeated failed matches do not repeatedly call match and search APIs.
- Add short-lived in-memory coalescing for Dandanplay bangumi detail requests.
- Route manual, batch, Cupertino, Jellyfin, and Emby anime searches through the shared search path.
- Prefer /bangumi/{animeId} for Jellyfin episode lists before falling back to /search/episodes.

## Why

Search counts were higher than file-recognition counts because hash matching had title-search fallbacks, media-server matching often searched without a file hash, and each caller had its own uncached search implementation.

## Validation

- dart format on changed files
- git diff --check
- File-level dart analyze on changed files and service files; no new analyzer errors found. Existing warnings/info remain in touched files.

Full-repo dart analyze is still blocked by existing unrelated issues such as missing erika_flutter and third-party example package imports.