### PR TITLE
feat: add Erika ART-CNN upscaler support

### DIFF
--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -191,6 +191,7 @@ class ErikaPlayerAdapter implements AbstractPlayer {
   String _media = '';
   double _volume = 1.0;
   double _playbackRate = 1.0;
+  PlayerUpscalerStatus _lastUpscalerStatus = const PlayerUpscalerStatus.off();
   int _lastPositionMs = 0;
   DateTime _lastPositionUpdate = DateTime.now();
   int? _pendingSeekTargetMs;
@@ -463,10 +464,45 @@ class ErikaPlayerAdapter implements AbstractPlayer {
     }
   }
 
+  bool get supportsUpscaler => _isSupported;
+
+  Future<void> setUpscaler(PlayerUpscalerMode mode) async {
+    _lastUpscalerStatus = PlayerUpscalerStatus(
+      requestedMode: mode,
+      activeBackend: mode == PlayerUpscalerMode.off
+          ? PlayerUpscalerBackendStatus.off
+          : PlayerUpscalerBackendStatus.inactive,
+      fallbackCount: _lastUpscalerStatus.fallbackCount,
+      upscaledFrames: _lastUpscalerStatus.upscaledFrames,
+      lastEncodeDuration: _lastUpscalerStatus.lastEncodeDuration,
+      lastGpuDuration: _lastUpscalerStatus.lastGpuDuration,
+    );
+    if (!_isSupported) return;
+    try {
+      await _player.setUpscaler(_toNativeUpscalerMode(mode));
+      _lastUpscalerStatus = await getUpscalerStatus();
+    } catch (error) {
+      debugPrint('Erika: set upscaler failed: $error');
+    }
+  }
+
+  Future<PlayerUpscalerStatus> getUpscalerStatus() async {
+    if (!_isSupported) {
+      return _lastUpscalerStatus;
+    }
+    try {
+      final status = await _player.getUpscalerStatus();
+      _lastUpscalerStatus = _convertUpscalerStatus(status);
+    } catch (error) {
+      debugPrint('Erika: get upscaler status failed: $error');
+    }
+    return _lastUpscalerStatus;
+  }
+
   @override
   void stepForward() {
     if (!_isSupported) return;
-    final frameDuration = 42; // ~24fps
+    const frameDuration = 42; // ~24fps
     final currentPos = position;
     seek(position: currentPos + frameDuration);
   }
