### PR TITLE
[codex] Build macOS arch-specific packages

### DIFF
--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -1,9 +1,13 @@
-name: 'Build macOS DMG'
-description: '构建 macOS 应用并生成 DMG 文件'
+name: 'Build macOS Packages'
+description: '构建 macOS 应用并生成 DMG、ZIP 和 PKG 文件'
 inputs:
   app-version:
     description: '应用版本号'
     required: true
+  build-architectures:
+    description: '要构建的 macOS 架构列表：universal arm64 x86_64'
+    required: false
+    default: 'universal'
   macos-certificate-base64:
     description: 'macOS Distribution Certificate (Base64)'
     required: false
@@ -28,6 +32,15 @@ outputs:
   dmg-path:
     description: '生成的 DMG 文件路径'
     value: ${{ steps.package.outputs.dmg_path }}
+  zip-path:
+    description: '生成的 ZIP 文件路径'
+    value: ${{ steps.package.outputs.zip_path }}
+  pkg-path:
+    description: '生成的 PKG 文件路径'
+    value: ${{ steps.package.outputs.pkg_path }}
+  package-paths:
+    description: '生成的所有 macOS 包路径'
+    value: ${{ steps.package.outputs.package_paths }}
 runs:
   using: 'composite'
   steps:
@@ -112,122 +125,264 @@ runs:
         else
           echo "⚠️ 未提供签名证书，将构建未签名版本"
           echo "ENABLE_CODE_SIGNING=false" >> $GITHUB_ENV
+          echo "ENABLE_NOTARIZATION=false" >> $GITHUB_ENV
         fi
+
+    - name: Configure macOS build variants
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        variants_dir="$RUNNER_TEMP/nipaplay-macos"
+        variants_file="${variants_dir}/variants.txt"
+        mkdir -p "$variants_dir"
+        : > "$variants_file"
+
+        for requested_arch in ${{ inputs.build-architectures }}; do
+          case "$requested_arch" in
+            universal)
+              echo "universal|x86_64 arm64|Universal|universal" >> "$variants_file"
+              ;;
+            arm64|apple-silicon|AppleSilicon)
+              echo "arm64|arm64|AppleSilicon|arm64" >> "$variants_file"
+              ;;
+            x86_64|intel|Intel)
+              echo "x86_64|x86_64|Intel|x86_64" >> "$variants_file"
+              ;;
+            *)
+              echo "❌ 不支持的 macOS 架构: $requested_arch"
+              echo "支持值: universal, arm64, x86_64"
+              exit 1
+              ;;
+          esac
+        done
+
+        if [ ! -s "$variants_file" ]; then
+          echo "❌ 至少需要指定一个 macOS 架构。"
+          exit 1
+        fi
+
+        echo "将构建以下 macOS 变体："
+        cat "$variants_file"
+
+        echo "MACOS_VARIANTS_FILE=$variants_file" >> "$GITHUB_ENV"
+        echo "MACOS_STAGING_ROOT=build/macos-artifacts" >> "$GITHUB_ENV"
 
     - name: Build macOS App
       shell: bash
       run: |
+        set -euo pipefail
+
         # --obfuscate + --split-debug-info：Dart 代码混淆 + 分离调试符号（体积↓ + 反逆向）
         # symbol map 由 workflow 的 dart-symbols-* artifact 上传，用于 crash stack 反混淆
         # 兼容性：与 macOS dSYM 不冲突（dSYM 是原生层，obfuscate 是 Dart 层，独立）
