### PR TITLE
Fix/dfm optimize@7

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -82,6 +82,30 @@
 				<string>com.microsoft.windows-media-wmv</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>NipaPlay Backup</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.nipaplay.backup.npb</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>NipaPlay Legacy Backup</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.nipaplay.backup.nph</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
@@ -274,6 +298,48 @@
 				<key>public.mime-type</key>
 				<array>
 					<string>video/webm</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>NipaPlay Backup</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.nipaplay.backup.npb</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>npb</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/json</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>NipaPlay Legacy Backup</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.nipaplay.backup.nph</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>nph</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/json</string>
 				</array>
 			</dict>
 		</dict>

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -78,7 +78,6 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   bool _updateInFlight = false;
   bool _updateQueued = false;
 
-  double _lastTimeSeconds = -1.0;
   bool _forceLayout = false;
 
   // Optimized texture update state: avoid redundant per-frame async calls
@@ -127,29 +126,42 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
     return widget.scrollDurationSeconds * scale;
   }
 
-  // ── Wall-clock time interpolation ──
-  // Instead of advancing each item's displayX per frame (which requires
-  // fragile drift correction), we accumulate wall-clock dt since the last
-  // playbackTimeMs update and add it to create a vsync-rate smooth time:
-  //   interpolatedTime = playbackTime + accumulatedDt * playbackRate
-  // The existing absolute-position layout() handles this naturally:
-  //   x = width - speed * (interpolatedTime - item.time)
-  // When playbackTimeMs changes, we reset accumulatedDt to zero — the
-  // anchor point jumps but the interpolation is smooth between updates.
+  // ── Wall-clock time interpolation (constant-speed model) ──
+  // The video player's playbackTimeMs updates at a coarse rate (~30Hz),
+  // but the display refreshes at vsync rate (60/120/240Hz). To get smooth,
+  // CONSTANT-speed motion, we interpolate between media-clock ticks using
+  // wall-clock time:
+  //   interpolatedTime = anchorMediaTime + wallElapsed * playbackRate
+  // where wallElapsed = (wallClock.now - wallClockAtAnchor).
+  //
+  // KEY: when the media clock advances, we move BOTH anchorMediaTime AND
+  // wallClockAtAnchor together → wallElapsed = 0 → no time jump. There is
+  // no accumulated-dt / EMA, so there is no convergence period after seek or
+  // resume: the very first frame after a jump already advances at the true
+  // wall-clock rate (constant speed), and the media clock keeps the result
+  // aligned to the correct playback time over the long run.
   final Stopwatch _wallClock = Stopwatch()..start();
-  int _lastWallUs = 0;
 
   /// Wall time captured at the vsync callback entry point (not inside
   /// _runUpdateLoop which includes _tryUpdateTexture latency). Using the
   /// vsync-stamped time for dt computation prevents the async GPU submission
   /// latency from distorting the frame interval measurement.
   int _vsyncWallUs = 0;
-  double _accumulatedWallDt = 0.0;
-  double _lastAnchorPlaybackTime = -1.0;
-  double _smoothedDtSeconds = 0.0;
-  static const double _dtEmaAlpha = 0.3;
-  int _resumeFrameCount = 0;
-  static const int _resumeEmaFrames = 3;
+
+  /// Last sampled media time (seconds), captured from playbackTimeMs.
+  double _anchorMediaTime = 0.0;
+
+  /// Wall-clock microseconds at the moment _anchorMediaTime was sampled.
+  /// interpolatedTime = _anchorMediaTime + (wallNow - _wallUsAtAnchor) * rate.
+  int _wallUsAtAnchor = 0;
+
+  /// Whether the anchor has been initialized (first frame / after dispose).
+  bool _anchorInitialized = false;
+
+  /// Cap wall-elapsed to avoid a runaway jump if vsyncs stall for a long time
+  /// (e.g. tab backgrounded). Beyond this, the media clock should have updated
+  /// and re-anchored us.
+  static const double _maxWallElapsedSec = 0.2;
 
   // ── Submit-rate throttle (P1-4) ──
   // On high-refresh panels (>60Hz) the Dart layout+setFrame pipeline is
@@ -228,8 +240,7 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
     if (oldWidget.playbackTimeMs != widget.playbackTimeMs) {
       oldWidget.playbackTimeMs.removeListener(_queueUpdate);
       widget.playbackTimeMs.addListener(_queueUpdate);
-      _accumulatedWallDt = 0.0;
-      _lastAnchorPlaybackTime = widget.playbackTimeMs.value / 1000.0;
+      _reanchorToMediaTime();
       _queueUpdate();
     }
 