@@ -474,7 +510,7 @@ class ErikaPlayerAdapter implements AbstractPlayer {
   @override
   void stepBackward() {
     if (!_isSupported) return;
-    final frameDuration = 42; // ~24fps
+    const frameDuration = 42; // ~24fps
     final currentPos = position;
     seek(position: (currentPos - frameDuration).clamp(0, currentPos));
   }
@@ -686,6 +722,7 @@ class ErikaPlayerAdapter implements AbstractPlayer {
       'state': _state.name,
       'position': position,
       'duration': _mediaInfo.duration,
+      'upscaler': _lastUpscalerStatus.toMap(),
       'videoWidth': _mediaInfo.video?.isNotEmpty == true
           ? _mediaInfo.video!.first.codec.width
           : null,
@@ -695,8 +732,60 @@ class ErikaPlayerAdapter implements AbstractPlayer {
     };
   }
 
-  Future<Map<String, dynamic>> getDetailedMediaInfoAsync() async =>
-      getDetailedMediaInfo();
+  Future<Map<String, dynamic>> getDetailedMediaInfoAsync() async {
+    await getUpscalerStatus();
+    return getDetailedMediaInfo();
+  }
+
+  ErikaUpscalerMode _toNativeUpscalerMode(PlayerUpscalerMode mode) {
+    switch (mode) {
+      case PlayerUpscalerMode.erikaArtCnnC4F16:
+        return ErikaUpscalerMode.artCnnC4F16;
+      case PlayerUpscalerMode.erikaArtCnnC4F32:
+        return ErikaUpscalerMode.artCnnC4F32;
+      case PlayerUpscalerMode.off:
+        return ErikaUpscalerMode.off;
+    }
+  }
+
+  PlayerUpscalerMode _fromNativeUpscalerMode(ErikaUpscalerMode mode) {
+    switch (mode) {
+      case ErikaUpscalerMode.artCnnC4F16:
+        return PlayerUpscalerMode.erikaArtCnnC4F16;
+      case ErikaUpscalerMode.artCnnC4F32:
+        return PlayerUpscalerMode.erikaArtCnnC4F32;
+      case ErikaUpscalerMode.off:
+        return PlayerUpscalerMode.off;
+    }
+  }
+
+  PlayerUpscalerBackendStatus _fromNativeUpscalerBackend(
+    ErikaUpscalerBackendStatus status,
+  ) {
+    switch (status) {
+      case ErikaUpscalerBackendStatus.off:
+        return PlayerUpscalerBackendStatus.off;
+      case ErikaUpscalerBackendStatus.inactive:
+        return PlayerUpscalerBackendStatus.inactive;
+      case ErikaUpscalerBackendStatus.building:
+        return PlayerUpscalerBackendStatus.building;
+      case ErikaUpscalerBackendStatus.scalar:
+        return PlayerUpscalerBackendStatus.scalar;
+      case ErikaUpscalerBackendStatus.simdgroupMatrix:
+        return PlayerUpscalerBackendStatus.simdgroupMatrix;
+    }
+  }
+
+  PlayerUpscalerStatus _convertUpscalerStatus(ErikaUpscalerStatus status) {
+    return PlayerUpscalerStatus(
+      requestedMode: _fromNativeUpscalerMode(status.requestedMode),
+      activeBackend: _fromNativeUpscalerBackend(status.activeBackend),
+      fallbackCount: status.fallbackCount,
+      upscaledFrames: status.upscaledFrames,
+      lastEncodeDuration: status.lastEncodeDuration,
+      lastGpuDuration: status.lastGpuDuration,
+    );
+  }
 
   void _handleEvent(ErikaPlayerEvent event) {
     if (event.kind == ErikaEventKind.stateChanged ||

--- a/lib/player_abstraction/player_abstraction.dart
+++ b/lib/player_abstraction/player_abstraction.dart
@@ -323,6 +323,35 @@ class Player {
     return getDetailedMediaInfo();
   }
 
+  bool get supportsUpscaler {
+    try {
+      final value = (_delegate as dynamic).supportsUpscaler;
+      return value is bool ? value : false;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<void> setUpscaler(PlayerUpscalerMode mode) async {
+    try {
+      final result = (_delegate as dynamic).setUpscaler(mode);
+      if (result is Future) {
+        await result;
+      }
+    } catch (_) {}
+  }
+
+  Future<PlayerUpscalerStatus?> getUpscalerStatus() async {
+    try {
+      final result = (_delegate as dynamic).getUpscalerStatus();
+      final status = result is Future ? await result : result;
+      if (status is PlayerUpscalerStatus) {
+        return status;
+      }
+    } catch (_) {}
+    return null;
+  }
+
   // ---- Native danmaku passthrough ----
   // Some kernels (Erika) composite danmaku into the video frame natively.
   // These forward to the delegate via dynamic dispatch so the abstraction

--- a/lib/player_abstraction/player_data_models.dart
+++ b/lib/player_abstraction/player_data_models.dart
@@ -1,5 +1,57 @@
 import 'dart:typed_data';
 
+enum PlayerUpscalerMode {
+  off,
+  erikaArtCnnC4F16,
+  erikaArtCnnC4F32,
+}
+
+enum PlayerUpscalerBackendStatus {
+  off,
+  inactive,
+  building,
+  scalar,
+  simdgroupMatrix,
+  unknown,
+}
+
+class PlayerUpscalerStatus {
+  final PlayerUpscalerMode requestedMode;
+  final PlayerUpscalerBackendStatus activeBackend;
+  final int fallbackCount;
+  final int upscaledFrames;
+  final Duration lastEncodeDuration;
+  final Duration lastGpuDuration;
+
+  const PlayerUpscalerStatus({
+    required this.requestedMode,
+    required this.activeBackend,
+    required this.fallbackCount,
+    required this.upscaledFrames,
+    required this.lastEncodeDuration,
+    required this.lastGpuDuration,
+  });
+
+  const PlayerUpscalerStatus.off()
+      : requestedMode = PlayerUpscalerMode.off,
+        activeBackend = PlayerUpscalerBackendStatus.off,
+        fallbackCount = 0,
+        upscaledFrames = 0,
+        lastEncodeDuration = Duration.zero,
+        lastGpuDuration = Duration.zero;
+
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'requestedMode': requestedMode.name,
+      'activeBackend': activeBackend.name,
+      'fallbackCount': fallbackCount,
+      'upscaledFrames': upscaledFrames,
+      'lastEncodeMicros': lastEncodeDuration.inMicroseconds,
+      'lastGpuMicros': lastGpuDuration.inMicroseconds,
+    };
+  }
+}
+
 class PlayerFrame {
   final int width;
   final int height;
@@ -94,7 +146,7 @@ class PlayerMediaInfo {
     this.subtitle,
     this.specificErrorMessage,
   });
-  
+
   // 添加copyWith方法以便更新个别字段
   PlayerMediaInfo copyWith({
     int? duration,
@@ -111,4 +163,4 @@ class PlayerMediaInfo {
       specificErrorMessage: specificErrorMessage ?? this.specificErrorMessage,
     );
   }
-} 
+}

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_player_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_player_settings_page.dart
@@ -10,6 +10,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 import 'package:nipaplay/danmaku_next/next2_platform_support.dart';
+import 'package:nipaplay/player_abstraction/player_data_models.dart';
 import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/providers/labs_settings_provider.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
@@ -311,6 +312,28 @@ class _CupertinoPlayerSettingsPageState
     }
   }
 