-        if [ "$ENABLE_CODE_SIGNING" = "true" ]; then
-          echo "🔨 构建已签名的macOS应用..."
-          flutter build macos --release \
-            --dart-define=APPLE_TEAM_ID=$APPLE_TEAM_ID \
-            --obfuscate --split-debug-info=build/symbols-macos
+        rm -rf "$MACOS_STAGING_ROOT"
+        mkdir -p "$MACOS_STAGING_ROOT" build/symbols-macos
+
+        while IFS='|' read -r variant_key xcode_archs artifact_label variant_suffix; do
+          echo "🔨 构建 macOS ${artifact_label} 应用 (ARCHS=${xcode_archs})..."
+
+          symbols_dir="build/symbols-macos/${variant_suffix}"
+          derived_data_path="build/macos-${variant_suffix}"
+          app_path="${derived_data_path}/Build/Products/Release/NipaPlay.app"
+          staged_app_path="${MACOS_STAGING_ROOT}/${variant_suffix}/NipaPlay.app"
+
+          flutter_args=(
+            flutter build macos
+            --release
+            --config-only
+            --no-pub
+            --obfuscate
+            "--split-debug-info=${symbols_dir}"
+          )
+
+          if [ "$ENABLE_CODE_SIGNING" = "true" ]; then
+            flutter_args+=(--dart-define=APPLE_TEAM_ID=$APPLE_TEAM_ID)
+          fi
+
+          "${flutter_args[@]}"
+
+          rm -rf "$derived_data_path"
+          xcodebuild \
+            -workspace macos/Runner.xcworkspace \
+            -configuration Release \
+            -scheme Runner \
+            -derivedDataPath "$derived_data_path" \
+            -destination 'generic/platform=macOS' \
+            "OBJROOT=${PWD}/${derived_data_path}/Build/Intermediates.noindex" \
+            "SYMROOT=${PWD}/${derived_data_path}/Build/Products" \
+            "ARCHS=${xcode_archs}" \
+            ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            "CODE_SIGN_IDENTITY=" \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            -quiet
+
+          if [ ! -d "$app_path" ]; then
+            echo "❌ 构建产物不存在: $app_path"
+            ls -la "${derived_data_path}/Build/Products/Release" || true
+            exit 1
+          fi
+
+          rm -rf "$(dirname "$staged_app_path")"
+          mkdir -p "$(dirname "$staged_app_path")"
+          ditto "$app_path" "$staged_app_path"
+
+          executable_path="${staged_app_path}/Contents/MacOS/NipaPlay"
+          if [ -f "$executable_path" ]; then
+            echo "✅ ${artifact_label} 主程序架构: $(lipo -archs "$executable_path")"
+          else
+            echo "⚠️ 未找到主程序可执行文件: $executable_path"
+          fi
+        done < "$MACOS_VARIANTS_FILE"
+
+    - name: Copy mdk.framework.dSYM to App Bundle
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        echo "Attempting to copy mdk.framework.dSYM for symbolication..."
+        MDK_ARTIFACTS_DIR="macos/Pods/mdk"
+        DSYM_SOURCE_PATH="${MDK_ARTIFACTS_DIR}/mdk.framework.dSYM"
+
+        APP_BUNDLE_NAME="NipaPlay.app"
+
+        if [ -d "$DSYM_SOURCE_PATH" ]; then
+          echo "Found mdk.framework.dSYM at $DSYM_SOURCE_PATH"
+
+          while IFS='|' read -r variant_key xcode_archs artifact_label variant_suffix; do
+            APP_BUNDLE_ROOT_DIR="${MACOS_STAGING_ROOT}/${variant_suffix}"
+            TARGET_DSYM_DIR="${APP_BUNDLE_ROOT_DIR}/${APP_BUNDLE_NAME}/Contents/Frameworks"
+
+            if [ ! -d "${APP_BUNDLE_ROOT_DIR}/${APP_BUNDLE_NAME}" ]; then
+              echo "Error: App bundle ${APP_BUNDLE_ROOT_DIR}/${APP_BUNDLE_NAME} not found after flutter build."
+              echo "Listing contents of ${APP_BUNDLE_ROOT_DIR}/:"
+              ls -la "${APP_BUNDLE_ROOT_DIR}/"
+              exit 1
+            fi
+
+            if [ ! -d "$TARGET_DSYM_DIR" ]; then
+               echo "Warning: Target Frameworks directory $TARGET_DSYM_DIR does not exist. Will attempt to create it."
+               mkdir -p "$TARGET_DSYM_DIR"
+            fi
+
+            echo "Copying $DSYM_SOURCE_PATH to $TARGET_DSYM_DIR/ for ${artifact_label}"
+            rm -rf "${TARGET_DSYM_DIR}/mdk.framework.dSYM"
+            cp -R "$DSYM_SOURCE_PATH" "$TARGET_DSYM_DIR/"
+            echo "Successfully copied mdk.framework.dSYM from $DSYM_SOURCE_PATH."
+            echo "Contents of $TARGET_DSYM_DIR after copy:"
+            ls -la "$TARGET_DSYM_DIR"
+          done < "$MACOS_VARIANTS_FILE"
         else
-          echo "🔨 构建未签名的macOS应用..."
-          flutter build macos --release \
-            --obfuscate --split-debug-info=build/symbols-macos
+          echo "Warning: mdk.framework.dSYM not found at the revised expected path $DSYM_SOURCE_PATH."
+          echo "Symbolicated crash logs for mdk might not be available."
         fi
 
     - name: Sign macOS App
       shell: bash
       run: |
+        set -euo pipefail
+
         if [ "$ENABLE_CODE_SIGNING" = "true" ]; then
           echo "🔐 对macOS应用进行代码签名..."
-          
-          APP_PATH="build/macos/Build/Products/Release/NipaPlay.app"
-          
+
           # 查找可用的签名身份
           echo "可用的签名身份："
           security find-identity -v -p codesigning
