### PR TITLE
[codex] Show DFM+ danmaku effect toggles

### DIFF
--- a/lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart
@@ -268,6 +268,12 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
   bool get _isDfmPlusKernel =>
       DanmakuKernelFactory.getKernelType() == DanmakuRenderEngine.dfmPlus;
 
+  bool get _usesBinaryDanmakuEffectToggles =>
+      _isNext2Kernel || _isDfmPlusKernel;
+
+  String get _binaryDanmakuEffectKernelName =>
+      _isDfmPlusKernel ? 'DFM+' : 'Next2';
+
   Future<void> _pickDanmakuFontFile(VideoPlayerState videoState) async {
     final selected = await openFile(
       acceptedTypeGroups: const [
@@ -649,10 +655,10 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
                 ),
                 Divider(
                     color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-                if (_isNext2Kernel)
+                if (_usesBinaryDanmakuEffectToggles)
                   SettingsItem.toggle(
                     title: '弹幕描边',
-                    subtitle: '开启后为 Next2 弹幕添加描边',
+                    subtitle: '开启后为 $_binaryDanmakuEffectKernelName 弹幕添加描边',
                     icon: Ionicons.text_outline,
                     value: videoState.next2DanmakuOutlineWidth > 0.0,
                     onChanged: (value) {
@@ -675,10 +681,10 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
                   ),
                 Divider(
                     color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-                if (_isNext2Kernel)
+                if (_usesBinaryDanmakuEffectToggles)
                   SettingsItem.toggle(
                     title: '弹幕阴影',
-                    subtitle: '开启后为 Next2 弹幕添加阴影',
+                    subtitle: '开启后为 $_binaryDanmakuEffectKernelName 弹幕添加阴影',
                     icon: Ionicons.color_wand_outline,
                     value: videoState.danmakuShadowStyle !=
                         DanmakuShadowStyle.none,


### PR DESCRIPTION
## Summary
- Show the same binary danmaku outline and shadow toggles for DFM+ that Next2 uses.
- Keep the existing dropdown controls for other danmaku kernels.
- Update the toggle subtitles to mention the active binary-effect kernel name, either Next2 or DFM+.

## Why
DFM+ already consumes the same outline width and shadow style settings in the render path, but the settings UI still exposed the older style dropdowns instead of the simpler Next2 toggles.

## Validation
- `dart format lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart`
- `git diff --check`
- `flutter analyze --no-fatal-infos lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart`

Note: plain `flutter analyze` still reports existing info-level lints in this file, mostly `withOpacity` deprecations and `prefer_const_constructors`, unrelated to this change.