+  String _getErikaUpscalerTitle(PlayerUpscalerMode mode) {
+    switch (mode) {
+      case PlayerUpscalerMode.off:
+        return '关闭';
+      case PlayerUpscalerMode.erikaArtCnnC4F16:
+        return 'ART-CNN C4F16';
+      case PlayerUpscalerMode.erikaArtCnnC4F32:
+        return 'ART-CNN C4F32';
+    }
+  }
+
+  String _getErikaUpscalerDescription(PlayerUpscalerMode mode) {
+    switch (mode) {
+      case PlayerUpscalerMode.off:
+        return '不启用 Erika 内核超分辨率';
+      case PlayerUpscalerMode.erikaArtCnnC4F16:
+        return '半精度 ART-CNN，速度优先，推荐日常播放';
+      case PlayerUpscalerMode.erikaArtCnnC4F32:
+        return '单精度 ART-CNN，画质优先，对 GPU 压力更高';
+    }
+  }
+
   String _getDanmakuRenderEngineDescription(DanmakuRenderEngine engine) {
     switch (engine) {
       case DanmakuRenderEngine.cpu:
@@ -402,13 +425,23 @@ class _CupertinoPlayerSettingsPageState
   }) {
     return PlayerKernelType.values
         .where(
-          (kernel) =>
-              kernel != PlayerKernelType.erika || showErikaKernel,
+          (kernel) => kernel != PlayerKernelType.erika || showErikaKernel,
         )
         .map(
           (kernel) => AdaptivePopupMenuItem<PlayerKernelType>(
             label: _kernelDisplayName(kernel),
             value: kernel,
+          ),
+        )
+        .toList();
+  }
+
+  List<AdaptivePopupMenuEntry> _erikaUpscalerMenuItems() {
+    return PlayerUpscalerMode.values
+        .map(
+          (mode) => AdaptivePopupMenuItem<PlayerUpscalerMode>(
+            label: _getErikaUpscalerTitle(mode),
+            value: mode,
           ),
         )
         .toList();
@@ -795,6 +828,54 @@ class _CupertinoPlayerSettingsPageState
             ),
           ],
         ),