-          
+
           # 获取证书信息
           echo "查找可用的代码签名证书..."
           CERT_LIST=$(security find-identity -v -p codesigning)
           echo "证书列表："
           echo "$CERT_LIST"
-          
+
           # 首先尝试 Developer ID Application 证书（用于分发和公证）
-          CERT_NAME=$(echo "$CERT_LIST" | grep "Developer ID Application" | head -1 | sed 's/.*) \([0-9A-F]*\) "\(.*\)"/\2/')
-          
+          CERT_NAME=$(echo "$CERT_LIST" | grep "Developer ID Application" | head -1 | sed 's/.*) \([0-9A-F]*\) "\(.*\)"/\2/' || true)
+
           if [ -z "$CERT_NAME" ]; then
             echo "⚠️ 未找到Developer ID Application证书，查找Apple Development证书..."
             # 备选：查找 Apple Development 证书
-            CERT_NAME=$(echo "$CERT_LIST" | grep "Apple Development" | head -1 | sed 's/.*) \([0-9A-F]*\) "\(.*\)"/\2/')
+            CERT_NAME=$(echo "$CERT_LIST" | grep "Apple Development" | head -1 | sed 's/.*) \([0-9A-F]*\) "\(.*\)"/\2/' || true)
           fi
-          
+
           if [ -z "$CERT_NAME" ]; then
             echo "⚠️ 未找到Apple Development证书，查找其他可用证书..."
             # 最后备选：查找任何可用证书
-            CERT_NAME=$(echo "$CERT_LIST" | grep -E "(Developer|Apple)" | head -1 | sed 's/.*) \([0-9A-F]*\) "\(.*\)"/\2/')
+            CERT_NAME=$(echo "$CERT_LIST" | grep -E "(Developer|Apple)" | head -1 | sed 's/.*) \([0-9A-F]*\) "\(.*\)"/\2/' || true)
           fi
-          
+
           if [ -n "$CERT_NAME" ]; then
             echo "使用证书: $CERT_NAME"
-            
+
             # 检查权限文件是否存在
             if [ ! -f "macos/Runner/Release.entitlements" ]; then
               echo "❌ 权限文件不存在"
               exit 1
             fi
-            
-            # 检查应用路径是否存在
-            if [ ! -d "$APP_PATH" ]; then
-              echo "❌ 应用路径不存在: $APP_PATH"
-              exit 1
-            fi
-            
-            # 对所有框架进行深度签名（确保使用 runtime 选项）
-            echo "正在对框架进行签名..."
-            find "$APP_PATH/Contents/Frameworks" -name "*.framework" -exec basename {} \; | sort | while read framework; do
-              framework_path="$APP_PATH/Contents/Frameworks/$framework"
-              if [ -d "$framework_path" ]; then
-                echo "签名框架: $framework_path"
-                codesign --force --deep --sign "$CERT_NAME" \
-                  --options runtime \
-                  --timestamp \
-                  "$framework_path"
-                
-                # 验证框架签名
-                if codesign --verify --deep --strict "$framework_path" 2>/dev/null; then
-                  echo "✅ 框架签名验证成功: $framework"
-                else
-                  echo "⚠️ 框架签名验证失败: $framework"
-                fi
+
+            while IFS='|' read -r variant_key xcode_archs artifact_label variant_suffix; do
+              APP_PATH="${MACOS_STAGING_ROOT}/${variant_suffix}/NipaPlay.app"
+              echo "🔐 签名 macOS ${artifact_label} 应用..."
+
+              # 检查应用路径是否存在
+              if [ ! -d "$APP_PATH" ]; then
+                echo "❌ 应用路径不存在: $APP_PATH"
+                exit 1
               fi
