### PR TITLE
fix: scope window-overlay letterboxing to iOS only (restore macOS)

### DIFF
--- a/lib/themes/nipaplay/widgets/video_player_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_player_ui.dart
@@ -306,23 +306,33 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
   }
 
   Widget _buildVideoSurfaceStage(VideoPlayerState videoState, int? textureId) {
-    // Size the surface to the real video aspect ratio and center it, matching
-    // the media-kit path. The window-hosted native plane mirrors this widget's
-    // rect, so this is what gives 21:9 content correct letterboxing instead of
-    // stretching/filling the whole screen.
+    if (_shouldUseWindowHostedVideoOverlay(videoState)) {
+      // iOS only: the native plane must not extend under the notch, so we
+      // letterbox the video into a centered safe-area sub-rect here and keep
+      // the surroundings transparent; Erika owns the black window background,
+      // which shows through as the bars.
+      //
+      // macOS keeps the full-bleed surface: there is no notch and Erika
+      // letterboxes natively into a full-screen plane. Flutter must NOT shrink
+      // the plane or paint around it, or the app UI behind shows through the
+      // (now transparent) bars.
+      if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) {
+        return Center(
+          child: AspectRatio(
+            aspectRatio: videoState.aspectRatio,
+            child: _buildVideoSurface(videoState, textureId),
+          ),
+        );
+      }
+      return _buildVideoSurface(videoState, textureId);
+    }
+
     final surface = Center(
       child: AspectRatio(
         aspectRatio: videoState.aspectRatio,
         child: _buildVideoSurface(videoState, textureId),
       ),
     );
-    if (_shouldUseWindowHostedVideoOverlay(videoState)) {
-      // The native surface sits below Flutter, so the area around the video
-      // must stay transparent; the black window background shows through as
-      // the letterbox bars. Painting a black ColoredBox here would cover the
-      // native video plane.
-      return surface;
-    }
     return ColoredBox(color: Colors.black, child: surface);
   }
 


### PR DESCRIPTION
## Summary
Follow-up to #657. That PR merged with `_buildVideoSurfaceStage` letterboxing the window-overlay video in Flutter (centered `AspectRatio` + transparent surroundings) on **every** platform. That is correct on iOS, but it regressed macOS.

## Regression on macOS
macOS hosts a **full-screen** native plane and Erika letterboxes into it natively. Shrinking that plane to an `AspectRatio` sub-rect and leaving the surroundings transparent made:
- the app UI behind the player show through the "letterbox bars" (they were transparent, not black), and
- the video shift / mis-position.

iOS needs the Flutter-side letterbox because the native plane must not extend under the notch (it's sized into a safe-area sub-rect, and the black window background shows through as the bars).

## Fix
Scope the Flutter-side `AspectRatio` path to **iOS only**; keep the full-bleed native surface on macOS (and any other window-overlay host).

## Verification
- `flutter analyze lib/themes/nipaplay/widgets/video_player_ui.dart` → no issues.
- macOS (Erika kernel): video centered with native black bars, no app UI bleed-through.
- iOS unchanged (centered 21:9 within the safe area; relies on Erika `6beff77` backing-layer fix already on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)