### PR TITLE
Use Erika prebuilt C API in CI builds

### DIFF
--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -19,11 +19,13 @@ runs:
       run: flutter precache --windows
 
     - name: Setup Rust for Erika native core
+      if: env.ERIKA_PREBUILT != '1' || env.ERIKA_FORCE_SOURCE_BUILD == '1'
       uses: dtolnay/rust-toolchain@stable
       with:
         targets: x86_64-pc-windows-msvc
 
     - name: Setup MSYS2 tools for Erika native dependencies
+      if: env.ERIKA_PREBUILT != '1' || env.ERIKA_FORCE_SOURCE_BUILD == '1'
       uses: msys2/setup-msys2@v2
       with:
         msystem: UCRT64
@@ -42,6 +44,7 @@ runs:
           perl
 
     - name: Configure Erika Windows native build
+      if: env.ERIKA_PREBUILT != '1' || env.ERIKA_FORCE_SOURCE_BUILD == '1'
       shell: pwsh
       run: |
         git config --global core.longpaths true
@@ -77,6 +80,7 @@ runs:
         }
 
     - name: Cache Erika Cargo dependencies
+      if: env.ERIKA_PREBUILT != '1' || env.ERIKA_FORCE_SOURCE_BUILD == '1'
       uses: actions/cache@v4
       with:
         path: |
@@ -88,6 +92,7 @@ runs:
           windows-erika-cargo-
 
     - name: Restore Erika native dependency bundle
+      if: env.ERIKA_PREBUILT != '1' || env.ERIKA_FORCE_SOURCE_BUILD == '1'
       id: restore-erika-native-deps
       uses: actions/cache/restore@v4
       with:
@@ -98,6 +103,7 @@ runs:
           windows-erika-native-x86_64-pc-windows-msvc-lgpl-
 
     - name: Restore Erika native source archives
+      if: env.ERIKA_PREBUILT != '1' || env.ERIKA_FORCE_SOURCE_BUILD == '1'
       id: restore-erika-native-sources
       uses: actions/cache/restore@v4
       with:
@@ -416,7 +422,7 @@ runs:
         echo "zip_path=$zipPath" >> $env:GITHUB_OUTPUT
 
     - name: Save Erika native dependency bundle
-      if: steps.restore-erika-native-deps.outputs.cache-hit != 'true'
+      if: (env.ERIKA_PREBUILT != '1' || env.ERIKA_FORCE_SOURCE_BUILD == '1') && steps.restore-erika-native-deps.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: |
@@ -424,7 +430,7 @@ runs:
         key: ${{ steps.restore-erika-native-deps.outputs.cache-primary-key }}
 
     - name: Save Erika native source archives
-      if: always() && steps.restore-erika-native-sources.outputs.cache-hit != 'true'
+      if: always() && (env.ERIKA_PREBUILT != '1' || env.ERIKA_FORCE_SOURCE_BUILD == '1') && steps.restore-erika-native-sources.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: ~/.pub-cache/git/Erika-*/third_party/cache

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -130,9 +130,17 @@ runs:
           exit 1
         fi
 
-        ERIKA_SHA="$(git ls-remote https://github.com/AimesSoft/Erika.git refs/heads/main | awk '{print $1}')"
+        ERIKA_REF="${ERIKA_REF:-main}"
+        ERIKA_REMOTE="https://github.com/AimesSoft/Erika.git"
+        ERIKA_SHA="$(git ls-remote "${ERIKA_REMOTE}" "refs/heads/${ERIKA_REF}" | awk '{print $1}')"
         if [ -z "${ERIKA_SHA}" ]; then
-          echo "❌ 无法解析 Erika main 最新提交。"
+          ERIKA_SHA="$(git ls-remote "${ERIKA_REMOTE}" "refs/tags/${ERIKA_REF}^{}" | awk '{print $1}')"
+        fi
+        if [ -z "${ERIKA_SHA}" ]; then
+          ERIKA_SHA="$(git ls-remote "${ERIKA_REMOTE}" "refs/tags/${ERIKA_REF}" | awk '{print $1}')"
+        fi
+        if [ -z "${ERIKA_SHA}" ]; then
+          echo "❌ 无法解析 Erika ref: ${ERIKA_REF}。"
           exit 1
         fi
 
