### PR TITLE
Fix Erika thumbnail snapshots

### DIFF
--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -427,9 +427,24 @@ class ErikaPlayerAdapter implements AbstractPlayer {
       return null;
     }
     try {
-      final Uint8List? bytes = await _player.screenshot();
+      final captureWidth = width > 0 ? width : null;
+      final captureHeight = height > 0 ? height : null;
+      final Uint8List? bytes = await _player.screenshot(
+        width: captureWidth,
+        height: captureHeight,
+      );
       if (bytes == null || bytes.isEmpty) {
         return null;
+      }
+      if (captureWidth != null && captureHeight != null) {
+        final expectedRgbaBytes = captureWidth * captureHeight * 4;
+        if (bytes.length != expectedRgbaBytes) {
+          debugPrint(
+            'Erika: screenshot native capture unavailable '
+            '(expected $expectedRgbaBytes RGBA bytes, got ${bytes.length})',
+          );
+          return null;
+        }
       }
       final video = _mediaInfo.video;
       final codec =

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -16,6 +16,7 @@ import 'package:universal_html/html.dart' as web_html;
 // Added import for subtitle parser
 import 'dart:io';
 import 'dart:async';
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 import 'package:http/http.dart' as http;

--- a/lib/utils/video_player_state/video_player_state_capture.dart
+++ b/lib/utils/video_player_state/video_player_state_capture.dart
@@ -132,9 +132,42 @@ extension VideoPlayerStateCapture on VideoPlayerState {
     return img.copyResize(image, height: _thumbnailMaxHeight);
   }
 
+  bool _isLikelyBlankThumbnailFrame(img.Image image) {
+    const sampleLimit = 4096;
+    const brightThreshold = 18;
+    final totalPixels = image.width * image.height;
+    if (totalPixels <= 0) return true;
+
+    final sampleStep = (totalPixels / sampleLimit).ceil().clamp(1, totalPixels);
+    var index = 0;
+    var sampled = 0;
+    var brightPixels = 0;
+
+    for (final pixel in image) {
+      if (index % sampleStep == 0) {
+        sampled++;
+        final maxChannel = math.max(
+          pixel.r.toInt(),
+          math.max(pixel.g.toInt(), pixel.b.toInt()),
+        );
+        if (maxChannel > brightThreshold) {
+          brightPixels++;
+        }
+      }
+      index++;
+    }
+
+    if (sampled == 0) return true;
+    return brightPixels / sampled < 0.002;
+  }
+
   Uint8List? _encodeFrameToThumbnailBytes(PlayerFrame frame) {
     final decoded = _decodeFrameToImage(frame);
     if (decoded == null) {
+      return null;
+    }
+    if (_isLikelyBlankThumbnailFrame(decoded)) {
+      debugPrint('截图失败: 捕获到近似全黑帧，跳过保存缩略图');
       return null;
     }
     final resized = _resizeThumbnailImage(decoded);
@@ -481,8 +514,11 @@ extension VideoPlayerStateCapture on VideoPlayerState {
             return bytes;
           }
         }
+        debugPrint('Erika截图失败: native snapshot 未返回可编码帧');
+        return null;
       } catch (e) {
-        debugPrint('Erika截图失败，回退到界面截图: $e');
+        debugPrint('Erika截图失败: $e');
+        return null;
       }
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -283,8 +283,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: "codex/windows-native-core"
-      resolved-ref: f8283395f0a45ba818a33e5a8cb5d8214e1c073f
+      ref: main
+      resolved-ref: a5704e0983de3ec5df984ca5b8cb93ea6e69e10e
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
     version: "0.0.1"


### PR DESCRIPTION
## Summary
- pass thumbnail/screenshot target size through to Erika so native RGBA capture is used instead of the view snapshot fallback
- reject non-RGBA fallback data when a sized Erika capture is requested
- skip writing thumbnails when the captured frame is effectively black, preserving the previous thumbnail instead
- update the Erika lockfile ref to current main with retained-frame screenshot support

## Verification
- dart format lib/utils/video_player_state.dart lib/utils/video_player_state/video_player_state_capture.dart lib/player_abstraction/erika_player_adapter.dart
- dart analyze lib/player_abstraction/erika_player_adapter.dart lib/utils/video_player_state.dart lib/utils/video_player_state/video_player_state_capture.dart (existing warnings/info remain in video_player_state files)