@@ -237,30 +248,36 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
     final shouldAnimate = widget.isVisible && widget.isPlaying;
     if (shouldAnimate && !_vsyncController.isAnimating) {
       _vsyncController.repeat();
-      // Reset wall-clock on resume to avoid a huge delta spanning the pause
-      _lastWallUs = _wallClock.elapsedMicroseconds;
-      _accumulatedWallDt = 0.0;
-      _smoothedDtSeconds = 0.0;
-      _resumeFrameCount = 0;
+      // Re-anchor on resume so wall-clock elapsed starts from zero — no huge
+      // delta spanning the pause, and the first frame already moves at the
+      // true wall-clock rate (constant speed, no slow convergence).
+      _reanchorToMediaTime();
     } else if (!shouldAnimate && _vsyncController.isAnimating) {
       _vsyncController.stop();
     }
 
-    // ── Playback rate change: reset interpolation ──
+    // ── Playback rate change: re-anchor ──
+    // Re-anchoring keeps wallElapsed = 0 at the instant of the rate change,
+    // so the new rate applies going forward without a speed blip.
     if (oldWidget.playbackRate != widget.playbackRate) {
-      _accumulatedWallDt = 0.0;
-      _lastAnchorPlaybackTime = widget.playbackTimeMs.value / 1000.0;
+      _reanchorToMediaTime();
     }
 
-    // ── isPlaying transition: reset wall-clock ──
+    // ── isPlaying transition: re-anchor ──
     if (oldWidget.isPlaying != widget.isPlaying) {
       if (widget.isPlaying) {
-        _lastWallUs = _wallClock.elapsedMicroseconds;
-        _accumulatedWallDt = 0.0;
-        _smoothedDtSeconds = 0.0;
-        _resumeFrameCount = 0;
+        _reanchorToMediaTime();
       }
     }
+  }
+
+  /// Re-anchor the wall-clock interpolation to the current media time.
+  /// Sets _anchorMediaTime and _wallUsAtAnchor together so that wallElapsed
+  /// becomes 0 at this instant — no time jump, no convergence period.
+  void _reanchorToMediaTime() {
+    _anchorMediaTime = widget.playbackTimeMs.value / 1000.0;
+    _wallUsAtAnchor = _wallClock.elapsedMicroseconds;
+    _anchorInitialized = true;
   }
 
   @override
@@ -415,89 +432,66 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
           continue;
         }
 
-        // ── Compute wall-clock dt from vsync-stamped time ──
+        // ── Constant-speed wall-clock interpolation ──
         // _vsyncWallUs is captured in _queueUpdate() (vsync callback entry),
         // NOT at the top of _runUpdateLoop — otherwise the async
         // _tryUpdateTexture latency from the previous iteration would
         // inflate the measured interval and cause interpolatedTime jumps.
         final currentWallUs = _vsyncWallUs;
-        final double rawDtSeconds;
-        if (_lastWallUs == 0 || currentWallUs < _lastWallUs) {
-          rawDtSeconds = 0.0;
-        } else {
-          final deltaUs = currentWallUs - _lastWallUs;
-          // Clamp (don't hard-zero) the per-frame delta at 100ms.
-          // Hard-zeroing any frame whose inter-vsync gap reaches >=100ms
-          // cascades on low-FPS devices (<=10fps): every frame zeroes,
-          // _accumulatedWallDt never grows, and motion stalls until the
-          // media clock itself jumps — producing discrete stepping instead
-          // of vsync-rate scroll. Clamping lets a slow/jittery frame still
-          // advance time by a capped amount, preserving smooth motion. The
-          // 100ms cap below (_accumulatedWallDt > 0.1) keeps total drift
-          // bounded until the media-clock anchor next updates.
-          final double clampedUs = deltaUs > 100000
-              ? 100000.0
-              : deltaUs.toDouble();
-          rawDtSeconds = clampedUs / 1000000.0;
-        }
-        _lastWallUs = currentWallUs;
 
