### PR TITLE
Fix iOS Erika surface sizing

### DIFF
--- a/lib/themes/nipaplay/widgets/video_player_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_player_ui.dart
@@ -315,7 +315,10 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
       // macOS keeps the full-bleed surface: Erika letterboxes natively into
       // the reserved plane. Flutter must NOT shrink the plane or paint around
       // it, or the app UI behind shows through the transparent bars.
-      if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) {
+      final useLegacyIosAspectSurface = !kIsWeb &&
+          defaultTargetPlatform == TargetPlatform.iOS &&
+          Platform.environment['NIPAPLAY_IOS_ERIKA_ASPECT_SURFACE'] == '1';
+      if (useLegacyIosAspectSurface) {
         return Center(
           child: AspectRatio(
             aspectRatio: videoState.aspectRatio,


### PR DESCRIPTION
## Summary
- keep the iOS Erika platform surface full-size by default so Erika can render danmaku into letterbox bars
- keep the previous iOS AspectRatio wrapper available behind `NIPAPLAY_IOS_ERIKA_ASPECT_SURFACE=1` for fallback/debugging

## Validation
- `dart format --set-exit-if-changed lib/themes/nipaplay/widgets/video_player_ui.dart`
- ran iOS simulator with local Erika source build; user confirmed iOS behavior is correct
- ran macOS debug app with local Erika source build