### PR TITLE
[codex] Use server-provided random recommendations

### DIFF
--- a/lib/pages/dashboard_home_page.dart
+++ b/lib/pages/dashboard_home_page.dart
@@ -19,13 +19,12 @@ import 'package:nipaplay/services/emby_service.dart';
 import 'package:nipaplay/services/bangumi_service.dart';
 import 'package:nipaplay/utils/network_settings.dart';
 import 'package:nipaplay/services/dandanplay_service.dart';
-import 'package:nipaplay/services/search_service.dart';
 import 'package:nipaplay/services/scan_service.dart';
 import 'package:nipaplay/services/web_remote_access_service.dart';
+import 'package:nipaplay/services/random_recommendation_service.dart';
 import 'package:nipaplay/models/jellyfin_model.dart';
 import 'package:nipaplay/models/emby_model.dart';
 import 'package:nipaplay/models/bangumi_model.dart';
-import 'package:nipaplay/models/search_model.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/horizontal_anime_card.dart';
@@ -165,6 +164,8 @@ class _DashboardHomePageState extends State<DashboardHomePage>
 
   // 随机推荐数据
   List<RandomRecommendationItem> _randomRecommendations = [];
+  List<RandomRecommendationGroup> _randomRecommendationGroups = [];
+  int _randomRecommendationGroupIndex = 0;
   bool _isLoadingRandomRecommendations = false;
   ScrollController? _randomRecommendationsScrollController;
 