-        // V4 dt decision: paused=0, first frame=rawDt, resume first 5=EMA, steady=rawDt
-        final double dtSeconds;
-        if (!widget.isPlaying) {
-          dtSeconds = 0.0;
-        } else if (rawDtSeconds == 0.0) {
-          dtSeconds = 0.0;
-        } else if (_smoothedDtSeconds == 0.0) {
-          dtSeconds = rawDtSeconds;
-          _smoothedDtSeconds = rawDtSeconds;
-          _resumeFrameCount = 1;
-        } else if (_resumeFrameCount > 0 &&
-            _resumeFrameCount < _resumeEmaFrames) {
-          _smoothedDtSeconds =
-              _dtEmaAlpha * rawDtSeconds +
-              (1.0 - _dtEmaAlpha) * _smoothedDtSeconds;
-          dtSeconds = _smoothedDtSeconds;
-          _resumeFrameCount++;
-        } else {
-          _smoothedDtSeconds =
-              _dtEmaAlpha * rawDtSeconds +
-              (1.0 - _dtEmaAlpha) * _smoothedDtSeconds;
-          dtSeconds = rawDtSeconds;
-          _resumeFrameCount = 0;
+        // ── Sample the media clock ──
+        final double mediaTime = widget.playbackTimeMs.value / 1000.0;
+
+        // Initialize the anchor on the very first frame.
+        if (!_anchorInitialized) {
+          _anchorMediaTime = mediaTime;
+          _wallUsAtAnchor = currentWallUs;
+          _anchorInitialized = true;
         }
 
-        // ── Read current playback time anchor ──
-        final double anchorTime = widget.playbackTimeMs.value / 1000.0;
-
-        // ── Detect playbackTimeMs update: reset accumulated dt ──
-        // When playbackTimeMs changes, the anchor point jumps. We reset
-        // accumulatedWallDt to zero so the interpolation starts fresh from
-        // the new anchor. Between updates, dt accumulates smoothly.
-        if ((anchorTime - _lastAnchorPlaybackTime).abs() >= 0.0001) {
-          _accumulatedWallDt = 0.0;
-          _lastAnchorPlaybackTime = anchorTime;
-        } else if (dtSeconds > 0.0) {
-          _accumulatedWallDt += dtSeconds * widget.playbackRate;
+        // ── Detect a media-clock advance and re-anchor atomically ──
+        // When playbackTimeMs moves forward, we update BOTH _anchorMediaTime
+        // and _wallUsAtAnchor together. wallElapsed = 0 at this instant, so
+        // interpolatedTime snaps to the true media time (keeping danmaku
+        // aligned with the video). Between media-clock ticks wallElapsed grows
+        // smoothly at the true vsync rate → constant speed, no EMA, no
+        // convergence period.
+        //
+        // Seek/backward detection: if the media clock moved backward or jumped
+        // by more than 1s, treat it as a seek and snap to the new time.
+        //
+        // The 1ms threshold ignores sub-millisecond jitter in playbackTimeMs
+        // (which would otherwise re-anchor every frame and defeat smoothness).
+        final double mediaDelta = mediaTime - _anchorMediaTime;
+        if (mediaDelta > 0.001 || mediaDelta < -0.001) {
+          if (mediaDelta < 0.0 || mediaDelta > 1.0) {
+            // Seek / loop: snap anchor to the new media time.
+            _anchorMediaTime = mediaTime;
+            _wallUsAtAnchor = currentWallUs;
+          } else {
+            // Normal media-clock tick: advance the anchor to the new media
+            // time and move the wall reference to now. wallElapsed resets to
+            // 0 — no double-counting of the time the media clock covered.
+            _anchorMediaTime = mediaTime;
+            _wallUsAtAnchor = currentWallUs;
+          }
         }
 
-        // ── Clamp accumulated dt to avoid runaway on frame drops ──
-        // Cap at 100ms of interpolated time. Beyond that, the playback
-        // time anchor should have updated.
-        if (_accumulatedWallDt > 0.1) {
-          _accumulatedWallDt = 0.1;
+        // ── wallElapsed = wall-clock seconds since the last anchor ──
+        // This is the true display-frame time (constant speed), capped to
+        // bound drift if vsyncs stall.
+        double wallElapsed = 0.0;
+        if (widget.isPlaying && currentWallUs > _wallUsAtAnchor) {
+          final deltaUs = currentWallUs - _wallUsAtAnchor;
+          wallElapsed = (deltaUs / 1000000.0).clamp(0.0, _maxWallElapsedSec);
         }
 
-        // ── Interpolated time = anchor + accumulated dt + offset ──
+        // ── Interpolated time = anchor + wall_elapsed * rate + offset ──
+        // Fold playbackRate in: at 2× speed each wall second is worth 2 media
+        // seconds, matching the media clock's own advancement rate.
         final double interpolatedTime =
-            anchorTime + _accumulatedWallDt + widget.timeOffset;
-
-        // ── Seek/loop detection ──
-        if (interpolatedTime < _lastTimeSeconds ||
-            (interpolatedTime - _lastTimeSeconds).abs() > 1.0) {
-          _accumulatedWallDt = 0.0;
-          _lastAnchorPlaybackTime = anchorTime;
-        }
+            _anchorMediaTime + wallElapsed * widget.playbackRate +
+                widget.timeOffset;
 
         // If config changed, run async configure first.
         final bool mustSubmit = _forceLayout;
@@ -523,8 +517,9 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
           if (!mounted) {
             return;
           }
-          _accumulatedWallDt = 0.0;
-          _lastAnchorPlaybackTime = widget.playbackTimeMs.value / 1000.0;
+          // Re-anchor after configure so motion resumes from the current media
+          // time at constant wall-clock rate (no slow convergence).
+          _reanchorToMediaTime();
         }
 
         // ── Submit-rate throttle (P1-4) ──
@@ -549,7 +544,6 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
         // We submit every vsync frame — the Rust engine's 16ms tick loop
         // drains its mpsc queue and always renders the latest submission.
         final frame = _bridge.layout(interpolatedTime);
-        _lastTimeSeconds = interpolatedTime;
 
         await _tryUpdateTexture(frame);
         widget.onLayoutCalculated?.call(frame);
@@ -578,9 +572,20 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
     final supersample = context
         .read<SettingsProvider>()
         .danmakuSupersample;
-    final double pixelRatio =
-        (dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0) *
-        (supersample > 0.0 ? supersample : 1.0);
+    // True supersampling: texture pixels = backing × supersample, where
+    // backing = layout × dpr. Flutter downsamples the texture to the backing
+    // store on display, which is what produces the anti-aliased edges (the
+    // whole point of supersampling). So the ratio MUST be dpr × supersample.
+    //
+    // This means on a DPR=2 panel, 2x supersample renders at 4× backing
+    // (16× texture area) — a real cost. That cost is the price of real
+    // supersampling; the 1.5x setting exists as a lighter alternative. We do
+    // NOT collapse it to max(dpr, ss) — that would make 1.5x/2x silently no-op
+    // on DPR≥2 devices (rendering == backing, zero AA benefit), defeating the
+    // setting. The clamp only guards extreme cases (e.g. DPR=4 + 2x = 8×).
+    final baseDpr = dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0;
+    final ss = supersample > 0.0 ? supersample : 1.0;
+    final double pixelRatio = (baseDpr * ss).clamp(1.0, 6.0);
 
     final int pixelWidth = (_layoutSize.width * pixelRatio)
         .round()

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -126,20 +126,16 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
     return widget.scrollDurationSeconds * scale;
   }
 
-  // ── Wall-clock time interpolation (constant-speed model) ──
-  // The video player's playbackTimeMs updates at a coarse rate (~30Hz),
-  // but the display refreshes at vsync rate (60/120/240Hz). To get smooth,
-  // CONSTANT-speed motion, we interpolate between media-clock ticks using
-  // wall-clock time:
-  //   interpolatedTime = anchorMediaTime + wallElapsed * playbackRate
-  // where wallElapsed = (wallClock.now - wallClockAtAnchor).
+  // ── Wall-clock display-time model ──
+  // Keep a continuously advancing display media time that is driven by the
+  // real vsync wall-clock delta, not by every coarse playbackTimeMs tick.
   //
-  // KEY: when the media clock advances, we move BOTH anchorMediaTime AND
-  // wallClockAtAnchor together → wallElapsed = 0 → no time jump. There is
-  // no accumulated-dt / EMA, so there is no convergence period after seek or
-  // resume: the very first frame after a jump already advances at the true
-  // wall-clock rate (constant speed), and the media clock keeps the result
-  // aligned to the correct playback time over the long run.
+  //   displayMediaTime += wallDt * playbackRate
+  //
+  // playbackTimeMs is used only to correct drift (or snap on seek), instead of
+  // re-anchoring on every media-clock tick. This avoids quantizing 120Hz motion
+  // back to the media clock's lower update rate, which looks like a sticky /
+  // 60Hz-ish texture movement even when frames are being produced at 120Hz.
   final Stopwatch _wallClock = Stopwatch()..start();
 
   /// Wall time captured at the vsync callback entry point (not inside
@@ -148,20 +144,30 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   /// latency from distorting the frame interval measurement.
   int _vsyncWallUs = 0;
 
-  /// Last sampled media time (seconds), captured from playbackTimeMs.
-  double _anchorMediaTime = 0.0;
+  /// Continuous media time used for layout. Advances by real wall-clock dt and
+  /// is gently corrected toward playbackTimeMs during normal playback.
+  double _displayMediaTime = 0.0;
 
-  /// Wall-clock microseconds at the moment _anchorMediaTime was sampled.
-  /// interpolatedTime = _anchorMediaTime + (wallNow - _wallUsAtAnchor) * rate.
-  int _wallUsAtAnchor = 0;
+  /// Wall-clock microseconds of the previous display-time update.
+  int _lastDisplayWallUs = 0;
 
-  /// Whether the anchor has been initialized (first frame / after dispose).
-  bool _anchorInitialized = false;
+  /// Whether _displayMediaTime has been initialized from playbackTimeMs.
+  bool _displayTimeInitialized = false;
 
-  /// Cap wall-elapsed to avoid a runaway jump if vsyncs stall for a long time
-  /// (e.g. tab backgrounded). Beyond this, the media clock should have updated
-  /// and re-anchored us.
-  static const double _maxWallElapsedSec = 0.2;
+  /// Per-frame wall dt cap. Prevents a long app stall/backgrounding event from
+  /// jumping danmaku far ahead; playbackTimeMs will snap/correct us afterward.
+  static const double _maxFrameDtSec = 0.2;
+
+  /// Normal playback drift below this is ignored to preserve perfectly smooth
+  /// wall-clock motion between coarse media-clock ticks.
+  static const double _driftCorrectionThresholdSec = 0.080;
+
+  /// Drift correction rate once the threshold is exceeded. Small enough to be
+  /// visually smooth, large enough to converge without a long slow/fast period.
+  static const double _driftCorrectionRate = 0.15;
+
+  /// Treat very large drift as seek / loop / stale clock and snap to media time.
+  static const double _hardResyncThresholdSec = 1.0;
 
   // ── Submit-rate throttle (P1-4) ──
   // On high-refresh panels (>60Hz) the Dart layout+setFrame pipeline is
@@ -240,7 +246,7 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
     if (oldWidget.playbackTimeMs != widget.playbackTimeMs) {
       oldWidget.playbackTimeMs.removeListener(_queueUpdate);
       widget.playbackTimeMs.addListener(_queueUpdate);
-      _reanchorToMediaTime();
+      _resetDisplayTimeToMedia();
       _queueUpdate();
     }
 
@@ -248,36 +254,34 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
     final shouldAnimate = widget.isVisible && widget.isPlaying;
     if (shouldAnimate && !_vsyncController.isAnimating) {
       _vsyncController.repeat();
-      // Re-anchor on resume so wall-clock elapsed starts from zero — no huge
-      // delta spanning the pause, and the first frame already moves at the
-      // true wall-clock rate (constant speed, no slow convergence).
-      _reanchorToMediaTime();
+      // Reset on resume so wall dt does not include the paused duration. The
+      // next frame starts from the current media time and then advances by the
+      // true display-frame dt — no slow convergence period.
+      _resetDisplayTimeToMedia();
     } else if (!shouldAnimate && _vsyncController.isAnimating) {
       _vsyncController.stop();
     }
 
-    // ── Playback rate change: re-anchor ──
-    // Re-anchoring keeps wallElapsed = 0 at the instant of the rate change,
-    // so the new rate applies going forward without a speed blip.
+    // ── Playback rate change: reset wall dt baseline ──
     if (oldWidget.playbackRate != widget.playbackRate) {
-      _reanchorToMediaTime();
+      _resetDisplayTimeToMedia();
     }
 
-    // ── isPlaying transition: re-anchor ──
+    // ── isPlaying transition: reset wall dt baseline ──
     if (oldWidget.isPlaying != widget.isPlaying) {
       if (widget.isPlaying) {
-        _reanchorToMediaTime();
+        _resetDisplayTimeToMedia();
       }
     }
   }
 
