### PR TITLE
ci:fix build fail v3

### DIFF
--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -58,16 +58,65 @@ runs:
         }
 
         $mdkSdkPkg = "mdk-sdk-windows-desktop-vs2022-x64.7z"
-        $depsUrl = $env:FVP_DEPS_URL
-        if ($depsUrl -match "^http") {
-          $downloadUrl = "$depsUrl/$mdkSdkPkg"
-        } else {
-          $downloadUrl = "https://sourceforge.net/projects/mdk-sdk/files/nightly/$mdkSdkPkg"
+        $archivePath = Join-Path $fvpDir "windows\$mdkSdkPkg"
+
+        # SourceForge intermittently serves an HTML interstitial/anti-bot page
+        # to CI runners instead of the 7z archive, which makes 7-Zip fail with
+        # "Is not archive". Download from several mirrors and validate the 7z
+        # magic bytes (37 7A BC AF 27 1C) before extracting; fall back to the
+        # GitHub release asset (which fvp's deps.cmake cannot use directly
+        # because it hardcodes the vs2022-x64 filename that only SourceForge has).
+        $sig = [byte[]](0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c)
+        $ua = @{ "User-Agent" = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" }
+
+        function Test-SevenZip {
+          param([string]$Path)
+          if (-not (Test-Path $Path)) { return $false }
+          $bytes = [System.IO.File]::ReadAllBytes($Path)
+          if ($bytes.Length -lt 6) { return $false }
+          for ($i = 0; $i -lt 6; $i++) { if ($bytes[$i] -ne $sig[$i]) { return $false } }
+          return $true
         }
 
-        $archivePath = Join-Path $fvpDir "windows\$mdkSdkPkg"
-        Write-Host "Downloading mdk-sdk from $downloadUrl ..."
-        Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath -UseBasicParsing
+        $candidates = @(
+          "https://sourceforge.net/projects/mdk-sdk/files/nightly/$mdkSdkPkg/download",
+          "https://downloads.sourceforge.net/project/mdk-sdk/nightly/$mdkSdkPkg",
+          "https://master.dl.sourceforge.net/project/mdk-sdk/nightly/$mdkSdkPkg"
+        )
+
+        $downloaded = $false
+        foreach ($url in $candidates) {
+          foreach ($attempt in 1..3) {
+            Write-Host "Downloading mdk-sdk from $url (attempt $attempt) ..."
+            try {
+              Invoke-WebRequest -Uri $url -OutFile $archivePath -UseBasicParsing -TimeoutSec 180 -Headers $ua
+            } catch {
+              Write-Warning "Download error from $url : $($_.Exception.Message)"
+              continue
+            }
+            if (Test-SevenZip $archivePath) {
+              Write-Host "Got valid 7z archive from $url"
+              $downloaded = $true
+              break
+            }
+            $len = (Get-Item $archivePath).Length
+            Write-Warning "Response from $url was not a 7z archive (size=$len bytes, likely HTML interstitial); retrying."
+            Remove-Item $archivePath -Force -ErrorAction SilentlyContinue
+            Start-Sleep -Seconds 3
+          }
+          if ($downloaded) { break }
+        }
+
+        if (-not $downloaded) {
+          $ghPkg = "mdk-sdk-windows-x64.7z"
+          $ghUrl = "https://github.com/wang-bin/mdk-sdk/releases/latest/download/$ghPkg"
+          $archivePath = Join-Path $fvpDir "windows\$ghPkg"
+          Write-Host "SourceForge mirrors unavailable; falling back to GitHub release $ghUrl ..."
+          Invoke-WebRequest -Uri $ghUrl -OutFile $archivePath -UseBasicParsing -TimeoutSec 180 -Headers $ua
+          if (-not (Test-SevenZip $archivePath)) {
+            throw "GitHub fallback download was not a valid 7z archive: $archivePath"
+          }
+        }
 
         # Extract using 7-Zip (CMake's tar can't handle 7z on Windows reliably)
         $sevenZip = Join-Path ${env:ProgramFiles} "7-Zip\7z.exe"
@@ -81,7 +130,7 @@ runs:
         if (Test-Path $findMdk) {
           Write-Host "mdk-sdk pre-downloaded and extracted successfully."
         } else {
-          Write-Error "mdk-sdk extraction failed; FindMDK.cmake not found at $findMdk"
+          throw "mdk-sdk extraction failed; FindMDK.cmake not found at $findMdk"
         }
 
     - name: Build Web and copy assets

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -111,7 +111,10 @@ jobs:
           OLD_URL='https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz'
           NEW_URL='https://deb.debian.org/debian/pool/main/u/uchardet/uchardet_0.0.8.orig.tar.xz'
           if grep -qF "$OLD_URL" "$LOCK_FILE"; then
-            sed -i "s|${OLD_URL}|${NEW_URL}|" "$LOCK_FILE"
+            # BSD sed (macOS) requires an argument for -i; `sed -i.bak` is
+            # portable across BSD and GNU sed. Remove the backup afterwards.
+            sed -i.bak "s|${OLD_URL}|${NEW_URL}|" "$LOCK_FILE"
+            rm -f "$LOCK_FILE.bak"
             echo "Patched uchardet URL to Debian mirror."
           else
             echo "uchardet URL already patched or different; skipping."

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,7 +19,12 @@ jobs:
       artifact-name: release-Windows-x64
     env:
       FVP_DEPS_URL: https://sourceforge.net/projects/mdk-sdk/files/nightly
-      FVP_DEPS_LATEST: 1
+      # Keep FVP_DEPS_LATEST unset (treated as 0): with it on, fvp's deps.cmake
+      # re-fetches mdk-sdk's .md5 from the SourceForge web frontend during
+      # `flutter build windows`, and SourceForge serves an HTML interstitial to
+      # CI runners that fatally breaks extraction. The mdk-sdk is pre-downloaded
+      # by the build-windows action, so fvp must trust it and skip downloads.
+      FVP_DEPS_LATEST: 0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Issue Analysis

macOS (build-macos.yml): uchardet-URL 补丁步骤使用了 sed -i "s|...|..."。BSD sed（macOS）的 -i 需要一个备份后缀参数；它将替换字符串误认为是后缀，并将文件名解析为脚本 → 导致 undefined label 'hird_party/...' 退出码 1。（已在实际的 BSD sed 上验证复现；修复方案可行。）

Windows: 两个复合缺陷，均源于对 SourceForge 的依赖：
1. 预下载步骤获取了原始的 SourceForge URL …/files/nightly/<pkg>，SourceForge 向 GitHub Actions runner 提供了 HTML 反爬虫/插页式页面，而不是 7z 压缩包 → 7-Zip 报错 Is not archive / Is not archive。没有对下载内容进行验证。
2. fvp 的 deps.cmake 为 Windows 硬编码了 mdk-sdk-windows-desktop-vs2022-x64.7z（该文件仅存在于 SourceForge 上；GitHub 发布版使用的是 mdk-sdk-windows-x64.7z），并且在 FVP_DEPS_LATEST=1 的情况下，它会在 flutter build windows 期间从 SourceForge Web 前端重新获取 .md5 文件。因此，即使预下载成功，在 deps.cmake 阶段构建仍会再次失败。（通过 CMake 确认 FVP_DEPS_LATEST=0 会使 if($ENV{…}) 为 false，从而跳过下载块。）

## What Changed

1. .github/workflows/build-macos.yml — sed -i.bak … && rm -f .bak（BSD/GNU 可移植）。
2. .github/workflows/build-windows.yml — FVP_DEPS_LATEST: 1 → 0，以便 fvp 信任预解压的 mdk-sdk（存在 FindMDK.cmake），并且在构建期间永远不会访问 SourceForge。
3. .github/actions/build-windows/action.yml — 强化了预下载：尝试 3 个 SourceForge 镜像 URL（/download、downloads.sourceforge.net、master.dl.sourceforge.net），每个重试 3 次，在解压前验证 7z 魔数（37 7A BC AF 27 1C，拒绝 HTML 插页式页面），并以 GitHub 发布版资源 mdk-sdk-windows-x64.7z 作为回退方案（已验证其可解压为 mdk-sdk/lib/cmake/FindMDK.cmake — 与 SourceForge 压缩包结构相同）。

## Test

- macOS sed 行为在本地 BSD sed 上已确认（旧命令报错，新命令可正常工作）。
- SourceForge 和 GitHub mdk 压缩包均可解压为相同的 mdk-sdk/lib/cmake/FindMDK.cmake 布局（通过 py7zr）。
- master.dl.sourceforge.net GET 请求返回 HTML → 魔数检查能正确拒绝它。
- CMake if($ENV{FVP_DEPS_LATEST}) 在值 0 时为 false。