+      if (visibleKernelType == PlayerKernelType.erika) ...[
+        const SizedBox(height: 16),
+        Consumer<VideoPlayerState>(
+          builder: (context, videoState, child) {
+            final currentMode = videoState.erikaUpscalerMode;
+            return CupertinoSettingsGroupCard(
+              margin: EdgeInsets.zero,
+              backgroundColor: sectionBackground,
+              addDividers: true,
+              dividerIndent: 16,
+              children: [
+                CupertinoSettingsTile(
+                  leading: Icon(
+                    CupertinoIcons.sparkles,
+                    color: resolveSettingsIconColor(context),
+                  ),
+                  title: const Text('Erika 超分辨率'),
+                  subtitle: Text(_getErikaUpscalerDescription(currentMode)),
+                  trailing: AdaptivePopupMenuButton.widget<PlayerUpscalerMode>(
+                    items: _erikaUpscalerMenuItems(),
+                    buttonStyle: PopupButtonStyle.gray,
+                    child: _buildMenuChip(
+                      context,
+                      _getErikaUpscalerTitle(currentMode),
+                    ),
+                    onSelected: (index, entry) async {
+                      final mode =
+                          entry.value ?? PlayerUpscalerMode.values[index];
+                      if (mode == currentMode) return;
+                      await videoState.setErikaUpscalerMode(mode);
+                      if (!context.mounted) return;
+                      final message = mode == PlayerUpscalerMode.off
+                          ? '已关闭 Erika 超分辨率'
+                          : 'Erika 超分辨率已切换为${_getErikaUpscalerTitle(mode)}';
+                      AdaptiveSnackBar.show(
+                        context,
+                        message: message,
+                        type: AdaptiveSnackBarType.success,
+                      );
+                    },
+                  ),
+                  backgroundColor: tileBackground,
+                ),
+              ],
+            );
+          },
+        ),
+      ],
       if (visibleKernelType == PlayerKernelType.mdk ||
           visibleKernelType == PlayerKernelType.mediaKit) ...[
         const SizedBox(height: 16),

--- a/lib/themes/nipaplay/pages/settings/player_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/player_settings_page.dart
@@ -16,6 +16,7 @@ import 'package:nipaplay/l10n/l10n.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_button.dart';
+import 'package:nipaplay/player_abstraction/player_data_models.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_card.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_item.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
@@ -57,6 +58,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
   final GlobalKey _danmakuRenderEngineDropdownKey = GlobalKey();
   final GlobalKey _spoilerAiApiFormatDropdownKey = GlobalKey();
   final GlobalKey _androidAudioOutputDropdownKey = GlobalKey();
+  final GlobalKey _erikaUpscalerDropdownKey = GlobalKey();
 
   final TextEditingController _spoilerAiUrlController = TextEditingController();
   final TextEditingController _spoilerAiModelController =
@@ -497,6 +499,28 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
     }
   }
 