@@ -141,10 +149,11 @@ runs:
           PYTHON_BIN="python"
         fi
 
-        ERIKA_SHA="${ERIKA_SHA}" "${PYTHON_BIN}" - <<'PY'
+        ERIKA_REF="${ERIKA_REF}" ERIKA_SHA="${ERIKA_SHA}" "${PYTHON_BIN}" - <<'PY'
         import os
         from pathlib import Path
 
+        erika_ref = os.environ["ERIKA_REF"]
         erika_sha = os.environ["ERIKA_SHA"]
 
         def update_erika_block(path, replacements):
@@ -184,18 +193,19 @@ runs:
 
             Path(path).write_text("".join(output), encoding='utf-8')
 
-        update_erika_block("pubspec.yaml", {"ref": "main"})
+        update_erika_block("pubspec.yaml", {"ref": erika_ref})
         update_erika_block(
             "pubspec.lock",
             {
-                "ref": "main",
+                "ref": erika_ref,
                 "resolved-ref": f'"{erika_sha}"',
             },
         )
         PY
 
+        echo "ERIKA_REF=${ERIKA_REF}" >> "$GITHUB_ENV"
         echo "ERIKA_SHA=${ERIKA_SHA}" >> "$GITHUB_ENV"
-        echo "Erika main resolved to ${ERIKA_SHA}."
+        echo "Erika ${ERIKA_REF} resolved to ${ERIKA_SHA}."
     
     - name: Flutter Pub Get
       shell: bash

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -21,6 +21,9 @@ jobs:
     env:
       FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
       FVP_DEPS_LATEST: 1
+      ERIKA_REF: v0.1.1
+      ERIKA_PREBUILT: "1"
+      ERIKA_PREBUILT_TAG: v0.1.1
     steps:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
@@ -36,7 +39,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ios/Pods
-          key: ios-pods-${{ hashFiles('ios/Podfile.lock') }}
+          key: ios-pods-${{ hashFiles('ios/Podfile.lock', 'pubspec.lock') }}
           restore-keys: |
             ios-pods-
       

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -40,6 +40,9 @@ jobs:
     env:
       FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
       FVP_DEPS_LATEST: 1
+      ERIKA_REF: v0.1.1
+      ERIKA_PREBUILT: "1"
+      ERIKA_PREBUILT_TAG: v0.1.1
     steps:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -25,6 +25,9 @@ jobs:
       # CI runners that fatally breaks extraction. The mdk-sdk is pre-downloaded
       # by the build-windows action, so fvp must trust it and skip downloads.
       FVP_DEPS_LATEST: 0
+      ERIKA_REF: v0.1.1
+      ERIKA_PREBUILT: "1"
+      ERIKA_PREBUILT_TAG: v0.1.1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/cpp_native/scripts/build_macos.sh
+++ b/cpp_native/scripts/build_macos.sh
@@ -2,78 +2,11 @@
 set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CPP_NATIVE_DIR="$(dirname "$SCRIPT_DIR")"
-NIPAPLAY_ROOT="$(cd "${CPP_NATIVE_DIR}/.." && pwd)"
-ERIKA_NATIVE_PROFILE="${ERIKA_NATIVE_PROFILE:-lgpl}"
-HOST_JOBS="$(sysctl -n hw.ncpu)"
-ERIKA_RUST_TARGETS=("aarch64-apple-darwin" "x86_64-apple-darwin")
+HOST_JOBS="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
 
 # Xcode Run Script 阶段的 PATH 不会继承 shell 配置，显式补上 Homebrew 路径
 # 让 Apple Silicon (/opt/homebrew) 和 Intel (/usr/local) 都能找到 cmake 等工具
 export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
