### PR TITLE
[codex] fix latest action build failures

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -148,7 +148,7 @@ runs:
         erika_sha = os.environ["ERIKA_SHA"]
 
         def update_erika_block(path, replacements):
-            lines = Path(path).read_text().splitlines(keepends=True)
+            lines = Path(path).read_text(encoding="utf-8").splitlines(keepends=True)
             output = []
             in_block = False
             seen = set()
@@ -182,7 +182,7 @@ runs:
                 if missing:
                     raise SystemExit(f"{path}: missing Erika fields: {sorted(missing)}")
 
-            Path(path).write_text("".join(output))
+            Path(path).write_text("".join(output), encoding="utf-8")
 
         update_erika_block("pubspec.yaml", {"ref": "main"})
         update_erika_block(

--- a/.github/patches/libmpv-darwin-build-macos-hdr-target-arch.patch
+++ b/.github/patches/libmpv-darwin-build-macos-hdr-target-arch.patch
@@ -71,3 +71,16 @@ diff --git a/nix/packages/mk-pkg-mpv/default.nix b/nix/packages/mk-pkg-mpv/defau
      else
        null;
    isMacOSHdrProfile =
+diff --git a/nix/packages/mk-pkg-uchardet/default.nix b/nix/packages/mk-pkg-uchardet/default.nix
+--- a/nix/packages/mk-pkg-uchardet/default.nix
++++ b/nix/packages/mk-pkg-uchardet/default.nix
+@@ -14,7 +14,8 @@
+   pname = import ../../utils/name/package.nix name;
+   src = callPackage ../../utils/fetch-tarball/default.nix {
+     name = "${pname}-source-${version}";
+-    inherit (packageLock) url sha256;
++    url = "https://distfiles.macports.org/uchardet/uchardet-${version}.tar.xz";
++    inherit (packageLock) sha256;
+   };
+   patchedSource = pkgs.runCommand "${pname}-patched-source-${version}" { } ''
+     mkdir -p $out/subprojects/uchardet

--- a/lib/utils/subtitle_parser.dart
+++ b/lib/utils/subtitle_parser.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'dart:convert';
 import 'dart:typed_data';
 import 'package:charset_converter/charset_converter.dart';
-import 'package:nipaplay/cpp_native/nipaplay_native.dart';
+import 'package:nipaplay/cpp_native/bindings/subtitle_parser.dart';
 
 class SubtitleDecodeResult {
   final String text;

--- a/lib/utils/system_resource_monitor.dart
+++ b/lib/utils/system_resource_monitor.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:fvp/mdk.dart'
-    if (dart.library.html) 'package:nipaplay/utils/mock_mdk.dart';
+import 'package:nipaplay/utils/mock_mdk.dart'
+    if (dart.library.io) 'package:fvp/mdk.dart';
 import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/src/rust/api/performance.dart' as rust_perf;


### PR DESCRIPTION
## Summary

- Keep the Web build off native-only FFI paths by importing the existing subtitle parser conditional export and using the MDK mock as the default Web import.
- Read and write `pubspec.yaml` / `pubspec.lock` as UTF-8 in the setup action so Windows runners do not fall back to cp1252.
- Extend the macOS libmpv patch to fetch uchardet from the MacPorts distfiles mirror, preserving the existing locked SHA256 after the freedesktop URL returned HTTP 418.

## Root Cause

The latest `Build & Release (Modular)` run failed in multiple platform jobs:

- Linux amd64/arm64 failed during `build_and_copy_web.sh` because the Web build imported native FFI libraries (`dart:ffi`) through `subtitle_parser.dart` and the MDK import path.
- Windows failed in `Setup Flutter Environment` because Python used the Windows default cp1252 encoding while reading UTF-8 project files.
- macOS failed while building libmpv xcframeworks because Nix could not download `uchardet-0.0.8.tar.xz` from freedesktop.org (`HTTP 418`).

## Validation

- `flutter pub get`
- `flutter build web`
- `flutter analyze lib/utils/subtitle_parser.dart lib/utils/system_resource_monitor.dart`
- `git -C third_party/libmpv-darwin-build apply --check .github/patches/libmpv-darwin-build-macos-hdr-target-arch.patch`
- Verified the MacPorts uchardet tarball hash matches the lockfile SHA256: `e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0`