-            done
-            
-            # 对动态库进行签名
-            echo "正在对动态库进行签名..."
-            find "$APP_PATH" -name "*.dylib" -exec codesign --force --sign "$CERT_NAME" --options runtime --timestamp {} \;
-              
-            echo "正在对主应用进行签名..."
-            echo "应用路径: $APP_PATH"
-            echo "证书名称: $CERT_NAME (隐藏敏感信息)"
-            echo "权限文件: macos/Runner/Release.entitlements"
-            
-            # 对主应用进行签名（使用与本地相同的参数）
-            codesign --force --deep --sign "$CERT_NAME" \
-              --options runtime \
-              --timestamp \
-              --entitlements macos/Runner/Release.entitlements \
-              "$APP_PATH"
-              
-            # 详细验证签名
-            echo "验证应用签名..."
-            codesign --verify --deep --strict --verbose=2 "$APP_PATH"
-            
-            if [ $? -eq 0 ]; then
-              echo "✅ 应用签名完成"
-              # 显示签名信息
-              echo "签名信息："
-              codesign -dv --verbose=4 "$APP_PATH"
-            else
-              echo "❌ 应用签名验证失败"
-              exit 1
-            fi
+
+              # 对所有框架进行深度签名（确保使用 runtime 选项）
+              if [ -d "$APP_PATH/Contents/Frameworks" ]; then
+                echo "正在对框架进行签名..."
+                find "$APP_PATH/Contents/Frameworks" -name "*.framework" -exec basename {} \; | sort | while read framework; do
+                  framework_path="$APP_PATH/Contents/Frameworks/$framework"
+                  if [ -d "$framework_path" ]; then
+                    echo "签名框架: $framework_path"
+                    codesign --force --deep --sign "$CERT_NAME" \
+                      --options runtime \
+                      --timestamp \
+                      "$framework_path"
+
+                    # 验证框架签名
+                    if codesign --verify --deep --strict "$framework_path" 2>/dev/null; then
+                      echo "✅ 框架签名验证成功: $framework"
+                    else
+                      echo "⚠️ 框架签名验证失败: $framework"
+                    fi
+                  fi
+                done
+              fi
+
+              # 对动态库进行签名
+              echo "正在对动态库进行签名..."
+              while IFS= read -r dylib_path; do
+                codesign --force --sign "$CERT_NAME" --options runtime --timestamp "$dylib_path"
+              done < <(find "$APP_PATH" -name "*.dylib" -type f)
+
+              echo "正在对主应用进行签名..."
+              echo "应用路径: $APP_PATH"
+              echo "证书名称: $CERT_NAME (隐藏敏感信息)"
+              echo "权限文件: macos/Runner/Release.entitlements"
+
+              # 对主应用进行签名（使用与本地相同的参数）
+              codesign --force --deep --sign "$CERT_NAME" \
+                --options runtime \
+                --timestamp \
+                --entitlements macos/Runner/Release.entitlements \
+                "$APP_PATH"
+
+              # 详细验证签名
+              echo "验证应用签名..."
+              if codesign --verify --deep --strict --verbose=2 "$APP_PATH"; then
+                echo "✅ 应用签名完成"
+                # 显示签名信息
+                echo "签名信息："
+                codesign -dv --verbose=4 "$APP_PATH"
+              else
+                echo "❌ 应用签名验证失败"
+                exit 1
+              fi
+            done < "$MACOS_VARIANTS_FILE"
           else
             echo "❌ 未找到有效的签名证书"
             exit 1
@@ -239,185 +394,245 @@ runs:
     - name: Notarize macOS App
       shell: bash
       run: |
+        set -euo pipefail
+
         if [ "$ENABLE_NOTARIZATION" = "true" ] && [ "$ENABLE_CODE_SIGNING" = "true" ]; then
           echo "🔐 开始公证 macOS 应用..."