--- a/lib/services/random_recommendation_service.dart
+++ b/lib/services/random_recommendation_service.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:nipaplay/models/search_model.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class RandomRecommendationService {
+  RandomRecommendationService._();
+
+  static final RandomRecommendationService instance =
+      RandomRecommendationService._();
+
+  static const String _endpoint =
+      'https://nipaplay.aimes-soft.com/api/random-recommendations';
+  static const String _cacheKey = 'daily_random_recommendations_cache';
+  static const Duration _requestTimeout = Duration(seconds: 8);
+
+  Future<DailyRandomRecommendations> fetchDailyRecommendations() async {
+    try {
+      final response = await http.get(Uri.parse(_endpoint),
+          headers: {'Accept': 'application/json'}).timeout(_requestTimeout);
+      if (response.statusCode != 200) {
+        throw Exception('HTTP ${response.statusCode}');
+      }
+
+      final data = json.decode(utf8.decode(response.bodyBytes));
+      if (data is! Map<String, dynamic> || data['success'] != true) {
+        throw const FormatException('Invalid random recommendations payload');
+      }
+
+      final recommendations = DailyRandomRecommendations.fromJson(data);
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_cacheKey, json.encode(recommendations.toJson()));
+      return recommendations;
+    } catch (e) {
+      debugPrint('[RandomRecommendationService] 官方推荐接口不可用，尝试本地缓存: $e');
+      final cached = await _readCachedRecommendations();
+      if (cached != null) {
+        return cached;
+      }
+      rethrow;
+    }
+  }
+
+  Future<DailyRandomRecommendations?> _readCachedRecommendations() async {
+    final prefs = await SharedPreferences.getInstance();
+    final cachedString = prefs.getString(_cacheKey);
+    if (cachedString == null || cachedString.isEmpty) return null;
+
+    try {
+      final data = json.decode(cachedString);
+      if (data is! Map<String, dynamic>) return null;
+      return DailyRandomRecommendations.fromJson(data);
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+class DailyRandomRecommendations {
+  final String date;
+  final DateTime? generatedAt;
+  final List<RandomRecommendationGroup> groups;
+
+  const DailyRandomRecommendations({
+    required this.date,
+    required this.generatedAt,
+    required this.groups,
+  });
+
+  factory DailyRandomRecommendations.fromJson(Map<String, dynamic> json) {
+    final groups = (json['groups'] as List<dynamic>?)
+            ?.whereType<Map<String, dynamic>>()
+            .map(RandomRecommendationGroup.fromJson)
+            .where((group) => group.items.isNotEmpty)
+            .toList() ??
+        [];
+    if (groups.isEmpty) {
+      throw const FormatException('Random recommendations contain no groups');
+    }
+
+    return DailyRandomRecommendations(
+      date: json['date']?.toString() ?? '',
+      generatedAt: DateTime.tryParse(json['generatedAt']?.toString() ?? ''),
+      groups: groups,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'success': true,
+      'date': date,
+      'generatedAt': generatedAt?.toIso8601String(),
+      'groups': groups.map((group) => group.toJson()).toList(),
+    };
+  }
+}
+
+class RandomRecommendationGroup {
+  final int index;
+  final String id;
+  final List<RandomRecommendationItem> items;
+
+  const RandomRecommendationGroup({
+    required this.index,
+    required this.id,
+    required this.items,
+  });
+
+  factory RandomRecommendationGroup.fromJson(Map<String, dynamic> json) {
+    return RandomRecommendationGroup(
+      index: (json['index'] as num?)?.toInt() ?? 0,
+      id: json['id']?.toString() ?? '',
+      items: (json['items'] as List<dynamic>?)
+              ?.whereType<Map<String, dynamic>>()
+              .map(RandomRecommendationItem.fromJson)
+              .where((item) => item.anime.animeId > 0)
+              .toList() ??
+          [],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'index': index,
+      'id': id,
+      'items': items.map((item) => item.toJson()).toList(),
+    };
+  }
+}
+
+class RandomRecommendationItem {
+  final String tag;
+  final SearchResultAnime anime;
+
+  const RandomRecommendationItem({
+    required this.tag,
+    required this.anime,
+  });
+
+  factory RandomRecommendationItem.fromJson(Map<String, dynamic> json) {
+    final anime = json['anime'];
+    if (anime is! Map<String, dynamic>) {
+      throw const FormatException('Random recommendation item has no anime');
+    }
+    return RandomRecommendationItem(
+      tag: json['tag']?.toString() ?? '',
+      anime: SearchResultAnime.fromJson(anime),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'tag': tag,
+      'anime': anime.toJson(),
+    };
+  }
+}

--- a/lib/themes/cupertino/pages/cupertino_home_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_home_page.dart
@@ -12,7 +12,6 @@ import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:nipaplay/models/emby_model.dart';
 import 'package:nipaplay/models/jellyfin_model.dart';
@@ -26,9 +25,9 @@ import 'package:nipaplay/providers/jellyfin_provider.dart';
 import 'package:nipaplay/providers/watch_history_provider.dart';
 import 'package:nipaplay/services/bangumi_service.dart';
 import 'package:nipaplay/utils/network_settings.dart';
-import 'package:nipaplay/services/search_service.dart';
 import 'package:nipaplay/services/emby_service.dart';
 import 'package:nipaplay/services/jellyfin_service.dart';
+import 'package:nipaplay/services/random_recommendation_service.dart';
 import 'package:nipaplay/services/server_history_sync_service.dart';
 import 'package:nipaplay/services/web_remote_access_service.dart';
 import 'package:http/http.dart' as http;
@@ -77,7 +76,9 @@ class _CupertinoHomePageState extends State<CupertinoHomePage> {
 
   List<BangumiAnime> _todayAnimes = [];
   bool _isLoadingTodayAnimes = false;
-  List<_CupertinoRandomRecommendationItem> _randomRecommendations = [];
+  List<RandomRecommendationItem> _randomRecommendations = [];
+  List<RandomRecommendationGroup> _randomRecommendationGroups = [];
+  int _randomRecommendationGroupIndex = 0;
   bool _isLoadingRandomRecommendations = false;
   
   // 最近添加数据
@@ -518,92 +519,26 @@ class _CupertinoHomePageState extends State<CupertinoHomePage> {
 
   Future<void> _loadRandomRecommendations({bool forceRefresh = false}) async {
     if (!mounted || _isLoadingRandomRecommendations) return;
+    if (forceRefresh && _randomRecommendationGroups.isNotEmpty) {
+      _showNextRandomRecommendationGroup();
+      return;
+    }
     if (!forceRefresh && _randomRecommendations.isNotEmpty) return;
 
     setState(() => _isLoadingRandomRecommendations = true);
 
     try {
-      final config = await SearchService.instance.getSearchConfig();
-      final tags = config.tags
-          .map((tag) => tag.value.trim())
-          .where((value) => value.isNotEmpty)
-          .toList();
-
-      if (tags.isEmpty) {
-        if (mounted) {
-          setState(() {
-            _randomRecommendations = [];
-            _isLoadingRandomRecommendations = false;
-          });
-        }
-        return;
-      }
-
-      final prefs = await SharedPreferences.getInstance();
-      final bool filterAdultContentGlobally =
-          prefs.getBool('global_filter_adult_content') ?? true;
-
-      final random = math.Random();
-      tags.shuffle(random);
-
-      final items = <_CupertinoRandomRecommendationItem>[];
-      final usedAnimeIds = <int>{};
-
-      for (int start = 0; start < tags.length && items.length < 5; start += 5) {
-        final batch = tags.sublist(start, math.min(start + 5, tags.length));
-        final futures = batch.map((tag) async {
-          try {
-            final result = await SearchService.instance.searchAnimeByTags([tag]);
-            return _CupertinoRandomTagSearchResult(tag, result.animes);
-          } catch (e) {
-            debugPrint('CupertinoHomePage: 随机推荐标签搜索失败: $tag, error: $e');
-            return null;
-          }
-        }).toList();
-
-        final results = await Future.wait(futures, eagerError: false);
-        for (final entry in results) {
-          if (entry == null) continue;
-
-          final cappedResults = entry.animes.take(100).toList();
-          final candidates = cappedResults.where((anime) {
-            if (anime.animeId <= 0 || anime.animeTitle.isEmpty) return false;
-            if (anime.imageUrl == null || anime.imageUrl!.isEmpty) return false;
-            if (filterAdultContentGlobally && anime.isRestricted == true) {
-              return false;
-            }
-            if (_isMyHeroAcademiaRelated(anime)) return false;
-            return true;
-          }).toList();
-
-          if (candidates.isEmpty) continue;
-
-          candidates.shuffle(random);
-          SearchResultAnime? selected;
-          for (final anime in candidates) {
-            if (!usedAnimeIds.contains(anime.animeId)) {
-              selected = anime;
-              break;
-            }
-          }
-
-          if (selected != null) {
-            usedAnimeIds.add(selected.animeId);
-            items.add(
-              _CupertinoRandomRecommendationItem(
-                tag: entry.tag,
-                anime: selected,
-              ),
-            );
-          }
-
-          if (items.length >= 5) break;
-        }
-      }
+      final daily =
+          await RandomRecommendationService.instance.fetchDailyRecommendations();
+      final groups =
+          daily.groups.where((group) => group.items.isNotEmpty).toList();
+      final groupIndex = _randomRecommendationGroupIndex % groups.length;
 
       if (mounted) {
         setState(() {
-          _randomRecommendations = items;
+          _randomRecommendationGroups = groups;
+          _randomRecommendationGroupIndex = groupIndex;
+          _randomRecommendations = groups[groupIndex].items;
           _isLoadingRandomRecommendations = false;
         });
       }
@@ -1304,7 +1239,7 @@ class _CupertinoHomePageState extends State<CupertinoHomePage> {
   }
 
   Widget _buildRandomRecommendationCard(
-      _CupertinoRandomRecommendationItem item) {
+      RandomRecommendationItem item) {
     final anime = item.anime;
     final summary = (anime.intro != null && anime.intro!.isNotEmpty)
         ? anime.intro!
@@ -2211,12 +2146,16 @@ class _CupertinoHomePageState extends State<CupertinoHomePage> {
     return '#${tag.substring(0, maxLength)}...';
   }
 
-  bool _isMyHeroAcademiaRelated(SearchResultAnime anime) {
-    final title = anime.animeTitle.trim();
-    if (title.isEmpty) return false;
-    final normalizedTitle = title.toLowerCase();
-    return _blockedRandomRecommendationKeywords
-        .any((keyword) => normalizedTitle.contains(keyword));
+  void _showNextRandomRecommendationGroup() {
+    final groups = _randomRecommendationGroups
+        .where((group) => group.items.isNotEmpty)
+        .toList();
+    if (groups.isEmpty) return;
+    final nextIndex = (_randomRecommendationGroupIndex + 1) % groups.length;
+    setState(() {
+      _randomRecommendationGroupIndex = nextIndex;
+      _randomRecommendations = groups[nextIndex].items;
+    });
   }
 
   Widget _buildEmptyRecentPlaceholder() {
@@ -3150,34 +3089,6 @@ class _CupertinoHomePageState extends State<CupertinoHomePage> {
         return;
     }
   }
-}
-
-const _blockedRandomRecommendationKeywords = <String>[
-  '我的英雄学院',
-  '我的英雄學院',
-  '僕のヒーローアカデミア',
-  'ヒロアカ',
-  'my hero academia',
-  'boku no hero academia',
-  'hero academia',
-  'mha',
-];
-
-class _CupertinoRandomRecommendationItem {
-  final String tag;
-  final SearchResultAnime anime;
-
-  const _CupertinoRandomRecommendationItem({
-    required this.tag,
-    required this.anime,
-  });
-}
-
-class _CupertinoRandomTagSearchResult {
-  final String tag;
-  final List<SearchResultAnime> animes;
-
-  const _CupertinoRandomTagSearchResult(this.tag, this.animes);
 }
 
 class _CupertinoRecommendedItem {

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_random_recommendations.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_random_recommendations.dart
@@ -1,33 +1,5 @@
 part of dashboard_home_page;
 
-const _blockedRandomRecommendationKeywords = <String>[
-  '我的英雄学院',
-  '我的英雄學院',
-  '僕のヒーローアカデミア',
-  'ヒロアカ',
-  'my hero academia',
-  'boku no hero academia',
-  'hero academia',
-  'mha',
-];
-
-class RandomRecommendationItem {
-  final String tag;
-  final SearchResultAnime anime;
-
-  const RandomRecommendationItem({
-    required this.tag,
-    required this.anime,
-  });
-}
-
-class _RandomTagSearchResult {
-  final String tag;
-  final List<SearchResultAnime> animes;
-
-  const _RandomTagSearchResult(this.tag, this.animes);
-}
-
 extension DashboardHomePageRandomRecommendations on _DashboardHomePageState {
   ScrollController _getRandomRecommendationsScrollController() {
     _randomRecommendationsScrollController ??= ScrollController();
@@ -36,91 +8,29 @@ extension DashboardHomePageRandomRecommendations on _DashboardHomePageState {
 
   Future<void> _loadRandomRecommendations({bool forceRefresh = false}) async {
     if (!mounted || _isLoadingRandomRecommendations) return;
+    if (forceRefresh && _randomRecommendationGroups.isNotEmpty) {
+      _showNextRandomRecommendationGroup();
+      return;
+    }
     if (!forceRefresh && _randomRecommendations.isNotEmpty) return;
 
     setState(() => _isLoadingRandomRecommendations = true);
 
     try {
-      final config = await SearchService.instance.getSearchConfig();
-      final tags = config.tags
-          .map((tag) => tag.value.trim())
-          .where((value) => value.isNotEmpty)
-          .toList();
-
-      if (tags.isEmpty) {
-        if (mounted) {
-          setState(() {
-            _randomRecommendations = [];
-            _isLoadingRandomRecommendations = false;
-          });
-        }
-        return;
-      }
-
-      final prefs = await SharedPreferences.getInstance();
-      final bool filterAdultContentGlobally =
-          prefs.getBool('global_filter_adult_content') ?? true;
-
-      final random = math.Random();
-      tags.shuffle(random);
-
-      final items = <RandomRecommendationItem>[];
-      final usedAnimeIds = <int>{};
-
-      for (int start = 0; start < tags.length && items.length < 5; start += 5) {
-        final batch = tags.sublist(start, math.min(start + 5, tags.length));
-        final futures = batch.map((tag) async {
-          try {
-            final result =
-                await SearchService.instance.searchAnimeByTags([tag]);
-            return _RandomTagSearchResult(tag, result.animes);
-          } catch (e) {
-            debugPrint('随机推荐标签搜索失败: $tag, error: $e');
-            return null;
-          }
-        }).toList();
-
-        final results = await Future.wait(futures, eagerError: false);
-        for (final entry in results) {
-          if (entry == null) continue;
-
-          final cappedResults = entry.animes.take(100).toList();
-          final candidates = cappedResults.where((anime) {
-            if (anime.animeId <= 0 || anime.animeTitle.isEmpty) return false;
-            if (anime.imageUrl == null || anime.imageUrl!.isEmpty) return false;
-            if (filterAdultContentGlobally && anime.isRestricted == true) {
-              return false;
-            }
-            if (_isMyHeroAcademiaRelated(anime)) return false;
-            return true;
-          }).toList();
-
-          if (candidates.isEmpty) continue;
-
-          candidates.shuffle(random);
-          SearchResultAnime? selected;
-          for (final anime in candidates) {
-            if (!usedAnimeIds.contains(anime.animeId)) {
-              selected = anime;
-              break;
-            }
-          }
-
-          if (selected != null) {
-            usedAnimeIds.add(selected.animeId);
-            items
-                .add(RandomRecommendationItem(tag: entry.tag, anime: selected));
-          }
-
-          if (items.length >= 5) break;
-        }
-      }
+      final daily = await RandomRecommendationService.instance
+          .fetchDailyRecommendations();
+      final groups =
+          daily.groups.where((group) => group.items.isNotEmpty).toList();
+      final groupIndex = _randomRecommendationGroupIndex % groups.length;
 
       if (mounted) {
         setState(() {
-          _randomRecommendations = items;
+          _randomRecommendationGroups = groups;
+          _randomRecommendationGroupIndex = groupIndex;
+          _randomRecommendations = groups[groupIndex].items;
           _isLoadingRandomRecommendations = false;
         });
+        _resetRandomRecommendationScroll();
       }
     } catch (e) {
       debugPrint('加载随机推荐失败: $e');
@@ -246,11 +156,26 @@ extension DashboardHomePageRandomRecommendations on _DashboardHomePageState {
     return '#${tag.substring(0, maxLength)}...';
   }
 
-  bool _isMyHeroAcademiaRelated(SearchResultAnime anime) {
-    final title = anime.animeTitle.trim();
-    if (title.isEmpty) return false;
-    final normalizedTitle = title.toLowerCase();
-    return _blockedRandomRecommendationKeywords
-        .any((keyword) => normalizedTitle.contains(keyword));
+  void _showNextRandomRecommendationGroup() {
+    final groups = _randomRecommendationGroups
+        .where((group) => group.items.isNotEmpty)
+        .toList();
+    if (groups.isEmpty) return;
+    final nextIndex = (_randomRecommendationGroupIndex + 1) % groups.length;
+    setState(() {
+      _randomRecommendationGroupIndex = nextIndex;
+      _randomRecommendations = groups[nextIndex].items;
+    });
+    _resetRandomRecommendationScroll();
+  }
+
+  void _resetRandomRecommendationScroll() {
+    final controller = _randomRecommendationsScrollController;
+    if (controller == null || !controller.hasClients) return;
+    controller.animateTo(
+      0,
+      duration: const Duration(milliseconds: 220),
+      curve: Curves.easeOut,
+    );
   }
 }

--- a/test/random_recommendation_service_test.dart
+++ b/test/random_recommendation_service_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/services/random_recommendation_service.dart';
+
+void main() {
+  group('DailyRandomRecommendations', () {
+    test('parses server groups and anime fields', () {
+      final payload = DailyRandomRecommendations.fromJson({
+        'success': true,
+        'date': '2026-06-28',
+        'generatedAt': '2026-06-28T08:00:00.000Z',
+        'groups': [
+          {
+            'index': 0,
+            'id': '2026-06-28-1',
+            'items': [
+              {
+                'tag': '治愈',
+                'anime': {
+                  'animeId': 123,
+                  'bangumiId': '456',
+                  'animeTitle': '测试番剧',
+                  'type': 'tv',
+                  'typeDescription': 'TV',
+                  'imageUrl': 'https://example.com/cover.jpg',
+                  'startDate': '2026-06-28',
+                  'episodeCount': 12,
+                  'rating': 8.5,
+                  'isFavorited': false,
+                  'rank': 10,
+                  'searchKeyword': '测试',
+                  'isOnAir': true,
+                  'isRestricted': false,
+                  'intro': '简介',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(payload.date, '2026-06-28');
+      expect(payload.groups, hasLength(1));
+      expect(payload.groups.single.items, hasLength(1));
+
+      final item = payload.groups.single.items.single;
+      expect(item.tag, '治愈');
+      expect(item.anime.animeId, 123);
+      expect(item.anime.animeTitle, '测试番剧');
+      expect(item.anime.imageUrl, 'https://example.com/cover.jpg');
+    });
+
+    test('rejects payloads without usable groups', () {
+      expect(
+        () => DailyRandomRecommendations.fromJson({
+          'success': true,
+          'date': '2026-06-28',
+          'generatedAt': '2026-06-28T08:00:00.000Z',
+          'groups': const [],
+        }),
+        throwsFormatException,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a client service for the official `/api/random-recommendations` payload
- replace local tag-search generation in both NipaPlay and Cupertino home pages
- make refresh cycle through the five server-provided groups instead of calling tag search APIs again
- add parsing coverage for the daily recommendation payload

## Depends on
- MCDFsteve/NipaPlay-OfficialWebUrl#2

## Validation
- `flutter analyze --no-fatal-infos lib/services/random_recommendation_service.dart lib/pages/dashboard_home_page.dart lib/themes/cupertino/pages/cupertino_home_page.dart`
- `flutter test test/random_recommendation_service_test.dart test/remote_access_qr_service_test.dart`
