### PR TITLE
ci: use release GitHub token for publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Generate Changelog with AI
         id: ai_changelog
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
           AI_API_URL: ${{ vars.RELEASE_AI_API_URL }}
           AI_MODEL: ${{ vars.RELEASE_AI_MODEL || 'gemini-3-flash-preview' }}
           AI_API_TOKEN: ${{ secrets.RELEASE_AI_TOKEN }}
@@ -359,7 +359,7 @@ jobs:
           artifacts: /tmp/artifacts/release-Android/*.apk,/tmp/artifacts/release-macOS/*.dmg,/tmp/artifacts/release-macOS/*.zip,/tmp/artifacts/release-macOS/*.pkg,/tmp/artifacts/release-Windows-x64/*.zip,/tmp/artifacts/release-Windows-x64/*.exe,/tmp/artifacts/release-Windows-x64/*.msix,/tmp/artifacts/release-Linux-amd64/*.deb,/tmp/artifacts/release-Linux-amd64/*.AppImage,/tmp/artifacts/release-Linux-amd64/*.tar.gz,/tmp/artifacts/release-Linux-amd64/*.rpm,/tmp/artifacts/release-Linux-arm64/*.deb,/tmp/artifacts/release-Linux-arm64/*.tar.gz,/tmp/artifacts/release-Linux-arm64/*.rpm
           artifactErrorsFailBuild: true
           replacesArtifacts: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
 
   UpdateVersion:
     needs: [Publish]

--- a/.github/workflows/release-notes-dry-run.yml
+++ b/.github/workflows/release-notes-dry-run.yml
@@ -22,7 +22,7 @@ jobs:
     name: Generate Release Notes Preview
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
       AI_API_URL: ${{ vars.RELEASE_AI_API_URL }}
       AI_MODEL: ${{ vars.RELEASE_AI_MODEL || 'gemini-3-flash-preview' }}
       AI_API_TOKEN: ${{ secrets.RELEASE_AI_TOKEN }}


### PR DESCRIPTION
Use the dedicated RELEASE_GITHUB_TOKEN secret for release-note GitHub API calls and release uploads, falling back to github.token when the secret is unavailable. This lets publishing use the FurudeRika123 PAT instead of the Actions installation token.