+  String _getErikaUpscalerTitle(PlayerUpscalerMode mode) {
+    switch (mode) {
+      case PlayerUpscalerMode.off:
+        return '关闭';
+      case PlayerUpscalerMode.erikaArtCnnC4F16:
+        return 'ART-CNN C4F16';
+      case PlayerUpscalerMode.erikaArtCnnC4F32:
+        return 'ART-CNN C4F32';
+    }
+  }
+
+  String _getErikaUpscalerDescription(PlayerUpscalerMode mode) {
+    switch (mode) {
+      case PlayerUpscalerMode.off:
+        return '不启用 Erika 内核超分辨率';
+      case PlayerUpscalerMode.erikaArtCnnC4F16:
+        return '半精度 ART-CNN，速度优先，推荐日常播放';
+      case PlayerUpscalerMode.erikaArtCnnC4F32:
+        return '单精度 ART-CNN，画质优先，对 GPU 压力更高';
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -548,6 +572,43 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
               _savePlayerKernelSettings(kernelType);
             },
             dropdownKey: _playerKernelDropdownKey,
+          ),
+          Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+        ],
+        if (visibleKernelType == PlayerKernelType.erika) ...[
+          Consumer<VideoPlayerState>(
+            builder: (context, videoState, child) {
+              final currentMode = videoState.erikaUpscalerMode;
+              final items = PlayerUpscalerMode.values
+                  .map(
+                    (mode) => DropdownMenuItemData(
+                      title: _getErikaUpscalerTitle(mode),
+                      value: mode,
+                      isSelected: mode == currentMode,
+                      description: _getErikaUpscalerDescription(mode),
+                    ),
+                  )
+                  .toList();
+              return SettingsItem.dropdown(
+                title: 'Erika 超分辨率',
+                subtitle: '使用 Erika Metal ART-CNN 对视频帧做实时超分',
+                icon: Ionicons.sparkles_outline,
+                items: items,
+                onChanged: (dynamic value) async {
+                  if (value is! PlayerUpscalerMode) return;
+                  await videoState.setErikaUpscalerMode(value);
+                  if (!context.mounted) return;
+                  final option = _getErikaUpscalerTitle(value);
+                  BlurSnackBar.show(
+                    context,
+                    value == PlayerUpscalerMode.off
+                        ? '已关闭 Erika 超分辨率'
+                        : 'Erika 超分辨率已切换为$option',
+                  );
+                },
+                dropdownKey: _erikaUpscalerDropdownKey,
+              );
+            },
           ),
           Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
         ],

