### PR TITLE
Add release CI smoke workflow

### DIFF
--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -307,9 +307,85 @@ runs:
       id: build
       shell: pwsh
       run: |
+        function Show-ErikaNativeDiagnostics {
+          Write-Host "::group::Erika native diagnostics"
+          try {
+            $patterns = @()
+            if ($env:LOCALAPPDATA) {
+              $patterns += Join-Path $env:LOCALAPPDATA "Pub\Cache\git\Erika-*"
+            }
+            if ($env:USERPROFILE) {
+              $patterns += Join-Path $env:USERPROFILE ".pub-cache\git\Erika-*"
+            }
+            $patterns += "windows\flutter\ephemeral\.plugin_symlinks\erika_flutter"
+
+            $roots = @()
+            foreach ($pattern in $patterns) {
+              $roots += Get-ChildItem -Path $pattern -Directory -ErrorAction SilentlyContinue
+            }
+            if (-not $roots) {
+              Write-Host "No Erika checkout found in Pub cache or plugin symlinks."
+              return
+            }
+
+            $roots = $roots | Sort-Object FullName -Unique
+            foreach ($root in $roots) {
+              Write-Host "Erika root: $($root.FullName)"
+              $thirdParty = Join-Path $root.FullName "third_party"
+              if (-not (Test-Path $thirdParty)) {
+                Write-Host "third_party directory is missing."
+                continue
+              }
+
+              Write-Host "third_party top-level directories:"
+              Get-ChildItem -Path $thirdParty -Directory -ErrorAction SilentlyContinue |
+                Select-Object -First 20 |
+                ForEach-Object { Write-Host "  $($_.FullName)" }
+
+              $metadataFiles = Get-ChildItem -Path $thirdParty -Recurse -File -Filter "erika-native-deps.txt" -ErrorAction SilentlyContinue
+              foreach ($file in $metadataFiles) {
+                Write-Host "--- $($file.FullName) ---"
+                Get-Content -Path $file.FullName -Tail 200 -ErrorAction SilentlyContinue
+              }
+
+              $logFiles = Get-ChildItem -Path $thirdParty -Recurse -File -ErrorAction SilentlyContinue |
+                Where-Object {
+                  $_.FullName -match "[\\/]ffbuild[\\/]config\.log$" -or
+                  $_.Name -in @("config.log", "build.log")
+                } |
+                Sort-Object LastWriteTime -Descending |
+                Select-Object -First 8
+              foreach ($file in $logFiles) {
+                Write-Host "--- tail $($file.FullName) ---"
+                Get-Content -Path $file.FullName -Tail 300 -ErrorAction SilentlyContinue
+              }
+            }
+          } finally {
+            Write-Host "::endgroup::"
+          }
+        }
+
         # --obfuscate + --split-debug-info：Dart 代码混淆 + 分离调试符号（体积↓ + 反逆向）
         # symbol map 由 workflow 的 dart-symbols-* artifact 上传，用于 crash stack 反混淆
-        flutter build windows --release --no-pub --obfuscate --split-debug-info=build/symbols-windows
+        $flutterArgs = @(
+          "build",
+          "windows",
+          "--release",
+          "--no-pub",
+          "--obfuscate",
+          "--split-debug-info=build/symbols-windows"
+        )
+        if ($env:NIPAPLAY_VERBOSE_WINDOWS_BUILD -ne "0") {
+          $flutterArgs += "--verbose"
+        }
+        Write-Host "Running: flutter $($flutterArgs -join ' ')"
+        & flutter @flutterArgs
+        $flutterExitCode = $LASTEXITCODE
+        if ($flutterExitCode -ne 0) {
+          Show-ErikaNativeDiagnostics
+          throw "flutter build windows failed with exit code $flutterExitCode"
+        }
+
         $arch = "x64"
         $version = "${{ inputs.app-version }}"
         $DestDir = "build\windows\NipaPlay_${version}_Windows_x64"

--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -80,10 +80,11 @@ runs:
       uses: actions/cache@v4
       with:
         path: |
-          ${{ env.USERPROFILE }}\.cargo\registry
-          ${{ env.USERPROFILE }}\.cargo\git
-        key: windows-erika-cargo-${{ hashFiles('pubspec.lock') }}-v1
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: windows-erika-cargo-${{ env.ERIKA_SHA || hashFiles('pubspec.lock') }}-v1
         restore-keys: |
+          windows-erika-cargo-${{ env.ERIKA_SHA }}-
           windows-erika-cargo-
 
     - name: Restore Erika native dependency bundle
@@ -91,9 +92,17 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: |
-          ${{ env.LOCALAPPDATA }}\Pub\Cache\git\Erika-*\third_party\cache
-          ${{ env.LOCALAPPDATA }}\Pub\Cache\git\Erika-*\third_party\dist\x86_64-pc-windows-msvc\lgpl
-        key: windows-erika-native-${{ hashFiles('pubspec.lock') }}-v1
+          ~/.pub-cache/git/Erika-*/third_party/dist/x86_64-pc-windows-msvc/lgpl
+        key: windows-erika-native-x86_64-pc-windows-msvc-lgpl-${{ env.ERIKA_SHA || hashFiles('pubspec.lock') }}-v1
+        restore-keys: |
+          windows-erika-native-x86_64-pc-windows-msvc-lgpl-
+
+    - name: Restore Erika native source archives
+      id: restore-erika-native-sources
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.pub-cache/git/Erika-*/third_party/cache
+        key: windows-erika-native-sources-v1
 
     - name: Setup Chinese Font for Windows
       shell: pwsh
