### PR TITLE
fix(ci):macos&windows build fail

### DIFF
--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -32,6 +32,58 @@ runs:
         }
         cd ..
     
+    - name: Pre-download FVP mdk-sdk (workaround symlink extraction issue)
+      shell: pwsh
+      run: |
+        # FVP's deps.cmake extracts mdk-sdk into CMAKE_CURRENT_SOURCE_DIR, which
+        # resolves through Flutter's .plugin_symlinks to a UNC path (\\?\D:\...).
+        # CMake's "cmake -E tar" cannot extract 7z archives through such paths.
+        # Workaround: pre-download and extract mdk-sdk into the real FVP package
+        # directory so that deps.cmake detects it and skips extraction.
+        $fvpDirs = Get-ChildItem -Path "$env:LOCALAPPDATA\Pub\Cache\hosted\pub.dev\fvp-*" -Directory -ErrorAction SilentlyContinue
+        if (-not $fvpDirs) {
+          # Fallback: try .pub-cache (older Flutter)
+          $fvpDirs = Get-ChildItem -Path "$env:USERPROFILE\.pub-cache\hosted\pub.dev\fvp-*" -Directory -ErrorAction SilentlyContinue
+        }
+        if (-not $fvpDirs) {
+          Write-Host "FVP package not found in pub cache; will rely on CMake extraction."
+          return
+        }
+        $fvpDir = $fvpDirs[0].FullName
+        $mdkSdkDir = Join-Path $fvpDir "windows\mdk-sdk"
+        $findMdk = Join-Path $mdkSdkDir "lib\cmake\FindMDK.cmake"
+        if (Test-Path $findMdk) {
+          Write-Host "mdk-sdk already exists at $mdkSdkDir; skipping pre-download."
+          return
+        }
+
+        $mdkSdkPkg = "mdk-sdk-windows-desktop-vs2022-x64.7z"
+        $depsUrl = $env:FVP_DEPS_URL
+        if ($depsUrl -match "^http") {
+          $downloadUrl = "$depsUrl/$mdkSdkPkg"
+        } else {
+          $downloadUrl = "https://sourceforge.net/projects/mdk-sdk/files/nightly/$mdkSdkPkg"
+        }
+
+        $archivePath = Join-Path $fvpDir "windows\$mdkSdkPkg"
+        Write-Host "Downloading mdk-sdk from $downloadUrl ..."
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath -UseBasicParsing
+
+        # Extract using 7-Zip (CMake's tar can't handle 7z on Windows reliably)
+        $sevenZip = Join-Path ${env:ProgramFiles} "7-Zip\7z.exe"
+        if (-not (Test-Path $sevenZip)) {
+          choco install 7zip -y --no-progress
+        }
+        $windowsDir = Join-Path $fvpDir "windows"
+        Write-Host "Extracting mdk-sdk to $windowsDir ..."
+        & $sevenZip x $archivePath "-o$windowsDir" -y | Out-Null
+
+        if (Test-Path $findMdk) {
+          Write-Host "mdk-sdk pre-downloaded and extracted successfully."
+        } else {
+          Write-Error "mdk-sdk extraction failed; FindMDK.cmake not found at $findMdk"
+        }
+
     - name: Build Web and copy assets
       shell: bash
       run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -101,6 +101,22 @@ jobs:
             git -C third_party/libmpv-darwin-build apply "$PATCH_FILE"
           fi
 
+      - name: Patch uchardet download URL (Debian mirror)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # freedesktop.org returns HTTP 418 (Anubis anti-bot) from CI.
+          # Replace with Debian mirror that hosts the same tarball (identical sha256).
+          LOCK_FILE="third_party/libmpv-darwin-build/packages.lock.nix"
+          OLD_URL='https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz'
+          NEW_URL='https://deb.debian.org/debian/pool/main/u/uchardet/uchardet_0.0.8.orig.tar.xz'
+          if grep -qF "$OLD_URL" "$LOCK_FILE"; then
+            sed -i "s|${OLD_URL}|${NEW_URL}|" "$LOCK_FILE"
+            echo "Patched uchardet URL to Debian mirror."
+          else
+            echo "uchardet URL already patched or different; skipping."
+          fi
+
       - name: Build macOS libmpv xcframeworks from source
         id: build-libmpv
         shell: bash

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -60,20 +60,30 @@ jobs:
           set -euo pipefail
           FETCH_CACHE="$(mktemp -d)"
           echo "LIBMPV_DARWIN_FETCH_CACHE_DIR=${FETCH_CACHE}" >> "$GITHUB_ENV"
