### PR TITLE
[codex] Add double-click window display toggle

### DIFF
--- a/lib/themes/nipaplay/pages/settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings_page.dart
@@ -55,6 +55,10 @@ class SettingsPage extends StatefulWidget {
                     NipaplayWindowPositionProvider.of(innerContext)
                         ?.onMove(details.delta);
                   },
+                  onDoubleTap: () {
+                    NipaplayWindowPositionProvider.of(innerContext)
+                        ?.onToggleDisplayMode();
+                  },
                   child: Padding(
                     padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
                     child: Text(

--- a/lib/themes/nipaplay/widgets/anime_detail_shell.dart
+++ b/lib/themes/nipaplay/widgets/anime_detail_shell.dart
@@ -57,6 +57,9 @@ class NipaplayAnimeDetailLayout extends StatelessWidget {
           onPanUpdate: (details) {
             NipaplayWindowPositionProvider.of(context)?.onMove(details.delta);
           },
+          onDoubleTap: () {
+            NipaplayWindowPositionProvider.of(context)?.onToggleDisplayMode();
+          },
           child: Padding(
             padding: const EdgeInsets.fromLTRB(16, 12, 8, 0),
             child: Row(

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_build_sections.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_build_sections.dart
@@ -300,6 +300,10 @@ extension DashboardHomePageSectionsBuild on _DashboardHomePageState {
                   NipaplayWindowPositionProvider.of(innerContext)
                       ?.onMove(details.delta);
                 },
+                onDoubleTap: () {
+                  NipaplayWindowPositionProvider.of(innerContext)
+                      ?.onToggleDisplayMode();
+                },
                 child: Padding(
                   padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
                   child: Row(

--- a/lib/themes/nipaplay/widgets/nipaplay_window.dart
+++ b/lib/themes/nipaplay/widgets/nipaplay_window.dart
@@ -136,6 +136,19 @@ class _NipaplayWindowScaffoldState extends State<NipaplayWindowScaffold> {
     });
   }
 
+  void _toggleWindowDisplayMode(AppearanceSettingsProvider settings) {
+    final nextMode =
+        settings.windowDisplayMode == NipaplayWindowDisplayMode.filledScreen
+            ? NipaplayWindowDisplayMode.windowed
+            : NipaplayWindowDisplayMode.filledScreen;
+    if (_offset != Offset.zero) {
+      setState(() {
+        _offset = Offset.zero;
+      });
+    }
+    settings.setWindowDisplayMode(nextMode);
+  }
+
   VoidCallback _resolveCloseHandler(BuildContext context) {
     return widget.onClose ?? () => Navigator.of(context).maybePop();
   }
@@ -326,6 +339,10 @@ class _NipaplayWindowScaffoldState extends State<NipaplayWindowScaffold> {
                                   style: windowTextStyle,
                                   child: NipaplayWindowPositionProvider(
                                     onMove: _applyWindowOffset,
+                                    onToggleDisplayMode: () =>
+                                        _toggleWindowDisplayMode(
+                                      appearanceSettings,
+                                    ),
                                     child: Padding(
                                       padding: const EdgeInsets.only(
                                         top: _contentTopPadding,
@@ -341,6 +358,9 @@ class _NipaplayWindowScaffoldState extends State<NipaplayWindowScaffold> {
                                   height: _contentTopPadding,
                                   child: GestureDetector(
                                     behavior: HitTestBehavior.translucent,
+                                    onDoubleTap: () => _toggleWindowDisplayMode(
+                                      appearanceSettings,
+                                    ),
                                     onPanUpdate: (details) =>
                                         _applyWindowOffset(details.delta),
                                   ),
@@ -399,9 +419,11 @@ class _NipaplayWindowScaffoldState extends State<NipaplayWindowScaffold> {
 /// 用于在窗口内容中处理拖动的手势提供者
 class NipaplayWindowPositionProvider extends InheritedWidget {
   final Function(Offset delta) onMove;
+  final VoidCallback onToggleDisplayMode;
 
   const NipaplayWindowPositionProvider({
     required this.onMove,
+    required this.onToggleDisplayMode,
     required super.child,
     super.key,
   });


### PR DESCRIPTION
## Summary
- Toggle `NipaplayWindowDisplayMode` between windowed and filled-screen when the top drag strip is double-clicked.
- Expose the same toggle through `NipaplayWindowPositionProvider` so existing window title/header drag areas can double-click to switch modes.
- Reset the local dragged offset before toggling, keeping filled-screen windows centered instead of shifted.

## Validation
- `git diff --check`
- `flutter analyze --no-fatal-warnings --no-fatal-infos lib/themes/nipaplay/widgets/nipaplay_window.dart lib/themes/nipaplay/pages/settings_page.dart lib/themes/nipaplay/widgets/dashboard_home_page_build_sections.dart lib/themes/nipaplay/widgets/anime_detail_shell.dart`

## Notes
- Full `flutter analyze` is currently blocked by existing repository issues under `build/`, `third_party/`, and dependency sample tests; the targeted analyze above completed successfully with existing warning/info output treated as non-fatal.