### PR TITLE
fix(ios): link Erika simulator build on Apple Silicon

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,4 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
+
+EXCLUDED_ARCHS[sdk=iphonesimulator*]=x86_64

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -27,6 +27,70 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 
 flutter_ios_podfile_setup
 
+def erika_ios_cabi_linker_flags
+  erika_cabi_symbols = %w[
+    erika_danmaku_track_info_free
+    erika_presenter_add_danmaku_track_file
+    erika_presenter_add_danmaku_track_json
+    erika_presenter_add_external_subtitle
+    erika_presenter_attach_metal_layer
+    erika_presenter_clear_danmaku
+    erika_presenter_close
+    erika_presenter_create
+    erika_presenter_create_with_output_mode
+    erika_presenter_danmaku_tracks
+    erika_presenter_destroy
+    erika_presenter_detach_surface
+    erika_presenter_get_danmaku_config
+    erika_presenter_get_upscaler_status
+    erika_presenter_load_danmaku_file
+    erika_presenter_load_danmaku_json
+    erika_presenter_open
+    erika_presenter_pause
+    erika_presenter_play
+    erika_presenter_poll_event
+    erika_presenter_remove_danmaku_track
+    erika_presenter_remove_subtitle_track
+    erika_presenter_render_tick
+    erika_presenter_resize_surface
+    erika_presenter_seek
+    erika_presenter_select_audio_track
+    erika_presenter_select_subtitle_track
+    erika_presenter_set_danmaku_block_words_json
+    erika_presenter_set_danmaku_config_ptr
+    erika_presenter_set_danmaku_enabled
+    erika_presenter_set_danmaku_font
+    erika_presenter_set_danmaku_global_offset
+    erika_presenter_set_danmaku_track_enabled
+    erika_presenter_set_danmaku_track_offset
+    erika_presenter_set_playback_rate
+    erika_presenter_set_upscaler
+    erika_presenter_set_volume
+    erika_presenter_stop
+    erika_presenter_track_selection
+    erika_presenter_tracks
+    erika_track_info_free
+  ]
+
+  erika_cabi_symbols.map { |symbol| "-Wl,-u,_#{symbol}" } + [
+    '$(PODS_TARGET_SRCROOT)/native/liberika_capi.a',
+    '-framework', 'Flutter',
+    '-framework', 'AVFoundation',
+    '-framework', 'AudioToolbox',
+    '-framework', 'QuartzCore',
+    '-framework', 'Metal',
+    '-framework', 'CoreVideo',
+    '-framework', 'CoreMedia',
+    '-framework', 'VideoToolbox',
+    '-framework', 'CoreFoundation',
+    '-framework', 'CoreGraphics',
+    '-framework', 'Foundation',
+    '-liconv',
+    '-lbz2',
+    '-lz',
+  ]
+end
+
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
@@ -46,6 +110,14 @@ post_install do |installer|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
       config.build_settings['SUPPORTED_PLATFORMS'] = 'iphoneos iphonesimulator'
       config.build_settings['ENABLE_BITCODE'] = 'NO'
+
+      next unless target.name == 'erika_flutter'
+
+      config.build_settings['OTHER_LDFLAGS'] = erika_ios_cabi_linker_flags
+      if `uname -m`.strip == 'arm64'
+        config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'i386 x86_64'
+        config.build_settings['ONLY_ACTIVE_ARCH'] = 'YES'
+      end
     end
   end
 end

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -753,7 +753,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = H6Y9B5HQ74;
 				ENABLE_BITCODE = NO;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",


### PR DESCRIPTION
Fix the iOS simulator build for Erika on Apple Silicon by:\n- forcing the erika_flutter C ABI flags to load before the static archive\n- excluding x86_64 for Erika's simulator pod target\n- excluding x86_64 for Runner debug simulator builds\n\nVerified with: flutter build ios --simulator --debug