--- a/lib/themes/nipaplay/widgets/playback_info_menu.dart
+++ b/lib/themes/nipaplay/widgets/playback_info_menu.dart
@@ -77,6 +77,7 @@ class _PlaybackInfoMenuState extends State<PlaybackInfoMenu> {
   Widget build(BuildContext context) {
     return Consumer<VideoPlayerState>(
       builder: (context, videoState, child) {
+        final erikaUpscalerInfo = _getErikaUpscalerInfo(videoState);
         return BaseSettingsMenu(
           title: '播放信息',
           onClose: widget.onClose,
@@ -92,6 +93,10 @@ class _PlaybackInfoMenuState extends State<PlaybackInfoMenu> {
                 _buildInfoCard('播放状态', _getPlaybackStatusInfo(videoState)),
                 const SizedBox(height: 12),
                 _buildInfoCard('视频信息', _getVideoInfo(videoState)),
+                if (erikaUpscalerInfo.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  _buildInfoCard('Erika 超分', erikaUpscalerInfo),
+                ],
                 const SizedBox(height: 12),
                 _buildInfoCard('音频信息', _getAudioInfo(videoState)),
                 const SizedBox(height: 12),
@@ -352,6 +357,81 @@ style: TextStyle(
         if (colorSpace != '未知') InfoItem('色彩空间', colorSpace),
       ];
     }
+  }
+
+  List<InfoItem> _getErikaUpscalerInfo(VideoPlayerState videoState) {
+    final detailedInfo =
+        _asyncDetailedInfo ?? videoState.player.getDetailedMediaInfo();
+    final rawUpscaler = detailedInfo['upscaler'];
+    if (rawUpscaler is! Map) {
+      return const <InfoItem>[];
+    }
+
+    final requestedMode = _normalizeText(rawUpscaler['requestedMode']) ?? 'off';
+    final activeBackend =
+        _normalizeText(rawUpscaler['activeBackend']) ?? 'unknown';
+    final fallbackCount = _toNum(rawUpscaler['fallbackCount'])?.toInt() ?? 0;
+    final upscaledFrames = _toNum(rawUpscaler['upscaledFrames'])?.toInt() ?? 0;
+    final encodeMicros =
+        _toNum(rawUpscaler['lastEncodeMicros'])?.toInt() ?? 0;
+    final gpuMicros = _toNum(rawUpscaler['lastGpuMicros'])?.toInt() ?? 0;
+    final activeFastPath = activeBackend == 'simdgroupMatrix';
+
+    return [
+      InfoItem('请求模式', _formatErikaUpscalerMode(requestedMode)),
+      InfoItem(
+        '实际后端',
+        _formatErikaUpscalerBackend(activeBackend),
+        activeFastPath,
+      ),
+      InfoItem('回退次数', '$fallbackCount', fallbackCount == 0),
+      InfoItem('已处理帧', '$upscaledFrames'),
+      InfoItem(
+        '最近耗时',
+        'encode ${_formatMicrosAsMs(encodeMicros)} / gpu ${_formatMicrosAsMs(gpuMicros)}',
+      ),
+    ];
+  }
+
+  String _formatErikaUpscalerMode(String mode) {
+    switch (mode) {
+      case 'erikaArtCnnC4F16':
+      case 'artCnnC4F16':
+        return 'ART-CNN C4F16';
+      case 'erikaArtCnnC4F32':
+      case 'artCnnC4F32':
+        return 'ART-CNN C4F32';
+      case 'off':
+        return '关闭';
+      default:
+        return mode;
+    }
+  }
+
+  String _formatErikaUpscalerBackend(String backend) {
+    switch (backend) {
+      case 'simdgroupMatrix':
+        return 'SIMD-group Matrix';
+      case 'scalar':
+        return 'Scalar fallback';
+      case 'building':
+        return '构建中';
+      case 'inactive':
+        return '未激活';
+      case 'off':
+        return '关闭';
+      case 'unknown':
+        return '未知';
+      default:
+        return backend;
+    }
+  }
+
+  String _formatMicrosAsMs(int micros) {
+    if (micros <= 0) {
+      return '0 ms';
+    }
+    return '${(micros / 1000.0).toStringAsFixed(2)} ms';
   }
 
   List<InfoItem> _getAudioInfo(VideoPlayerState videoState) {

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -417,6 +417,8 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   };
   final String _doubleResolutionPlaybackKey = 'double_resolution_playback';
   bool _doubleResolutionPlaybackEnabled = false;
+  final String _erikaUpscalerModeKey = 'erika_upscaler_mode';
+  PlayerUpscalerMode _erikaUpscalerMode = PlayerUpscalerMode.off;
   final String _crtProfileKey = 'crt_profile';
   CrtProfile _crtProfile = CrtProfile.off;
   List<String> _crtShaderPaths = const <String>[];
@@ -1246,6 +1248,8 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   bool get isAnime4KSupported => _supportsAnime4KForCurrentPlayer();
   bool get doubleResolutionPlaybackEnabled => _doubleResolutionPlaybackEnabled;
   bool get isDoubleResolutionSupported => _supportsAnime4KForCurrentPlayer();
+  PlayerUpscalerMode get erikaUpscalerMode => _erikaUpscalerMode;
+  bool get isErikaUpscalerSupported => _supportsErikaUpscalerForCurrentPlayer();
   List<String> get anime4kShaderPaths => List.unmodifiable(_anime4kShaderPaths);
   CrtProfile get crtProfile => _crtProfile;
   bool get isCrtEnabled => _crtProfile != CrtProfile.off;

--- a/lib/utils/video_player_state/video_player_state_initialization.dart
+++ b/lib/utils/video_player_state/video_player_state_initialization.dart
@@ -8,6 +8,11 @@ extension VideoPlayerStateInitialization on VideoPlayerState {
       debugPrint('[VideoPlayerState] 提前加载双倍分辨率设置失败: $e');
     }
     try {
+      await _loadErikaUpscalerMode();
+    } catch (e) {
+      debugPrint('[VideoPlayerState] 提前加载 Erika 超分设置失败: $e');
+    }
+    try {
       await _loadAnime4KProfile();
     } catch (e) {
       debugPrint('[VideoPlayerState] 提前加载 Anime4K 设置失败: $e');

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -345,6 +345,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
       }
 
       player.media = playUrl;
+      await applyErikaUpscalerModeToCurrentPlayer();
 
       //debugPrint('4. 准备播放器...');
       // 准备播放器
@@ -749,6 +750,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
 
       // 新视频加载后应用超分辨率/CRT 等设置（避免播放中切换导致卡顿）
       await applyAnime4KProfileToCurrentPlayer();
+      await applyErikaUpscalerModeToCurrentPlayer();
 
       // 使用屏幕方向管理器设置播放时的屏幕方向
       if (globals.isMobilePlatform) {

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -738,6 +738,58 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _notifyListeners();
   }
 
+  Future<void> _loadErikaUpscalerMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getInt(_erikaUpscalerModeKey);
+    final resolved = stored != null &&
+            stored >= 0 &&
+            stored < PlayerUpscalerMode.values.length
+        ? PlayerUpscalerMode.values[stored]
+        : PlayerUpscalerMode.off;
+    if (_erikaUpscalerMode != resolved) {
+      _erikaUpscalerMode = resolved;
+      _notifyListeners();
+    } else {
+      _erikaUpscalerMode = resolved;
+    }
+    await applyErikaUpscalerModeToCurrentPlayer();
+  }
+
+  Future<void> setErikaUpscalerMode(PlayerUpscalerMode mode) async {
+    if (_erikaUpscalerMode == mode) {
+      await applyErikaUpscalerModeToCurrentPlayer();
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await _persistIntWithRetry(
+      prefs,
+      _erikaUpscalerModeKey,
+      mode.index,
+      settingName: 'Erika 超分辨率',
+    );
+    _erikaUpscalerMode = mode;
+    await applyErikaUpscalerModeToCurrentPlayer();
+    _notifyListeners();
+  }
+
+  Future<void> applyErikaUpscalerModeToCurrentPlayer() async {
+    if (_isDisposed || !player.supportsUpscaler) {
+      return;
+    }
+    await player.setUpscaler(_erikaUpscalerMode);
+  }
+
+  bool _supportsErikaUpscalerForCurrentPlayer() {
+    if (kIsWeb) {
+      return false;
+    }
+    try {
+      return player.supportsUpscaler;
+    } catch (_) {
+      return false;
+    }
+  }
+
   Future<void> _loadAnime4KProfile() async {
     try {
       final prefs = await SharedPreferences.getInstance();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -283,8 +283,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: "403049af63cd104d7a99855d48069abc1169529b"
-      resolved-ref: "403049af63cd104d7a99855d48069abc1169529b"
+      ref: "156fedc6052b95a0ab6f31d825794a85b55b8ec5"
+      resolved-ref: "156fedc6052b95a0ab6f31d825794a85b55b8ec5"
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,7 @@ dependencies:
   erika_flutter:
     git:
       url: https://github.com/AimesSoft/Erika.git
-      ref: 403049af63cd104d7a99855d48069abc1169529b
+      ref: 156fedc6052b95a0ab6f31d825794a85b55b8ec5
       path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   qr_code_scanner_plus: ^2.0.12


### PR DESCRIPTION
## Summary
- Add Erika Metal ART-CNN real-time video upscaler integration with two quality presets (C4F16 speed / C4F32 quality)
- Add settings UI in both Cupertino and Nipaplay themes for selecting upscaler mode
- Show upscaler status (active backend, fallback count, processed frames, encode/gpu timing) in playback info menu
- Persist upscaler preference and auto-apply on media load

## Changes
- **player_data_models.dart**: New `PlayerUpscalerMode`, `PlayerUpscalerBackendStatus` enums and `PlayerUpscalerStatus` model
- **erika_player_adapter.dart**: Implement `setUpscaler` / `getUpscalerStatus` with native bridge conversion
- **player_abstraction.dart**: Dynamic dispatch wrapper for upscaler methods
- **video_player_state_*.dart**: Preference persistence, initialization, and auto-apply on player setup
- **cupertino_player_settings_page.dart** / **player_settings_page.dart**: Settings dropdown for upscaler mode
- **playback_info_menu.dart**: Upcasted info card showing upscaler runtime status
- **pubspec.yaml**: Bump Erika dependency to include upscaler API