@@ -411,9 +420,15 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: |
-          ${{ env.LOCALAPPDATA }}\Pub\Cache\git\Erika-*\third_party\cache
-          ${{ env.LOCALAPPDATA }}\Pub\Cache\git\Erika-*\third_party\dist\x86_64-pc-windows-msvc\lgpl
+          ~/.pub-cache/git/Erika-*/third_party/dist/x86_64-pc-windows-msvc/lgpl
         key: ${{ steps.restore-erika-native-deps.outputs.cache-primary-key }}
+
+    - name: Save Erika native source archives
+      if: always() && steps.restore-erika-native-sources.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.pub-cache/git/Erika-*/third_party/cache
+        key: ${{ steps.restore-erika-native-sources.outputs.cache-primary-key }}
 
     - name: Install Inno Setup
       shell: pwsh

--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -37,6 +37,9 @@ runs:
           make
           tar
           diffutils
+          coreutils
+          pkgconf
+          perl
 
     - name: Configure Erika Windows native build
       shell: pwsh
@@ -68,6 +71,9 @@ runs:
         }
         if (-not (Test-Path "C:\msys64\usr\bin\make.exe")) {
           throw "MSYS2 make.exe was not found"
+        }
+        if (-not (Test-Path "C:\msys64\usr\bin\false.exe")) {
+          throw "MSYS2 false.exe was not found"
         }
 
     - name: Cache Erika Cargo dependencies

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -194,6 +194,7 @@ runs:
         )
         PY
 
+        echo "ERIKA_SHA=${ERIKA_SHA}" >> "$GITHUB_ENV"
         echo "Erika main resolved to ${ERIKA_SHA}."
     
     - name: Flutter Pub Get

--- a/.github/workflows/erika-windows-native-smoke.yml
+++ b/.github/workflows/erika-windows-native-smoke.yml
@@ -1,0 +1,53 @@
+name: Erika Windows Native Smoke
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/erika-windows-native-smoke.yml'
+  push:
+    branches:
+      - codex/release-ci-smoke
+    paths:
+      - '.github/workflows/erika-windows-native-smoke.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: erika-windows-native-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ffmpeg-make:
+    name: FFmpeg Make Shell Smoke
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup MSYS2 tools
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          release: false
+          update: false
+          path-type: inherit
+          install: >-
+            make
+            coreutils
+            gawk
+
+      - name: Run Erika FFmpeg make smoke
+        shell: pwsh
+        run: |
+          git config --global core.longpaths true
+          git clone --depth 1 https://github.com/AimesSoft/Erika.git "$env:RUNNER_TEMP\Erika"
+          cd "$env:RUNNER_TEMP\Erika"
+          git rev-parse HEAD
+          cargo run -p xtask -- deps smoke-ffmpeg-make --target x86_64-pc-windows-msvc

--- a/.github/workflows/release-ci-smoke.yml
+++ b/.github/workflows/release-ci-smoke.yml
@@ -1,0 +1,97 @@
+name: Release CI Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_validation:
+        description: 'Run Flutter analyze/test gate'
+        default: true
+        required: true
+        type: boolean
+      run_windows:
+        description: 'Run Windows release build, including Erika native core'
+        default: true
+        required: true
+        type: boolean
+      run_linux:
+        description: 'Run Linux amd64 release build'
+        default: false
+        required: true
+        type: boolean
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.fvmrc'
+      - '.github/actions/**'
+      - '.github/workflows/build-*.yml'
+      - '.github/workflows/release-ci-smoke.yml'
+      - 'assets/**'
+      - 'build_and_copy_web.sh'
+      - 'cpp_native/**'
+      - 'lib/**'
+      - 'pubspec.lock'
+      - 'pubspec.yaml'
+      - 'rust/**'
+      - 'rust_builder/**'
+      - 'test/**'
+      - 'third_party/**'
+      - 'web/**'
+      - 'windows/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-ci-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Analyze and Test
+    if: github.event_name == 'pull_request' || inputs.run_validation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ github.token }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Flutter Environment
+        uses: ./.github/actions/setup-flutter
+
+      - name: Generate build info json
+        run: python3 .github/workflows/scripts/generate-build-info-json.py assets/build_info.json
+
+      - name: Run flutter analyze
+        run: flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings lib
+
+      - name: Detect root test files
+        id: detect_tests
+        shell: bash
+        run: |
+          if [ -d test ] && find test -type f -name '*_test.dart' -print -quit | grep -q .; then
+            echo "has_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run flutter test
+        if: steps.detect_tests.outputs.has_tests == 'true'
+        run: flutter test --no-pub --reporter expanded
+
+      - name: Skip flutter test
+        if: steps.detect_tests.outputs.has_tests != 'true'
+        run: echo "No root-level *_test.dart files found. Skipping flutter test."
+
+  build-windows:
+    name: Windows Release Build
+    if: github.event_name == 'pull_request' || inputs.run_windows
+    uses: ./.github/workflows/build-windows.yml
+
+  build-linux:
+    name: Linux amd64 Release Build
+    if: github.event_name == 'workflow_dispatch' && inputs.run_linux
+    uses: ./.github/workflows/build-linux.yml


### PR DESCRIPTION
## Summary
- add a non-publishing Release CI Smoke workflow for release readiness checks
- run Flutter analyze/test and Windows release build automatically on relevant PRs
- allow manual Linux release builds when needed

## Notes
- Windows smoke uses the existing reusable Windows release build, including the Erika native core path.