-  /// Re-anchor the wall-clock interpolation to the current media time.
-  /// Sets _anchorMediaTime and _wallUsAtAnchor together so that wallElapsed
-  /// becomes 0 at this instant — no time jump, no convergence period.
-  void _reanchorToMediaTime() {
-    _anchorMediaTime = widget.playbackTimeMs.value / 1000.0;
-    _wallUsAtAnchor = _wallClock.elapsedMicroseconds;
-    _anchorInitialized = true;
+  /// Snap the continuous display time to the current media time and reset the
+  /// wall-clock baseline. Used for first frame, seek, resume, and clock source
+  /// changes. This is a hard reset, not the normal playback correction path.
+  void _resetDisplayTimeToMedia() {
+    _displayMediaTime = widget.playbackTimeMs.value / 1000.0;
+    _lastDisplayWallUs = _wallClock.elapsedMicroseconds;
+    _displayTimeInitialized = true;
   }
 
   @override
@@ -373,10 +377,10 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   }
 
   /// Detect the display refresh rate and set the submit interval accordingly.
-  /// On panels faster than 60Hz, Dart layout+setFrame is capped at 60Hz
-  /// (16ms) — the native renderer interpolates scroll motion between
-  /// submissions, so motion stays smooth at the display rate while halving
-  /// Dart CPU work on 120Hz screens. ≤60Hz or undetectable → no throttle.
+  /// Do NOT throttle 120Hz ProMotion panels: throttling them to ~60Hz makes the
+  /// whole texture layer update every other vsync, perceived as all scrolling
+  /// danmaku synchronously micro-stuttering. Only keep the protective 60Hz cap
+  /// for very-high-refresh panels (>120Hz). ≤120Hz or undetectable → no throttle.
   void _maybeUpdateSubmitInterval() {
     double refreshRate = 0.0;
     try {
@@ -391,7 +395,10 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
       return;
     }
     _cachedRefreshRate = refreshRate;
-    _minSubmitIntervalUs = refreshRate > 60.0 ? 16000 : 0;
+    // iPad ProMotion reports ~120Hz. Keep that unthrottled; otherwise texture
+    // updates land every other vsync and the entire danmaku layer appears to
+    // hiccup in sync. Use a small margin for platform-reported 120.0x values.
+    _minSubmitIntervalUs = refreshRate > 121.0 ? 16000 : 0;
     // Reset so the next frame after a rate change submits immediately.
     _lastSubmitWallUs = 0;
   }