-          
-          APP_PATH="build/macos/Build/Products/Release/NipaPlay.app"
-          
-          # 验证应用已正确签名
-          if ! codesign --verify --deep --strict --verbose=2 "$APP_PATH" 2>/dev/null; then
-            echo "❌ 应用签名验证失败，无法进行公证"
-            exit 1
-          fi
-          
-          # 检查应用是否使用了 Hardened Runtime
-          echo "检查 Hardened Runtime 设置..."
-          codesign -d --entitlements - "$APP_PATH"
-          
-          # 创建 zip 文件用于公证（与本地一致的方式）
-          echo "📦 创建应用压缩包..."
-          ditto -c -k --keepParent "$APP_PATH" "NipaPlay.zip"
-          
-          # 上传公证
-          echo "☁️ 上传到 Apple 进行公证..."
-          SUBMISSION_ID=$(xcrun notarytool submit "NipaPlay.zip" \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_APP_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --output-format json \
-            --wait | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))")
-          
-          if [ -z "$SUBMISSION_ID" ] || [ "$SUBMISSION_ID" = "null" ]; then
-            echo "❌ 获取提交ID失败"
-            rm -f "NipaPlay.zip"
-            exit 1
-          fi
-          
-          echo "提交ID: $SUBMISSION_ID"
-          
-          # 获取公证状态
-          echo "检查公证状态..."
-          STATUS=$(xcrun notarytool info "$SUBMISSION_ID" \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_APP_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --output-format json | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))")
-          
-          echo "公证状态: $STATUS"
-          
-          if [ "$STATUS" != "Accepted" ]; then
-            echo "❌ 公证失败，状态: $STATUS"
-            echo "获取公证日志..."
-            xcrun notarytool log "$SUBMISSION_ID" \
+
+          while IFS='|' read -r variant_key xcode_archs artifact_label variant_suffix; do
+            APP_PATH="${MACOS_STAGING_ROOT}/${variant_suffix}/NipaPlay.app"
+            NOTARIZATION_ZIP="${RUNNER_TEMP}/nipaplay-macos/NipaPlay-${variant_suffix}-notarization.zip"
+
+            echo "🔐 公证 macOS ${artifact_label} 应用..."
+
+            # 验证应用已正确签名
+            if ! codesign --verify --deep --strict --verbose=2 "$APP_PATH" 2>/dev/null; then
+              echo "❌ 应用签名验证失败，无法进行公证"
+              exit 1
+            fi
+
+            # 检查应用是否使用了 Hardened Runtime
+            echo "检查 Hardened Runtime 设置..."
+            codesign -d --entitlements - "$APP_PATH"
+
+            # 创建 zip 文件用于公证（与本地一致的方式）
+            echo "📦 创建应用压缩包..."
+            rm -f "$NOTARIZATION_ZIP"
+            ditto -c -k --keepParent "$APP_PATH" "$NOTARIZATION_ZIP"
+
+            # 上传公证
+            echo "☁️ 上传到 Apple 进行公证..."
+            SUBMISSION_ID=$(xcrun notarytool submit "$NOTARIZATION_ZIP" \
               --apple-id "$APPLE_ID" \
               --password "$APPLE_APP_PASSWORD" \
-              --team-id "$APPLE_TEAM_ID"
-            rm -f "NipaPlay.zip"
-            exit 1
-          fi
-          
-          echo "✅ 公证成功"
-          
-          # 清理临时文件
-          rm -f "NipaPlay.zip"
-          
-          # 等待公证票据在 Apple 服务器上准备就绪
-          echo "等待公证票据准备就绪..."
-          sleep 60
-          
-          # 尝试附加票据，最多重试5次，每次间隔更长
-          echo "🎫 附加公证票据..."
-          STAPLE_SUCCESS=false
-          for attempt in 1 2 3 4 5; do
-            echo "尝试附加票据 (第 $attempt 次)..."
-            if xcrun stapler staple "$APP_PATH" 2>&1; then
-              echo "✅ 公证票据附加成功"
-              STAPLE_SUCCESS=true
-              break
+              --team-id "$APPLE_TEAM_ID" \
+              --output-format json \
+              --wait | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))")
+
+            if [ -z "$SUBMISSION_ID" ] || [ "$SUBMISSION_ID" = "null" ]; then
+              echo "❌ 获取提交ID失败"
+              rm -f "$NOTARIZATION_ZIP"
+              exit 1
+            fi
+
+            echo "提交ID: $SUBMISSION_ID"
+
+            # 获取公证状态
+            echo "检查公证状态..."
+            STATUS=$(xcrun notarytool info "$SUBMISSION_ID" \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_APP_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" \
+              --output-format json | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))")
+
+            echo "公证状态: $STATUS"
+
+            if [ "$STATUS" != "Accepted" ]; then
+              echo "❌ 公证失败，状态: $STATUS"
+              echo "获取公证日志..."
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --apple-id "$APPLE_ID" \
+                --password "$APPLE_APP_PASSWORD" \
+                --team-id "$APPLE_TEAM_ID"
+              rm -f "$NOTARIZATION_ZIP"
+              exit 1
+            fi
+
+            echo "✅ 公证成功"
+
+            # 清理临时文件
+            rm -f "$NOTARIZATION_ZIP"
+
+            # 等待公证票据在 Apple 服务器上准备就绪
+            echo "等待公证票据准备就绪..."
+            sleep 60
+
+            # 尝试附加票据，最多重试5次，每次间隔更长
+            echo "🎫 附加公证票据..."
+            STAPLE_SUCCESS=false
+            for attempt in 1 2 3 4 5; do
+              echo "尝试附加票据 (第 $attempt 次)..."
+              if xcrun stapler staple "$APP_PATH" 2>&1; then
+                echo "✅ 公证票据附加成功"
+                STAPLE_SUCCESS=true
+                break
+              else
+                echo "⚠️ 第 $attempt 次附加失败"
+                if [ $attempt -lt 5 ]; then
+                  wait_time=$((attempt * 30))
+                  echo "等待 $wait_time 秒后重试..."
+                  sleep $wait_time
+                fi
+              fi
+            done
+
+            if [ "$STAPLE_SUCCESS" = "false" ]; then
+              echo "⚠️ 公证票据附加失败，但应用已经公证"
+              echo "应用仍然可以正常分发，用户首次运行时会在线验证"
+              # 不要因为票据附加失败而退出，因为应用已经公证成功
             else
