### PR TITLE
docs: remove AUR link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,6 @@ brew tap AimesSoft/nipaplay-reload
 brew install --cask nipaplay-reload
 ```
 
-#### Arch Linux (AUR)
-
-```bash
-paru -S nipaplay-reload-bin
-# 或
-yay -S nipaplay-reload-bin
-```
-
 #### Gentoo Linux
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ brew tap AimesSoft/nipaplay-reload
 brew install --cask nipaplay-reload
 ```
 
+
+> **⚠️ 安全警告**
+> Arch Linux AUR 中的 `nipaplay-reload-bin` 和 `misuzu-music-bin` 包已被恶意用户接管，**请勿安装**。如需在 Arch Linux 上使用，请从 GitHub Releases 下载。
+
 #### Gentoo Linux
 
 ```bash


### PR DESCRIPTION
## Summary
- Remove the Arch Linux (AUR) section from README.md
- Add security warning about compromised AUR packages

## Reason
The original AUR packages (`nipaplay-reload-bin` and `misuzu-music-bin`) have been abandoned by their maintainer and subsequently taken over by malicious users. The installation instructions are removed and a prominent warning is added to prevent users from installing potentially compromised packages.

## Changes
- Removed `#### Arch Linux (AUR)` section and associated `paru`/`yay` install commands from README
- Added a security warning blockquote alerting users about the compromised AUR packages