-
-resolve_erika_root() {
-    if [ -n "${ERIKA_ROOT:-}" ]; then
-        if [ -f "${ERIKA_ROOT}/Cargo.toml" ]; then
-            (cd "${ERIKA_ROOT}" && pwd -P)
-            return
-        fi
-        echo "error: ERIKA_ROOT does not point to Erika source: ${ERIKA_ROOT}" >&2
-        return 1
-    fi
-
-    local vendored_root="${NIPAPLAY_ROOT}/third_party/erika"
-    if [ -f "${vendored_root}/Cargo.toml" ]; then
-        (cd "${vendored_root}" && pwd -P)
-        return
-    fi
-
-    local package_config="${NIPAPLAY_ROOT}/.dart_tool/package_config.json"
-    if [ ! -f "${package_config}" ]; then
-        echo "error: ${package_config} not found. Run flutter pub get first." >&2
-        return 1
-    fi
-
-    local erika_flutter_root
-    erika_flutter_root="$(python3 - "${package_config}" <<'PY'
-import json
-import pathlib
-import sys
-import urllib.parse
-
-package_config = pathlib.Path(sys.argv[1]).resolve()
-with package_config.open("r", encoding="utf-8") as handle:
-    data = json.load(handle)
-
-for package in data.get("packages", []):
-    if package.get("name") != "erika_flutter":
-        continue
-    root_uri = package.get("rootUri", "")
-    parsed = urllib.parse.urlparse(root_uri)
-    if parsed.scheme == "file":
-        root = pathlib.Path(urllib.parse.unquote(parsed.path))
-    elif parsed.scheme:
-        raise SystemExit(f"unsupported erika_flutter rootUri: {root_uri}")
-    else:
-        root = (package_config.parent / urllib.parse.unquote(root_uri)).resolve()
-    print(root)
-    break
-else:
-    raise SystemExit("erika_flutter not found in package_config.json")
-PY
-)"
-
-    local resolved_root
-    resolved_root="$(cd "${erika_flutter_root}/../.." && pwd -P)"
-    if [ -f "${resolved_root}/Cargo.toml" ]; then
-        echo "${resolved_root}"
-        return
-    fi
-
-    echo "error: Could not resolve Erika source root from erika_flutter package at ${erika_flutter_root}" >&2
-    return 1
-}
-
-ERIKA_ROOT="$(resolve_erika_root)"
 
 # Map Xcode configuration to CMake build type
 if [ "${CONFIGURATION}" = "Debug" ]; then
@@ -110,62 +43,19 @@ cmake -S "${CPP_NATIVE_DIR}" -B "${BUILD_DIR}/x86_64" \
 
 cmake --build "${BUILD_DIR}/x86_64" -j"${HOST_JOBS}"
 
-# 3) lipo 合并为 universal dylib
+# 3) lipo 合并为 universal dylib。Erika C ABI 由 erika_flutter 的
+# CocoaPods script phase 负责下载/构建并复制到 app Frameworks 目录。
 mkdir -p "${BUILD_DIR}"
 lipo -create \
     "${BUILD_DIR}/arm64/libnipaplay_native.dylib" \
     "${BUILD_DIR}/x86_64/libnipaplay_native.dylib" \
     -output "${BUILD_DIR}/libnipaplay_native.dylib"
 
