### PR TITLE
Feat：buckup system improve

### DIFF
--- a/cpp_native/src/danmaku_parser.cpp
+++ b/cpp_native/src/danmaku_parser.cpp
@@ -26,12 +26,9 @@
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-#include <charconv>       // std::from_chars (C++17, 不依赖 null 终止)
-#include <system_error>   // std::errc
+#include <cstdlib>        // std::strtod, std::strtol, std::strtoll
 #include <cstring>
-#include <cstdlib>
 #include <cstdio>
-#include <format>
 #include <array>
 #include <algorithm>
 
@@ -89,43 +86,40 @@ std::string DanmakuParser::colorToRgb(int32_t color_code) {
     const int32_t r = (color_code >> 16) & 0xFF;
     const int32_t g = (color_code >> 8) & 0xFF;
     const int32_t b = color_code & 0xFF;
-    return std::format("rgb({},{},{})", r, g, b);
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "rgb(%d,%d,%d)", r, g, b);
+    return buf;
 }
 
-// ──── from_chars 辅助：从 string_view 解析数值（不依赖 null 终止，C++17） ────
+// ──── 数值解析辅助：从 string_view 解析数值 ────
+// 使用 strtod/strtol/strtoll 替代 std::from_chars，
+// 以兼容 macOS 部署目标低于 from_chars 可用版本的情况。
 
 // 解析 double，失败返回 default_val