-              echo "⚠️ 第 $attempt 次附加失败"
-              if [ $attempt -lt 5 ]; then
-                wait_time=$((attempt * 30))
-                echo "等待 $wait_time 秒后重试..."
-                sleep $wait_time
+              # 验证公证
+              if xcrun stapler validate "$APP_PATH"; then
+                echo "✅ 公证验证成功 - 应用现在可以离线运行"
+              else
+                echo "⚠️ 公证验证失败，但应用已公证，仍可在线验证"
               fi
             fi
-          done
-          
-          if [ "$STAPLE_SUCCESS" = "false" ]; then
-            echo "⚠️ 公证票据附加失败，但应用已经公证"
-            echo "应用仍然可以正常分发，用户首次运行时会在线验证"
-            # 不要因为票据附加失败而退出，因为应用已经公证成功
-          else
-            # 验证公证
-            if xcrun stapler validate "$APP_PATH"; then
-              echo "✅ 公证验证成功 - 应用现在可以离线运行"
-            else
-              echo "⚠️ 公证验证失败，但应用已公证，仍可在线验证"
-            fi
-          fi
-          
+
+          done < "$MACOS_VARIANTS_FILE"
         elif [ "$ENABLE_CODE_SIGNING" = "true" ]; then
           echo "⚠️ 应用已签名但未公证，用户可能需要手动允许运行"
         else
           echo "⏭️ 跳过公证（未签名或未配置）"
         fi
 
-    - name: Copy mdk.framework.dSYM to App Bundle
-      shell: bash
-      run: |
-        echo "Attempting to copy mdk.framework.dSYM for symbolication..."
-        MDK_ARTIFACTS_DIR="macos/Pods/mdk"
-        DSYM_SOURCE_PATH="${MDK_ARTIFACTS_DIR}/mdk.framework.dSYM"
-        
-        APP_BUNDLE_NAME="NipaPlay.app"
-        APP_BUNDLE_ROOT_DIR="build/macos/Build/Products/Release"
-        TARGET_DSYM_DIR="${APP_BUNDLE_ROOT_DIR}/${APP_BUNDLE_NAME}/Contents/Frameworks"
-
-        if [ -d "$DSYM_SOURCE_PATH" ]; then
-          echo "Found mdk.framework.dSYM at $DSYM_SOURCE_PATH"
-          
-          if [ ! -d "${APP_BUNDLE_ROOT_DIR}/${APP_BUNDLE_NAME}" ]; then
-            echo "Error: App bundle ${APP_BUNDLE_ROOT_DIR}/${APP_BUNDLE_NAME} not found after flutter build."
-            echo "Listing contents of ${APP_BUNDLE_ROOT_DIR}/:"
-            ls -la "${APP_BUNDLE_ROOT_DIR}/"
-            exit 1
-          fi
-          
-          if [ ! -d "$TARGET_DSYM_DIR" ]; then
-             echo "Warning: Target Frameworks directory $TARGET_DSYM_DIR does not exist. Will attempt to create it."
-             mkdir -p "$TARGET_DSYM_DIR"
-          fi
-
-          echo "Copying $DSYM_SOURCE_PATH to $TARGET_DSYM_DIR/"
-          cp -R "$DSYM_SOURCE_PATH" "$TARGET_DSYM_DIR/"
-          if [ $? -eq 0 ]; then
-            echo "Successfully copied mdk.framework.dSYM from $DSYM_SOURCE_PATH."
-            echo "Contents of $TARGET_DSYM_DIR after copy:"
-            ls -la "$TARGET_DSYM_DIR"
-          else
-            echo "Error: Failed to copy mdk.framework.dSYM from $DSYM_SOURCE_PATH."
-            exit 1
-          fi
-        else
-          echo "Warning: mdk.framework.dSYM not found at the revised expected path $DSYM_SOURCE_PATH."
-          echo "Symbolicated crash logs for mdk might not be available."
-        fi
-
-    - name: Package macOS DMG
+    - name: Package macOS installers
       id: package
       shell: bash
       run: |
         set -euo pipefail
 
         version="${{ inputs.app-version }}"
-        dmg_name="NipaPlay_${version}_macOS_Universal.dmg"
-        app_path="build/macos/Build/Products/Release/NipaPlay.app"
+        installer_cert_name=""
 
-        if [ ! -d "$app_path" ]; then
-          echo "Error: App not found at $app_path"
-          ls -la "build/macos/Build/Products/Release" || true
-          exit 1
+        if [ "$ENABLE_CODE_SIGNING" = "true" ]; then
+          installer_cert_name=$(security find-identity -v -p basic | grep "Developer ID Installer" | head -1 | sed 's/.*) \([0-9A-F]*\) "\(.*\)"/\2/' || true)
+          if [ -n "$installer_cert_name" ]; then
+            echo "使用 Installer 证书签名 PKG: $installer_cert_name"
+          else
+            echo "⚠️ 未找到 Developer ID Installer 证书，将生成未签名 PKG。"
+          fi
         fi
 
