### PR TITLE
[codex] Fix scaled overlays and promote remote QR setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ ebuild gentoo/media-video/nipaplay-bin/nipaplay-bin-1.8.11.ebuild merge
 ### 鸣谢
 
 感谢以下贡献者和支持者：
-EmoSakura, Mr.果仁, 姬田诗乃, 微光, 大祥老师, 卡拜, JMT, 无之将, 博易伯伯, 千葉あおい, Kean
+EmoSakura, Mr.果仁, 姬田诗乃, 微光, 大祥老师, 卡拜, JMT, 无之将, 博易伯伯, 千葉あおい, Kean, SKYWOW, 爱跑步的男孩, Bassman
 
 ### 看板娘 
 

--- a/lib/constants/acknowledgements.dart
+++ b/lib/constants/acknowledgements.dart
@@ -10,4 +10,7 @@ const List<String> kAcknowledgementNames = [
   '博易伯伯',
   '千葉あおい',
   'Kean',
+  'SKYWOW',
+  '爱跑步的男孩',
+  'Bassman',
 ];

--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -23,6 +23,8 @@ class SettingsKeys {
   static const String legacyAutoCheckUpdatesOnAboutPage =
       'auto_check_updates_on_about_page';
 
+  static const String showRemoteAccessQrCode = 'show_remote_access_qr_code';
+
   static const String labsEnableLargeScreenMode =
       'labs_enable_large_screen_mode';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,6 +47,7 @@ import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
 import 'package:nipaplay/providers/home_sections_settings_provider.dart';
 import 'package:nipaplay/providers/shared_remote_library_provider.dart';
 import 'package:nipaplay/providers/ui_theme_provider.dart';
+import 'package:nipaplay/providers/remote_access_settings_provider.dart';
 import 'package:nipaplay/providers/jellyfin_transcode_provider.dart';
 import 'package:nipaplay/providers/emby_transcode_provider.dart';
 import 'package:nipaplay/providers/labs_settings_provider.dart';
@@ -578,6 +579,7 @@ void main(List<String> args) async {
           ChangeNotifierProvider(create: (_) => AppearanceSettingsProvider()),
           ChangeNotifierProvider(create: (_) => DownloaderSettingsProvider()),
           ChangeNotifierProvider(create: (_) => LabsSettingsProvider()),
+          ChangeNotifierProvider(create: (_) => RemoteAccessSettingsProvider()),
           ChangeNotifierProvider(create: (_) => PluginService()),
           ChangeNotifierProvider(create: (_) => HomeSectionsSettingsProvider()),
           ChangeNotifierProvider(create: (_) => UIThemeProvider()),

--- a/lib/providers/labs_settings_provider.dart
+++ b/lib/providers/labs_settings_provider.dart
@@ -9,14 +9,12 @@ class LabsSettingsProvider extends ChangeNotifier {
   }
 
   bool _enableLargeScreenMode = false;
-  bool _showRemoteAccessQrCode = false;
   bool _enableNext2DanmakuKernel = false;
   bool _enableErikaPlayerKernel = false;
   bool _enableNextPlusPlusEngine = false; // 默认关闭：Next++ 激进优化引擎
   bool _isLoaded = false;
 
   bool get enableLargeScreenMode => _enableLargeScreenMode;
-  bool get showRemoteAccessQrCode => _showRemoteAccessQrCode;
   bool get enableNext2DanmakuKernel => _enableNext2DanmakuKernel;
   bool get enableErikaPlayerKernel => _enableErikaPlayerKernel;
   bool get enableNextPlusPlusEngine => _enableNextPlusPlusEngine;
@@ -25,10 +23,6 @@ class LabsSettingsProvider extends ChangeNotifier {
   Future<void> _loadSettings() async {
     _enableLargeScreenMode = await SettingsStorage.loadBool(
       SettingsKeys.labsEnableLargeScreenMode,
-      defaultValue: false,
-    );
-    _showRemoteAccessQrCode = await SettingsStorage.loadBool(
-      SettingsKeys.labsShowRemoteAccessQrCode,
       defaultValue: false,
     );
     _enableNext2DanmakuKernel = await SettingsStorage.loadBool(
@@ -54,16 +48,6 @@ class LabsSettingsProvider extends ChangeNotifier {
     notifyListeners();
     await SettingsStorage.saveBool(
       SettingsKeys.labsEnableLargeScreenMode,
-      enabled,
-    );
-  }
-
-  Future<void> setShowRemoteAccessQrCode(bool enabled) async {
-    if (_showRemoteAccessQrCode == enabled) return;
-    _showRemoteAccessQrCode = enabled;
-    notifyListeners();
-    await SettingsStorage.saveBool(
-      SettingsKeys.labsShowRemoteAccessQrCode,
       enabled,
     );
   }

--- a/lib/providers/remote_access_settings_provider.dart
+++ b/lib/providers/remote_access_settings_provider.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class RemoteAccessSettingsProvider extends ChangeNotifier {
+  RemoteAccessSettingsProvider() {
+    _loadSettings();
+  }
+
+  bool _showRemoteAccessQrCode = false;
+  bool _isLoaded = false;
+
+  bool get showRemoteAccessQrCode => _showRemoteAccessQrCode;
+  bool get isLoaded => _isLoaded;
+
+  Future<void> _loadSettings() async {
+    final prefs = await SharedPreferences.getInstance();
+    final savedValue = prefs.getBool(SettingsKeys.showRemoteAccessQrCode);
+    final legacyValue = prefs.getBool(SettingsKeys.labsShowRemoteAccessQrCode);
+    _showRemoteAccessQrCode = savedValue ?? legacyValue ?? false;
+    if (savedValue == null && legacyValue != null) {
+      await prefs.setBool(SettingsKeys.showRemoteAccessQrCode, legacyValue);
+    }
+    _isLoaded = true;
+    notifyListeners();
+  }
+
+  Future<void> setShowRemoteAccessQrCode(bool enabled) async {
+    if (_showRemoteAccessQrCode == enabled) return;
+    _showRemoteAccessQrCode = enabled;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(SettingsKeys.showRemoteAccessQrCode, enabled);
+  }
+}

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_labs_settings_page.dart
@@ -64,32 +64,11 @@ class CupertinoLabsSettingsPage extends StatelessWidget {
                       ),
                       CupertinoSettingsTile(
                         leading: Icon(
-                          CupertinoIcons.qrcode,
-                          color: resolveSettingsIconColor(context),
-                        ),
-                        title: const Text('显示远程访问二维码'),
-                        subtitle: const Text('开启后，远程访问服务页面会显示供手机扫码连接的二维码'),
-                        trailing: AdaptiveSwitch(
-                          value: labsSettings.showRemoteAccessQrCode,
-                          onChanged: (value) {
-                            labsSettings.setShowRemoteAccessQrCode(value);
-                          },
-                        ),
-                        onTap: () {
-                          labsSettings.setShowRemoteAccessQrCode(
-                            !labsSettings.showRemoteAccessQrCode,
-                          );
-                        },
-                        backgroundColor: resolveSettingsTileBackground(context),
-                      ),
-                      CupertinoSettingsTile(
-                        leading: Icon(
                           CupertinoIcons.lab_flask,
                           color: resolveSettingsIconColor(context),
                         ),
                         title: const Text('显示 Next2 弹幕内核'),
-                        subtitle:
-                            const Text('开启后，弹幕渲染引擎下拉菜单显示 NipaPlay Next2'),
+                        subtitle: const Text('开启后，弹幕渲染引擎下拉菜单显示 NipaPlay Next2'),
                         trailing: AdaptiveSwitch(
                           value: labsSettings.enableNext2DanmakuKernel,
                           onChanged: (value) {
@@ -131,8 +110,7 @@ class CupertinoLabsSettingsPage extends StatelessWidget {
                           color: resolveSettingsIconColor(context),
                         ),
                         title: const Text('Next++ 激进优化引擎'),
-                        subtitle: const Text(
-                            '激进优化，推荐。关闭则回退至 Next 原始引擎路径'),
+                        subtitle: const Text('激进优化，推荐。关闭则回退至 Next 原始引擎路径'),
                         trailing: AdaptiveSwitch(
                           value: labsSettings.enableNextPlusPlusEngine,
                           onChanged: (value) {

--- a/lib/themes/nipaplay/pages/settings/labs_page.dart
+++ b/lib/themes/nipaplay/pages/settings/labs_page.dart
@@ -31,19 +31,6 @@ class LabsPage extends StatelessWidget {
               height: 1,
             ),
             SettingsItem.toggle(
-              title: '显示远程访问二维码',
-              subtitle: '开启后，远程访问服务页面会显示供手机扫码连接的二维码',
-              icon: Ionicons.qr_code_outline,
-              value: labsSettings.showRemoteAccessQrCode,
-              onChanged: (bool value) {
-                labsSettings.setShowRemoteAccessQrCode(value);
-              },
-            ),
-            Divider(
-              color: colorScheme.onSurface.withValues(alpha: 0.12),
-              height: 1,
-            ),
-            SettingsItem.toggle(
               title: '显示 Next2和 DFM+ 弹幕内核',
               subtitle: '开启后，弹幕渲染引擎下拉菜单显示 NipaPlay Next2 和 DFM+',
               icon: Ionicons.flask_outline,

--- a/lib/themes/nipaplay/pages/settings/remote_access_page.dart
+++ b/lib/themes/nipaplay/pages/settings/remote_access_page.dart
@@ -1,7 +1,7 @@
 // remote_access_page.dart
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
-import 'package:nipaplay/providers/labs_settings_provider.dart';
+import 'package:nipaplay/providers/remote_access_settings_provider.dart';
 import 'package:nipaplay/providers/service_provider.dart';
 import 'package:nipaplay/services/remote_control_access_guard_service.dart';
 import 'package:nipaplay/services/remote_access_qr_service.dart';
@@ -415,8 +415,8 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
 
   Widget _buildWebServerSection() {
     final colorScheme = Theme.of(context).colorScheme;
-    final showRemoteAccessQrCode =
-        context.watch<LabsSettingsProvider>().showRemoteAccessQrCode;
+    final remoteAccessSettings = context.watch<RemoteAccessSettingsProvider>();
+    final showRemoteAccessQrCode = remoteAccessSettings.showRemoteAccessQrCode;
     return DefaultTextStyle.merge(
       style: _pageTextStyle(context),
       child: Column(
@@ -502,6 +502,16 @@ class _RemoteAccessPageState extends State<RemoteAccessPage> {
             trailing: FluentSettingsSwitch(
               value: _ipv6Enabled,
               onChanged: _toggleIpv6,
+            ),
+          ),
+
+          _buildSettingItem(
+            icon: Icons.qr_code_2,
+            title: '显示远程访问二维码',
+            subtitle: '开启后，远程访问服务页面会显示供手机扫码连接的二维码',
+            trailing: FluentSettingsSwitch(
+              value: showRemoteAccessQrCode,
+              onChanged: remoteAccessSettings.setShowRemoteAccessQrCode,
             ),
           ),
 

--- a/lib/themes/nipaplay/widgets/tooltip_bubble.dart
+++ b/lib/themes/nipaplay/widgets/tooltip_bubble.dart
@@ -46,27 +46,53 @@ class _TooltipBubbleState extends State<TooltipBubble> {
   Timer? _enterTimer;
   Timer? _exitTimer;
 
-  void _recalculatePosition() {
-    final RenderBox renderBox =
-        _childKey.currentContext?.findRenderObject() as RenderBox;
-    final position = renderBox.localToGlobal(Offset.zero);
-    final size = renderBox.size;
+  RenderBox? _overlayRenderBox() {
+    final renderObject = Overlay.maybeOf(context)?.context.findRenderObject();
+    if (renderObject is RenderBox && renderObject.hasSize) {
+      return renderObject;
+    }
+    return null;
+  }
+
+  Offset _toOverlayPosition(Offset globalPosition, RenderBox? overlayBox) {
+    if (overlayBox == null) {
+      return globalPosition;
+    }
+    return overlayBox.globalToLocal(globalPosition);
+  }
+
+  bool _recalculatePosition() {
+    final RenderObject? renderObject =
+        _childKey.currentContext?.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.hasSize) {
+      return false;
+    }
+
+    final overlayBox = _overlayRenderBox();
+    final position = overlayBox == null
+        ? renderObject.localToGlobal(Offset.zero)
+        : renderObject.localToGlobal(Offset.zero, ancestor: overlayBox);
+    final size = renderObject.size;
     final bubbleWidth = _getBubbleWidth();
     final bubbleHeight = _getBubbleHeight();
+    final mousePosition = _mousePosition == null
+        ? null
+        : _toOverlayPosition(_mousePosition!, overlayBox);
 
     double left;
     double top;
 
     if (widget.position != null) {
-      left = widget.position! - bubbleWidth / 2;
+      left = _toOverlayPosition(Offset(widget.position!, 0), overlayBox).dx -
+          bubbleWidth / 2;
       top = widget.showOnTop
           ? position.dy - bubbleHeight - widget.verticalOffset
           : position.dy + size.height + widget.verticalOffset;
-    } else if (widget.followMouse && _mousePosition != null) {
-      left = _mousePosition!.dx - bubbleWidth / 2;
+    } else if (widget.followMouse && mousePosition != null) {
+      left = mousePosition.dx - bubbleWidth / 2;
       top = widget.showOnTop
-          ? _mousePosition!.dy - bubbleHeight - widget.verticalOffset
-          : _mousePosition!.dy + widget.verticalOffset;
+          ? mousePosition.dy - bubbleHeight - widget.verticalOffset
+          : mousePosition.dy + widget.verticalOffset;
     } else if (widget.showOnRight) {
       left = position.dx + size.width + widget.verticalOffset;
       top = position.dy + (size.height - bubbleHeight) / 2;
@@ -77,7 +103,7 @@ class _TooltipBubbleState extends State<TooltipBubble> {
           : position.dy + size.height + widget.verticalOffset;
     }
 
-    final screenSize = MediaQuery.of(context).size;
+    final screenSize = overlayBox?.size ?? MediaQuery.of(context).size;
     final maxLeft = screenSize.width - bubbleWidth - 10.0;
     if (maxLeft <= 10.0) {
       left = 10.0;
@@ -93,6 +119,7 @@ class _TooltipBubbleState extends State<TooltipBubble> {
 
     _overlayOffset = Offset(left, top);
     _overlayWidth = bubbleWidth;
+    return true;
   }
 
   void _updateOverlay(BuildContext context, [Offset? newMousePosition]) {
@@ -105,7 +132,10 @@ class _TooltipBubbleState extends State<TooltipBubble> {
       return;
     }
 
-    _recalculatePosition();
+    if (!_recalculatePosition()) {
+      _hideOverlay();
+      return;
+    }
 
     if (_overlayEntry != null) {
       // Overlay already exists — update in place without removing/reinserting

--- a/lib/widgets/macos_native_video_view.dart
+++ b/lib/widgets/macos_native_video_view.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -47,6 +48,34 @@ Duration _nativeVideoAttachRetryDelay(int attempt) {
     return const Duration(milliseconds: 1200);
   }
   return const Duration(seconds: 2);
+}
+
+Rect _transformedGlobalRectOf(RenderBox box) {
+  final topLeft = box.localToGlobal(Offset.zero);
+  final topRight = box.localToGlobal(Offset(box.size.width, 0));
+  final bottomLeft = box.localToGlobal(Offset(0, box.size.height));
+  final bottomRight = box.localToGlobal(
+    Offset(box.size.width, box.size.height),
+  );
+
+  final left = math.min(
+    math.min(topLeft.dx, topRight.dx),
+    math.min(bottomLeft.dx, bottomRight.dx),
+  );
+  final top = math.min(
+    math.min(topLeft.dy, topRight.dy),
+    math.min(bottomLeft.dy, bottomRight.dy),
+  );
+  final right = math.max(
+    math.max(topLeft.dx, topRight.dx),
+    math.max(bottomLeft.dx, bottomRight.dx),
+  );
+  final bottom = math.max(
+    math.max(topLeft.dy, topRight.dy),
+    math.max(bottomLeft.dy, bottomRight.dy),
+  );
+
+  return Rect.fromLTRB(left, top, right, bottom);
 }
 
 class MacOSNativeVideoView extends StatefulWidget {
@@ -356,7 +385,8 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
       return;
     }
 
-    final Rect rect;
+    final Rect platformRect;
+    final Rect? cutoutRect;
     if (visible) {
       if (!mounted) {
         return;
@@ -370,17 +400,19 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
         return;
       }
       final origin = box.localToGlobal(Offset.zero);
-      rect = origin & box.size;
+      platformRect = _transformedGlobalRectOf(box);
+      cutoutRect = origin & box.size;
     } else {
-      rect = Rect.zero;
+      platformRect = Rect.zero;
+      cutoutRect = null;
     }
 
     final signature = [
       visible,
-      rect.left.toStringAsFixed(2),
-      rect.top.toStringAsFixed(2),
-      rect.width.toStringAsFixed(2),
-      rect.height.toStringAsFixed(2),
+      platformRect.left.toStringAsFixed(2),
+      platformRect.top.toStringAsFixed(2),
+      platformRect.width.toStringAsFixed(2),
+      platformRect.height.toStringAsFixed(2),
     ].join('|');
     if (signature == _lastFrameSignature) {
       return;
@@ -391,10 +423,10 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
       return;
     }
     _lastFrameSignature = signature;
-    widget.onFrameRectChanged?.call(visible ? rect : null);
+    widget.onFrameRectChanged?.call(cutoutRect);
     if (!visible || force) {
       _logMacOSHdrExitTrace(
-        'setOverlayFrame state=${identityHashCode(this)} visible=$visible force=$force rect=$rect label=${widget.debugLabel}',
+        'setOverlayFrame state=${identityHashCode(this)} visible=$visible force=$force rect=$platformRect label=${widget.debugLabel}',
       );
     }
 
@@ -405,10 +437,10 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
         <String, dynamic>{
           'viewId': _windowHostedPlatformSurfaceId,
           'generation': _surfaceGeneration,
-          'x': rect.left,
-          'y': rect.top,
-          'width': rect.width,
-          'height': rect.height,
+          'x': platformRect.left,
+          'y': platformRect.top,
+          'width': platformRect.width,
+          'height': platformRect.height,
           'visible': visible,
           if (widget.debugLabel != null) 'debugLabel': widget.debugLabel,
         },

--- a/test/tooltip_bubble_test.dart
+++ b/test/tooltip_bubble_test.dart
@@ -1,0 +1,67 @@
+import 'dart:ui' show PointerDeviceKind;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/tooltip_bubble.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/ui_scale_wrapper.dart';
+
+void main() {
+  testWidgets('positions tooltip in overlay coordinates when UI is scaled',
+      (tester) async {
+    tester.view.physicalSize = const Size(1000, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const tooltipText = 'Scaled tooltip';
+    const anchorKey = Key('tooltip-anchor');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (context, child) {
+          return UiScaleWrapper(
+            scale: 1.25,
+            child: child ?? const SizedBox.shrink(),
+          );
+        },
+        home: const Scaffold(
+          body: Stack(
+            children: [
+              Positioned(
+                left: 200,
+                top: 500,
+                child: TooltipBubble(
+                  text: tooltipText,
+                  showOnTop: true,
+                  verticalOffset: 8,
+                  child: SizedBox(
+                    key: anchorKey,
+                    width: 40,
+                    height: 40,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    await tester.pump();
+    await gesture.moveTo(tester.getCenter(find.byKey(anchorKey)));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text(tooltipText), findsOneWidget);
+
+    final positionedFinder = find.ancestor(
+      of: find.text(tooltipText),
+      matching: find.byType(Positioned),
+    );
+    final tooltipPositioned = tester.widget<Positioned>(positionedFinder);
+
+    expect(tooltipPositioned.top, isNotNull);
+    expect(tooltipPositioned.top!, lessThan(500));
+  });
+}


### PR DESCRIPTION
## Summary
- Fix TooltipBubble positioning when UI scale is enabled and add a regression test for #461.
- Fix window-hosted native video overlay sizing under UI scale.
- Promote the remote access QR-code toggle out of Labs while migrating the legacy setting.
- Add SKYWOW, ??????, and Bassman to acknowledgements.

## Tests
- flutter test --no-pub -r expanded test\\tooltip_bubble_test.dart
- dart analyze changed Dart files (no errors/warnings; existing style/deprecation infos remain)