### PR TITLE
Enable Erika Windows kernel support

### DIFF
--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -219,7 +219,8 @@ class ErikaPlayerAdapter implements AbstractPlayer {
   static bool get _isSupported =>
       !kIsWeb &&
       (defaultTargetPlatform == TargetPlatform.macOS ||
-          defaultTargetPlatform == TargetPlatform.iOS);
+          defaultTargetPlatform == TargetPlatform.iOS ||
+          defaultTargetPlatform == TargetPlatform.windows);
 
   bool get prefersPlatformVideoSurface => _isSupported;
 
@@ -409,10 +410,7 @@ class ErikaPlayerAdapter implements AbstractPlayer {
       return null;
     }
     try {
-      final Uint8List? bytes = await _player.screenshot(
-        width: width > 0 ? width : null,
-        height: height > 0 ? height : null,
-      );
+      final Uint8List? bytes = await _player.screenshot();
       if (bytes == null || bytes.isEmpty) {
         return null;
       }
@@ -950,7 +948,7 @@ class ErikaPlayerAdapter implements AbstractPlayer {
 
   void _ensureSupported() {
     if (!_isSupported) {
-      throw UnsupportedError('Erika is currently only wired on macOS/iOS.');
+      throw UnsupportedError('Erika is currently only wired on macOS/iOS/Windows.');
     }
   }
 }

--- a/lib/player_abstraction/player_factory.dart
+++ b/lib/player_abstraction/player_factory.dart
@@ -42,7 +42,8 @@ class PlayerFactory {
   static bool get isErikaKernelSupported {
     if (kIsWeb) return false;
     return defaultTargetPlatform == TargetPlatform.macOS ||
-        defaultTargetPlatform == TargetPlatform.iOS;
+        defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.windows;
   }
 
   // 初始化方法，在应用启动时调用

--- a/lib/themes/cupertino/pages/settings/pages/cupertino_player_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_player_settings_page.dart
@@ -308,7 +308,7 @@ class _CupertinoPlayerSettingsPageState
       case PlayerKernelType.mediaKit:
         return context.l10n.playerKernelDescriptionLibmpv;
       case PlayerKernelType.erika:
-        return 'Erika Rust 播放器（实验性）：iOS/macOS 原生 Metal 输出，播放、渲染和音频由 Rust 内核负责。';
+        return 'Erika Rust 播放器（实验性）：iOS/macOS 原生 Metal 输出，Windows 原生 D3D11 输出，播放、渲染和音频由 Rust 内核负责。';
     }
   }
 

--- a/lib/themes/nipaplay/pages/settings/player_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/player_settings_page.dart
@@ -441,7 +441,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
       case PlayerKernelType.mediaKit:
         return 'MediaKit (Libmpv) 播放器\n基于MPV，功能强大，支持硬件解码，支持复杂媒体格式';
       case PlayerKernelType.erika:
-        return 'Erika Rust 播放器（实验性）\niOS/macOS 原生 Metal 输出，播放、渲染和音频由 Rust 内核负责';
+        return 'Erika Rust 播放器（实验性）\niOS/macOS 原生 Metal 输出，Windows 原生 D3D11 输出，播放、渲染和音频由 Rust 内核负责';
     }
   }
 
@@ -656,7 +656,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
                   .toList();
               return SettingsItem.dropdown(
                 title: 'Erika 超分辨率',
-                subtitle: '使用 Erika Metal ART-CNN 对视频帧做实时超分',
+                subtitle: '使用 Erika ART-CNN 对视频帧做实时超分',
                 icon: Ionicons.sparkles_outline,
                 items: items,
                 onChanged: (dynamic value) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -283,8 +283,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: "93cd15483fa4f1b25c4d82985bbcf14e1048776f"
-      resolved-ref: "93cd15483fa4f1b25c4d82985bbcf14e1048776f"
+      ref: "codex/windows-native-core"
+      resolved-ref: e66d6ef6e47f228a5e6eb2e8caa487c225df476c
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -284,7 +284,7 @@ packages:
     description:
       path: "packages/erika_flutter"
       ref: "codex/windows-native-core"
-      resolved-ref: e66d6ef6e47f228a5e6eb2e8caa487c225df476c
+      resolved-ref: f8283395f0a45ba818a33e5a8cb5d8214e1c073f
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,7 @@ dependencies:
   erika_flutter:
     git:
       url: https://github.com/AimesSoft/Erika.git
-      ref: 93cd15483fa4f1b25c4d82985bbcf14e1048776f
+      ref: codex/windows-native-core
       path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   qr_code_scanner_plus: ^2.0.12

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <desktop_multi_window/desktop_multi_window_plugin.h>
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
+#include <erika_flutter/erika_flutter_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_js/flutter_js_plugin.h>
 #include <fvp/fvp_plugin_c_api.h>
@@ -37,6 +38,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("DesktopMultiWindowPlugin"));
   DynamicColorPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
+  ErikaFlutterPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ErikaFlutterPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterJsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -11,7 +11,7 @@
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <desktop_multi_window/desktop_multi_window_plugin.h>
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
-#include <erika_flutter/erika_flutter_plugin.h>
+#include <erika_flutter/erika_flutter_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_js/flutter_js_plugin.h>
 #include <fvp/fvp_plugin_c_api.h>
@@ -38,8 +38,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("DesktopMultiWindowPlugin"));
   DynamicColorPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
-  ErikaFlutterPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("ErikaFlutterPlugin"));
+  ErikaFlutterPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ErikaFlutterPluginCApi"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterJsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   desktop_drop
   desktop_multi_window
   dynamic_color
+  erika_flutter
   file_selector_windows
   flutter_js
   fvp


### PR DESCRIPTION
## Summary
- allow the Erika player kernel on Windows in NipaPlay
- point `erika_flutter` at Erika's Windows native core branch
- register the Erika Flutter Windows plugin through its C API entrypoint and update settings copy for D3D11 output

## Verification
- `flutter pub get`
- `dart analyze lib\player_abstraction\erika_player_adapter.dart lib\player_abstraction\player_factory.dart`
- elevated `flutter clean && flutter pub get && flutter build windows`

## Notes
- The Windows build now succeeds and produces `build\windows\x64\runner\Release\NipaPlay.exe` with `erika_flutter_plugin.dll` bundled.