### PR TITLE
ci: avoid default Windows release smoke on PRs

### DIFF
--- a/.github/workflows/release-ci-smoke.yml
+++ b/.github/workflows/release-ci-smoke.yml
@@ -10,7 +10,7 @@ on:
         type: boolean
       run_windows:
         description: 'Run Windows release build, including Erika native core'
-        default: true
+        default: false
         required: true
         type: boolean
       run_linux:
@@ -88,7 +88,7 @@ jobs:
 
   build-windows:
     name: Windows Release Build
-    if: github.event_name == 'pull_request' || inputs.run_windows
+    if: github.event_name == 'workflow_dispatch' && inputs.run_windows
     uses: ./.github/workflows/build-windows.yml
 
   build-linux:


### PR DESCRIPTION
## Summary\n- stop running the Windows release build automatically for pull requests\n- make manual Release CI Smoke default to validation only; Windows still runs when run_windows is explicitly selected\n\n## Test plan\n- checked workflow guard text locally