-        echo "Packaging DMG via hdiutil (no Homebrew dependencies)..."
-        rm -f "$dmg_name"
+        dmg_paths=()
+        zip_paths=()
+        pkg_paths=()
+        package_paths=()
 
-        temp_dir=$(mktemp -d)
-        cp -R "$app_path" "${temp_dir}/"
-        ln -s /Applications "${temp_dir}/Applications"
+        while IFS='|' read -r variant_key xcode_archs artifact_label variant_suffix; do
+          base_name="NipaPlay_${version}_macOS_${artifact_label}"
+          dmg_name="${base_name}.dmg"
+          zip_name="${base_name}.zip"
+          pkg_name="${base_name}.pkg"
+          app_path="${MACOS_STAGING_ROOT}/${variant_suffix}/NipaPlay.app"
 
-        hdiutil create \
-          -volname "NipaPlay-${version}" \
-          -srcfolder "${temp_dir}" \
-          -ov \
-          -format UDZO \
-          "$dmg_name"
+          if [ ! -d "$app_path" ]; then
+            echo "Error: App not found at $app_path"
+            ls -la "${MACOS_STAGING_ROOT}/${variant_suffix}" || true
+            exit 1
+          fi
 
-        hdiutil internet-enable -no "$dmg_name" || true
-        rm -rf "${temp_dir}"
+          echo "Packaging macOS ${artifact_label} DMG via hdiutil (no Homebrew dependencies)..."
+          rm -f "$dmg_name"
 
-        echo "Listing final DMG:"
-        ls -la "$dmg_name"
+          temp_dir=$(mktemp -d)
+          cp -R "$app_path" "${temp_dir}/"
+          ln -s /Applications "${temp_dir}/Applications"
 
