### PR TITLE
Update Erika dependency to main

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -283,8 +283,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: "codex/windows-native-core"
-      resolved-ref: f8283395f0a45ba818a33e5a8cb5d8214e1c073f
+      ref: main
+      resolved-ref: e04a273c947c6520db2926797b9deedea4b7f4b3
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,7 @@ dependencies:
   erika_flutter:
     git:
       url: https://github.com/AimesSoft/Erika.git
-      ref: codex/windows-native-core
+      ref: main
       path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   qr_code_scanner_plus: ^2.0.12

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -11,7 +11,6 @@
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <desktop_multi_window/desktop_multi_window_plugin.h>
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
-#include <erika_flutter/erika_flutter_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_js/flutter_js_plugin.h>
 #include <fvp/fvp_plugin_c_api.h>
@@ -38,8 +37,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("DesktopMultiWindowPlugin"));
   DynamicColorPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
-  ErikaFlutterPluginCApiRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("ErikaFlutterPluginCApi"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterJsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -8,7 +8,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   desktop_drop
   desktop_multi_window
   dynamic_color
-  erika_flutter
   file_selector_windows
   flutter_js
   fvp


### PR DESCRIPTION
## Summary
- switch `erika_flutter` from the temporary Windows core branch to Erika `main`
- update `pubspec.lock` to the merged Erika commit `e04a273c947c6520db2926797b9deedea4b7f4b3`
- refresh Windows generated plugin registration after the dependency update

## Validation
- `PUB_HOSTED_URL=https://pub.dev FLUTTER_STORAGE_BASE_URL=https://storage.googleapis.com flutter pub get`
- `PUB_HOSTED_URL=https://pub.dev FLUTTER_STORAGE_BASE_URL=https://storage.googleapis.com flutter analyze` currently fails because the repo analyzer scans existing `build/` and `third_party/media-kit-upstream` sources, producing pre-existing generated/upstream analyzer errors unrelated to this dependency-only change.