### PR TITLE
fix(ci):android build path error

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -94,9 +94,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-Android
-          path: |
-            build/app/outputs/apk/release/NipaPlay-*.apk
-            build/symbols-android-*/
+          # Keep this a single path. upload-artifact@v4 uses the least common
+          # ancestor of all matched files as the artifact root; adding more paths
+          # (e.g. build/symbols-android-*/) here lifts that root up to build/,
+          # which nests the APKs under app/outputs/apk/release/ and breaks the
+          # release-Android/*.apk glob in main.yml. Native symbols are uploaded
+          # separately as dart-symbols-Android below.
+          path: build/app/outputs/apk/release/NipaPlay-*.apk
 
       - name: Upload Dart debug symbols (for de-obfuscating crash stacks)
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- 修复安卓构建产物的路径冗余错误

## What Changed

删除了冗余 `build/symbols-android-*/` —— 因为 build-android.yml 的 `dart-symbols-Android artifact` 本来就单独上传了完全相同的 `native symbols(app.android-arm/arm64/x64.symbols`,已在 ls -R 里确认)。所以不丢任何符号化能力,直接回到 #655 之前已知可用状态。