-          # The Nix fetch-file helper looks for <cache-dir>/<url-basename>.
-          # packages.lock.nix URL ends in uchardet-0.0.8.tar.xz, so the
-          # cached file MUST be named exactly that (same format & content).
-          TARGET="${FETCH_CACHE}/uchardet-0.0.8.tar.xz"
-          PRIMARY="https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz"
-          # Try primary URL with retries (HTTP 418 is usually transient)
-          for attempt in 1 2 3; do
-            echo "Attempt ${attempt}: ${PRIMARY}"
-            if curl -fSL --retry 3 --retry-delay 5 -o "$TARGET" "$PRIMARY" 2>/dev/null; then
-              echo "Downloaded uchardet from primary URL"
-              exit 0
+          # The Nix fetch-file helper resolves the URL basename for the cache.
+          # packages.lock.nix now points to the Debian mirror, so the expected
+          # cache filename is uchardet_0.0.8.orig.tar.xz
+          TARGET="${FETCH_CACHE}/uchardet_0.0.8.orig.tar.xz"
+          MIRRORS=(
+            "https://deb.debian.org/debian/pool/main/u/uchardet/uchardet_0.0.8.orig.tar.xz"
+            "https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz"
+          )
+          for url in "${MIRRORS[@]}"; do
+            echo "Trying ${url} ..."
+            if curl -fSL --retry 3 --retry-delay 5 -o "$TARGET" "$url" 2>/dev/null; then
+              echo "Downloaded uchardet from ${url}"
+              # Verify sha256 matches packages.lock.nix
+              EXPECTED="e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0"
+              ACTUAL="$(shasum -a 256 "$TARGET" | cut -d' ' -f1)"
+              if [ "$ACTUAL" = "$EXPECTED" ]; then
+                echo "SHA256 verified OK"
+                exit 0
+              else
+                echo "SHA256 mismatch! Expected $EXPECTED, got $ACTUAL"
+                rm -f "$TARGET"
+              fi
             fi
-            echo "Attempt ${attempt} failed, waiting before retry..."
-            sleep 10
+            echo "Failed to download from ${url}, trying next mirror..."
           done
           echo "WARNING: Could not pre-fetch uchardet; Nix build will attempt direct download."
 


### PR DESCRIPTION
## Summary

1. macOS - uchardet 下载 HTTP 418（持续失败）
根因: freedesktop.org 部署了 Anubis 反爬虫保护，CI 环境的请求被拦截返回 HTTP 418。上一轮的预下载步骤也用了同一 URL，自然也失败。

修复:

将 uchardet 的下载 URL 从 freedesktop.org 改为 Debian 镜像 https://deb.debian.org/debian/pool/main/u/uchardet/uchardet_0.0.8.orig.tar.xz （sha256 已验证一致）
build-macos.yml: 更新预下载步骤，优先从 Debian 镜像下载，并验证 sha256

2. Windows - FVP mdk-sdk 解压失败
根因: FVP 的 deps.cmake 使用 CMAKE_CURRENT_SOURCE_DIR 解压 mdk-sdk，但 Flutter 的 .plugin_symlinks 使路径变成 UNC 格式 \\?\D:\...，CMake 的 cmake -E tar 无法通过此路径解压 7z。

修复: 在 build-windows/action.yml 中添加 "Pre-download FVP mdk-sdk" 步骤，在 CMake 构建前用 7-Zip 将 mdk-sdk 预解压到 FVP 包的实际目录，这样 deps.cmake 检测到 mdk-sdk/lib/cmake/FindMDK.cmake 已存在就跳过解压。