@@ -432,66 +439,41 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
           continue;
         }
 
-        // ── Constant-speed wall-clock interpolation ──
+        // ── Continuous display-time update ──
         // _vsyncWallUs is captured in _queueUpdate() (vsync callback entry),
-        // NOT at the top of _runUpdateLoop — otherwise the async
-        // _tryUpdateTexture latency from the previous iteration would
-        // inflate the measured interval and cause interpolatedTime jumps.
+        // NOT at the top of _runUpdateLoop — otherwise async texture latency
+        // would inflate the measured frame interval.
         final currentWallUs = _vsyncWallUs;
-
-        // ── Sample the media clock ──
         final double mediaTime = widget.playbackTimeMs.value / 1000.0;
 
-        // Initialize the anchor on the very first frame.
-        if (!_anchorInitialized) {
-          _anchorMediaTime = mediaTime;
-          _wallUsAtAnchor = currentWallUs;
-          _anchorInitialized = true;
+        if (!_displayTimeInitialized) {
+          _displayMediaTime = mediaTime;
+          _lastDisplayWallUs = currentWallUs;
+          _displayTimeInitialized = true;
         }
 
-        // ── Detect a media-clock advance and re-anchor atomically ──
-        // When playbackTimeMs moves forward, we update BOTH _anchorMediaTime
-        // and _wallUsAtAnchor together. wallElapsed = 0 at this instant, so
-        // interpolatedTime snaps to the true media time (keeping danmaku
-        // aligned with the video). Between media-clock ticks wallElapsed grows
-        // smoothly at the true vsync rate → constant speed, no EMA, no
-        // convergence period.
-        //
-        // Seek/backward detection: if the media clock moved backward or jumped
-        // by more than 1s, treat it as a seek and snap to the new time.
-        //
-        // The 1ms threshold ignores sub-millisecond jitter in playbackTimeMs
-        // (which would otherwise re-anchor every frame and defeat smoothness).
-        final double mediaDelta = mediaTime - _anchorMediaTime;
-        if (mediaDelta > 0.001 || mediaDelta < -0.001) {
-          if (mediaDelta < 0.0 || mediaDelta > 1.0) {
-            // Seek / loop: snap anchor to the new media time.
-            _anchorMediaTime = mediaTime;
-            _wallUsAtAnchor = currentWallUs;
-          } else {
-            // Normal media-clock tick: advance the anchor to the new media
-            // time and move the wall reference to now. wallElapsed resets to
-            // 0 — no double-counting of the time the media clock covered.
-            _anchorMediaTime = mediaTime;
-            _wallUsAtAnchor = currentWallUs;
-          }
+        // Advance by real wall-clock frame time. This is what gives 120Hz
+        // panels 120 distinct positions instead of re-anchoring to a coarser
+        // playbackTimeMs tick and making motion look sticky/60Hz-like.
+        if (widget.isPlaying && currentWallUs > _lastDisplayWallUs) {
+          final deltaUs = currentWallUs - _lastDisplayWallUs;
+          final dt = (deltaUs / 1000000.0).clamp(0.0, _maxFrameDtSec);
+          _displayMediaTime += dt * widget.playbackRate;
+        }
+        _lastDisplayWallUs = currentWallUs;
+
+        // Correct against the authoritative media clock only when needed.
+        // Small drift is ignored to preserve smooth per-vsync motion; larger
+        // drift is corrected gently; seek/loop-sized drift snaps immediately.
+        final drift = mediaTime - _displayMediaTime;
+        if (drift.abs() >= _hardResyncThresholdSec) {
+          _displayMediaTime = mediaTime;
+          _lastDisplayWallUs = currentWallUs;
+        } else if (drift.abs() > _driftCorrectionThresholdSec) {
+          _displayMediaTime += drift * _driftCorrectionRate;
         }
 
-        // ── wallElapsed = wall-clock seconds since the last anchor ──
-        // This is the true display-frame time (constant speed), capped to
-        // bound drift if vsyncs stall.
-        double wallElapsed = 0.0;
-        if (widget.isPlaying && currentWallUs > _wallUsAtAnchor) {
-          final deltaUs = currentWallUs - _wallUsAtAnchor;
-          wallElapsed = (deltaUs / 1000000.0).clamp(0.0, _maxWallElapsedSec);
-        }
-
-        // ── Interpolated time = anchor + wall_elapsed * rate + offset ──
-        // Fold playbackRate in: at 2× speed each wall second is worth 2 media
-        // seconds, matching the media clock's own advancement rate.
-        final double interpolatedTime =
-            _anchorMediaTime + wallElapsed * widget.playbackRate +
-                widget.timeOffset;
+        final double interpolatedTime = _displayMediaTime + widget.timeOffset;
 
         // If config changed, run async configure first.
         final bool mustSubmit = _forceLayout;
@@ -517,9 +499,9 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
           if (!mounted) {
             return;
           }
-          // Re-anchor after configure so motion resumes from the current media
-          // time at constant wall-clock rate (no slow convergence).
-          _reanchorToMediaTime();
+          // Reset after configure so motion resumes from the current media time
+          // with a fresh wall-clock baseline.
+          _resetDisplayTimeToMedia();
         }
 
         // ── Submit-rate throttle (P1-4) ──

--- a/lib/danmaku_next/nipaplay_next2_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next2_overlay.dart
@@ -247,9 +247,13 @@ class _NipaPlayNext2OverlayState extends State<NipaPlayNext2Overlay> {
     final supersample = context
         .read<SettingsProvider>()
         .danmakuSupersample;
-    final double pixelRatio =
-        (dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0) *
-        (supersample > 0.0 ? supersample : 1.0);
+    // True supersampling: texture = backing × supersample (backing = layout ×
+    // dpr). Flutter downsamples on display → anti-aliased edges. Must be
+    // dpr × supersample (NOT max) or 1.5x/2x silently no-op on DPR≥2 devices.
+    // The 1.5x setting is the lighter alternative. Clamp only guards extremes.
+    final baseDpr = dpr.isFinite ? dpr.clamp(1.0, 4.0).toDouble() : 1.0;
+    final ss = supersample > 0.0 ? supersample : 1.0;
+    final double pixelRatio = (baseDpr * ss).clamp(1.0, 6.0);
 
     final int pixelWidth =
         (_layoutSize.width * pixelRatio).round().clamp(1, 16384).toInt();


### PR DESCRIPTION
## Summary

- 对弹幕时间收敛机制进行了优化：修复了时间收敛时弹幕移速变慢的问题
- 为ProMotion 120Hz机制提供了专项优化
- 为iOS注册 .npb 和 .nph 文件格式，修复了文件选择器无法选择备份文件的问题

## What Changed
### 1. 时间收敛优化

文件：[`lib/danmaku_dfm/dfm_plus_overlay.dart`](lib/danmaku_dfm/dfm_plus_overlay.dart)

把 DFM+ 原来的“媒体时间锚点 + wallElapsed 每次重置”模型，改成了**连续 display media time** 模型。

现在弹幕时间由真实 wall-clock 帧间隔连续推进：

```dart
_displayMediaTime += wallDt * playbackRate;
```

再用播放器媒体时间做漂移校正：

```dart
final drift = mediaTime - _displayMediaTime;

if (drift.abs() >= _hardResyncThresholdSec) {
  _displayMediaTime = mediaTime;
} else if (drift.abs() > _driftCorrectionThresholdSec) {
  _displayMediaTime += drift * _driftCorrectionRate;
}
```

效果：

- pause/resume 后不再从慢速逐渐收敛
- seek 后直接贴合正确时间
- 正常播放时移动速度保持恒定
- 长期播放仍会通过 drift correction 对齐媒体时间

---

### 2. 粘滞感优化

文件：[`lib/danmaku_dfm/dfm_plus_overlay.dart`](lib/danmaku_dfm/dfm_plus_overlay.dart)

之前每次 `playbackTimeMs` 更新时都会重新锚定：

```dart
_anchorMediaTime = mediaTime;
_wallUsAtAnchor = currentWallUs;
```

这会导致 120Hz ProMotion 屏幕上，高频帧被低频媒体时间 tick “钉住”，视觉上像 60Hz 位置更新，出现“清晰但粘滞”的感觉。

现在改为：

- `playbackTimeMs` 不再每 tick 重锚
- 每个 vsync 都按真实 wall-clock 推进 `_displayMediaTime`
- 只在漂移超过阈值时才校正
- 大跳变才硬同步

效果：

- 120Hz 下每个显示帧都有连续位置变化
- 滚动弹幕不再被媒体时间 tick 量化
- “像 60Hz 的粘滞感”明显改善

---

### 3. 新增状态字段

文件：[`lib/danmaku_dfm/dfm_plus_overlay.dart`](lib/danmaku_dfm/dfm_plus_overlay.dart)

新增/替换为：

```dart
double _displayMediaTime = 0.0;
int _lastDisplayWallUs = 0;
bool _displayTimeInitialized = false;

static const double _maxFrameDtSec = 0.2;
static const double _driftCorrectionThresholdSec = 0.080;
static const double _driftCorrectionRate = 0.15;
static const double _hardResyncThresholdSec = 1.0;
```

含义：

- `_displayMediaTime`：用于布局的连续媒体时间
- `_lastDisplayWallUs`：上一帧 wall-clock 时间
- `_displayTimeInitialized`：是否已初始化
- `_maxFrameDtSec`：防止长时间卡顿后一次性跳太远
- `_driftCorrectionThresholdSec`：小漂移不修正，保证运动平滑
- `_driftCorrectionRate`：大于阈值后温和修正
- `_hardResyncThresholdSec`：seek/loop 等大跳变直接同步

---

### 4. 重置逻辑调整

文件：[`lib/danmaku_dfm/dfm_plus_overlay.dart`](lib/danmaku_dfm/dfm_plus_overlay.dart)

新增 `_resetDisplayTimeToMedia()`：

```dart
void _resetDisplayTimeToMedia() {
  _displayMediaTime = widget.playbackTimeMs.value / 1000.0;
  _lastDisplayWallUs = _wallClock.elapsedMicroseconds;
  _displayTimeInitialized = true;
}
```

用于：

- playbackTimeMs listenable 变化
- pause → resume
- playbackRate 变化
- configure 完成后

效果：

- 这些场景不会继承旧 wall-clock delta
- 不会出现恢复后一段时间慢速收敛
- 直接从当前媒体时间开始恒速滚动

---

### 5. 删除旧的收敛相关逻辑

文件：[`lib/danmaku_dfm/dfm_plus_overlay.dart`](lib/danmaku_dfm/dfm_plus_overlay.dart)

移除旧模型相关字段/逻辑：

```dart
_accumulatedWallDt
_lastAnchorPlaybackTime
_smoothedDtSeconds
_resumeFrameCount
_dtEmaAlpha
_resumeEmaFrames
_lastWallUs
_lastTimeSeconds
```

旧逻辑的问题：

- pause/resume 后 EMA 从 0 开始收敛
- seek 后 `_accumulatedWallDt` 清零
- 前几帧 `dtSeconds` 偏小
- 弹幕表现为“从慢速逐渐恢复正常”

现在改为 wall-clock 连续推进，不再需要这些收敛状态。