-if [ "${CONFIGURATION}" = "Debug" ]; then
-    ERIKA_CARGO_PROFILE="debug"
-    ERIKA_CARGO_ARGS=()
-else
-    ERIKA_CARGO_PROFILE="release"
-    ERIKA_CARGO_ARGS=(--release)
-fi
-
-echo "Building Erika C API from ${ERIKA_ROOT} (${ERIKA_CARGO_PROFILE})"
-if command -v rustup >/dev/null 2>&1; then
-    rustup target add "${ERIKA_RUST_TARGETS[@]}"
-fi
-
-ERIKA_DYLIB_INPUTS=()
-for RUST_TARGET in "${ERIKA_RUST_TARGETS[@]}"; do
-    ERIKA_TARGET_DIST="${ERIKA_ROOT}/third_party/dist/${RUST_TARGET}/${ERIKA_NATIVE_PROFILE}"
-    ERIKA_FFMPEG_DIR="${ERIKA_ROOT}/third_party/dist/${RUST_TARGET}/${ERIKA_NATIVE_PROFILE}/ffmpeg"
-    ERIKA_LIBASS_DIR="${ERIKA_TARGET_DIST}/libass"
-    ERIKA_FREETYPE_DIR="${ERIKA_TARGET_DIST}/freetype"
-    ERIKA_HARFBUZZ_DIR="${ERIKA_TARGET_DIST}/harfbuzz"
-    ERIKA_FRIBIDI_DIR="${ERIKA_TARGET_DIST}/fribidi"
-    ERIKA_FFMPEG_HEADERS="${ERIKA_FFMPEG_DIR}/include/libavformat/avformat.h"
-    ERIKA_LIBASS_ARCHIVE="${ERIKA_LIBASS_DIR}/lib/libass.a"
-    if [ ! -f "${ERIKA_FFMPEG_HEADERS}" ] || [ ! -f "${ERIKA_LIBASS_ARCHIVE}" ]; then
-        echo "Erika native dependencies not found for ${RUST_TARGET}; building ${ERIKA_NATIVE_PROFILE} dependency profile with libass"
-        (cd "${ERIKA_ROOT}" && cargo run -p xtask -- deps build --all --profile "${ERIKA_NATIVE_PROFILE}" --target "${RUST_TARGET}" --jobs "${HOST_JOBS}")
-    fi
-
-    echo "Building Erika C API for ${RUST_TARGET}"
-    (cd "${ERIKA_ROOT}" && ERIKA_NATIVE_PROFILE="${ERIKA_NATIVE_PROFILE}" ERIKA_NATIVE_TARGET="${RUST_TARGET}" ERIKA_FFMPEG_DIR="${ERIKA_FFMPEG_DIR}" ERIKA_LIBASS_DIR="${ERIKA_LIBASS_DIR}" ERIKA_FREETYPE_DIR="${ERIKA_FREETYPE_DIR}" ERIKA_HARFBUZZ_DIR="${ERIKA_HARFBUZZ_DIR}" ERIKA_FRIBIDI_DIR="${ERIKA_FRIBIDI_DIR}" cargo build -p erika_capi --target "${RUST_TARGET}" --no-default-features --features libass "${ERIKA_CARGO_ARGS[@]}")
-
-    ERIKA_DYLIB="${ERIKA_ROOT}/target/${RUST_TARGET}/${ERIKA_CARGO_PROFILE}/liberika_capi.dylib"
-    if [ ! -f "${ERIKA_DYLIB}" ]; then
-        echo "error: ${ERIKA_DYLIB} was not produced by Erika build." >&2
-        exit 1
-    fi
-    ERIKA_DYLIB_INPUTS+=("${ERIKA_DYLIB}")
-done
-
 # 复制 dylib 到 Frameworks
+mkdir -p "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}"
 cp "${BUILD_DIR}/libnipaplay_native.dylib" \
     "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/"
-
-ERIKA_BUNDLED_DYLIB="${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/liberika_capi.dylib"
-lipo -create "${ERIKA_DYLIB_INPUTS[@]}" -output "${ERIKA_BUNDLED_DYLIB}"
-install_name_tool -id "@rpath/liberika_capi.dylib" "${ERIKA_BUNDLED_DYLIB}"
 
 # Code sign the dylib (required for macOS app notarization)
 codesign --force --sign "${EXPANDED_CODE_SIGN_IDENTITY:--}" \
     "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/libnipaplay_native.dylib"
-
-codesign --force --sign "${EXPANDED_CODE_SIGN_IDENTITY:--}" "${ERIKA_BUNDLED_DYLIB}"


### PR DESCRIPTION
## Summary
- stop building Erika C API from cpp_native/scripts/build_macos.sh
- let erika_flutter own downloading/building/copying/linking Erika C API artifacts
- allow CI to pin Erika by ERIKA_REF and use the matching ERIKA_PREBUILT_TAG
- configure macOS, iOS, and Windows CI to consume Erika v0.1.1 prebuilt artifacts
- keep Windows Erika source-build toolchain/cache steps available only when prebuilt mode is disabled or source build is forced

## Testing
- bash -n cpp_native/scripts/build_macos.sh
- ruby -e 'require "yaml"; %w[.github/actions/setup-flutter/action.yml .github/workflows/build-macos.yml .github/workflows/build-ios.yml .github/workflows/build-windows.yml .github/actions/build-windows/action.yml].each { |f| YAML.load_file(f) }'\n- verified ERIKA_REF tag resolution with v0.1.0\n\nErika v0.1.1 is tagged and its prebuilt release artifacts are published.