-// 注意：Android NDK (libc++) 尚未实现浮点 std::from_chars，
-// 因此回退到 strtod（需要 null 终止，创建临时 std::string）。
 static double from_chars_double(std::string_view sv, double default_val) {
     if (sv.empty()) return default_val;
-#if defined(__clang__) && defined(__ANDROID__)
-    // NDK libc++ 缺少浮点 from_chars，回退到 strtod
     const std::string tmp(sv);
     char* end = nullptr;
     const double val = std::strtod(tmp.c_str(), &end);
     return (end != tmp.c_str()) ? val : default_val;
-#else
-    double val = default_val;
-    const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), val);
-    return (ec == std::errc()) ? val : default_val;
-#endif
 }
 
 // 解析 int32_t，失败返回 default_val
 static int32_t from_chars_int32(std::string_view sv, int32_t default_val) {
     if (sv.empty()) return default_val;
-    int32_t val = default_val;
-    const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), val);
-    return (ec == std::errc()) ? val : default_val;
+    const std::string tmp(sv);
+    char* end = nullptr;
+    const long val = std::strtol(tmp.c_str(), &end, 10);
+    return (end != tmp.c_str() && val >= INT32_MIN && val <= INT32_MAX) ? static_cast<int32_t>(val) : default_val;
 }
 
 // 解析 int64_t，失败返回 default_val
 static int64_t from_chars_int64(std::string_view sv, int64_t default_val) {
     if (sv.empty()) return default_val;
-    int64_t val = default_val;
-    const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), val);
-    return (ec == std::errc()) ? val : default_val;
+    const std::string tmp(sv);
+    char* end = nullptr;
+    const long long val = std::strtoll(tmp.c_str(), &end, 10);
+    return (end != tmp.c_str()) ? static_cast<int64_t>(val) : default_val;
 }
 
 bool DanmakuParser::parsePAttribute(std::string_view p_attr, DanmakuItem& item) {
@@ -133,8 +127,7 @@ bool DanmakuParser::parsePAttribute(std::string_view p_attr, DanmakuItem& item) 
     if (p_attr.empty()) return false;
 
     // 手动分割逗号分隔字段，避免 stringstream 分配开销
-    // 使用 std::from_chars (C++17) 替代 strtod/atoi/atoll，
-    // 直接从 string_view 解析，不依赖 null 终止，消除越界读取风险。
+    // 使用 strtod/strtol/strtoll 从 string_view 解析数值。
     int32_t field_index = 0;
     size_t start = 0;
     size_t end = 0;

--- a/lib/services/full_backup_service.dart
+++ b/lib/services/full_backup_service.dart
@@ -8,11 +8,15 @@ import 'package:nipaplay/models/watch_history_database.dart';
 import 'package:nipaplay/models/server_profile_model.dart';
 import 'package:nipaplay/utils/storage_service.dart';
 import 'package:nipaplay/services/multi_address_server_service.dart';
+import 'package:nipaplay/services/webdav_service.dart';
+import 'package:nipaplay/services/smb_service.dart';
+import 'package:nipaplay/services/dandanplay_remote_service.dart';
 import 'package:crypto/crypto.dart';
 
 /// 备份数据类别枚举，支持按需选择导出/导入
 enum BackupCategory {
-  preferences, // 偏好设置（含软件设置和媒体库配置）
+  preferences, // 偏好设置（仅软件设置）
+  mediaLibraries, // 添加的媒体库（本地、在线、WebDAV、SMB、DDP远程、共享服务）
   watchHistory, // 观看历史记录
   episodeMatches, // 已匹配的所有剧集
   accounts, // 个人中心已绑定的账户
@@ -26,6 +30,7 @@ enum BackupCategory {
 ///   "timestamp": "2026-06-11T...",   // 备份创建时间
 ///   "appVersion": "1.4.9",           // 应用版本号
 ///   "preferences": { ... },          // 偏好设置（可选）
+///   "mediaLibraries": { ... },       // 媒体库配置（可选）
 ///   "watchHistory": [ ... ],         // 观看历史（可选）
 ///   "episodeMatches": [ ... ],       // 剧集匹配数据（可选）
 ///   "accounts": { ... },             // 账户绑定数据（可选）
@@ -55,6 +60,10 @@ class FullBackupService {
 
       if (categories.contains(BackupCategory.preferences)) {
         backupData['preferences'] = await _collectPreferences();
+      }
+
+      if (categories.contains(BackupCategory.mediaLibraries)) {
+        backupData['mediaLibraries'] = await _collectMediaLibraries();
       }
 
       if (categories.contains(BackupCategory.watchHistory)) {
@@ -108,6 +117,9 @@ class FullBackupService {
     if (categories.contains(BackupCategory.preferences)) {
       backupData['preferences'] = await _collectPreferences();
     }
+    if (categories.contains(BackupCategory.mediaLibraries)) {
+      backupData['mediaLibraries'] = await _collectMediaLibraries();
+    }
     if (categories.contains(BackupCategory.watchHistory)) {
       backupData['watchHistory'] = await _collectWatchHistory(includeThumbnails: true);
     }
@@ -123,26 +135,33 @@ class FullBackupService {
 
   // ---------- 偏好设置收集 ----------
 
-  /// 收集偏好设置数据
+  /// 收集偏好设置数据（仅软件设置，不含媒体库配置）
   ///
   /// 包含：
   /// - 软件设置（语言、弹幕、播放器、下载等）
-  /// - 本地媒体库路径
-  /// - 在线媒体库（Emby/Jellyfin）服务器配置和选中的媒体库
   Future<Map<String, dynamic>> _collectPreferences() async {
     final prefs = await SharedPreferences.getInstance();
     final result = <String, dynamic>{};
 
-    // 1. 收集所有 SharedPreferences 中的设置项
+    // 收集所有 SharedPreferences 中的设置项（排除媒体库和账户相关）
     final allKeys = prefs.getKeys();
     final settingsKeys = allKeys.where((key) =>
         !key.startsWith('dandanplay_') && // 账户相关单独处理
-        !key.startsWith('server_profiles') && // 服务器配置单独处理
+        !key.startsWith('server_profiles') && // 服务器配置属于媒体库
         key != 'video_positions' && // 播放位置属于观看历史
         key != 'watch_history_web_store' && // Web观看历史单独处理
         !key.startsWith('nipaplay_subfolder_hash_cache') && // 扫描缓存不需要备份
-        !key.endsWith('_library_sort_settings') && // 排序设置跟随服务器配置
-        key != 'custom_storage_path'); // 存储路径是设备相关的
+        !key.endsWith('_library_sort_settings') && // 排序设置属于媒体库
+        key != 'custom_storage_path' && // 存储路径是设备相关的
+        key != 'nipaplay_scanned_folders' && // 本地媒体库属于媒体库
+        !key.startsWith('emby_selected_library_ids') && // 选中媒体库属于媒体库
+        !key.startsWith('jellyfin_selected_library_ids') && // 选中媒体库属于媒体库
+        key != 'webdav_connections' && // WebDAV连接属于媒体库
+        key != 'smb_connections' && // SMB连接属于媒体库
+        !key.startsWith('web_server_') && // Web服务器配置属于媒体库
+        key != 'bangumi_access_token' && // Bangumi账户属于账户
+        key != 'bangumi_user_info' && // Bangumi账户属于账户
+        key != 'bangumi_logged_in'); // Bangumi账户属于账户
 
     final settingsMap = <String, dynamic>{};
     for (final key in settingsKeys) {
@@ -153,28 +172,46 @@ class FullBackupService {
     }
     result['settings'] = settingsMap;
 
-    // 2. 收集本地媒体库路径
+    return result;
+  }
+
+  // ---------- 媒体库配置收集 ----------
+
+  /// 收集媒体库配置数据
+  ///
+  /// 包含：
+  /// - 本地媒体库路径
+  /// - 在线媒体库（Emby/Jellyfin）服务器配置和选中的媒体库
+  /// - WebDAV 连接配置
+  /// - SMB 连接配置
+  /// - 弹弹play远程服务配置
+  /// - Nipaplay 媒体库共享配置
+  Future<Map<String, dynamic>> _collectMediaLibraries() async {
+    final prefs = await SharedPreferences.getInstance();
+    final result = <String, dynamic>{};
+
+    // 1. 收集本地媒体库路径
     final scannedFolders = prefs.getStringList('nipaplay_scanned_folders');
     result['localMediaLibraries'] = scannedFolders ?? [];
 
-    // 3. 收集在线媒体库服务器配置
+    // 2. 收集在线媒体库服务器配置
     final serverProfiles = await _collectServerProfiles();
     result['serverProfiles'] = serverProfiles;
 
-    // 4. 收集 Emby 选中的媒体库
+    // 3. 收集 Emby 选中的媒体库
     final embySelectedLibs = prefs.getStringList('emby_selected_library_ids');
     if (embySelectedLibs != null) {
       result['embySelectedLibraryIds'] = embySelectedLibs;
     }
 
-    // 5. 收集 Jellyfin 选中的媒体库
+    // 4. 收集 Jellyfin 选中的媒体库
     final jellyfinSelectedLibs =
         prefs.getStringList('jellyfin_selected_library_ids');
     if (jellyfinSelectedLibs != null) {
       result['jellyfinSelectedLibraryIds'] = jellyfinSelectedLibs;
     }
 
-    // 6. 收集排序设置
+    // 5. 收集排序设置
     final embySortSettings = prefs.getString('emby_library_sort_settings');
     if (embySortSettings != null) {
       result['embyLibrarySortSettings'] = embySortSettings;
@@ -184,6 +221,62 @@ class FullBackupService {
     if (jellyfinSortSettings != null) {
       result['jellyfinLibrarySortSettings'] = jellyfinSortSettings;
     }
+
+    // 6. 收集 WebDAV 连接配置
+    try {
+      final webdavService = WebDAVService.instance;
+      await webdavService.initialize();
+      final webdavConnections = webdavService.connections;
+      if (webdavConnections.isNotEmpty) {
+        result['webdavConnections'] =
+            webdavConnections.map((c) => c.toJson()).toList();
+      }
+    } catch (e) {
+      debugPrint('收集WebDAV连接配置失败: $e');
+    }
+
+    // 7. 收集 SMB 连接配置
+    try {
+      final smbService = SMBService.instance;
+      await smbService.initialize();
+      final smbConnections = smbService.connections;
+      if (smbConnections.isNotEmpty) {
+        result['smbConnections'] =
+            smbConnections.map((c) => c.toJson()).toList();
+      }
+    } catch (e) {
+      debugPrint('收集SMB连接配置失败: $e');
+    }
+
+    // 8. 收集弹弹play远程服务配置
+    try {
+      final remoteService = DandanplayRemoteService.instance;
+      await remoteService.loadSavedSettings(backgroundRefresh: true);
+      if (remoteService.serverUrl != null &&
+          remoteService.serverUrl!.isNotEmpty) {
+        result['dandanplayRemote'] = {
+          'baseUrl': prefs.getString('dandanplay_remote_base_url'),
+          'apiToken': prefs.getString('dandanplay_remote_api_token'),
+          'tokenRequired':
+              prefs.getBool('dandanplay_remote_token_required') ?? false,
+        };
+      }
+    } catch (e) {
+      debugPrint('收集弹弹play远程服务配置失败: $e');
+    }
+
+    // 9. 收集 Nipaplay 媒体库共享（Web服务器）配置
+    final webServerAutoStart = prefs.getBool('web_server_auto_start') ??
+        prefs.getBool('web_server_enabled') ??
+        false;
+    final webServerPort = prefs.getInt('web_server_port');
+    final webServerIpv6Enabled =
+        prefs.getBool('web_server_ipv6_enabled') ?? false;
+    result['nipaplayShare'] = {
+      'autoStart': webServerAutoStart,
+      'port': webServerPort ?? 1180,
+      'ipv6Enabled': webServerIpv6Enabled,
+    };
 
     return result;
   }
@@ -393,6 +486,12 @@ class FullBackupService {
             await _restorePreferences(backupData['preferences'] as Map<String, dynamic>);
       }
 
+      if (categories.contains(BackupCategory.mediaLibraries) &&
+          backupData.containsKey('mediaLibraries')) {
+        result.mediaLibrariesResult =
+            await _restoreMediaLibraries(backupData['mediaLibraries'] as Map<String, dynamic>);
+      }
+
       if (categories.contains(BackupCategory.watchHistory) &&
           backupData.containsKey('watchHistory')) {
         result.watchHistoryResult =
@@ -441,6 +540,11 @@ class FullBackupService {
         result.preferencesResult =
             await _restorePreferences(backupData['preferences'] as Map<String, dynamic>);
       }
+      if (categories.contains(BackupCategory.mediaLibraries) &&
+          backupData.containsKey('mediaLibraries')) {
+        result.mediaLibrariesResult =
+            await _restoreMediaLibraries(backupData['mediaLibraries'] as Map<String, dynamic>);
+      }
       if (categories.contains(BackupCategory.watchHistory) &&
           backupData.containsKey('watchHistory')) {
         result.watchHistoryResult =
@@ -476,7 +580,7 @@ class FullBackupService {
     try {
       final prefs = await SharedPreferences.getInstance();
 
-      // 1. 恢复软件设置
+      // 恢复软件设置
       final settings = preferencesData['settings'] as Map<String, dynamic>?;
       if (settings != null) {
         int restoredCount = 0;
@@ -505,8 +609,27 @@ class FullBackupService {
         debugPrint('恢复了 $restoredCount 项偏好设置');
       }
 
-      // 2. 恢复本地媒体库路径
-      final localLibs = preferencesData['localMediaLibraries'] as List<dynamic>?;
+      result.success = true;
+    } catch (e) {
+      debugPrint('恢复偏好设置失败: $e');
+      result.success = false;
+      result.errorMessage = e.toString();
+    }
+
+    return result;
+  }
+
+  // ---------- 媒体库配置恢复 ----------
+
+  Future<CategoryRestoreResult> _restoreMediaLibraries(
+      Map<String, dynamic> mediaLibrariesData) async {
+    final result = CategoryRestoreResult();
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+
+      // 1. 恢复本地媒体库路径
+      final localLibs = mediaLibrariesData['localMediaLibraries'] as List<dynamic>?;
       if (localLibs != null) {
         final folderList = localLibs.cast<String>().toList();
         await prefs.setStringList('nipaplay_scanned_folders', folderList);
@@ -514,9 +637,9 @@ class FullBackupService {
         debugPrint('恢复了 ${folderList.length} 个本地媒体库路径');
       }
 
-      // 3. 恢复在线媒体库服务器配置
+      // 2. 恢复在线媒体库服务器配置
       final serverProfilesData =
-          preferencesData['serverProfiles'] as List<dynamic>?;
+          mediaLibrariesData['serverProfiles'] as List<dynamic>?;
       if (serverProfilesData != null) {
         final profiles = serverProfilesData
             .map((p) => ServerProfile.fromJson(p as Map<String, dynamic>))
@@ -525,15 +648,6 @@ class FullBackupService {
         // 合并而非替换：保留本地已有的、添加备份中新增的
         await MultiAddressServerService.instance.loadProfiles();
         final existingProfiles = MultiAddressServerService.instance.profiles;
-        final existingIds = existingProfiles.map((p) => p.id).toSet();
-
-        for (final profile in profiles) {
-          if (!existingIds.contains(profile.id)) {
-            // 新增配置
-            MultiAddressServerService.instance.profiles;
-            // 直接通过保存方式添加
-          }
-        }
 
         // 保存合并后的配置
         final mergedProfiles = <ServerProfile>[...existingProfiles];
@@ -548,8 +662,6 @@ class FullBackupService {
           }
         }
 
-        // 使用 MultiAddressServerService 保存
-        // 直接保存合并后的列表
         final prefsInstance = await SharedPreferences.getInstance();
         final profilesJson =
             json.encode(mergedProfiles.map((p) => p.toJson()).toList());
@@ -559,38 +671,147 @@ class FullBackupService {
         debugPrint('恢复了 ${profiles.length} 个服务器配置');
       }
 
-      // 4. 恢复选中的媒体库
+      // 3. 恢复选中的媒体库
       final embySelectedLibs =
-          preferencesData['embySelectedLibraryIds'] as List<dynamic>?;
+          mediaLibrariesData['embySelectedLibraryIds'] as List<dynamic>?;
       if (embySelectedLibs != null) {
         await prefs.setStringList(
             'emby_selected_library_ids', embySelectedLibs.cast<String>().toList());
       }
 
       final jellyfinSelectedLibs =
-          preferencesData['jellyfinSelectedLibraryIds'] as List<dynamic>?;
+          mediaLibrariesData['jellyfinSelectedLibraryIds'] as List<dynamic>?;
       if (jellyfinSelectedLibs != null) {
         await prefs.setStringList('jellyfin_selected_library_ids',
             jellyfinSelectedLibs.cast<String>().toList());
       }
 
-      // 5. 恢复排序设置
+      // 4. 恢复排序设置
       final embySortSettings =
-          preferencesData['embyLibrarySortSettings'] as String?;
+          mediaLibrariesData['embyLibrarySortSettings'] as String?;
       if (embySortSettings != null) {
         await prefs.setString('emby_library_sort_settings', embySortSettings);
       }
 
       final jellyfinSortSettings =
-          preferencesData['jellyfinLibrarySortSettings'] as String?;
+          mediaLibrariesData['jellyfinLibrarySortSettings'] as String?;
       if (jellyfinSortSettings != null) {
         await prefs.setString(
             'jellyfin_library_sort_settings', jellyfinSortSettings);
       }
 
+      // 5. 恢复 WebDAV 连接配置（合并：按 name 匹配，已存在则更新，不存在则新增）
+      final webdavConnectionsData =
+          mediaLibrariesData['webdavConnections'] as List<dynamic>?;
+      if (webdavConnectionsData != null && webdavConnectionsData.isNotEmpty) {
+        try {
+          final webdavService = WebDAVService.instance;
+          await webdavService.initialize();
+          final existingConnections = webdavService.connections;
+          final existingNames =
+              existingConnections.map((c) => c.name).toSet();
+
+          for (final connData in webdavConnectionsData) {
+            try {
+              final connection =
+                  WebDAVConnection.fromJson(connData as Map<String, dynamic>);
+              if (existingNames.contains(connection.name)) {
+                await webdavService
+                    .removeConnection(connection.name);
+              }
+              await webdavService.addConnection(connection);
+            } catch (e) {
+              debugPrint('恢复单条WebDAV连接失败: $e');
+            }
+          }
+          debugPrint('恢复了 ${webdavConnectionsData.length} 个WebDAV连接');
+        } catch (e) {
+          debugPrint('恢复WebDAV连接配置失败: $e');
+        }
+      }
+
+      // 6. 恢复 SMB 连接配置（合并：按 name 匹配）
+      final smbConnectionsData =
+          mediaLibrariesData['smbConnections'] as List<dynamic>?;
+      if (smbConnectionsData != null && smbConnectionsData.isNotEmpty) {
+        try {
+          final smbService = SMBService.instance;
+          await smbService.initialize();
+          final existingConnections = smbService.connections;
+          final existingNames =
+              existingConnections.map((c) => c.name).toSet();
+
+          for (final connData in smbConnectionsData) {
+            try {
+              final connection =
+                  SMBConnection.fromJson(connData as Map<String, dynamic>);
+              if (existingNames.contains(connection.name)) {
+                await smbService
+                    .updateConnection(connection.name, connection);
+              } else {
+                await smbService.addConnection(connection);
+              }
+            } catch (e) {
+              debugPrint('恢复单条SMB连接失败: $e');
+            }
+          }
+          debugPrint('恢复了 ${smbConnectionsData.length} 个SMB连接');
+        } catch (e) {
+          debugPrint('恢复SMB连接配置失败: $e');
+        }
+      }
+
+      // 7. 恢复弹弹play远程服务配置
+      final dandanplayRemoteData =
+          mediaLibrariesData['dandanplayRemote'] as Map<String, dynamic>?;
+      if (dandanplayRemoteData != null) {
+        try {
+          final baseUrl = dandanplayRemoteData['baseUrl'] as String?;
+          if (baseUrl != null && baseUrl.isNotEmpty) {
+            final apiToken = dandanplayRemoteData['apiToken'] as String?;
+            // 使用 connect 方法恢复连接（会验证并持久化）
+            await DandanplayRemoteService.instance
+                .connect(baseUrl, token: apiToken);
+            debugPrint('恢复了弹弹play远程服务配置');
+          }
+        } catch (e) {
+          // 如果连接验证失败，仍然保存配置到 SharedPreferences
+          debugPrint('弹弹play远程服务连接验证失败，仍保存配置: $e');
+          try {
+            final baseUrl = dandanplayRemoteData['baseUrl'] as String?;
+            if (baseUrl != null) {
+              await prefs.setString('dandanplay_remote_base_url', baseUrl);
+            }
+            final apiToken = dandanplayRemoteData['apiToken'] as String?;
+            if (apiToken != null) {
+              await prefs.setString('dandanplay_remote_api_token', apiToken);
+            }
+            final tokenRequired =
+                dandanplayRemoteData['tokenRequired'] as bool? ?? false;
+            await prefs.setBool(
+                'dandanplay_remote_token_required', tokenRequired);
+          } catch (_) {}
+        }
+      }
+
+      // 8. 恢复 Nipaplay 媒体库共享（Web服务器）配置
+      final nipaplayShareData =
+          mediaLibrariesData['nipaplayShare'] as Map<String, dynamic>?;
+      if (nipaplayShareData != null) {
+        final autoStart = nipaplayShareData['autoStart'] as bool? ?? false;
+        final port = nipaplayShareData['port'] as int? ?? 1180;
+        final ipv6Enabled =
+            nipaplayShareData['ipv6Enabled'] as bool? ?? false;
+
+        await prefs.setBool('web_server_auto_start', autoStart);
+        await prefs.setInt('web_server_port', port);
+        await prefs.setBool('web_server_ipv6_enabled', ipv6Enabled);
+        debugPrint('恢复了Nipaplay媒体库共享配置');
+      }
+
       result.success = true;
     } catch (e) {
-      debugPrint('恢复偏好设置失败: $e');
+      debugPrint('恢复媒体库配置失败: $e');
       result.success = false;
       result.errorMessage = e.toString();
     }
@@ -972,6 +1193,7 @@ class FullBackupService {
     }
     final parts = <String>[];
     if (categories.contains(BackupCategory.preferences)) parts.add('pref');
+    if (categories.contains(BackupCategory.mediaLibraries)) parts.add('lib');
     if (categories.contains(BackupCategory.watchHistory)) parts.add('hist');
     if (categories.contains(BackupCategory.episodeMatches)) parts.add('match');
     if (categories.contains(BackupCategory.accounts)) parts.add('acct');
@@ -992,6 +1214,7 @@ class FullBackupService {
         timestamp: backupData['timestamp'] as String? ?? '',
         appVersion: backupData['appVersion'] as String? ?? '',
         hasPreferences: backupData.containsKey('preferences'),
+        hasMediaLibraries: backupData.containsKey('mediaLibraries'),
         hasWatchHistory: backupData.containsKey('watchHistory'),
         hasEpisodeMatches: backupData.containsKey('episodeMatches'),
         hasAccounts: backupData.containsKey('accounts'),
@@ -1002,13 +1225,25 @@ class FullBackupService {
                 ?.length ??
             0,
         serverProfileCount:
-            (backupData['preferences']?['serverProfiles'] as List<dynamic>?)
+            (backupData['mediaLibraries']?['serverProfiles'] as List<dynamic>?)
                     ?.length ??
                 0,
         localLibraryCount:
-            (backupData['preferences']?['localMediaLibraries'] as List<dynamic>?)
+            (backupData['mediaLibraries']?['localMediaLibraries'] as List<dynamic>?)
                     ?.length ??
                 0,
+        webdavConnectionCount:
+            (backupData['mediaLibraries']?['webdavConnections'] as List<dynamic>?)
+                    ?.length ??
+                0,
+        smbConnectionCount:
+            (backupData['mediaLibraries']?['smbConnections'] as List<dynamic>?)
+                    ?.length ??
+                0,
+        hasDandanplayRemote:
+            backupData['mediaLibraries']?['dandanplayRemote'] != null,
+        hasNipaplayShare:
+            backupData['mediaLibraries']?['nipaplayShare'] != null,
       );
     } catch (e) {
       debugPrint('预览备份文件失败: $e');
@@ -1023,6 +1258,7 @@ class BackupRestoreResult {
   String? errorMessage;
 
   CategoryRestoreResult? preferencesResult;
+  CategoryRestoreResult? mediaLibrariesResult;
   CategoryRestoreResult? watchHistoryResult;
   CategoryRestoreResult? episodeMatchesResult;
   CategoryRestoreResult? accountsResult;
@@ -1065,6 +1301,7 @@ class BackupPreviewInfo {
   final String timestamp;
   final String appVersion;
   final bool hasPreferences;
+  final bool hasMediaLibraries;
   final bool hasWatchHistory;
   final bool hasEpisodeMatches;
   final bool hasAccounts;
@@ -1072,12 +1309,17 @@ class BackupPreviewInfo {
   final int episodeMatchCount;
   final int serverProfileCount;
   final int localLibraryCount;
+  final int webdavConnectionCount;
+  final int smbConnectionCount;
+  final bool hasDandanplayRemote;
+  final bool hasNipaplayShare;
 
   BackupPreviewInfo({
     required this.version,
     required this.timestamp,
     required this.appVersion,
     required this.hasPreferences,
+    required this.hasMediaLibraries,
     required this.hasWatchHistory,
     required this.hasEpisodeMatches,
     required this.hasAccounts,
@@ -1085,5 +1327,9 @@ class BackupPreviewInfo {
     required this.episodeMatchCount,
     required this.serverProfileCount,
     required this.localLibraryCount,
+    this.webdavConnectionCount = 0,
+    this.smbConnectionCount = 0,
+    this.hasDandanplayRemote = false,
+    this.hasNipaplayShare = false,
   });
 }

--- a/lib/services/full_backup_service.dart
+++ b/lib/services/full_backup_service.dart
@@ -1,0 +1,1089 @@
+import 'dart:io';
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as path;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:nipaplay/models/watch_history_model.dart';
+import 'package:nipaplay/models/watch_history_database.dart';
+import 'package:nipaplay/models/server_profile_model.dart';
+import 'package:nipaplay/utils/storage_service.dart';
+import 'package:nipaplay/services/multi_address_server_service.dart';
+import 'package:crypto/crypto.dart';
+
+/// 备份数据类别枚举，支持按需选择导出/导入
+enum BackupCategory {
+  preferences, // 偏好设置（含软件设置和媒体库配置）
+  watchHistory, // 观看历史记录
+  episodeMatches, // 已匹配的所有剧集
+  accounts, // 个人中心已绑定的账户
+}
+
+/// 全量备份服务
+///
+/// 备份文件格式为 JSON，结构如下：
+/// {
+///   "version": 2,                    // 备份格式版本号
+///   "timestamp": "2026-06-11T...",   // 备份创建时间
+///   "appVersion": "1.4.9",           // 应用版本号
+///   "preferences": { ... },          // 偏好设置（可选）
+///   "watchHistory": [ ... ],         // 观看历史（可选）
+///   "episodeMatches": [ ... ],       // 剧集匹配数据（可选）
+///   "accounts": { ... },             // 账户绑定数据（可选）
+/// }
+class FullBackupService {
+  static const int _backupFormatVersion = 2;
+
+  // ==================== 导出（信息收集） ====================
+
+  /// 导出全量备份到文件
+  ///
+  /// [directoryPath] 保存目录路径
+  /// [categories] 要导出的数据类别集合
+  /// [appVersion] 当前应用版本号
+  /// 返回保存的文件路径，如果失败返回 null
+  Future<String?> exportBackup({
+    required String directoryPath,
+    required Set<BackupCategory> categories,
+    String appVersion = '',
+  }) async {
+    try {
+      final backupData = <String, dynamic>{
+        'version': _backupFormatVersion,
+        'timestamp': DateTime.now().toIso8601String(),
+        'appVersion': appVersion,
+      };
+
+      if (categories.contains(BackupCategory.preferences)) {
+        backupData['preferences'] = await _collectPreferences();
+      }
+
+      if (categories.contains(BackupCategory.watchHistory)) {
+        backupData['watchHistory'] = await _collectWatchHistory(includeThumbnails: true);
+      }
+
+      if (categories.contains(BackupCategory.episodeMatches)) {
+        backupData['episodeMatches'] = await _collectEpisodeMatches();
+      }
+
+      if (categories.contains(BackupCategory.accounts)) {
+        backupData['accounts'] = await _collectAccounts();
+      }
+
+      // 生成文件名
+      final now = DateTime.now();
+      final dateString =
+          '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+      final timeString =
+          '${now.hour.toString().padLeft(2, '0')}${now.minute.toString().padLeft(2, '0')}';
+      final categorySuffix = _buildCategorySuffix(categories);
+      final fileName =
+          'nipaplay_backup_${categorySuffix}_${dateString}_$timeString.npb';
+      final filePath = path.join(directoryPath, fileName);
+
+      // 写入文件
+      final jsonString =
+          const JsonEncoder.withIndent('  ').convert(backupData);
+      final file = File(filePath);
+      await file.writeAsString(jsonString);
+
+      debugPrint('成功导出备份到: $filePath');
+      return filePath;
+    } catch (e) {
+      debugPrint('导出备份失败: $e');
+      return null;
+    }
+  }
+
+  /// 仅收集备份数据（不写文件），供外部使用
+  Future<Map<String, dynamic>> collectBackupData({
+    required Set<BackupCategory> categories,
+    String appVersion = '',
+  }) async {
+    final backupData = <String, dynamic>{
+      'version': _backupFormatVersion,
+      'timestamp': DateTime.now().toIso8601String(),
+      'appVersion': appVersion,
+    };
+
+    if (categories.contains(BackupCategory.preferences)) {
+      backupData['preferences'] = await _collectPreferences();
+    }
+    if (categories.contains(BackupCategory.watchHistory)) {
+      backupData['watchHistory'] = await _collectWatchHistory(includeThumbnails: true);
+    }
+    if (categories.contains(BackupCategory.episodeMatches)) {
+      backupData['episodeMatches'] = await _collectEpisodeMatches();
+    }
+    if (categories.contains(BackupCategory.accounts)) {
+      backupData['accounts'] = await _collectAccounts();
+    }
+
+    return backupData;
+  }
+
+  // ---------- 偏好设置收集 ----------
+
+  /// 收集偏好设置数据
+  ///
+  /// 包含：
+  /// - 软件设置（语言、弹幕、播放器、下载等）
+  /// - 本地媒体库路径
+  /// - 在线媒体库（Emby/Jellyfin）服务器配置和选中的媒体库
+  Future<Map<String, dynamic>> _collectPreferences() async {
+    final prefs = await SharedPreferences.getInstance();
+    final result = <String, dynamic>{};
+
+    // 1. 收集所有 SharedPreferences 中的设置项
+    final allKeys = prefs.getKeys();
+    final settingsKeys = allKeys.where((key) =>
+        !key.startsWith('dandanplay_') && // 账户相关单独处理
+        !key.startsWith('server_profiles') && // 服务器配置单独处理
+        key != 'video_positions' && // 播放位置属于观看历史
+        key != 'watch_history_web_store' && // Web观看历史单独处理
+        !key.startsWith('nipaplay_subfolder_hash_cache') && // 扫描缓存不需要备份
+        !key.endsWith('_library_sort_settings') && // 排序设置跟随服务器配置
+        key != 'custom_storage_path'); // 存储路径是设备相关的
+
+    final settingsMap = <String, dynamic>{};
+    for (final key in settingsKeys) {
+      final value = prefs.get(key);
+      if (value != null) {
+        settingsMap[key] = value;
+      }
+    }
+    result['settings'] = settingsMap;
+
+    // 2. 收集本地媒体库路径
+    final scannedFolders = prefs.getStringList('nipaplay_scanned_folders');
+    result['localMediaLibraries'] = scannedFolders ?? [];
+
+    // 3. 收集在线媒体库服务器配置
+    final serverProfiles = await _collectServerProfiles();
+    result['serverProfiles'] = serverProfiles;
+
+    // 4. 收集 Emby 选中的媒体库
+    final embySelectedLibs = prefs.getStringList('emby_selected_library_ids');
+    if (embySelectedLibs != null) {
+      result['embySelectedLibraryIds'] = embySelectedLibs;
+    }
+
+    // 5. 收集 Jellyfin 选中的媒体库
+    final jellyfinSelectedLibs =
+        prefs.getStringList('jellyfin_selected_library_ids');
+    if (jellyfinSelectedLibs != null) {
+      result['jellyfinSelectedLibraryIds'] = jellyfinSelectedLibs;
+    }
+
+    // 6. 收集排序设置
+    final embySortSettings = prefs.getString('emby_library_sort_settings');
+    if (embySortSettings != null) {
+      result['embyLibrarySortSettings'] = embySortSettings;
+    }
+    final jellyfinSortSettings =
+        prefs.getString('jellyfin_library_sort_settings');
+    if (jellyfinSortSettings != null) {
+      result['jellyfinLibrarySortSettings'] = jellyfinSortSettings;
+    }
+
+    return result;
+  }
+
+  /// 收集服务器配置列表
+  Future<List<Map<String, dynamic>>> _collectServerProfiles() async {
+    try {
+      await MultiAddressServerService.instance.loadProfiles();
+      final profiles = MultiAddressServerService.instance.profiles;
+      return profiles.map((p) => p.toJson()).toList();
+    } catch (e) {
+      debugPrint('收集服务器配置失败: $e');
+      return [];
+    }
+  }
+
+  // ---------- 观看历史收集 ----------
+
+  /// 收集观看历史数据
+  ///
+  /// [includeThumbnails] 是否包含截图的 base64 数据
+  Future<List<Map<String, dynamic>>> _collectWatchHistory({
+    bool includeThumbnails = true,
+  }) async {
+    try {
+      final database = WatchHistoryDatabase.instance;
+      final historyItems = await database.getAllWatchHistory();
+
+      final resultList = <Map<String, dynamic>>[];
+      for (final item in historyItems) {
+        final recordData = {
+          'filePath': item.filePath,
+          'animeName': item.animeName,
+          'episodeTitle': item.episodeTitle,
+          'episodeId': item.episodeId,
+          'animeId': item.animeId,
+          'watchProgress': item.watchProgress,
+          'lastPosition': item.lastPosition,
+          'duration': item.duration,
+          'lastWatchTime': item.lastWatchTime.toIso8601String(),
+          'isFromScan': item.isFromScan,
+          'videoHash': item.videoHash,
+        };
+
+        // 读取截图文件
+        if (includeThumbnails && item.thumbnailPath != null) {
+          try {
+            final thumbnailFile = File(item.thumbnailPath!);
+            if (thumbnailFile.existsSync()) {
+              final thumbnailBytes = thumbnailFile.readAsBytesSync();
+              recordData['thumbnailBase64'] = base64Encode(thumbnailBytes);
+            }
+          } catch (e) {
+            debugPrint('读取截图文件失败: ${item.thumbnailPath}, 错误: $e');
+          }
+        }
+
+        resultList.add(recordData);
+      }
+
+      return resultList;
+    } catch (e) {
+      debugPrint('收集观看历史失败: $e');
+      return [];
+    }
+  }
+
+  // ---------- 剧集匹配数据收集 ----------
+
+  /// 收集已匹配的剧集数据
+  ///
+  /// 从观看历史中提取所有已匹配（有 animeId 和 episodeId）的记录
+  Future<List<Map<String, dynamic>>> _collectEpisodeMatches() async {
+    try {
+      final database = WatchHistoryDatabase.instance;
+      final historyItems = await database.getAllWatchHistory();
+
+      // 只收集已匹配的记录（animeId 和 episodeId 都不为空）
+      final matchedItems = historyItems
+          .where((item) => item.animeId != null && item.episodeId != null)
+          .map((item) => {
+                'filePath': item.filePath,
+                'animeName': item.animeName,
+                'episodeTitle': item.episodeTitle,
+                'episodeId': item.episodeId,
+                'animeId': item.animeId,
+                'videoHash': item.videoHash,
+              })
+          .toList();
+
+      return matchedItems.cast<Map<String, dynamic>>();
+    } catch (e) {
+      debugPrint('收集剧集匹配数据失败: $e');
+      return [];
+    }
+  }
+
+  // ---------- 账户绑定数据收集 ----------
+
+  /// 收集账户绑定数据
+  ///
+  /// 包含：
+  /// - 弹弹play 账户信息
+  /// - Bangumi 独立账户信息（令牌登录）
+  /// - 弹弹play 内绑定的 Bangumi 信息
+  /// - Emby/Jellyfin 服务器账户（accessToken、userId）
+  Future<Map<String, dynamic>> _collectAccounts() async {
+    final result = <String, dynamic>{};
+    final prefs = await SharedPreferences.getInstance();
+
+    // 1. 弹弹play 账户
+    final dandanplayAccount = <String, dynamic>{};
+    final dandanplayLoggedIn = prefs.getBool('dandanplay_logged_in') ?? false;
+    dandanplayAccount['isLoggedIn'] = dandanplayLoggedIn;
+    if (dandanplayLoggedIn) {
+      dandanplayAccount['token'] = prefs.getString('dandanplay_token');
+      dandanplayAccount['username'] = prefs.getString('dandanplay_username');
+      dandanplayAccount['screenName'] =
+          prefs.getString('dandanplay_screenname');
+      dandanplayAccount['lastTokenRenewTime'] =
+          prefs.getInt('last_token_renew_time');
+
+      // 弹弹play 内绑定的 Bangumi 信息
+      final linkedBangumiRaw =
+          prefs.getString('dandanplay_linked_bangumi_account');
+      if (linkedBangumiRaw != null) {
+        try {
+          dandanplayAccount['linkedBangumiAccount'] =
+              json.decode(linkedBangumiRaw);
+        } catch (_) {}
+      }
+      dandanplayAccount['loginTimestamp'] =
+          prefs.getInt('dandanplay_login_timestamp');
+    }
+    result['dandanplay'] = dandanplayAccount;
+
+    // 2. Bangumi 独立账户（通过令牌直接登录 Bangumi）
+    final bangumiAccount = <String, dynamic>{};
+    final bangumiLoggedIn = prefs.getBool('bangumi_logged_in') ?? false;
+    bangumiAccount['isLoggedIn'] = bangumiLoggedIn;
+    if (bangumiLoggedIn) {
+      bangumiAccount['accessToken'] = prefs.getString('bangumi_access_token');
+      final bangumiUserInfoRaw = prefs.getString('bangumi_user_info');
+      if (bangumiUserInfoRaw != null) {
+        try {
+          bangumiAccount['userInfo'] = json.decode(bangumiUserInfoRaw);
+        } catch (_) {}
+      }
+    }
+    result['bangumi'] = bangumiAccount;
+
+    // 3. Emby/Jellyfin 服务器账户（从 ServerProfile 中提取认证信息）
+    try {
+      await MultiAddressServerService.instance.loadProfiles();
+      final profiles = MultiAddressServerService.instance.profiles;
+      final serverAccounts = profiles
+          .map((p) => {
+                'id': p.id,
+                'serverName': p.serverName,
+                'serverType': p.serverType,
+                'username': p.username,
+                'accessToken': p.accessToken,
+                'userId': p.userId,
+                'serverId': p.serverId,
+                'addresses': p.addresses.map((a) => a.toJson()).toList(),
+              })
+          .toList();
+      result['serverAccounts'] = serverAccounts;
+    } catch (e) {
+      debugPrint('收集服务器账户信息失败: $e');
+      result['serverAccounts'] = [];
+    }
+
+    return result;
+  }
+
+  // ==================== 导入（信息解析恢复） ====================
+
+  /// 导入备份的恢复结果
+  Future<BackupRestoreResult> importBackup({
+    required String filePath,
+    required Set<BackupCategory> categories,
+  }) async {
+    final result = BackupRestoreResult();
+
+    try {
+      final file = File(filePath);
+      if (!file.existsSync()) {
+        debugPrint('备份文件不存在: $filePath');
+        return result;
+      }
+
+      final jsonString = await file.readAsString();
+      final backupData = json.decode(jsonString) as Map<String, dynamic>;
+
+      // 检查版本
+      final version = backupData['version'] as int? ?? 0;
+      if (version > _backupFormatVersion) {
+        debugPrint('不支持的备份格式版本: $version');
+        return result;
+      }
+
+      // 按类别恢复
+      if (categories.contains(BackupCategory.preferences) &&
+          backupData.containsKey('preferences')) {
+        result.preferencesResult =
+            await _restorePreferences(backupData['preferences'] as Map<String, dynamic>);
+      }
+
+      if (categories.contains(BackupCategory.watchHistory) &&
+          backupData.containsKey('watchHistory')) {
+        result.watchHistoryResult =
+            await _restoreWatchHistory(backupData['watchHistory'] as List<dynamic>);
+      }
+
+      if (categories.contains(BackupCategory.episodeMatches) &&
+          backupData.containsKey('episodeMatches')) {
+        result.episodeMatchesResult =
+            await _restoreEpisodeMatches(backupData['episodeMatches'] as List<dynamic>);
+      }
+
+      if (categories.contains(BackupCategory.accounts) &&
+          backupData.containsKey('accounts')) {
+        result.accountsResult =
+            await _restoreAccounts(backupData['accounts'] as Map<String, dynamic>);
+      }
+
+      result.success = true;
+      debugPrint('备份恢复完成');
+    } catch (e) {
+      debugPrint('导入备份失败: $e');
+      result.success = false;
+      result.errorMessage = e.toString();
+    }
+
+    return result;
+  }
+
+  /// 从备份数据解析（不读文件），直接恢复
+  Future<BackupRestoreResult> restoreFromData({
+    required Map<String, dynamic> backupData,
+    required Set<BackupCategory> categories,
+  }) async {
+    final result = BackupRestoreResult();
+
+    try {
+      final version = backupData['version'] as int? ?? 0;
+      if (version > _backupFormatVersion) {
+        debugPrint('不支持的备份格式版本: $version');
+        return result;
+      }
+
+      if (categories.contains(BackupCategory.preferences) &&
+          backupData.containsKey('preferences')) {
+        result.preferencesResult =
+            await _restorePreferences(backupData['preferences'] as Map<String, dynamic>);
+      }
+      if (categories.contains(BackupCategory.watchHistory) &&
+          backupData.containsKey('watchHistory')) {
+        result.watchHistoryResult =
+            await _restoreWatchHistory(backupData['watchHistory'] as List<dynamic>);
+      }
+      if (categories.contains(BackupCategory.episodeMatches) &&
+          backupData.containsKey('episodeMatches')) {
+        result.episodeMatchesResult =
+            await _restoreEpisodeMatches(backupData['episodeMatches'] as List<dynamic>);
+      }
+      if (categories.contains(BackupCategory.accounts) &&
+          backupData.containsKey('accounts')) {
+        result.accountsResult =
+            await _restoreAccounts(backupData['accounts'] as Map<String, dynamic>);
+      }
+
+      result.success = true;
+    } catch (e) {
+      debugPrint('从数据恢复备份失败: $e');
+      result.success = false;
+      result.errorMessage = e.toString();
+    }
+
+    return result;
+  }
+
+  // ---------- 偏好设置恢复 ----------
+
+  Future<CategoryRestoreResult> _restorePreferences(
+      Map<String, dynamic> preferencesData) async {
+    final result = CategoryRestoreResult();
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+
+      // 1. 恢复软件设置
+      final settings = preferencesData['settings'] as Map<String, dynamic>?;
+      if (settings != null) {
+        int restoredCount = 0;
+        for (final entry in settings.entries) {
+          try {
+            final key = entry.key;
+            final value = entry.value;
+            if (value is bool) {
+              await prefs.setBool(key, value);
+            } else if (value is int) {
+              await prefs.setInt(key, value);
+            } else if (value is double) {
+              await prefs.setDouble(key, value);
+            } else if (value is String) {
+              await prefs.setString(key, value);
+            } else if (value is List) {
+              await prefs.setStringList(
+                  key, value.map((e) => e.toString()).toList());
+            }
+            restoredCount++;
+          } catch (e) {
+            debugPrint('恢复设置项 ${entry.key} 失败: $e');
+          }
+        }
+        result.restoredCount = restoredCount;
+        debugPrint('恢复了 $restoredCount 项偏好设置');
+      }
+
+      // 2. 恢复本地媒体库路径
+      final localLibs = preferencesData['localMediaLibraries'] as List<dynamic>?;
+      if (localLibs != null) {
+        final folderList = localLibs.cast<String>().toList();
+        await prefs.setStringList('nipaplay_scanned_folders', folderList);
+        result.localLibraryCount = folderList.length;
+        debugPrint('恢复了 ${folderList.length} 个本地媒体库路径');
+      }
+
+      // 3. 恢复在线媒体库服务器配置
+      final serverProfilesData =
+          preferencesData['serverProfiles'] as List<dynamic>?;
+      if (serverProfilesData != null) {
+        final profiles = serverProfilesData
+            .map((p) => ServerProfile.fromJson(p as Map<String, dynamic>))
+            .toList();
+
+        // 合并而非替换：保留本地已有的、添加备份中新增的
+        await MultiAddressServerService.instance.loadProfiles();
+        final existingProfiles = MultiAddressServerService.instance.profiles;
+        final existingIds = existingProfiles.map((p) => p.id).toSet();
+
+        for (final profile in profiles) {
+          if (!existingIds.contains(profile.id)) {
+            // 新增配置
+            MultiAddressServerService.instance.profiles;
+            // 直接通过保存方式添加
+          }
+        }
+
+        // 保存合并后的配置
+        final mergedProfiles = <ServerProfile>[...existingProfiles];
+        for (final profile in profiles) {
+          final existingIndex =
+              mergedProfiles.indexWhere((p) => p.id == profile.id);
+          if (existingIndex == -1) {
+            mergedProfiles.add(profile);
+          } else {
+            // 已存在则更新（备份覆盖本地）
+            mergedProfiles[existingIndex] = profile;
+          }
+        }
+
+        // 使用 MultiAddressServerService 保存
+        // 直接保存合并后的列表
+        final prefsInstance = await SharedPreferences.getInstance();
+        final profilesJson =
+            json.encode(mergedProfiles.map((p) => p.toJson()).toList());
+        await prefsInstance.setString('server_profiles', profilesJson);
+
+        result.serverProfileCount = profiles.length;
+        debugPrint('恢复了 ${profiles.length} 个服务器配置');
+      }
+
+      // 4. 恢复选中的媒体库
+      final embySelectedLibs =
+          preferencesData['embySelectedLibraryIds'] as List<dynamic>?;
+      if (embySelectedLibs != null) {
+        await prefs.setStringList(
+            'emby_selected_library_ids', embySelectedLibs.cast<String>().toList());
+      }
+
+      final jellyfinSelectedLibs =
+          preferencesData['jellyfinSelectedLibraryIds'] as List<dynamic>?;
+      if (jellyfinSelectedLibs != null) {
+        await prefs.setStringList('jellyfin_selected_library_ids',
+            jellyfinSelectedLibs.cast<String>().toList());
+      }
+
+      // 5. 恢复排序设置
+      final embySortSettings =
+          preferencesData['embyLibrarySortSettings'] as String?;
+      if (embySortSettings != null) {
+        await prefs.setString('emby_library_sort_settings', embySortSettings);
+      }
+
+      final jellyfinSortSettings =
+          preferencesData['jellyfinLibrarySortSettings'] as String?;
+      if (jellyfinSortSettings != null) {
+        await prefs.setString(
+            'jellyfin_library_sort_settings', jellyfinSortSettings);
+      }
+
+      result.success = true;
+    } catch (e) {
+      debugPrint('恢复偏好设置失败: $e');
+      result.success = false;
+      result.errorMessage = e.toString();
+    }
+
+    return result;
+  }
+
+  // ---------- 观看历史恢复 ----------
+
+  Future<CategoryRestoreResult> _restoreWatchHistory(
+      List<dynamic> watchHistoryData) async {
+    final result = CategoryRestoreResult();
+
+    try {
+      final database = WatchHistoryDatabase.instance;
+      int restoredCount = 0;
+      int skippedCount = 0;
+
+      for (final itemData in watchHistoryData) {
+        try {
+          final recordData = itemData as Map<String, dynamic>;
+
+          final item = WatchHistoryItem(
+            filePath: recordData['filePath'] as String,
+            animeName: recordData['animeName'] as String,
+            episodeTitle: recordData['episodeTitle'] as String?,
+            episodeId: recordData['episodeId'] as int?,
+            animeId: recordData['animeId'] as int?,
+            watchProgress: (recordData['watchProgress'] ?? 0.0).toDouble(),
+            lastPosition: recordData['lastPosition'] as int? ?? 0,
+            duration: recordData['duration'] as int? ?? 0,
+            lastWatchTime: DateTime.parse(recordData['lastWatchTime'] as String),
+            isFromScan: recordData['isFromScan'] as bool? ?? false,
+            videoHash: recordData['videoHash'] as String?,
+          );
+
+          // 检查文件是否可访问（本地文件需要存在，远程协议始终视为可访问）
+          if (!await _isFileAccessible(item.filePath)) {
+            // 即使文件不可访问，仍然保存记录（用户可能稍后挂载对应路径）
+            debugPrint('文件当前不可访问，仍保存记录: ${item.animeName}');
+          }
+
+          // 恢复截图
+          String? restoredThumbnailPath;
+          final thumbnailBase64 = recordData['thumbnailBase64'] as String?;
+          if (thumbnailBase64 != null && thumbnailBase64.isNotEmpty) {
+            restoredThumbnailPath =
+                await _restoreThumbnail(item.filePath, thumbnailBase64);
+          }
+
+          // 更新或插入记录
+          final existingItem =
+              await database.getHistoryByFilePath(item.filePath);
+          if (existingItem != null) {
+            // 已存在：仅当备份记录更新时覆盖
+            if (item.lastWatchTime.isAfter(existingItem.lastWatchTime)) {
+              final finalThumbnailPath =
+                  restoredThumbnailPath ?? existingItem.thumbnailPath;
+              final updatedItem = item.copyWith(
+                  thumbnailPath: finalThumbnailPath);
+              await database.insertOrUpdateWatchHistory(updatedItem);
+              await _updateSharedPreferencesPosition(
+                  item.filePath, item.lastPosition);
+              restoredCount++;
+            } else {
+              // 本地记录更新，保留本地版本但恢复截图
+              if (restoredThumbnailPath != null &&
+                  existingItem.thumbnailPath == null) {
+                final updatedItem = existingItem.copyWith(
+                    thumbnailPath: restoredThumbnailPath);
+                await database.insertOrUpdateWatchHistory(updatedItem);
+              }
+              skippedCount++;
+            }
+          } else {
+            // 不存在：直接插入
+            final finalItem =
+                item.copyWith(thumbnailPath: restoredThumbnailPath);
+            await database.insertOrUpdateWatchHistory(finalItem);
+            await _updateSharedPreferencesPosition(
+                item.filePath, item.lastPosition);
+            restoredCount++;
+          }
+        } catch (e) {
+          debugPrint('恢复单条观看历史失败: $e');
+          continue;
+        }
+      }
+
+      result.restoredCount = restoredCount;
+      result.skippedCount = skippedCount;
+      result.success = true;
+      debugPrint('观看历史恢复完成: 恢复 $restoredCount 条，跳过 $skippedCount 条');
+    } catch (e) {
+      debugPrint('恢复观看历史失败: $e');
+      result.success = false;
+      result.errorMessage = e.toString();
+    }
+
+    return result;
+  }
+
+  // ---------- 剧集匹配数据恢复 ----------
+
+  Future<CategoryRestoreResult> _restoreEpisodeMatches(
+      List<dynamic> episodeMatchesData) async {
+    final result = CategoryRestoreResult();
+
+    try {
+      final database = WatchHistoryDatabase.instance;
+      int restoredCount = 0;
+      int skippedCount = 0;
+
+      for (final matchData in episodeMatchesData) {
+        try {
+          final recordData = matchData as Map<String, dynamic>;
+          final filePath = recordData['filePath'] as String;
+          final animeId = recordData['animeId'] as int?;
+          final episodeId = recordData['episodeId'] as int?;
+
+          if (animeId == null || episodeId == null) continue;
+
+          // 查找本地是否有对应文件的历史记录
+          final existingItem =
+              await database.getHistoryByFilePath(filePath);
+
+          if (existingItem != null) {
+            // 已有记录：更新匹配信息
+            if (existingItem.animeId != animeId ||
+                existingItem.episodeId != episodeId) {
+              final updatedItem = existingItem.copyWith(
+                animeId: animeId,
+                episodeId: episodeId,
+                animeName:
+                    recordData['animeName'] as String? ?? existingItem.animeName,
+                episodeTitle: recordData['episodeTitle'] as String? ??
+                    existingItem.episodeTitle,
+                videoHash:
+                    recordData['videoHash'] as String? ?? existingItem.videoHash,
+              );
+              await database.insertOrUpdateWatchHistory(updatedItem);
+              restoredCount++;
+            } else {
+              skippedCount++;
+            }
+          } else {
+            // 没有对应记录：创建一条仅包含匹配信息的记录
+            final newItem = WatchHistoryItem(
+              filePath: filePath,
+              animeName: recordData['animeName'] as String? ?? '未知',
+              episodeTitle: recordData['episodeTitle'] as String?,
+              episodeId: episodeId,
+              animeId: animeId,
+              watchProgress: 0.0,
+              lastPosition: 0,
+              duration: 0,
+              lastWatchTime: DateTime.now(),
+              isFromScan: true,
+              videoHash: recordData['videoHash'] as String?,
+            );
+            await database.insertOrUpdateWatchHistory(newItem);
+            restoredCount++;
+          }
+        } catch (e) {
+          debugPrint('恢复单条剧集匹配失败: $e');
+          continue;
+        }
+      }
+
+      result.restoredCount = restoredCount;
+      result.skippedCount = skippedCount;
+      result.success = true;
+      debugPrint('剧集匹配恢复完成: 恢复 $restoredCount 条，跳过 $skippedCount 条');
+    } catch (e) {
+      debugPrint('恢复剧集匹配数据失败: $e');
+      result.success = false;
+      result.errorMessage = e.toString();
+    }
+
+    return result;
+  }
+
+  // ---------- 账户绑定数据恢复 ----------
+
+  Future<CategoryRestoreResult> _restoreAccounts(
+      Map<String, dynamic> accountsData) async {
+    final result = CategoryRestoreResult();
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+
+      // 1. 恢复弹弹play 账户
+      final dandanplayData =
+          accountsData['dandanplay'] as Map<String, dynamic>?;
+      if (dandanplayData != null) {
+        final isLoggedIn = dandanplayData['isLoggedIn'] as bool? ?? false;
+        if (isLoggedIn) {
+          final token = dandanplayData['token'] as String?;
+          if (token != null) {
+            await prefs.setString('dandanplay_token', token);
+          }
+          final username = dandanplayData['username'] as String?;
+          if (username != null) {
+            await prefs.setString('dandanplay_username', username);
+          }
+          final screenName = dandanplayData['screenName'] as String?;
+          if (screenName != null) {
+            await prefs.setString('dandanplay_screenname', screenName);
+          }
+          await prefs.setBool('dandanplay_logged_in', true);
+
+          final lastRenewTime = dandanplayData['lastTokenRenewTime'] as int?;
+          if (lastRenewTime != null) {
+            await prefs.setInt('last_token_renew_time', lastRenewTime);
+          }
+
+          // 弹弹play 内绑定的 Bangumi 信息
+          final linkedBangumi =
+              dandanplayData['linkedBangumiAccount'] as Map<String, dynamic>?;
+          if (linkedBangumi != null) {
+            await prefs.setString(
+              'dandanplay_linked_bangumi_account',
+              json.encode(linkedBangumi),
+            );
+          }
+
+          final loginTimestamp = dandanplayData['loginTimestamp'] as int?;
+          if (loginTimestamp != null) {
+            await prefs.setInt('dandanplay_login_timestamp', loginTimestamp);
+          }
+
+          result.dandanplayRestored = true;
+          debugPrint('恢复了弹弹play账户信息');
+        }
+      }
+
+      // 2. 恢复 Bangumi 独立账户
+      final bangumiData = accountsData['bangumi'] as Map<String, dynamic>?;
+      if (bangumiData != null) {
+        final bangumiLoggedIn = bangumiData['isLoggedIn'] as bool? ?? false;
+        if (bangumiLoggedIn) {
+          final accessToken = bangumiData['accessToken'] as String?;
+          if (accessToken != null) {
+            await prefs.setString('bangumi_access_token', accessToken);
+          }
+          final userInfo = bangumiData['userInfo'] as Map<String, dynamic>?;
+          if (userInfo != null) {
+            await prefs.setString('bangumi_user_info', json.encode(userInfo));
+          }
+          await prefs.setBool('bangumi_logged_in', true);
+
+          result.bangumiRestored = true;
+          debugPrint('恢复了Bangumi独立账户信息');
+        }
+      }
+
+      // 3. 恢复 Emby/Jellyfin 服务器账户
+      final serverAccountsData =
+          accountsData['serverAccounts'] as List<dynamic>?;
+      if (serverAccountsData != null && serverAccountsData.isNotEmpty) {
+        // 合并到现有的服务器配置中
+        await MultiAddressServerService.instance.loadProfiles();
+        final existingProfiles = MultiAddressServerService.instance.profiles;
+        final mergedProfiles = <ServerProfile>[...existingProfiles];
+
+        for (final accountData in serverAccountsData) {
+          try {
+            final data = accountData as Map<String, dynamic>;
+            final profile = ServerProfile.fromJson(data);
+
+            final existingIndex =
+                mergedProfiles.indexWhere((p) => p.id == profile.id);
+            if (existingIndex == -1) {
+              mergedProfiles.add(profile);
+            } else {
+              // 更新认证信息（accessToken、userId），保留本地连接状态
+              final existing = mergedProfiles[existingIndex];
+              mergedProfiles[existingIndex] = existing.copyWith(
+                accessToken: profile.accessToken ?? existing.accessToken,
+                userId: profile.userId ?? existing.userId,
+              );
+            }
+          } catch (e) {
+            debugPrint('恢复服务器账户失败: $e');
+          }
+        }
+
+        final prefsInstance = await SharedPreferences.getInstance();
+        final profilesJson =
+            json.encode(mergedProfiles.map((p) => p.toJson()).toList());
+        await prefsInstance.setString('server_profiles', profilesJson);
+
+        result.serverAccountCount = serverAccountsData.length;
+        debugPrint('恢复了 ${serverAccountsData.length} 个服务器账户');
+      }
+
+      result.success = true;
+    } catch (e) {
+      debugPrint('恢复账户绑定数据失败: $e');
+      result.success = false;
+      result.errorMessage = e.toString();
+    }
+
+    return result;
+  }
+
+  // ==================== 辅助方法 ====================
+
+  /// 恢复截图文件
+  Future<String?> _restoreThumbnail(
+      String filePath, String thumbnailBase64) async {
+    try {
+      final thumbnailBytes = base64Decode(thumbnailBase64);
+      final appDir = await StorageService.getAppStorageDirectory();
+      final thumbnailsDir = Directory(path.join(appDir.path, 'thumbnails'));
+
+      if (!thumbnailsDir.existsSync()) {
+        await thumbnailsDir.create(recursive: true);
+      }
+
+      final pathHash =
+          sha256.convert(utf8.encode(filePath)).toString().substring(0, 16);
+      final videoName = path.basenameWithoutExtension(filePath);
+      final thumbnailFileName = '${videoName}_${pathHash}_thumbnail.jpg';
+      final thumbnailPath = path.join(thumbnailsDir.path, thumbnailFileName);
+
+      final thumbnailFile = File(thumbnailPath);
+      await thumbnailFile.writeAsBytes(thumbnailBytes);
+
+      return thumbnailPath;
+    } catch (e) {
+      debugPrint('恢复截图失败: $e');
+      return null;
+    }
+  }
+
+  /// 更新 SharedPreferences 中的播放位置
+  Future<void> _updateSharedPreferencesPosition(
+      String filePath, int position) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      const String videoPositionsKey = 'video_positions';
+
+      final positions = prefs.getString(videoPositionsKey) ?? '{}';
+      final Map<String, dynamic> positionMap =
+          Map<String, dynamic>.from(json.decode(positions));
+
+      positionMap[filePath] = position;
+
+      await prefs.setString(videoPositionsKey, json.encode(positionMap));
+    } catch (e) {
+      debugPrint('更新 SharedPreferences 播放位置失败: $e');
+    }
+  }
+
+  /// 检查文件是否可访问
+  Future<bool> _isFileAccessible(String filePath) async {
+    try {
+      // 远程协议始终视为可访问
+      if (filePath.startsWith('jellyfin://') ||
+          filePath.startsWith('emby://') ||
+          filePath.startsWith('dandanplay://') ||
+          filePath.startsWith('http://') ||
+          filePath.startsWith('https://')) {
+        return true;
+      }
+
+      final file = File(filePath);
+      return await file.exists();
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /// 构建类别后缀字符串
+  String _buildCategorySuffix(Set<BackupCategory> categories) {
+    if (categories.length == BackupCategory.values.length) {
+      return 'full';
+    }
+    final parts = <String>[];
+    if (categories.contains(BackupCategory.preferences)) parts.add('pref');
+    if (categories.contains(BackupCategory.watchHistory)) parts.add('hist');
+    if (categories.contains(BackupCategory.episodeMatches)) parts.add('match');
+    if (categories.contains(BackupCategory.accounts)) parts.add('acct');
+    return parts.join('_');
+  }
+
+  /// 读取备份文件信息（不执行恢复），用于预览
+  Future<BackupPreviewInfo?> previewBackup(String filePath) async {
+    try {
+      final file = File(filePath);
+      if (!file.existsSync()) return null;
+
+      final jsonString = await file.readAsString();
+      final backupData = json.decode(jsonString) as Map<String, dynamic>;
+
+      return BackupPreviewInfo(
+        version: backupData['version'] as int? ?? 0,
+        timestamp: backupData['timestamp'] as String? ?? '',
+        appVersion: backupData['appVersion'] as String? ?? '',
+        hasPreferences: backupData.containsKey('preferences'),
+        hasWatchHistory: backupData.containsKey('watchHistory'),
+        hasEpisodeMatches: backupData.containsKey('episodeMatches'),
+        hasAccounts: backupData.containsKey('accounts'),
+        watchHistoryCount: (backupData['watchHistory'] as List<dynamic>?)
+                ?.length ??
+            0,
+        episodeMatchCount: (backupData['episodeMatches'] as List<dynamic>?)
+                ?.length ??
+            0,
+        serverProfileCount:
+            (backupData['preferences']?['serverProfiles'] as List<dynamic>?)
+                    ?.length ??
+                0,
+        localLibraryCount:
+            (backupData['preferences']?['localMediaLibraries'] as List<dynamic>?)
+                    ?.length ??
+                0,
+      );
+    } catch (e) {
+      debugPrint('预览备份文件失败: $e');
+      return null;
+    }
+  }
+}
+
+/// 备份恢复总结果
+class BackupRestoreResult {
+  bool success = false;
+  String? errorMessage;
+
+  CategoryRestoreResult? preferencesResult;
+  CategoryRestoreResult? watchHistoryResult;
+  CategoryRestoreResult? episodeMatchesResult;
+  CategoryRestoreResult? accountsResult;
+
+  /// 获取恢复的总记录数
+  int get totalRestoredCount {
+    return (preferencesResult?.restoredCount ?? 0) +
+        (watchHistoryResult?.restoredCount ?? 0) +
+        (episodeMatchesResult?.restoredCount ?? 0) +
+        (accountsResult?.restoredCount ?? 0);
+  }
+
+  /// 获取跳过的总记录数
+  int get totalSkippedCount {
+    return (watchHistoryResult?.skippedCount ?? 0) +
+        (episodeMatchesResult?.skippedCount ?? 0);
+  }
+}
+
+/// 单个类别的恢复结果
+class CategoryRestoreResult {
+  bool success = false;
+  String? errorMessage;
+  int restoredCount = 0;
+  int skippedCount = 0;
+
+  // 偏好设置特有
+  int localLibraryCount = 0;
+  int serverProfileCount = 0;
+
+  // 账户特有
+  bool dandanplayRestored = false;
+  bool bangumiRestored = false;
+  int serverAccountCount = 0;
+}
+
+/// 备份预览信息
+class BackupPreviewInfo {
+  final int version;
+  final String timestamp;
+  final String appVersion;
+  final bool hasPreferences;
+  final bool hasWatchHistory;
+  final bool hasEpisodeMatches;
+  final bool hasAccounts;
+  final int watchHistoryCount;
+  final int episodeMatchCount;
+  final int serverProfileCount;
+  final int localLibraryCount;
+
+  BackupPreviewInfo({
+    required this.version,
+    required this.timestamp,
+    required this.appVersion,
+    required this.hasPreferences,
+    required this.hasWatchHistory,
+    required this.hasEpisodeMatches,
+    required this.hasAccounts,
+    required this.watchHistoryCount,
+    required this.episodeMatchCount,
+    required this.serverProfileCount,
+    required this.localLibraryCount,
+  });
+}

--- a/lib/themes/nipaplay/pages/settings/backup_restore_page.dart
+++ b/lib/themes/nipaplay/pages/settings/backup_restore_page.dart
@@ -1,14 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_item.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
 import 'package:nipaplay/services/backup_service.dart';
+import 'package:nipaplay/services/full_backup_service.dart';
 import 'package:nipaplay/services/auto_sync_service.dart';
+import 'package:nipaplay/services/multi_address_server_service.dart';
 import 'package:nipaplay/utils/auto_sync_settings.dart';
+import 'package:nipaplay/utils/app_accent_color.dart';
+import 'package:nipaplay/models/watch_history_model.dart';
+import 'package:nipaplay/models/watch_history_database.dart';
 import 'package:provider/provider.dart';
 import 'package:nipaplay/providers/watch_history_provider.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 class BackupRestorePage extends StatefulWidget {
   const BackupRestorePage({super.key});
@@ -31,7 +39,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
   Future<void> _loadAutoSyncSettings() async {
     final enabled = await AutoSyncSettings.isEnabled();
     final path = await AutoSyncSettings.getSyncPath();
-    
+
     setState(() {
       _autoSyncEnabled = enabled;
       _autoSyncPath = path;
@@ -40,12 +48,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
 
   void _showMessage(String message, {bool isError = false}) {
     if (!mounted) return;
-    
-    // 使用项目的 BlurSnackBar
     BlurSnackBar.show(context, message);
-    
-    // 如果是错误消息，也可以考虑使用不同的颜色或样式
-    // 这里暂时使用同样的样式，因为 BlurSnackBar 没有错误样式参数
   }
 
   Future<void> _toggleAutoSync(bool enabled) async {
@@ -55,7 +58,6 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
 
     try {
       if (enabled && _autoSyncPath == null) {
-        // 需要先选择路径
         await _selectAutoSyncPath();
         return;
       }
@@ -79,8 +81,9 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
   }
 
   Future<void> _selectAutoSyncPath() async {
-    final String? selectedDirectory = await FilePicker.platform.getDirectoryPath();
-    
+    final String? selectedDirectory =
+        await FilePicker.platform.getDirectoryPath();
+
     if (selectedDirectory == null) {
       _showMessage('未选择同步路径');
       return;
@@ -120,21 +123,204 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     }
   }
 
+  // ==================== 全量备份 ====================
+
+  Future<void> _showFullBackupDialog() async {
+    // 先收集计数信息
+    final historyItems = await WatchHistoryManager.getAllHistory();
+    final watchHistoryCount = historyItems.length;
+    final episodeMatchCount =
+        historyItems.where((i) => i.animeId != null && i.episodeId != null).length;
+
+    // 获取账户计数
+    final prefs = await SharedPreferences.getInstance();
+    int accountCount = 0;
+    final dandanplayLoggedIn = prefs.getBool('dandanplay_logged_in') ?? false;
+    if (dandanplayLoggedIn) accountCount++;
+    final bangumiLoggedIn = prefs.getBool('bangumi_logged_in') ?? false;
+    if (bangumiLoggedIn) accountCount++;
+    // 服务器账户数
+    try {
+      await MultiAddressServerService.instance.loadProfiles();
+      accountCount += MultiAddressServerService.instance.profiles.length;
+    } catch (_) {}
+
+    if (!mounted) return;
+
+    final result = await NipaplayWindow.show<Set<BackupCategory>>(
+      context: context,
+      child: _BackupSelectionDialog(
+        watchHistoryCount: watchHistoryCount,
+        episodeMatchCount: episodeMatchCount,
+        accountCount: accountCount,
+      ),
+    );
+
+    if (result == null || result.isEmpty) return;
+
+    // 选择保存位置
+    final String? selectedDirectory =
+        await FilePicker.platform.getDirectoryPath();
+
+    if (selectedDirectory == null) {
+      _showMessage('未选择保存位置');
+      return;
+    }
+
+    setState(() {
+      _isProcessing = true;
+    });
+
+    try {
+      String appVersion = '';
+      try {
+        final packageInfo = await PackageInfo.fromPlatform();
+        appVersion = packageInfo.version;
+      } catch (_) {}
+
+      final backupService = FullBackupService();
+      final filePath = await backupService.exportBackup(
+        directoryPath: selectedDirectory,
+        categories: result,
+        appVersion: appVersion,
+      );
+
+      if (filePath != null) {
+        _showMessage('备份成功！文件保存至: $filePath');
+      } else {
+        _showMessage('备份失败', isError: true);
+      }
+    } catch (e) {
+      _showMessage('备份失败: $e', isError: true);
+    } finally {
+      setState(() {
+        _isProcessing = false;
+      });
+    }
+  }
+
+  // ==================== 全量恢复 ====================
+
+  Future<void> _showFullRestoreDialog() async {
+    // 选择备份文件
+    final FilePickerResult? result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['npb'],
+    );
+
+    if (result == null || result.files.single.path == null) {
+      _showMessage('未选择文件');
+      return;
+    }
+
+    final filePath = result.files.single.path!;
+
+    // 预览备份内容
+    final backupService = FullBackupService();
+    final preview = await backupService.previewBackup(filePath);
+
+    if (preview == null) {
+      _showMessage('无法读取备份文件', isError: true);
+      return;
+    }
+
+    if (!mounted) return;
+
+    // 显示预览和选择对话框
+    final categories = await NipaplayWindow.show<Set<BackupCategory>>(
+      context: context,
+      child: _RestoreSelectionDialog(preview: preview),
+    );
+
+    if (categories == null || categories.isEmpty) return;
+
+    // 确认对话框
+    final confirmed = await BlurDialog.show<bool>(
+      context: context,
+      title: '确认恢复',
+      content: '恢复操作将合并备份数据到当前记录中。已有的本地数据不会被删除，仅更新或新增。是否继续？',
+      actions: [
+        HoverScaleTextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child:
+              const Text('取消', style: TextStyle(color: Colors.white70)),
+        ),
+        HoverScaleTextButton(
+          onPressed: () => Navigator.pop(context, true),
+          child: const Text('确认', style: TextStyle(color: Colors.white)),
+        ),
+      ],
+    );
+
+    if (confirmed != true) return;
+
+    setState(() {
+      _isProcessing = true;
+    });
+
+    try {
+      final restoreResult = await backupService.importBackup(
+        filePath: filePath,
+        categories: categories,
+      );
+
+      if (restoreResult.success) {
+        // 刷新观看历史
+        if (context.mounted) {
+          final watchHistoryProvider =
+              Provider.of<WatchHistoryProvider>(context, listen: false);
+          watchHistoryProvider.clearInvalidPathCache();
+          await watchHistoryProvider.loadHistory();
+        }
+
+        final parts = <String>[];
+        if (restoreResult.preferencesResult != null) {
+          final r = restoreResult.preferencesResult!;
+          parts.add('设置${r.success ? "✓" : "✗"}');
+        }
+        if (restoreResult.watchHistoryResult != null) {
+          final r = restoreResult.watchHistoryResult!;
+          parts.add('历史${r.restoredCount}条${r.success ? "✓" : "✗"}');
+        }
+        if (restoreResult.episodeMatchesResult != null) {
+          final r = restoreResult.episodeMatchesResult!;
+          parts.add('匹配${r.restoredCount}条${r.success ? "✓" : "✗"}');
+        }
+        if (restoreResult.accountsResult != null) {
+          final r = restoreResult.accountsResult!;
+          parts.add('账户${r.success ? "✓" : "✗"}');
+        }
+
+        _showMessage('恢复完成: ${parts.join(" ")}');
+      } else {
+        _showMessage('恢复失败: ${restoreResult.errorMessage ?? "未知错误"}',
+            isError: true);
+      }
+    } catch (e) {
+      _showMessage('恢复失败: $e', isError: true);
+    } finally {
+      setState(() {
+        _isProcessing = false;
+      });
+    }
+  }
+
+  // ==================== 旧版观看历史备份恢复（保留兼容） ====================
+
   Future<void> _backupHistory() async {
     setState(() {
       _isProcessing = true;
     });
 
     try {
-      // 选择保存位置
-      final String? selectedDirectory = await FilePicker.platform.getDirectoryPath();
-      
+      final String? selectedDirectory =
+          await FilePicker.platform.getDirectoryPath();
+
       if (selectedDirectory == null) {
         _showMessage('未选择保存位置');
         return;
       }
 
-      // 执行备份
       final backupService = BackupService();
       final result = await backupService.exportWatchHistory(selectedDirectory);
 
@@ -158,7 +344,6 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     });
 
     try {
-      // 选择备份文件
       final FilePickerResult? result = await FilePicker.platform.pickFiles(
         type: FileType.custom,
         allowedExtensions: ['nph'],
@@ -170,16 +355,17 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
       }
 
       final filePath = result.files.single.path!;
-      
-      // 确认对话框
+
       final confirmed = await BlurDialog.show<bool>(
         context: context,
         title: '确认恢复',
-        content: '恢复操作将会合并备份文件中的观看进度（包括截图）到当前记录中，且只会恢复本地存在的媒体文件的进度。是否继续？',
+        content:
+            '恢复操作将会合并备份文件中的观看进度（包括截图）到当前记录中，且只会恢复本地存在的媒体文件的进度。是否继续？',
         actions: [
           HoverScaleTextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: const Text('取消', style: TextStyle(color: Colors.white70)),
+            child:
+                const Text('取消', style: TextStyle(color: Colors.white70)),
           ),
           HoverScaleTextButton(
             onPressed: () => Navigator.pop(context, true),
@@ -190,19 +376,17 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
 
       if (confirmed != true) return;
 
-      // 执行恢复
       final backupService = BackupService();
       final restoredCount = await backupService.importWatchHistory(filePath);
 
       if (restoredCount > 0) {
-        // 刷新观看历史
         if (context.mounted) {
-          final watchHistoryProvider = Provider.of<WatchHistoryProvider>(context, listen: false);
-          // 清除缓存并重新加载
+          final watchHistoryProvider =
+              Provider.of<WatchHistoryProvider>(context, listen: false);
           watchHistoryProvider.clearInvalidPathCache();
           await watchHistoryProvider.loadHistory();
         }
-        
+
         _showMessage('恢复成功！已恢复 $restoredCount 条观看记录');
       } else {
         _showMessage('未找到可恢复的观看记录', isError: true);
@@ -224,6 +408,37 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
       body: ListView(
         padding: const EdgeInsets.all(16.0),
         children: [
+          // 全量备份与恢复
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '全量备份与恢复',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+              const SizedBox(height: 16),
+              SettingsItem.button(
+                title: '全量备份',
+                subtitle: '选择性导出设置、观看历史、剧集匹配和账户信息',
+                enabled: !_isProcessing,
+                onTap: _showFullBackupDialog,
+                icon: Icons.cloud_upload,
+              ),
+              const SizedBox(height: 8),
+              SettingsItem.button(
+                title: '全量恢复',
+                subtitle: '从 .npb 备份文件选择性恢复数据',
+                enabled: !_isProcessing,
+                onTap: _showFullRestoreDialog,
+                icon: Icons.cloud_download,
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
           // 自动同步设置卡片
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -239,9 +454,9 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
               const SizedBox(height: 16),
               SettingsItem.toggle(
                 title: '启用自动同步',
-                subtitle: _autoSyncEnabled 
-                  ? '观看进度会自动同步到本地路径或云端' 
-                  : '启用后可实现多设备同步',
+                subtitle: _autoSyncEnabled
+                    ? '观看进度会自动同步到本地路径或云端'
+                    : '启用后可实现多设备同步',
                 enabled: !_isProcessing,
                 value: _autoSyncEnabled,
                 onChanged: _toggleAutoSync,
@@ -251,7 +466,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
                 const SizedBox(height: 8),
                 SettingsItem.button(
                   title: '同步路径',
-                  subtitle: _autoSyncPath!.length > 50 
+                  subtitle: _autoSyncPath!.length > 50
                       ? '...${_autoSyncPath!.substring(_autoSyncPath!.length - 50)}'
                       : _autoSyncPath!,
                   enabled: !_isProcessing,
@@ -270,12 +485,12 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
             ],
           ),
           const SizedBox(height: 16),
-          // 手动备份恢复卡片
+          // 旧版手动备份恢复
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                '手动备份与恢复',
+                '观看进度备份（旧版）',
                 style: TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.bold,
@@ -285,7 +500,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
               const SizedBox(height: 16),
               SettingsItem.button(
                 title: '备份观看进度',
-                subtitle: '将观看进度导出为.nph文件',
+                subtitle: '将观看进度导出为 .nph 文件',
                 enabled: !_isProcessing,
                 onTap: _backupHistory,
                 icon: Icons.backup,
@@ -293,7 +508,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
               const SizedBox(height: 8),
               SettingsItem.button(
                 title: '恢复观看进度',
-                subtitle: '从.nph文件恢复观看进度',
+                subtitle: '从 .nph 文件恢复观看进度',
                 enabled: !_isProcessing,
                 onTap: _restoreHistory,
                 icon: Icons.restore,
@@ -314,43 +529,46 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
               ),
               const SizedBox(height: 16),
               Text(
+                '• 全量备份：可选择导出偏好设置、观看历史、剧集匹配和账户信息',
+                style: TextStyle(
+                    fontSize: 14,
+                    color: colorScheme.onSurface.withOpacity(0.7)),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '• 全量恢复：从 .npb 文件恢复，支持选择性恢复各类数据',
+                style: TextStyle(
+                    fontSize: 14,
+                    color: colorScheme.onSurface.withOpacity(0.7)),
+              ),
+              const SizedBox(height: 8),
+              Text(
                 '• 自动同步：启用后观看进度会自动保存到指定路径',
-                style: TextStyle(fontSize: 14, color: colorScheme.onSurface.withOpacity(0.7)),
+                style: TextStyle(
+                    fontSize: 14,
+                    color: colorScheme.onSurface.withOpacity(0.7)),
               ),
               const SizedBox(height: 8),
               Text(
-                '• 云同步：同步路径可以是SMB/NFS等网络位置',
-                style: TextStyle(fontSize: 14, color: colorScheme.onSurface.withOpacity(0.7)),
+                '• 云同步：同步路径可以是 SMB/NFS 等网络位置',
+                style: TextStyle(
+                    fontSize: 14,
+                    color: colorScheme.onSurface.withOpacity(0.7)),
               ),
               const SizedBox(height: 8),
               Text(
-                '• 固定文件：自动同步使用固定文件名 nipaplay_auto_sync.nph',
-                style: TextStyle(fontSize: 14, color: colorScheme.onSurface.withOpacity(0.7)),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                '• 手动备份：支持自定义文件名的一次性备份',
-                style: TextStyle(fontSize: 14, color: colorScheme.onSurface.withOpacity(0.7)),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                '• 备份内容：包含集数信息、观看时间戳和截图',
-                style: TextStyle(fontSize: 14, color: colorScheme.onSurface.withOpacity(0.7)),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                '• 恢复规则：只恢复本地扫描到的媒体文件的观看进度',
-                style: TextStyle(fontSize: 14, color: colorScheme.onSurface.withOpacity(0.7)),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                '• 截图存储：恢复的截图保存在应用缓存目录',
-                style: TextStyle(fontSize: 14, color: colorScheme.onSurface.withOpacity(0.7)),
+                '• 恢复规则：已有数据不会被删除，仅更新或新增',
+                style: TextStyle(
+                    fontSize: 14,
+                    color: colorScheme.onSurface.withOpacity(0.7)),
               ),
               const SizedBox(height: 8),
               Text(
                 '• 此功能仅在桌面端可用',
-                style: TextStyle(fontSize: 14, color: colorScheme.onSurface.withOpacity(0.7), fontStyle: FontStyle.italic),
+                style: TextStyle(
+                    fontSize: 14,
+                    color: colorScheme.onSurface.withOpacity(0.7),
+                    fontStyle: FontStyle.italic),
               ),
             ],
           ),
@@ -364,13 +582,482 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
                     const SizedBox(height: 16),
                     Text(
                       '处理中...',
-                      style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
+                      style: TextStyle(
+                          color: colorScheme.onSurface.withOpacity(0.7)),
                     ),
                   ],
                 ),
               ),
             ),
         ],
+      ),
+    );
+  }
+}
+
+// ==================== 备份选择弹窗 ====================
+
+class _BackupSelectionDialog extends StatefulWidget {
+  final int watchHistoryCount;
+  final int episodeMatchCount;
+  final int accountCount;
+
+  const _BackupSelectionDialog({
+    required this.watchHistoryCount,
+    required this.episodeMatchCount,
+    required this.accountCount,
+  });
+
+  @override
+  State<_BackupSelectionDialog> createState() => _BackupSelectionDialogState();
+}
+
+class _BackupSelectionDialogState extends State<_BackupSelectionDialog> {
+  late Map<BackupCategory, bool> _selections;
+
+  @override
+  void initState() {
+    super.initState();
+    _selections = {
+      BackupCategory.preferences: true,
+      BackupCategory.watchHistory: true,
+      BackupCategory.episodeMatches: true,
+      BackupCategory.accounts: true,
+    };
+  }
+
+  bool get _isAllSelected => _selections.values.every((v) => v);
+
+  void _toggleAll(bool value) {
+    setState(() {
+      for (final key in _selections.keys) {
+        _selections[key] = value;
+      }
+    });
+  }
+
+  void _toggle(BackupCategory category, bool value) {
+    setState(() {
+      _selections[category] = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final accentColor = AppAccentColors.current;
+
+    return NipaplayWindowScaffold(
+      onClose: () => Navigator.of(context).pop(),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '选择备份内容',
+              style: TextStyle(
+                color: colorScheme.onSurface,
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 20),
+            // 全选
+            _buildCheckboxTile(
+              title: '全选',
+              subtitle: '导出所有数据',
+              value: _isAllSelected,
+              onChanged: _toggleAll,
+              accentColor: accentColor,
+              isDark: isDark,
+              colorScheme: colorScheme,
+            ),
+            const Divider(height: 24),
+            // 偏好设置
+            _buildCheckboxTile(
+              title: '偏好设置',
+              subtitle: '软件设置、本地和在线媒体库配置',
+              value: _selections[BackupCategory.preferences]!,
+              onChanged: (v) => _toggle(BackupCategory.preferences, v),
+              accentColor: accentColor,
+              isDark: isDark,
+              colorScheme: colorScheme,
+            ),
+            const SizedBox(height: 4),
+            // 观看历史
+            _buildCheckboxTile(
+              title: '观看历史',
+              subtitle: '${widget.watchHistoryCount} 条记录',
+              value: _selections[BackupCategory.watchHistory]!,
+              onChanged: (v) => _toggle(BackupCategory.watchHistory, v),
+              accentColor: accentColor,
+              isDark: isDark,
+              colorScheme: colorScheme,
+            ),
+            const SizedBox(height: 4),
+            // 剧集匹配
+            _buildCheckboxTile(
+              title: '剧集匹配',
+              subtitle: '${widget.episodeMatchCount} 条匹配',
+              value: _selections[BackupCategory.episodeMatches]!,
+              onChanged: (v) => _toggle(BackupCategory.episodeMatches, v),
+              accentColor: accentColor,
+              isDark: isDark,
+              colorScheme: colorScheme,
+            ),
+            const SizedBox(height: 4),
+            // 账户绑定
+            _buildCheckboxTile(
+              title: '账户绑定',
+              subtitle: '${widget.accountCount} 个账户',
+              value: _selections[BackupCategory.accounts]!,
+              onChanged: (v) => _toggle(BackupCategory.accounts, v),
+              accentColor: accentColor,
+              isDark: isDark,
+              colorScheme: colorScheme,
+            ),
+            const SizedBox(height: 24),
+            // 底部按钮
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                HoverScaleTextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: Text('取消',
+                      style: TextStyle(color: Colors.white70)),
+                ),
+                const SizedBox(width: 16),
+                HoverScaleTextButton(
+                  onPressed: _selections.values.any((v) => v)
+                      ? () {
+                          final selected = _selections.entries
+                              .where((e) => e.value)
+                              .map((e) => e.key)
+                              .toSet();
+                          Navigator.of(context).pop(selected);
+                        }
+                      : null,
+                  child: Text('确定',
+                      style: TextStyle(color: Colors.white)),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCheckboxTile({
+    required String title,
+    required String subtitle,
+    required bool value,
+    required ValueChanged<bool> onChanged,
+    required Color accentColor,
+    required bool isDark,
+    required ColorScheme colorScheme,
+  }) {
+    return InkWell(
+      onTap: () => onChanged(!value),
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 24,
+              height: 24,
+              child: Checkbox(
+                value: value,
+                onChanged: (v) => onChanged(v ?? false),
+                activeColor: accentColor,
+                checkColor: Colors.white,
+                side: BorderSide(
+                  color: colorScheme.onSurface.withOpacity(0.4),
+                  width: 1.5,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: TextStyle(
+                      color: colorScheme.onSurface.withOpacity(0.6),
+                      fontSize: 13,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ==================== 恢复选择弹窗 ====================
+
+class _RestoreSelectionDialog extends StatefulWidget {
+  final BackupPreviewInfo preview;
+
+  const _RestoreSelectionDialog({required this.preview});
+
+  @override
+  State<_RestoreSelectionDialog> createState() =>
+      _RestoreSelectionDialogState();
+}
+
+class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
+  late Map<BackupCategory, bool> _selections;
+
+  @override
+  void initState() {
+    super.initState();
+    _selections = {
+      BackupCategory.preferences: widget.preview.hasPreferences,
+      BackupCategory.watchHistory: widget.preview.hasWatchHistory,
+      BackupCategory.episodeMatches: widget.preview.hasEpisodeMatches,
+      BackupCategory.accounts: widget.preview.hasAccounts,
+    };
+  }
+
+  bool get _isAllSelected => _selections.values.every((v) => v);
+
+  void _toggleAll(bool value) {
+    setState(() {
+      for (final key in _selections.keys) {
+        _selections[key] = value;
+      }
+    });
+  }
+
+  void _toggle(BackupCategory category, bool value) {
+    setState(() {
+      _selections[category] = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final accentColor = AppAccentColors.current;
+
+    final preview = widget.preview;
+    final backupDate = preview.timestamp.isNotEmpty
+        ? DateTime.tryParse(preview.timestamp)?.toLocal()
+        : null;
+    final dateStr = backupDate != null
+        ? '${backupDate.year}-${backupDate.month.toString().padLeft(2, '0')}-${backupDate.day.toString().padLeft(2, '0')} ${backupDate.hour.toString().padLeft(2, '0')}:${backupDate.minute.toString().padLeft(2, '0')}'
+        : '未知';
+
+    return NipaplayWindowScaffold(
+      onClose: () => Navigator.of(context).pop(),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '选择恢复内容',
+              style: TextStyle(
+                color: colorScheme.onSurface,
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 12),
+            // 备份信息
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: colorScheme.onSurface.withOpacity(0.05),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: colorScheme.onSurface.withOpacity(0.1),
+                ),
+              ),
+              child: Row(
+                children: [
+                  Icon(Icons.info_outline,
+                      size: 18,
+                      color: colorScheme.onSurface.withOpacity(0.6)),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '备份时间: $dateStr  版本: v${preview.appVersion}',
+                      style: TextStyle(
+                        color: colorScheme.onSurface.withOpacity(0.7),
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            // 全选
+            _buildCheckboxTile(
+              title: '全选',
+              subtitle: '恢复所有数据',
+              value: _isAllSelected,
+              onChanged: _toggleAll,
+              accentColor: accentColor,
+              colorScheme: colorScheme,
+            ),
+            const Divider(height: 24),
+            // 偏好设置
+            if (preview.hasPreferences)
+              _buildCheckboxTile(
+                title: '偏好设置',
+                subtitle:
+                    '${preview.localLibraryCount} 个本地媒体库, ${preview.serverProfileCount} 个服务器',
+                value: _selections[BackupCategory.preferences]!,
+                onChanged: (v) =>
+                    _toggle(BackupCategory.preferences, v),
+                accentColor: accentColor,
+                colorScheme: colorScheme,
+              ),
+            if (preview.hasPreferences) const SizedBox(height: 4),
+            // 观看历史
+            if (preview.hasWatchHistory)
+              _buildCheckboxTile(
+                title: '观看历史',
+                subtitle: '${preview.watchHistoryCount} 条记录',
+                value: _selections[BackupCategory.watchHistory]!,
+                onChanged: (v) =>
+                    _toggle(BackupCategory.watchHistory, v),
+                accentColor: accentColor,
+                colorScheme: colorScheme,
+              ),
+            if (preview.hasWatchHistory) const SizedBox(height: 4),
+            // 剧集匹配
+            if (preview.hasEpisodeMatches)
+              _buildCheckboxTile(
+                title: '剧集匹配',
+                subtitle: '${preview.episodeMatchCount} 条匹配',
+                value: _selections[BackupCategory.episodeMatches]!,
+                onChanged: (v) =>
+                    _toggle(BackupCategory.episodeMatches, v),
+                accentColor: accentColor,
+                colorScheme: colorScheme,
+              ),
+            if (preview.hasEpisodeMatches) const SizedBox(height: 4),
+            // 账户绑定
+            if (preview.hasAccounts)
+              _buildCheckboxTile(
+                title: '账户绑定',
+                subtitle: '已绑定的账户信息',
+                value: _selections[BackupCategory.accounts]!,
+                onChanged: (v) =>
+                    _toggle(BackupCategory.accounts, v),
+                accentColor: accentColor,
+                colorScheme: colorScheme,
+              ),
+            const SizedBox(height: 24),
+            // 底部按钮
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                HoverScaleTextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: Text('取消',
+                      style: TextStyle(color: Colors.white70)),
+                ),
+                const SizedBox(width: 16),
+                HoverScaleTextButton(
+                  onPressed: _selections.values.any((v) => v)
+                      ? () {
+                          final selected = _selections.entries
+                              .where((e) => e.value)
+                              .map((e) => e.key)
+                              .toSet();
+                          Navigator.of(context).pop(selected);
+                        }
+                      : null,
+                  child: Text('确定',
+                      style: TextStyle(color: Colors.white)),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCheckboxTile({
+    required String title,
+    required String subtitle,
+    required bool value,
+    required ValueChanged<bool> onChanged,
+    required Color accentColor,
+    required ColorScheme colorScheme,
+  }) {
+    return InkWell(
+      onTap: () => onChanged(!value),
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 24,
+              height: 24,
+              child: Checkbox(
+                value: value,
+                onChanged: (v) => onChanged(v ?? false),
+                activeColor: accentColor,
+                checkColor: Colors.white,
+                side: BorderSide(
+                  color: colorScheme.onSurface.withOpacity(0.4),
+                  width: 1.5,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: TextStyle(
+                      color: colorScheme.onSurface.withOpacity(0.6),
+                      fontSize: 13,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/themes/nipaplay/pages/settings/backup_restore_page.dart
+++ b/lib/themes/nipaplay/pages/settings/backup_restore_page.dart
@@ -9,6 +9,9 @@ import 'package:nipaplay/services/backup_service.dart';
 import 'package:nipaplay/services/full_backup_service.dart';
 import 'package:nipaplay/services/auto_sync_service.dart';
 import 'package:nipaplay/services/multi_address_server_service.dart';
+import 'package:nipaplay/services/webdav_service.dart';
+import 'package:nipaplay/services/smb_service.dart';
+import 'package:nipaplay/services/dandanplay_remote_service.dart';
 import 'package:nipaplay/utils/auto_sync_settings.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:nipaplay/models/watch_history_model.dart';
@@ -129,27 +132,56 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     // 先收集计数信息
     final historyItems = await WatchHistoryManager.getAllHistory();
     final watchHistoryCount = historyItems.length;
-    final episodeMatchCount =
-        historyItems.where((i) => i.animeId != null && i.episodeId != null).length;
+    final episodeMatchCount = historyItems
+        .where((i) => i.animeId != null && i.episodeId != null)
+        .length;
+
+    // 获取媒体库计数
+    final prefs = await SharedPreferences.getInstance();
+    int localLibraryCount =
+        prefs.getStringList('nipaplay_scanned_folders')?.length ?? 0;
+    int serverProfileCount = 0;
+    try {
+      await MultiAddressServerService.instance.loadProfiles();
+      serverProfileCount = MultiAddressServerService.instance.profiles.length;
+    } catch (_) {}
+    int webdavCount = 0;
+    try {
+      await WebDAVService.instance.initialize();
+      webdavCount = WebDAVService.instance.connections.length;
+    } catch (_) {}
+    int smbCount = 0;
+    try {
+      await SMBService.instance.initialize();
+      smbCount = SMBService.instance.connections.length;
+    } catch (_) {}
+    bool hasDandanplayRemote = false;
+    try {
+      await DandanplayRemoteService.instance
+          .loadSavedSettings(backgroundRefresh: true);
+      hasDandanplayRemote =
+          DandanplayRemoteService.instance.serverUrl != null &&
+              DandanplayRemoteService.instance.serverUrl!.isNotEmpty;
+    } catch (_) {}
 
     // 获取账户计数
-    final prefs = await SharedPreferences.getInstance();
     int accountCount = 0;
     final dandanplayLoggedIn = prefs.getBool('dandanplay_logged_in') ?? false;
     if (dandanplayLoggedIn) accountCount++;
     final bangumiLoggedIn = prefs.getBool('bangumi_logged_in') ?? false;
     if (bangumiLoggedIn) accountCount++;
-    // 服务器账户数
-    try {
-      await MultiAddressServerService.instance.loadProfiles();
-      accountCount += MultiAddressServerService.instance.profiles.length;
-    } catch (_) {}
+    accountCount += serverProfileCount;
 
     if (!mounted) return;
 
     final result = await NipaplayWindow.show<Set<BackupCategory>>(
       context: context,
       child: _BackupSelectionDialog(
+        localLibraryCount: localLibraryCount,
+        serverProfileCount: serverProfileCount,
+        webdavCount: webdavCount,
+        smbCount: smbCount,
+        hasDandanplayRemote: hasDandanplayRemote,
         watchHistoryCount: watchHistoryCount,
         episodeMatchCount: episodeMatchCount,
         accountCount: accountCount,
@@ -242,8 +274,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
       actions: [
         HoverScaleTextButton(
           onPressed: () => Navigator.pop(context, false),
-          child:
-              const Text('取消', style: TextStyle(color: Colors.white70)),
+          child: const Text('取消', style: TextStyle(color: Colors.white70)),
         ),
         HoverScaleTextButton(
           onPressed: () => Navigator.pop(context, true),
@@ -277,6 +308,10 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
         if (restoreResult.preferencesResult != null) {
           final r = restoreResult.preferencesResult!;
           parts.add('设置${r.success ? "✓" : "✗"}');
+        }
+        if (restoreResult.mediaLibrariesResult != null) {
+          final r = restoreResult.mediaLibrariesResult!;
+          parts.add('媒体库${r.success ? "✓" : "✗"}');
         }
         if (restoreResult.watchHistoryResult != null) {
           final r = restoreResult.watchHistoryResult!;
@@ -359,13 +394,11 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
       final confirmed = await BlurDialog.show<bool>(
         context: context,
         title: '确认恢复',
-        content:
-            '恢复操作将会合并备份文件中的观看进度（包括截图）到当前记录中，且只会恢复本地存在的媒体文件的进度。是否继续？',
+        content: '恢复操作将会合并备份文件中的观看进度（包括截图）到当前记录中，且只会恢复本地存在的媒体文件的进度。是否继续？',
         actions: [
           HoverScaleTextButton(
             onPressed: () => Navigator.pop(context, false),
-            child:
-                const Text('取消', style: TextStyle(color: Colors.white70)),
+            child: const Text('取消', style: TextStyle(color: Colors.white70)),
           ),
           HoverScaleTextButton(
             onPressed: () => Navigator.pop(context, true),
@@ -423,7 +456,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
               const SizedBox(height: 16),
               SettingsItem.button(
                 title: '全量备份',
-                subtitle: '选择性导出设置、观看历史、剧集匹配和账户信息',
+                subtitle: '选择性导出设置、媒体库、观看历史、剧集匹配和账户信息',
                 enabled: !_isProcessing,
                 onTap: _showFullBackupDialog,
                 icon: Icons.cloud_upload,
@@ -454,9 +487,8 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
               const SizedBox(height: 16),
               SettingsItem.toggle(
                 title: '启用自动同步',
-                subtitle: _autoSyncEnabled
-                    ? '观看进度会自动同步到本地路径或云端'
-                    : '启用后可实现多设备同步',
+                subtitle:
+                    _autoSyncEnabled ? '观看进度会自动同步到本地路径或云端' : '启用后可实现多设备同步',
                 enabled: !_isProcessing,
                 value: _autoSyncEnabled,
                 onChanged: _toggleAutoSync,
@@ -529,7 +561,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
               ),
               const SizedBox(height: 16),
               Text(
-                '• 全量备份：可选择导出偏好设置、观看历史、剧集匹配和账户信息',
+                '• 全量备份：可选择导出偏好设置、媒体库、观看历史、剧集匹配和账户信息',
                 style: TextStyle(
                     fontSize: 14,
                     color: colorScheme.onSurface.withOpacity(0.7)),
@@ -598,11 +630,21 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
 // ==================== 备份选择弹窗 ====================
 
 class _BackupSelectionDialog extends StatefulWidget {
+  final int localLibraryCount;
+  final int serverProfileCount;
+  final int webdavCount;
+  final int smbCount;
+  final bool hasDandanplayRemote;
   final int watchHistoryCount;
   final int episodeMatchCount;
   final int accountCount;
 
   const _BackupSelectionDialog({
+    required this.localLibraryCount,
+    required this.serverProfileCount,
+    required this.webdavCount,
+    required this.smbCount,
+    required this.hasDandanplayRemote,
     required this.watchHistoryCount,
     required this.episodeMatchCount,
     required this.accountCount,
@@ -620,6 +662,7 @@ class _BackupSelectionDialogState extends State<_BackupSelectionDialog> {
     super.initState();
     _selections = {
       BackupCategory.preferences: true,
+      BackupCategory.mediaLibraries: true,
       BackupCategory.watchHistory: true,
       BackupCategory.episodeMatches: true,
       BackupCategory.accounts: true,
@@ -679,9 +722,20 @@ class _BackupSelectionDialogState extends State<_BackupSelectionDialog> {
             // 偏好设置
             _buildCheckboxTile(
               title: '偏好设置',
-              subtitle: '软件设置、本地和在线媒体库配置',
+              subtitle: '软件设置（语言、弹幕、播放器等）',
               value: _selections[BackupCategory.preferences]!,
               onChanged: (v) => _toggle(BackupCategory.preferences, v),
+              accentColor: accentColor,
+              isDark: isDark,
+              colorScheme: colorScheme,
+            ),
+            const SizedBox(height: 4),
+            // 媒体库
+            _buildCheckboxTile(
+              title: '添加的媒体库',
+              subtitle: _buildMediaLibrariesSubtitle(),
+              value: _selections[BackupCategory.mediaLibraries]!,
+              onChanged: (v) => _toggle(BackupCategory.mediaLibraries, v),
               accentColor: accentColor,
               isDark: isDark,
               colorScheme: colorScheme,
@@ -726,8 +780,7 @@ class _BackupSelectionDialogState extends State<_BackupSelectionDialog> {
               children: [
                 HoverScaleTextButton(
                   onPressed: () => Navigator.of(context).pop(),
-                  child: Text('取消',
-                      style: TextStyle(color: Colors.white70)),
+                  child: Text('取消', style: TextStyle(color: Colors.white70)),
                 ),
                 const SizedBox(width: 16),
                 HoverScaleTextButton(
@@ -740,8 +793,7 @@ class _BackupSelectionDialogState extends State<_BackupSelectionDialog> {
                           Navigator.of(context).pop(selected);
                         }
                       : null,
-                  child: Text('确定',
-                      style: TextStyle(color: Colors.white)),
+                  child: Text('确定', style: TextStyle(color: Colors.white)),
                 ),
               ],
             ),
@@ -810,6 +862,27 @@ class _BackupSelectionDialogState extends State<_BackupSelectionDialog> {
       ),
     );
   }
+
+  String _buildMediaLibrariesSubtitle() {
+    final parts = <String>[];
+    if (widget.localLibraryCount > 0) {
+      parts.add('${widget.localLibraryCount} 本地库');
+    }
+    if (widget.serverProfileCount > 0) {
+      parts.add('${widget.serverProfileCount} 服务器');
+    }
+    if (widget.webdavCount > 0) {
+      parts.add('${widget.webdavCount} WebDAV');
+    }
+    if (widget.smbCount > 0) {
+      parts.add('${widget.smbCount} SMB');
+    }
+    if (widget.hasDandanplayRemote) {
+      parts.add('DDP远程');
+    }
+    parts.add('共享服务');
+    return parts.join(', ');
+  }
 }
 
 // ==================== 恢复选择弹窗 ====================
@@ -832,6 +905,7 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
     super.initState();
     _selections = {
       BackupCategory.preferences: widget.preview.hasPreferences,
+      BackupCategory.mediaLibraries: widget.preview.hasMediaLibraries,
       BackupCategory.watchHistory: widget.preview.hasWatchHistory,
       BackupCategory.episodeMatches: widget.preview.hasEpisodeMatches,
       BackupCategory.accounts: widget.preview.hasAccounts,
@@ -897,8 +971,7 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
               child: Row(
                 children: [
                   Icon(Icons.info_outline,
-                      size: 18,
-                      color: colorScheme.onSurface.withOpacity(0.6)),
+                      size: 18, color: colorScheme.onSurface.withOpacity(0.6)),
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
@@ -927,23 +1000,31 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
             if (preview.hasPreferences)
               _buildCheckboxTile(
                 title: '偏好设置',
-                subtitle:
-                    '${preview.localLibraryCount} 个本地媒体库, ${preview.serverProfileCount} 个服务器',
+                subtitle: '软件设置（语言、弹幕、播放器等）',
                 value: _selections[BackupCategory.preferences]!,
-                onChanged: (v) =>
-                    _toggle(BackupCategory.preferences, v),
+                onChanged: (v) => _toggle(BackupCategory.preferences, v),
                 accentColor: accentColor,
                 colorScheme: colorScheme,
               ),
             if (preview.hasPreferences) const SizedBox(height: 4),
+            // 媒体库
+            if (preview.hasMediaLibraries)
+              _buildCheckboxTile(
+                title: '添加的媒体库',
+                subtitle: _buildMediaLibrariesSubtitle(preview),
+                value: _selections[BackupCategory.mediaLibraries]!,
+                onChanged: (v) => _toggle(BackupCategory.mediaLibraries, v),
+                accentColor: accentColor,
+                colorScheme: colorScheme,
+              ),
+            if (preview.hasMediaLibraries) const SizedBox(height: 4),
             // 观看历史
             if (preview.hasWatchHistory)
               _buildCheckboxTile(
                 title: '观看历史',
                 subtitle: '${preview.watchHistoryCount} 条记录',
                 value: _selections[BackupCategory.watchHistory]!,
-                onChanged: (v) =>
-                    _toggle(BackupCategory.watchHistory, v),
+                onChanged: (v) => _toggle(BackupCategory.watchHistory, v),
                 accentColor: accentColor,
                 colorScheme: colorScheme,
               ),
@@ -954,8 +1035,7 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
                 title: '剧集匹配',
                 subtitle: '${preview.episodeMatchCount} 条匹配',
                 value: _selections[BackupCategory.episodeMatches]!,
-                onChanged: (v) =>
-                    _toggle(BackupCategory.episodeMatches, v),
+                onChanged: (v) => _toggle(BackupCategory.episodeMatches, v),
                 accentColor: accentColor,
                 colorScheme: colorScheme,
               ),
@@ -966,8 +1046,7 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
                 title: '账户绑定',
                 subtitle: '已绑定的账户信息',
                 value: _selections[BackupCategory.accounts]!,
-                onChanged: (v) =>
-                    _toggle(BackupCategory.accounts, v),
+                onChanged: (v) => _toggle(BackupCategory.accounts, v),
                 accentColor: accentColor,
                 colorScheme: colorScheme,
               ),
@@ -978,8 +1057,7 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
               children: [
                 HoverScaleTextButton(
                   onPressed: () => Navigator.of(context).pop(),
-                  child: Text('取消',
-                      style: TextStyle(color: Colors.white70)),
+                  child: Text('取消', style: TextStyle(color: Colors.white70)),
                 ),
                 const SizedBox(width: 16),
                 HoverScaleTextButton(
@@ -992,8 +1070,7 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
                           Navigator.of(context).pop(selected);
                         }
                       : null,
-                  child: Text('确定',
-                      style: TextStyle(color: Colors.white)),
+                  child: Text('确定', style: TextStyle(color: Colors.white)),
                 ),
               ],
             ),
@@ -1060,5 +1137,29 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
         ),
       ),
     );
+  }
+
+  String _buildMediaLibrariesSubtitle(BackupPreviewInfo preview) {
+    final parts = <String>[];
+    if (preview.localLibraryCount > 0) {
+      parts.add('${preview.localLibraryCount} 本地库');
+    }
+    if (preview.serverProfileCount > 0) {
+      parts.add('${preview.serverProfileCount} 服务器');
+    }
+    if (preview.webdavConnectionCount > 0) {
+      parts.add('${preview.webdavConnectionCount} WebDAV');
+    }
+    if (preview.smbConnectionCount > 0) {
+      parts.add('${preview.smbConnectionCount} SMB');
+    }
+    if (preview.hasDandanplayRemote) {
+      parts.add('DDP远程');
+    }
+    if (preview.hasNipaplayShare) {
+      parts.add('共享服务');
+    }
+    if (parts.isEmpty) parts.add('无连接');
+    return parts.join(', ');
   }
 }

--- a/lib/themes/nipaplay/pages/settings/backup_restore_page.dart
+++ b/lib/themes/nipaplay/pages/settings/backup_restore_page.dart
@@ -708,73 +708,84 @@ class _BackupSelectionDialogState extends State<_BackupSelectionDialog> {
               ),
             ),
             const SizedBox(height: 20),
-            // 全选
-            _buildCheckboxTile(
-              title: '全选',
-              subtitle: '导出所有数据',
-              value: _isAllSelected,
-              onChanged: _toggleAll,
-              accentColor: accentColor,
-              isDark: isDark,
-              colorScheme: colorScheme,
-            ),
-            const Divider(height: 24),
-            // 偏好设置
-            _buildCheckboxTile(
-              title: '偏好设置',
-              subtitle: '软件设置（语言、弹幕、播放器等）',
-              value: _selections[BackupCategory.preferences]!,
-              onChanged: (v) => _toggle(BackupCategory.preferences, v),
-              accentColor: accentColor,
-              isDark: isDark,
-              colorScheme: colorScheme,
-            ),
-            const SizedBox(height: 4),
-            // 媒体库
-            _buildCheckboxTile(
-              title: '添加的媒体库',
-              subtitle: _buildMediaLibrariesSubtitle(),
-              value: _selections[BackupCategory.mediaLibraries]!,
-              onChanged: (v) => _toggle(BackupCategory.mediaLibraries, v),
-              accentColor: accentColor,
-              isDark: isDark,
-              colorScheme: colorScheme,
-            ),
-            const SizedBox(height: 4),
-            // 观看历史
-            _buildCheckboxTile(
-              title: '观看历史',
-              subtitle: '${widget.watchHistoryCount} 条记录',
-              value: _selections[BackupCategory.watchHistory]!,
-              onChanged: (v) => _toggle(BackupCategory.watchHistory, v),
-              accentColor: accentColor,
-              isDark: isDark,
-              colorScheme: colorScheme,
-            ),
-            const SizedBox(height: 4),
-            // 剧集匹配
-            _buildCheckboxTile(
-              title: '剧集匹配',
-              subtitle: '${widget.episodeMatchCount} 条匹配',
-              value: _selections[BackupCategory.episodeMatches]!,
-              onChanged: (v) => _toggle(BackupCategory.episodeMatches, v),
-              accentColor: accentColor,
-              isDark: isDark,
-              colorScheme: colorScheme,
-            ),
-            const SizedBox(height: 4),
-            // 账户绑定
-            _buildCheckboxTile(
-              title: '账户绑定',
-              subtitle: '${widget.accountCount} 个账户',
-              value: _selections[BackupCategory.accounts]!,
-              onChanged: (v) => _toggle(BackupCategory.accounts, v),
-              accentColor: accentColor,
-              isDark: isDark,
-              colorScheme: colorScheme,
+            // 可滚动的选择区域
+            Flexible(
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 全选
+                    _buildCheckboxTile(
+                      title: '全选',
+                      subtitle: '导出所有数据',
+                      value: _isAllSelected,
+                      onChanged: _toggleAll,
+                      accentColor: accentColor,
+                      isDark: isDark,
+                      colorScheme: colorScheme,
+                    ),
+                    const Divider(height: 24),
+                    // 偏好设置
+                    _buildCheckboxTile(
+                      title: '偏好设置',
+                      subtitle: '软件设置（语言、弹幕、播放器等）',
+                      value: _selections[BackupCategory.preferences]!,
+                      onChanged: (v) => _toggle(BackupCategory.preferences, v),
+                      accentColor: accentColor,
+                      isDark: isDark,
+                      colorScheme: colorScheme,
+                    ),
+                    const SizedBox(height: 4),
+                    // 媒体库
+                    _buildCheckboxTile(
+                      title: '添加的媒体库',
+                      subtitle: _buildMediaLibrariesSubtitle(),
+                      value: _selections[BackupCategory.mediaLibraries]!,
+                      onChanged: (v) => _toggle(BackupCategory.mediaLibraries, v),
+                      accentColor: accentColor,
+                      isDark: isDark,
+                      colorScheme: colorScheme,
+                    ),
+                    const SizedBox(height: 4),
+                    // 观看历史
+                    _buildCheckboxTile(
+                      title: '观看历史',
+                      subtitle: '${widget.watchHistoryCount} 条记录',
+                      value: _selections[BackupCategory.watchHistory]!,
+                      onChanged: (v) => _toggle(BackupCategory.watchHistory, v),
+                      accentColor: accentColor,
+                      isDark: isDark,
+                      colorScheme: colorScheme,
+                    ),
+                    const SizedBox(height: 4),
+                    // 剧集匹配
+                    _buildCheckboxTile(
+                      title: '剧集匹配',
+                      subtitle: '${widget.episodeMatchCount} 条匹配',
+                      value: _selections[BackupCategory.episodeMatches]!,
+                      onChanged: (v) => _toggle(BackupCategory.episodeMatches, v),
+                      accentColor: accentColor,
+                      isDark: isDark,
+                      colorScheme: colorScheme,
+                    ),
+                    const SizedBox(height: 4),
+                    // 账户绑定
+                    _buildCheckboxTile(
+                      title: '账户绑定',
+                      subtitle: '${widget.accountCount} 个账户',
+                      value: _selections[BackupCategory.accounts]!,
+                      onChanged: (v) => _toggle(BackupCategory.accounts, v),
+                      accentColor: accentColor,
+                      isDark: isDark,
+                      colorScheme: colorScheme,
+                    ),
+                  ],
+                ),
+              ),
             ),
             const SizedBox(height: 24),
-            // 底部按钮
+            // 底部按钮（固定在底部）
             Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
@@ -986,72 +997,83 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
               ),
             ),
             const SizedBox(height: 16),
-            // 全选
-            _buildCheckboxTile(
-              title: '全选',
-              subtitle: '恢复所有数据',
-              value: _isAllSelected,
-              onChanged: _toggleAll,
-              accentColor: accentColor,
-              colorScheme: colorScheme,
+            // 可滚动的选择区域
+            Flexible(
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 全选
+                    _buildCheckboxTile(
+                      title: '全选',
+                      subtitle: '恢复所有数据',
+                      value: _isAllSelected,
+                      onChanged: _toggleAll,
+                      accentColor: accentColor,
+                      colorScheme: colorScheme,
+                    ),
+                    const Divider(height: 24),
+                    // 偏好设置
+                    if (preview.hasPreferences)
+                      _buildCheckboxTile(
+                        title: '偏好设置',
+                        subtitle: '软件设置（语言、弹幕、播放器等）',
+                        value: _selections[BackupCategory.preferences]!,
+                        onChanged: (v) => _toggle(BackupCategory.preferences, v),
+                        accentColor: accentColor,
+                        colorScheme: colorScheme,
+                      ),
+                    if (preview.hasPreferences) const SizedBox(height: 4),
+                    // 媒体库
+                    if (preview.hasMediaLibraries)
+                      _buildCheckboxTile(
+                        title: '添加的媒体库',
+                        subtitle: _buildMediaLibrariesSubtitle(preview),
+                        value: _selections[BackupCategory.mediaLibraries]!,
+                        onChanged: (v) => _toggle(BackupCategory.mediaLibraries, v),
+                        accentColor: accentColor,
+                        colorScheme: colorScheme,
+                      ),
+                    if (preview.hasMediaLibraries) const SizedBox(height: 4),
+                    // 观看历史
+                    if (preview.hasWatchHistory)
+                      _buildCheckboxTile(
+                        title: '观看历史',
+                        subtitle: '${preview.watchHistoryCount} 条记录',
+                        value: _selections[BackupCategory.watchHistory]!,
+                        onChanged: (v) => _toggle(BackupCategory.watchHistory, v),
+                        accentColor: accentColor,
+                        colorScheme: colorScheme,
+                      ),
+                    if (preview.hasWatchHistory) const SizedBox(height: 4),
+                    // 剧集匹配
+                    if (preview.hasEpisodeMatches)
+                      _buildCheckboxTile(
+                        title: '剧集匹配',
+                        subtitle: '${preview.episodeMatchCount} 条匹配',
+                        value: _selections[BackupCategory.episodeMatches]!,
+                        onChanged: (v) => _toggle(BackupCategory.episodeMatches, v),
+                        accentColor: accentColor,
+                        colorScheme: colorScheme,
+                      ),
+                    if (preview.hasEpisodeMatches) const SizedBox(height: 4),
+                    // 账户绑定
+                    if (preview.hasAccounts)
+                      _buildCheckboxTile(
+                        title: '账户绑定',
+                        subtitle: '已绑定的账户信息',
+                        value: _selections[BackupCategory.accounts]!,
+                        onChanged: (v) => _toggle(BackupCategory.accounts, v),
+                        accentColor: accentColor,
+                        colorScheme: colorScheme,
+                      ),
+                  ],
+                ),
+              ),
             ),
-            const Divider(height: 24),
-            // 偏好设置
-            if (preview.hasPreferences)
-              _buildCheckboxTile(
-                title: '偏好设置',
-                subtitle: '软件设置（语言、弹幕、播放器等）',
-                value: _selections[BackupCategory.preferences]!,
-                onChanged: (v) => _toggle(BackupCategory.preferences, v),
-                accentColor: accentColor,
-                colorScheme: colorScheme,
-              ),
-            if (preview.hasPreferences) const SizedBox(height: 4),
-            // 媒体库
-            if (preview.hasMediaLibraries)
-              _buildCheckboxTile(
-                title: '添加的媒体库',
-                subtitle: _buildMediaLibrariesSubtitle(preview),
-                value: _selections[BackupCategory.mediaLibraries]!,
-                onChanged: (v) => _toggle(BackupCategory.mediaLibraries, v),
-                accentColor: accentColor,
-                colorScheme: colorScheme,
-              ),
-            if (preview.hasMediaLibraries) const SizedBox(height: 4),
-            // 观看历史
-            if (preview.hasWatchHistory)
-              _buildCheckboxTile(
-                title: '观看历史',
-                subtitle: '${preview.watchHistoryCount} 条记录',
-                value: _selections[BackupCategory.watchHistory]!,
-                onChanged: (v) => _toggle(BackupCategory.watchHistory, v),
-                accentColor: accentColor,
-                colorScheme: colorScheme,
-              ),
-            if (preview.hasWatchHistory) const SizedBox(height: 4),
-            // 剧集匹配
-            if (preview.hasEpisodeMatches)
-              _buildCheckboxTile(
-                title: '剧集匹配',
-                subtitle: '${preview.episodeMatchCount} 条匹配',
-                value: _selections[BackupCategory.episodeMatches]!,
-                onChanged: (v) => _toggle(BackupCategory.episodeMatches, v),
-                accentColor: accentColor,
-                colorScheme: colorScheme,
-              ),
-            if (preview.hasEpisodeMatches) const SizedBox(height: 4),
-            // 账户绑定
-            if (preview.hasAccounts)
-              _buildCheckboxTile(
-                title: '账户绑定',
-                subtitle: '已绑定的账户信息',
-                value: _selections[BackupCategory.accounts]!,
-                onChanged: (v) => _toggle(BackupCategory.accounts, v),
-                accentColor: accentColor,
-                colorScheme: colorScheme,
-              ),
             const SizedBox(height: 24),
-            // 底部按钮
+            // 底部按钮（固定在底部）
             Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [

--- a/lib/themes/nipaplay/pages/settings/backup_restore_page.dart
+++ b/lib/themes/nipaplay/pages/settings/backup_restore_page.dart
@@ -326,7 +326,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
           parts.add('账户${r.success ? "✓" : "✗"}');
         }
 
-        _showMessage('恢复完成: ${parts.join(" ")}');
+        _showMessage('恢复完成: ${parts.join(" ")}，部分数据需要重启应用生效');
       } else {
         _showMessage('恢复失败: ${restoreResult.errorMessage ?? "未知错误"}',
             isError: true);
@@ -742,7 +742,8 @@ class _BackupSelectionDialogState extends State<_BackupSelectionDialog> {
                       title: '添加的媒体库',
                       subtitle: _buildMediaLibrariesSubtitle(),
                       value: _selections[BackupCategory.mediaLibraries]!,
-                      onChanged: (v) => _toggle(BackupCategory.mediaLibraries, v),
+                      onChanged: (v) =>
+                          _toggle(BackupCategory.mediaLibraries, v),
                       accentColor: accentColor,
                       isDark: isDark,
                       colorScheme: colorScheme,
@@ -764,7 +765,8 @@ class _BackupSelectionDialogState extends State<_BackupSelectionDialog> {
                       title: '剧集匹配',
                       subtitle: '${widget.episodeMatchCount} 条匹配',
                       value: _selections[BackupCategory.episodeMatches]!,
-                      onChanged: (v) => _toggle(BackupCategory.episodeMatches, v),
+                      onChanged: (v) =>
+                          _toggle(BackupCategory.episodeMatches, v),
                       accentColor: accentColor,
                       isDark: isDark,
                       colorScheme: colorScheme,
@@ -1020,7 +1022,8 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
                         title: '偏好设置',
                         subtitle: '软件设置（语言、弹幕、播放器等）',
                         value: _selections[BackupCategory.preferences]!,
-                        onChanged: (v) => _toggle(BackupCategory.preferences, v),
+                        onChanged: (v) =>
+                            _toggle(BackupCategory.preferences, v),
                         accentColor: accentColor,
                         colorScheme: colorScheme,
                       ),
@@ -1031,7 +1034,8 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
                         title: '添加的媒体库',
                         subtitle: _buildMediaLibrariesSubtitle(preview),
                         value: _selections[BackupCategory.mediaLibraries]!,
-                        onChanged: (v) => _toggle(BackupCategory.mediaLibraries, v),
+                        onChanged: (v) =>
+                            _toggle(BackupCategory.mediaLibraries, v),
                         accentColor: accentColor,
                         colorScheme: colorScheme,
                       ),
@@ -1042,7 +1046,8 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
                         title: '观看历史',
                         subtitle: '${preview.watchHistoryCount} 条记录',
                         value: _selections[BackupCategory.watchHistory]!,
-                        onChanged: (v) => _toggle(BackupCategory.watchHistory, v),
+                        onChanged: (v) =>
+                            _toggle(BackupCategory.watchHistory, v),
                         accentColor: accentColor,
                         colorScheme: colorScheme,
                       ),
@@ -1053,7 +1058,8 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
                         title: '剧集匹配',
                         subtitle: '${preview.episodeMatchCount} 条匹配',
                         value: _selections[BackupCategory.episodeMatches]!,
-                        onChanged: (v) => _toggle(BackupCategory.episodeMatches, v),
+                        onChanged: (v) =>
+                            _toggle(BackupCategory.episodeMatches, v),
                         accentColor: accentColor,
                         colorScheme: colorScheme,
                       ),


### PR DESCRIPTION
## Summary

- 扩展原有的备份与恢复系统，支持了全量备份和恢复功能：用户可在 ［偏好设置、添加的媒体库、观看历史、剧集匹配、账户绑定］ 5种类型的数据中选择性导出或导入，导出和导入弹窗中都可看到数据计数。
- 恢复功能采用增量恢复机制，只增不减，但冲突的已有数据会被覆盖
- 自动剔除无效数据：如已经不存在的本地媒体库文件夹，以及不存在源文件的匹配信息等
- 保留原版的云同步和播放记录备份以作为兼容性回退
- 修复了 cpp 在 macos 26.5 上 build 的兼容性问题

## Test

```
flutter build windows
flutter build macos
```
已通过 Windows 导出， Mac 导入的测试。

## Screen Shot

### 导出弹窗
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/b63a85be-c02d-49bc-bf94-773dee8fb7a3" />

### 导入弹窗
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/12469230-2931-48de-920e-e3f54d61fb8a" />

### 备份与恢复设置页面
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/f43ed571-e564-46a2-a76e-486753fb8e9e" />


## What Changed

### 新建文件

- **lib/services/full_backup_service.dart** — 全量备份后端服务，支持 5 类数据（偏好设置、媒体库、观看历史、剧集匹配、账户绑定）的按需导出/导入，包含 `BackupCategory` 枚举、`FullBackupService` 类（收集/恢复/预览）、`BackupRestoreResult`/`CategoryRestoreResult`/`BackupPreviewInfo` 数据模型

### 修改文件

- **lib/themes/nipaplay/pages/settings/backup_restore_page.dart** — 重写备份恢复页面，新增全量备份/恢复按钮及两个 NipaplayWindow 风格弹窗（`_BackupSelectionDialog`/`_RestoreSelectionDialog`），支持 5 类数据勾选（含全选、计数显示），选择区域用 `Flexible`+`SingleChildScrollView` 包裹防止窗口化模式下按钮被遮挡

- **cpp_native/src/danmaku_parser.cpp** — 将 `std::from_chars`/`std::format` 替换为 `std::strtod`/`std::strtol`/`std::strtoll`/`std::snprintf`，修复 Xcode 26.5 SDK 下部署目标 macOS 11.0 编译失败的问题
