### PR TITLE
ci(windows): install MSYS2 make into C:\msys64 for Erika native build

### DIFF
--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -27,6 +27,10 @@ runs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: UCRT64
+        # Operate on the runner's pre-installed C:\msys64 (the path Erika's xtask
+        # and the check below hard-code) instead of a fresh MSYS2 under RUNNER_TEMP,
+        # so the installed packages land in C:\msys64\usr\bin.
+        release: false
         update: false
         path-type: inherit
         install: >-


### PR DESCRIPTION
## Problem
The `Build Windows Package` job fails at the Erika native pre-flight check with:

```
throw "MSYS2 make.exe was not found"
##[error]Process completed with exit code 1.
```

`msys2/setup-msys2@v2` defaulted to `release: true`, which provisions a **fresh** MSYS2 under `RUNNER_TEMP` and installs `make`/`tar`/`diffutils` there. But both the pre-flight check and Erika's `xtask` (`gnu_make()` / `posix_shell()`) look in the runner's **pre-installed** `C:\msys64`, which ships `sh.exe` but not `make.exe`.

## Fix
Set `release: false` so `setup-msys2` operates on `C:\msys64`, landing the installed packages in `C:\msys64\usr\bin` where the check and xtask expect them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)