-        echo "dmg_path=$dmg_name" >> $GITHUB_OUTPUT
+          hdiutil create \
+            -volname "NipaPlay-${version}-${artifact_label}" \
+            -srcfolder "${temp_dir}" \
+            -ov \
+            -format UDZO \
+            "$dmg_name"
+
+          hdiutil internet-enable -no "$dmg_name" || true
+          rm -rf "${temp_dir}"
+
+          echo "Packaging macOS ${artifact_label} ZIP..."
+          rm -f "$zip_name"
+          ditto -c -k --keepParent "$app_path" "$zip_name"
+
+          echo "Packaging macOS ${artifact_label} PKG..."
+          rm -f "$pkg_name"
+          unsigned_pkg="${RUNNER_TEMP}/nipaplay-macos/${base_name}.unsigned.pkg"
+          rm -f "$unsigned_pkg"
+          pkgbuild \
+            --component "$app_path" \
+            --install-location /Applications \
+            --identifier "com.aimessoft.nipaplay.pkg" \
+            --version "$version" \
+            "$unsigned_pkg"
+
+          if [ -n "$installer_cert_name" ]; then
+            productsign --sign "$installer_cert_name" "$unsigned_pkg" "$pkg_name"
+            rm -f "$unsigned_pkg"
+
+            if [ "$ENABLE_NOTARIZATION" = "true" ]; then
+              echo "🔐 公证 macOS ${artifact_label} PKG..."
+              SUBMISSION_ID=$(xcrun notarytool submit "$pkg_name" \
+                --apple-id "$APPLE_ID" \
+                --password "$APPLE_APP_PASSWORD" \
+                --team-id "$APPLE_TEAM_ID" \
+                --output-format json \
+                --wait | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))")
+
+              if [ -z "$SUBMISSION_ID" ] || [ "$SUBMISSION_ID" = "null" ]; then
+                echo "❌ 获取 PKG 公证提交ID失败"
+                exit 1
+              fi
+
+              STATUS=$(xcrun notarytool info "$SUBMISSION_ID" \
+                --apple-id "$APPLE_ID" \
+                --password "$APPLE_APP_PASSWORD" \
+                --team-id "$APPLE_TEAM_ID" \
+                --output-format json | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))")
+
+              if [ "$STATUS" != "Accepted" ]; then
+                echo "❌ PKG 公证失败，状态: $STATUS"
+                xcrun notarytool log "$SUBMISSION_ID" \
+                  --apple-id "$APPLE_ID" \
+                  --password "$APPLE_APP_PASSWORD" \
+                  --team-id "$APPLE_TEAM_ID"
+                exit 1
+              fi
+
+              xcrun stapler staple "$pkg_name" || true
+            fi
+          else
+            mv "$unsigned_pkg" "$pkg_name"
+          fi
+
+          echo "Listing final macOS ${artifact_label} packages:"
+          ls -la "$dmg_name" "$zip_name" "$pkg_name"
+
+          dmg_paths+=("$dmg_name")
+          zip_paths+=("$zip_name")
+          pkg_paths+=("$pkg_name")
+          package_paths+=("$dmg_name" "$zip_name" "$pkg_name")
+        done < "$MACOS_VARIANTS_FILE"
+
+        {
+          echo "dmg_path<<EOF"
+          printf '%s\n' "${dmg_paths[@]}"
+          echo "EOF"
+          echo "zip_path<<EOF"
+          printf '%s\n' "${zip_paths[@]}"
+          echo "EOF"
+          echo "pkg_path<<EOF"
+          printf '%s\n' "${pkg_paths[@]}"
+          echo "EOF"
+          echo "package_paths<<EOF"
+          printf '%s\n' "${package_paths[@]}"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   build:
-    name: Build macOS DMG
+    name: Build macOS Packages
     runs-on: macos-26
     outputs:
       version: ${{ steps.setup.outputs.version }}
@@ -191,10 +191,11 @@ jobs:
         shell: bash
         run: python3 .github/workflows/scripts/generate-build-info-json.py assets/build_info.json
       
-      - name: Build macOS DMG
+      - name: Build macOS Packages
         uses: ./.github/actions/build-macos
         with:
           app-version: ${{ steps.setup.outputs.version }}
+          build-architectures: universal arm64 x86_64
           macos-certificate-base64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
           macos-certificate-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
           apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
@@ -213,7 +214,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-macOS
-          path: NipaPlay_*_macOS_Universal.dmg
+          path: |
+            NipaPlay_*_macOS_*.dmg
+            NipaPlay_*_macOS_*.zip
+            NipaPlay_*_macOS_*.pkg
 
       - name: Upload Dart debug symbols (for de-obfuscating crash stacks)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -347,7 +347,7 @@ jobs:
           name: Release v${{ needs.Build-Android.outputs.version }}
           bodyFile: "release_notes.md"
           allowUpdates: true
-          artifacts: /tmp/artifacts/release-Android/*.apk,/tmp/artifacts/release-macOS/*.dmg,/tmp/artifacts/release-Windows-x64/*.zip,/tmp/artifacts/release-Windows-x64/*.exe,/tmp/artifacts/release-Windows-x64/*.msix,/tmp/artifacts/release-Linux-amd64/*.deb,/tmp/artifacts/release-Linux-amd64/*.AppImage,/tmp/artifacts/release-Linux-amd64/*.tar.gz,/tmp/artifacts/release-Linux-amd64/*.rpm,/tmp/artifacts/release-Linux-arm64/*.deb,/tmp/artifacts/release-Linux-arm64/*.tar.gz,/tmp/artifacts/release-Linux-arm64/*.rpm
+          artifacts: /tmp/artifacts/release-Android/*.apk,/tmp/artifacts/release-macOS/*.dmg,/tmp/artifacts/release-macOS/*.zip,/tmp/artifacts/release-macOS/*.pkg,/tmp/artifacts/release-Windows-x64/*.zip,/tmp/artifacts/release-Windows-x64/*.exe,/tmp/artifacts/release-Windows-x64/*.msix,/tmp/artifacts/release-Linux-amd64/*.deb,/tmp/artifacts/release-Linux-amd64/*.AppImage,/tmp/artifacts/release-Linux-amd64/*.tar.gz,/tmp/artifacts/release-Linux-amd64/*.rpm,/tmp/artifacts/release-Linux-arm64/*.deb,/tmp/artifacts/release-Linux-arm64/*.tar.gz,/tmp/artifacts/release-Linux-arm64/*.rpm
           artifactErrorsFailBuild: true
           replacesArtifacts: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Extend the macOS composite build action to produce Universal, Apple Silicon, and Intel app variants.
- Package each macOS variant as DMG, ZIP, and PKG artifacts.
- Upload and publish the new macOS ZIP/PKG artifacts alongside existing DMGs.

## Impact

macOS release builds now include standalone Apple Silicon and Intel downloads in addition to the Universal build, and users can choose DMG, ZIP, or PKG packaging from the release assets.

## Validation

- Parsed the touched GitHub Actions YAML files with `yq`.
- Ran `bash -n` against every `run` block in `.github/actions/build-macos/action.yml`.
- Ran `git diff --check`.

Full macOS build and notarization still need to run in GitHub Actions because they depend on the macOS runner, signing secrets, and the release build chain.