### PR TITLE
[codex] Hide subtitle menu items without tracks

### DIFF
--- a/lib/player_menu/player_menu_definition_builder.dart
+++ b/lib/player_menu/player_menu_definition_builder.dart
@@ -17,7 +17,9 @@ class PlayerMenuDefinitionBuilder {
         icon: PlayerMenuIconToken.subtitleSettings,
         title: '字幕设置',
         visibilityPredicate: (ctx) =>
-            ctx.supportsSubtitleSettings && ctx.hasVideo,
+            ctx.supportsSubtitleSettings &&
+            ctx.hasVideo &&
+            ctx.hasSubtitleTracks,
       ),
       PlayerMenuItemDefinition(
         paneId: PlayerMenuPaneId.subtitleTracks,
@@ -33,7 +35,7 @@ class PlayerMenuDefinitionBuilder {
         icon: PlayerMenuIconToken.subtitleList,
         title: '字幕列表',
         visibilityPredicate: (ctx) =>
-            ctx.supportsAdvancedTracks && ctx.hasVideo,
+            ctx.supportsAdvancedTracks && ctx.hasVideo && ctx.hasSubtitleTracks,
       ),
       PlayerMenuItemDefinition(
         paneId: PlayerMenuPaneId.audioTracks,

--- a/lib/player_menu/player_menu_models.dart
+++ b/lib/player_menu/player_menu_models.dart
@@ -90,6 +90,17 @@ class PlayerMenuContext {
 
   bool get hasVideo => videoState.hasVideo;
 
+  bool get hasSubtitleTracks {
+    final embeddedSubtitleTracks = videoState.player.mediaInfo.subtitle;
+    if (embeddedSubtitleTracks != null && embeddedSubtitleTracks.isNotEmpty) {
+      return true;
+    }
+
+    final currentExternalSubtitlePath = videoState.currentExternalSubtitlePath;
+    return currentExternalSubtitlePath != null &&
+        currentExternalSubtitlePath.isNotEmpty;
+  }
+
   bool get hasVideoPath => videoState.currentVideoPath != null;
 
   bool get hasPlaylist =>

--- a/test/player_menu_definition_builder_test.dart
+++ b/test/player_menu_definition_builder_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/player_abstraction/player_abstraction.dart';
+import 'package:nipaplay/player_menu/player_menu_definition_builder.dart';
+import 'package:nipaplay/player_menu/player_menu_models.dart';
+import 'package:nipaplay/utils/video_player_state.dart';
+
+class _FakeVideoPlayerState extends ChangeNotifier implements VideoPlayerState {
+  _FakeVideoPlayerState({
+    required this.playerValue,
+    this.currentExternalSubtitlePathValue,
+  });
+
+  final Player playerValue;
+  final String? currentExternalSubtitlePathValue;
+
+  @override
+  Player get player => playerValue;
+
+  @override
+  bool get hasVideo => true;
+
+  @override
+  String? get currentVideoPath => null;
+
+  @override
+  String? get currentExternalSubtitlePath => currentExternalSubtitlePathValue;
+
+  @override
+  int? get animeId => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakePlayer implements Player {
+  _FakePlayer({List<PlayerSubtitleStreamInfo>? subtitleTracks})
+      : mediaInfoValue = PlayerMediaInfo(
+          duration: 0,
+          subtitle: subtitleTracks,
+        );
+
+  final PlayerMediaInfo mediaInfoValue;
+
+  @override
+  PlayerMediaInfo get mediaInfo => mediaInfoValue;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('PlayerMenuDefinitionBuilder', () {
+    test('hides subtitle settings and list when no subtitle tracks exist', () {
+      final paneIds = _visiblePaneIds(subtitleTracks: const []);
+
+      expect(paneIds, isNot(contains(PlayerMenuPaneId.subtitleSettings)));
+      expect(paneIds, contains(PlayerMenuPaneId.subtitleTracks));
+      expect(paneIds, isNot(contains(PlayerMenuPaneId.subtitleList)));
+    });
+
+    test('shows subtitle settings and list when embedded subtitles exist', () {
+      final paneIds = _visiblePaneIds(
+        subtitleTracks: [
+          PlayerSubtitleStreamInfo(
+            title: '简体中文',
+            language: 'zh-Hans',
+            rawRepresentation: 'Subtitle: 简体中文',
+          ),
+        ],
+      );
+
+      expect(paneIds, contains(PlayerMenuPaneId.subtitleSettings));
+      expect(paneIds, contains(PlayerMenuPaneId.subtitleTracks));
+      expect(paneIds, contains(PlayerMenuPaneId.subtitleList));
+    });
+
+    test('shows subtitle settings and list when external subtitle is active',
+        () {
+      final paneIds = _visiblePaneIds(
+        subtitleTracks: const [],
+        currentExternalSubtitlePath: '/tmp/subtitle.ass',
+      );
+
+      expect(paneIds, contains(PlayerMenuPaneId.subtitleSettings));
+      expect(paneIds, contains(PlayerMenuPaneId.subtitleTracks));
+      expect(paneIds, contains(PlayerMenuPaneId.subtitleList));
+    });
+  });
+}
+
+List<PlayerMenuPaneId> _visiblePaneIds({
+  required List<PlayerSubtitleStreamInfo>? subtitleTracks,
+  String? currentExternalSubtitlePath,
+}) {
+  final videoState = _FakeVideoPlayerState(
+    playerValue: _FakePlayer(subtitleTracks: subtitleTracks),
+    currentExternalSubtitlePathValue: currentExternalSubtitlePath,
+  );
+
+  return PlayerMenuDefinitionBuilder(
+    context: PlayerMenuContext(
+      videoState: videoState,
+      kernelType: PlayerKernelType.mediaKit,
+    ),
+  ).build().map((item) => item.paneId).toList(growable: false);
+}


### PR DESCRIPTION
## Summary
- Hide the player menu's subtitle settings and subtitle list entries when there are no subtitle tracks.
- Keep the subtitle tracks entry visible so users can still load local or remote subtitle files.
- Treat an active external subtitle path as available subtitle content so settings and list return after an external subtitle is loaded.

## Why
Videos without subtitle tracks were still showing subtitle-specific menu entries that could not provide useful content.

## Validation
- `flutter test test/player_menu_definition_builder_test.dart`
- `flutter analyze lib/player_menu/player_menu_definition_builder.dart lib/player_menu/player_menu_models.dart test/player_menu_definition_builder_test.dart`