### PR TITLE
[codex] Move danmaku display settings to player menu

### DIFF
--- a/lib/themes/cupertino/pages/settings/pages/cupertino_danmaku_settings_page.dart
+++ b/lib/themes/cupertino/pages/settings/pages/cupertino_danmaku_settings_page.dart
@@ -379,9 +379,8 @@ class _CupertinoDanmakuSettingsPageState
             Consumer<SettingsProvider>(
               builder: (context, settingsProvider, _) {
                 final supersampleValue = settingsProvider.danmakuSupersample;
-                final label = supersampleValue == 0.0
-                    ? '关闭'
-                    : '${supersampleValue}x';
+                final label =
+                    supersampleValue == 0.0 ? '关闭' : '${supersampleValue}x';
                 return CupertinoSettingsTile(
                   leading: Icon(
                     CupertinoIcons.fullscreen,
@@ -468,6 +467,44 @@ class _CupertinoDanmakuSettingsPageState
                         message: newValue
                             ? context.l10n.rememberDanmakuOffsetEnabled
                             : context.l10n.rememberDanmakuOffsetDisabled,
+                        type: AdaptiveSnackBarType.success,
+                      );
+                    },
+                    backgroundColor: tileBackground,
+                  );
+                },
+              ),
+              Consumer<VideoPlayerState>(
+                builder: (context, videoState, child) {
+                  return CupertinoSettingsTile(
+                    leading: Icon(
+                      CupertinoIcons.paintbrush,
+                      color: resolveSettingsIconColor(context),
+                    ),
+                    title: const Text('随机染色'),
+                    subtitle: const Text('忽略弹幕原始颜色，按发送弹幕预设色随机分配'),
+                    trailing: AdaptiveSwitch(
+                      value: videoState.danmakuRandomColorEnabled,
+                      onChanged: (value) async {
+                        final message = value ? '已开启随机染色' : '已关闭随机染色';
+                        await videoState.setDanmakuRandomColorEnabled(value);
+                        if (!context.mounted) return;
+                        AdaptiveSnackBar.show(
+                          context,
+                          message: message,
+                          type: AdaptiveSnackBarType.success,
+                        );
+                      },
+                    ),
+                    onTap: () async {
+                      final bool newValue =
+                          !videoState.danmakuRandomColorEnabled;
+                      final message = newValue ? '已开启随机染色' : '已关闭随机染色';
+                      await videoState.setDanmakuRandomColorEnabled(newValue);
+                      if (!context.mounted) return;
+                      AdaptiveSnackBar.show(
+                        context,
+                        message: message,
                         type: AdaptiveSnackBarType.success,
                       );
                     },

--- a/lib/themes/cupertino/widgets/player_menu/cupertino_danmaku_settings_pane.dart
+++ b/lib/themes/cupertino/widgets/player_menu/cupertino_danmaku_settings_pane.dart
@@ -11,6 +11,7 @@ import 'package:nipaplay/themes/cupertino/widgets/player_menu/cupertino_player_s
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/utils/danmaku_history_sync.dart';
 import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
+import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
 import 'package:path/path.dart' as p;
 
@@ -33,6 +34,23 @@ class CupertinoDanmakuSettingsPane extends StatefulWidget {
 
 class _CupertinoDanmakuSettingsPaneState
     extends State<CupertinoDanmakuSettingsPane> {
+  static const List<double> _danmakuDisplayAreaOptions = <double>[
+    0.0,
+    0.125,
+    0.25,
+    0.33,
+    0.67,
+    1.0,
+  ];
+  static final Map<double, String> _danmakuDisplayAreaLabels = <double, String>{
+    0.0: '单行显示',
+    0.125: '1/8 屏幕',
+    0.25: '1/4 屏幕',
+    0.33: '1/3 屏幕',
+    0.67: '2/3 屏幕',
+    1.0: '全屏',
+  };
+
   final TextEditingController _blockWordController = TextEditingController();
   String? _blockWordError;
   bool _isSavingDanmaku = false;
@@ -186,8 +204,100 @@ class _CupertinoDanmakuSettingsPaneState
     BlurSnackBar.show(context, message);
   }
 
+  Future<void> _pickDanmakuFontFile() async {
+    final selected = await openFile(
+      acceptedTypeGroups: const [
+        XTypeGroup(
+          label: 'Font',
+          extensions: ['ttf', 'otf', 'ttc', 'otc'],
+        ),
+      ],
+    );
+    if (selected == null) return;
+
+    final success =
+        await widget.videoState.importDanmakuFontFile(selected.path);
+    if (!mounted) return;
+    _showMessage(
+      success ? '已应用字体: ${p.basename(selected.path)}' : '字体加载失败，请选择有效的字体文件',
+    );
+  }
+
+  Future<void> _resetDanmakuFont() async {
+    await widget.videoState.resetDanmakuFont();
+    if (!mounted) return;
+    _showMessage('已恢复为系统默认字体');
+  }
+
+  String _danmakuFontLabel() {
+    final fontPath = widget.videoState.danmakuFontFilePath.trim();
+    if (fontPath.isEmpty) return '系统默认字体';
+    return p.basename(fontPath);
+  }
+
+  String _shadowStyleLabel(DanmakuShadowStyle style) {
+    switch (style) {
+      case DanmakuShadowStyle.none:
+        return '无阴影';
+      case DanmakuShadowStyle.soft:
+        return '柔和阴影';
+      case DanmakuShadowStyle.medium:
+        return '标准阴影';
+      case DanmakuShadowStyle.strong:
+        return '增强阴影';
+    }
+  }
+
+  String _outlineStyleLabel(DanmakuOutlineStyle style) {
+    switch (style) {
+      case DanmakuOutlineStyle.none:
+        return '无描边';
+      case DanmakuOutlineStyle.stroke:
+        return '标准描边';
+      case DanmakuOutlineStyle.uniform:
+        return '均匀描边';
+    }
+  }
+
+  bool get _isNext2Kernel =>
+      DanmakuKernelFactory.getKernelType() == DanmakuRenderEngine.next2;
+
+  bool get _isDfmPlusKernel =>
+      DanmakuKernelFactory.getKernelType() == DanmakuRenderEngine.dfmPlus;
+
+  bool get _usesBinaryDanmakuEffectToggles =>
+      _isNext2Kernel || _isDfmPlusKernel;
+
+  String get _binaryDanmakuEffectKernelName =>
+      _isDfmPlusKernel ? 'DFM+' : 'Next2';
+
+  double _snapDanmakuDisplayArea(double value) {
+    double best = _danmakuDisplayAreaOptions.first;
+    double bestDiff = (value - best).abs();
+    for (final option in _danmakuDisplayAreaOptions.skip(1)) {
+      final diff = (value - option).abs();
+      if (diff < bestDiff) {
+        bestDiff = diff;
+        best = option;
+      }
+    }
+    return best;
+  }
+
+  String _danmakuDisplayAreaText(double value) {
+    final snapped = _snapDanmakuDisplayArea(value);
+    return _danmakuDisplayAreaLabels[snapped] ?? '全屏';
+  }
+
   @override
   Widget build(BuildContext context) {
+    final isErikaPlayerKernel =
+        PlayerFactory.getKernelType() == PlayerKernelType.erika;
+    final showBinaryDanmakuEffectToggles =
+        isErikaPlayerKernel || _usesBinaryDanmakuEffectToggles;
+    final binaryDanmakuEffectKernelName =
+        isErikaPlayerKernel ? 'Erika' : _binaryDanmakuEffectKernelName;
+
     return CupertinoBottomSheetContentLayout(
       sliversBuilder: (context, topSpacing) => [
         SliverPadding(
@@ -284,12 +394,27 @@ class _CupertinoDanmakuSettingsPaneState
                 _buildSliderTile(
                   context,
                   title: '字体大小',
-                  description: '${widget.videoState.danmakuFontSize.round()}px',
-                  value: widget.videoState.danmakuFontSize,
+                  description:
+                      '${(widget.videoState.danmakuFontSize <= 0 ? widget.videoState.actualDanmakuFontSize : widget.videoState.danmakuFontSize).round()}px',
+                  value: widget.videoState.danmakuFontSize <= 0
+                      ? widget.videoState.actualDanmakuFontSize
+                      : widget.videoState.danmakuFontSize,
                   min: 12.0,
-                  max: 36.0,
-                  divisions: 24,
+                  max: 60.0,
+                  divisions: 96,
                   onChanged: widget.videoState.setDanmakuFontSize,
+                ),
+                CupertinoListTile(
+                  title: const Text('字体选择'),
+                  subtitle: Text('当前字体：${_danmakuFontLabel()}'),
+                  trailing: const Icon(CupertinoIcons.right_chevron),
+                  onTap: _pickDanmakuFontFile,
+                ),
+                CupertinoListTile(
+                  title: const Text('恢复默认字体'),
+                  subtitle: const Text('使用系统默认弹幕字体'),
+                  trailing: const Icon(CupertinoIcons.refresh),
+                  onTap: _resetDanmakuFont,
                 ),
                 _buildSliderTile(
                   context,
@@ -302,6 +427,60 @@ class _CupertinoDanmakuSettingsPaneState
                   divisions: 15,
                   onChanged: widget.videoState.setDanmakuSpeedMultiplier,
                 ),
+                if (showBinaryDanmakuEffectToggles)
+                  _buildSwitchTile(
+                    context,
+                    title: '弹幕描边',
+                    subtitle: '开启后为 $binaryDanmakuEffectKernelName 弹幕添加描边',
+                    value: widget.videoState.next2DanmakuOutlineWidth > 0.0,
+                    onChanged: (value) {
+                      widget.videoState
+                          .setNext2DanmakuOutlineWidth(value ? 1.0 : 0.0);
+                    },
+                  )
+                else
+                  _buildOptionButtonsTile<DanmakuOutlineStyle>(
+                    context,
+                    title: '弹幕描边',
+                    subtitle: '选择弹幕文字外缘的描边方式',
+                    values: DanmakuOutlineStyle.values,
+                    selectedValue: widget.videoState.danmakuOutlineStyle,
+                    labelBuilder: _outlineStyleLabel,
+                    onSelected: widget.videoState.setDanmakuOutlineStyle,
+                  ),
+                _buildOptionButtonsTile<DanmakuShadowStyle>(
+                  context,
+                  title: '弹幕阴影',
+                  subtitle: '选择弹幕文字的阴影强度',
+                  values: DanmakuShadowStyle.values,
+                  selectedValue: widget.videoState.danmakuShadowStyle,
+                  labelBuilder: _shadowStyleLabel,
+                  onSelected: widget.videoState.setDanmakuShadowStyle,
+                ),
+                _buildOptionButtonsTile<double>(
+                  context,
+                  title: '轨道显示区域',
+                  subtitle: '设置弹幕轨道在屏幕上的显示范围',
+                  values: _danmakuDisplayAreaOptions,
+                  selectedValue: _snapDanmakuDisplayArea(
+                    widget.videoState.danmakuDisplayArea,
+                  ),
+                  labelBuilder: _danmakuDisplayAreaText,
+                  onSelected: (value) {
+                    widget.videoState.setDanmakuDisplayArea(
+                      _snapDanmakuDisplayArea(value),
+                    );
+                  },
+                ),
+                if (DanmakuKernelFactory.getKernelType() !=
+                    DanmakuRenderEngine.canvas)
+                  _buildSwitchTile(
+                    context,
+                    title: '合并相同弹幕',
+                    subtitle: '将内容相同的弹幕合并为一条显示',
+                    value: widget.videoState.mergeDanmaku,
+                    onChanged: widget.videoState.setMergeDanmaku,
+                  ),
                 if (DanmakuKernelFactory.getKernelType() ==
                     DanmakuRenderEngine.dfmPlus)
                   _buildSliderTile(
@@ -315,6 +494,32 @@ class _CupertinoDanmakuSettingsPaneState
                     divisions: 50,
                     onChanged: widget.videoState.setDanmakuDfmPlusTrackGap,
                   ),
+              ],
+            ),
+            CupertinoListSection.insetGrouped(
+              header: const Text('弹幕屏蔽'),
+              children: [
+                _buildSwitchTile(
+                  context,
+                  title: '屏蔽顶部弹幕',
+                  subtitle: '不显示顶部固定弹幕',
+                  value: widget.videoState.blockTopDanmaku,
+                  onChanged: widget.videoState.setBlockTopDanmaku,
+                ),
+                _buildSwitchTile(
+                  context,
+                  title: '屏蔽底部弹幕',
+                  subtitle: '不显示底部固定弹幕',
+                  value: widget.videoState.blockBottomDanmaku,
+                  onChanged: widget.videoState.setBlockBottomDanmaku,
+                ),
+                _buildSwitchTile(
+                  context,
+                  title: '屏蔽滚动弹幕',
+                  subtitle: '不显示从右向左滚动的弹幕',
+                  value: widget.videoState.blockScrollDanmaku,
+                  onChanged: widget.videoState.setBlockScrollDanmaku,
+                ),
               ],
             ),
             CupertinoListSection.insetGrouped(
@@ -424,6 +629,79 @@ class _CupertinoDanmakuSettingsPaneState
             max: max,
             divisions: divisions,
             onChanged: onChanged,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOptionButtonsTile<T>(
+    BuildContext context, {
+    required String title,
+    required String subtitle,
+    required List<T> values,
+    required T selectedValue,
+    required String Function(T value) labelBuilder,
+    required ValueChanged<T> onSelected,
+  }) {
+    final textTheme = CupertinoTheme.of(context).textTheme.textStyle;
+    final selectedColor = CupertinoTheme.of(context).primaryColor;
+    final borderColor = CupertinoColors.separator.resolveFrom(context);
+    final selectedTextColor = CupertinoDynamicColor.resolve(
+      CupertinoColors.white,
+      context,
+    );
+    final normalTextColor = CupertinoColors.label.resolveFrom(context);
+
+    return CupertinoListTile(
+      padding: const EdgeInsetsDirectional.fromSTEB(20, 12, 20, 16),
+      title: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: textTheme.copyWith(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            subtitle,
+            style: textTheme.copyWith(
+              fontSize: 13,
+              color: CupertinoColors.secondaryLabel.resolveFrom(context),
+            ),
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: values.map((value) {
+              final selected = value == selectedValue;
+              return GestureDetector(
+                onTap: () => onSelected(value),
+                child: Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+                  decoration: BoxDecoration(
+                    color: selected
+                        ? selectedColor
+                        : CupertinoColors.systemGrey6.resolveFrom(context),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(
+                      color: selected ? selectedColor : borderColor,
+                    ),
+                  ),
+                  child: Text(
+                    labelBuilder(value),
+                    style: textTheme.copyWith(
+                      fontSize: 13,
+                      color: selected ? selectedTextColor : normalTextColor,
+                      fontWeight:
+                          selected ? FontWeight.w600 : FontWeight.normal,
+                    ),
+                  ),
+                ),
+              );
+            }).toList(),
           ),
         ],
       ),

--- a/lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart
@@ -1,8 +1,6 @@
 import 'package:fluent_ui/fluent_ui.dart' as fluent;
-import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
-import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 import 'package:nipaplay/danmaku_next/next2_platform_support.dart';
@@ -30,30 +28,11 @@ class DanmakuSettingsPage extends StatefulWidget {
 
 class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
   static Color get _fluentAccentColor => AppAccentColors.current;
-  static const List<double> _danmakuDisplayAreaOptions = <double>[
-    0.0,
-    0.125,
-    0.25,
-    0.33,
-    0.67,
-    1.0,
-  ];
-  static final Map<double, String> _danmakuDisplayAreaLabels = <double, String>{
-    0.0: '单行显示',
-    0.125: '1/8 屏幕',
-    0.25: '1/4 屏幕',
-    0.33: '1/3 屏幕',
-    0.67: '2/3 屏幕',
-    1.0: '全屏',
-  };
 
   DanmakuRenderEngine _selectedDanmakuRenderEngine = DanmakuRenderEngine.canvas;
 
   final GlobalKey _danmakuRenderEngineDropdownKey = GlobalKey();
   final GlobalKey _spoilerAiApiFormatDropdownKey = GlobalKey();
-  final GlobalKey _danmakuDisplayAreaDropdownKey = GlobalKey();
-  final GlobalKey _danmakuOutlineStyleDropdownKey = GlobalKey();
-  final GlobalKey _danmakuShadowStyleDropdownKey = GlobalKey();
   final GlobalKey _danmakuAutoLoadStrategyDropdownKey = GlobalKey();
 
   final TextEditingController _spoilerAiUrlController = TextEditingController();
@@ -263,73 +242,8 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
     return items;
   }
 
-  bool get _isNext2Kernel =>
-      DanmakuKernelFactory.getKernelType() == DanmakuRenderEngine.next2;
-
   bool get _isDfmPlusKernel =>
       DanmakuKernelFactory.getKernelType() == DanmakuRenderEngine.dfmPlus;
-
-  bool get _usesBinaryDanmakuEffectToggles =>
-      _isNext2Kernel || _isDfmPlusKernel;
-
-  String get _binaryDanmakuEffectKernelName =>
-      _isDfmPlusKernel ? 'DFM+' : 'Next2';
-
-  Future<void> _pickDanmakuFontFile(VideoPlayerState videoState) async {
-    final selected = await openFile(
-      acceptedTypeGroups: const [
-        XTypeGroup(
-          label: 'Font',
-          extensions: ['ttf', 'otf', 'ttc', 'otc'],
-        ),
-      ],
-    );
-    if (selected == null) return;
-
-    final success = await videoState.importDanmakuFontFile(selected.path);
-    if (!mounted) return;
-    if (success) {
-      BlurSnackBar.show(context, '已应用字体: ${p.basename(selected.path)}');
-    } else {
-      BlurSnackBar.show(context, '字体加载失败，请选择有效的字体文件');
-    }
-  }
-
-  Future<void> _resetDanmakuFont(VideoPlayerState videoState) async {
-    await videoState.resetDanmakuFont();
-    if (!mounted) return;
-    BlurSnackBar.show(context, '已恢复为系统默认字体');
-  }
-
-  String _danmakuFontLabel(VideoPlayerState videoState) {
-    final fontPath = videoState.danmakuFontFilePath.trim();
-    if (fontPath.isEmpty) return '系统默认字体';
-    return p.basename(fontPath);
-  }
-
-  String _outlineStyleLabel(DanmakuOutlineStyle style) {
-    switch (style) {
-      case DanmakuOutlineStyle.none:
-        return '无描边';
-      case DanmakuOutlineStyle.stroke:
-        return '标准描边';
-      case DanmakuOutlineStyle.uniform:
-        return '均匀描边';
-    }
-  }
-
-  String _shadowStyleLabel(DanmakuShadowStyle style) {
-    switch (style) {
-      case DanmakuShadowStyle.none:
-        return '无阴影';
-      case DanmakuShadowStyle.soft:
-        return '柔和阴影';
-      case DanmakuShadowStyle.medium:
-        return '标准阴影';
-      case DanmakuShadowStyle.strong:
-        return '增强阴影';
-    }
-  }
 
   String _danmakuAutoLoadStrategyLabel(DanmakuAutoLoadStrategy strategy) {
     switch (strategy) {
@@ -355,24 +269,6 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
       case DanmakuAutoLoadStrategy.manual:
         return context.l10n.danmakuAutoLoadStrategyManualDescription;
     }
-  }
-
-  double _snapDanmakuDisplayArea(double value) {
-    double best = _danmakuDisplayAreaOptions.first;
-    double bestDiff = (value - best).abs();
-    for (final option in _danmakuDisplayAreaOptions.skip(1)) {
-      final diff = (value - option).abs();
-      if (diff < bestDiff) {
-        bestDiff = diff;
-        best = option;
-      }
-    }
-    return best;
-  }
-
-  String _danmakuDisplayAreaText(double value) {
-    final snapped = _snapDanmakuDisplayArea(value);
-    return _danmakuDisplayAreaLabels[snapped] ?? '全屏';
   }
 
   @override
@@ -501,44 +397,7 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
         Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
         Consumer<VideoPlayerState>(
           builder: (context, videoState, child) {
-            final outlineItems = DanmakuOutlineStyle.values
-                .map(
-                  (style) => DropdownMenuItemData<DanmakuOutlineStyle>(
-                    title: _outlineStyleLabel(style),
-                    value: style,
-                    isSelected: videoState.danmakuOutlineStyle == style,
-                  ),
-                )
-                .toList();
-            final shadowItems = DanmakuShadowStyle.values
-                .map(
-                  (style) => DropdownMenuItemData<DanmakuShadowStyle>(
-                    title: _shadowStyleLabel(style),
-                    value: style,
-                    isSelected: videoState.danmakuShadowStyle == style,
-                  ),
-                )
-                .toList();
-            final displayAreaItems = _danmakuDisplayAreaOptions
-                .map(
-                  (area) => DropdownMenuItemData<double>(
-                    title: _danmakuDisplayAreaText(area),
-                    value: area,
-                    isSelected: _snapDanmakuDisplayArea(
-                          videoState.danmakuDisplayArea,
-                        ) ==
-                        area,
-                  ),
-                )
-                .toList();
-            final showBinaryDanmakuEffectToggles =
-                isErikaPlayerKernel || _usesBinaryDanmakuEffectToggles;
-            final binaryDanmakuEffectKernelName =
-                isErikaPlayerKernel ? 'Erika' : _binaryDanmakuEffectKernelName;
             final showTrackGapSlider = isErikaPlayerKernel || _isDfmPlusKernel;
-            final showMergeToggle = isErikaPlayerKernel ||
-                DanmakuKernelFactory.getKernelType() !=
-                    DanmakuRenderEngine.canvas;
             final showStackingToggle = isErikaPlayerKernel ||
                 (DanmakuKernelFactory.getKernelType() !=
                         DanmakuRenderEngine.canvas &&
@@ -571,199 +430,6 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
                     videoState.toggleTimelineDanmaku(value);
                   },
                 ),
-                Divider(
-                    color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-                SettingsItem.slider(
-                  title: '弹幕不透明度',
-                  subtitle: '调整弹幕文字透明度',
-                  icon: Ionicons.contrast_outline,
-                  value: videoState.danmakuOpacity,
-                  min: 0.0,
-                  max: 1.0,
-                  divisions: 100,
-                  onChanged: (value) {
-                    videoState.setDanmakuOpacity(value);
-                  },
-                  labelFormatter: (value) => '${(value * 100).round()}%',
-                ),
-                Divider(
-                    color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-                SettingsItem.slider(
-                  title: '弹幕字体大小',
-                  subtitle: '调整弹幕文字大小，轨道间距会自动适配',
-                  icon: Ionicons.text_outline,
-                  value: videoState.danmakuFontSize <= 0
-                      ? videoState.actualDanmakuFontSize
-                      : videoState.danmakuFontSize,
-                  min: 12.0,
-                  max: 60.0,
-                  divisions: 96,
-                  onChanged: (value) {
-                    videoState.setDanmakuFontSize(value, commit: true);
-                  },
-                  labelFormatter: (value) => '${value.toStringAsFixed(1)}px',
-                ),
-                Divider(
-                    color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16.0,
-                    vertical: 12.0,
-                  ),
-                  child: SettingsCard(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            Icon(
-                              Ionicons.text_outline,
-                              color: colorScheme.onSurface,
-                              size: 18,
-                            ),
-                            const SizedBox(width: 8),
-                            Text(
-                              '弹幕字体',
-                              style: TextStyle(
-                                color: colorScheme.onSurface,
-                                fontSize: 14,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          '当前字体：${_danmakuFontLabel(videoState)}',
-                          style: TextStyle(
-                            color: colorScheme.onSurface.withOpacity(0.7),
-                            fontSize: 13,
-                          ),
-                        ),
-                        const SizedBox(height: 12),
-                        Row(
-                          children: [
-                            Expanded(
-                              child: BlurButton(
-                                icon: Ionicons.folder_open_outline,
-                                text: '选择字体文件',
-                                onTap: () => _pickDanmakuFontFile(videoState),
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 12,
-                                  vertical: 10,
-                                ),
-                                fontSize: 13,
-                                iconSize: 16,
-                              ),
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: BlurButton(
-                                icon: Ionicons.refresh_outline,
-                                text: '恢复默认',
-                                onTap: () => _resetDanmakuFont(videoState),
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 12,
-                                  vertical: 10,
-                                ),
-                                fontSize: 13,
-                                iconSize: 16,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                Divider(
-                    color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-                if (showBinaryDanmakuEffectToggles)
-                  SettingsItem.toggle(
-                    title: '弹幕描边',
-                    subtitle: '开启后为 $binaryDanmakuEffectKernelName 弹幕添加描边',
-                    icon: Ionicons.text_outline,
-                    value: videoState.next2DanmakuOutlineWidth > 0.0,
-                    onChanged: (value) {
-                      videoState.setNext2DanmakuOutlineWidth(
-                        value ? 1.0 : 0.0,
-                      );
-                    },
-                  )
-                else
-                  SettingsItem.dropdown(
-                    title: '弹幕描边样式',
-                    subtitle: '选择弹幕文字外缘的描边方式',
-                    icon: Ionicons.text_outline,
-                    items: outlineItems,
-                    onChanged: (dynamic value) {
-                      if (value is! DanmakuOutlineStyle) return;
-                      videoState.setDanmakuOutlineStyle(value);
-                    },
-                    dropdownKey: _danmakuOutlineStyleDropdownKey,
-                  ),
-                if (!isErikaPlayerKernel) ...[
-                  Divider(
-                      color: colorScheme.onSurface.withOpacity(0.12),
-                      height: 1),
-                  if (_usesBinaryDanmakuEffectToggles)
-                    SettingsItem.toggle(
-                      title: '弹幕阴影',
-                      subtitle: '开启后为 $_binaryDanmakuEffectKernelName 弹幕添加阴影',
-                      icon: Ionicons.color_wand_outline,
-                      value: videoState.danmakuShadowStyle !=
-                          DanmakuShadowStyle.none,
-                      onChanged: (value) {
-                        videoState.setDanmakuShadowStyle(
-                          value
-                              ? DanmakuShadowStyle.strong
-                              : DanmakuShadowStyle.none,
-                        );
-                      },
-                    )
-                  else
-                    SettingsItem.dropdown(
-                      title: '弹幕阴影样式',
-                      subtitle: '选择弹幕文字的阴影强度',
-                      icon: Ionicons.color_wand_outline,
-                      items: shadowItems,
-                      onChanged: (dynamic value) {
-                        if (value is! DanmakuShadowStyle) return;
-                        videoState.setDanmakuShadowStyle(value);
-                      },
-                      dropdownKey: _danmakuShadowStyleDropdownKey,
-                    ),
-                ],
-                Divider(
-                    color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-                SettingsItem.slider(
-                  title: '滚动弹幕速度',
-                  subtitle: '向左减慢滚动弹幕速度，向右加快',
-                  icon: Ionicons.speedometer_outline,
-                  value: videoState.danmakuSpeedMultiplier,
-                  min: 0.5,
-                  max: 2.0,
-                  divisions: 30,
-                  onChanged: (value) {
-                    videoState.setDanmakuSpeedMultiplier(value);
-                  },
-                  labelFormatter: (value) => '${value.toStringAsFixed(2)}x',
-                ),
-                Divider(
-                    color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-                SettingsItem.dropdown(
-                  title: '轨道显示区域',
-                  subtitle: '设置弹幕轨道在屏幕上的显示范围',
-                  icon: Ionicons.resize_outline,
-                  items: displayAreaItems,
-                  onChanged: (dynamic value) {
-                    if (value is! double) return;
-                    videoState.setDanmakuDisplayArea(
-                      _snapDanmakuDisplayArea(value),
-                    );
-                  },
-                  dropdownKey: _danmakuDisplayAreaDropdownKey,
-                ),
                 if (showTrackGapSlider) ...[
                   Divider(
                       color: colorScheme.onSurface.withOpacity(0.12),
@@ -782,20 +448,6 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
                     labelFormatter: (value) => '${(value * 100).round()}%',
                   ),
                 ],
-                if (showMergeToggle) ...[
-                  Divider(
-                      color: colorScheme.onSurface.withOpacity(0.12),
-                      height: 1),
-                  SettingsItem.toggle(
-                    title: '合并相同弹幕',
-                    subtitle: '将内容相同的弹幕合并为一条显示',
-                    icon: Ionicons.git_merge_outline,
-                    value: videoState.mergeDanmaku,
-                    onChanged: (value) {
-                      videoState.setMergeDanmaku(value);
-                    },
-                  ),
-                ],
                 if (showStackingToggle) ...[
                   Divider(
                       color: colorScheme.onSurface.withOpacity(0.12),
@@ -810,39 +462,6 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
                     },
                   ),
                 ],
-                Divider(
-                    color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-                SettingsItem.toggle(
-                  title: '屏蔽顶部弹幕',
-                  subtitle: '不显示顶部固定弹幕',
-                  icon: Ionicons.arrow_up_outline,
-                  value: videoState.blockTopDanmaku,
-                  onChanged: (value) {
-                    videoState.setBlockTopDanmaku(value);
-                  },
-                ),
-                Divider(
-                    color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-                SettingsItem.toggle(
-                  title: '屏蔽底部弹幕',
-                  subtitle: '不显示底部固定弹幕',
-                  icon: Ionicons.arrow_down_outline,
-                  value: videoState.blockBottomDanmaku,
-                  onChanged: (value) {
-                    videoState.setBlockBottomDanmaku(value);
-                  },
-                ),
-                Divider(
-                    color: colorScheme.onSurface.withOpacity(0.12), height: 1),
-                SettingsItem.toggle(
-                  title: '屏蔽滚动弹幕',
-                  subtitle: '不显示从右向左滚动的弹幕',
-                  icon: Ionicons.swap_horizontal_outline,
-                  value: videoState.blockScrollDanmaku,
-                  onChanged: (value) {
-                    videoState.setBlockScrollDanmaku(value);
-                  },
-                ),
               ],
             );
           },

--- a/lib/themes/nipaplay/widgets/danmaku_settings_menu.dart
+++ b/lib/themes/nipaplay/widgets/danmaku_settings_menu.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
+import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
 import 'base_settings_menu.dart';
 import 'player_menu_theme.dart';
@@ -7,7 +9,9 @@ import 'settings_hint_text.dart';
 import 'dart:convert';
 import 'dart:io';
 import 'blur_button.dart';
+import 'blur_dropdown.dart';
 import 'fluent_settings_switch.dart';
+import 'settings_slider.dart';
 import 'package:nipaplay/services/manual_danmaku_matcher.dart';
 import 'package:nipaplay/utils/danmaku_history_sync.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
@@ -36,6 +40,23 @@ class DanmakuSettingsMenu extends StatefulWidget {
 }
 
 class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
+  static const List<double> _danmakuDisplayAreaOptions = <double>[
+    0.0,
+    0.125,
+    0.25,
+    0.33,
+    0.67,
+    1.0,
+  ];
+  static final Map<double, String> _danmakuDisplayAreaLabels = <double, String>{
+    0.0: '单行显示',
+    0.125: '1/8 屏幕',
+    0.25: '1/4 屏幕',
+    0.33: '1/3 屏幕',
+    0.67: '2/3 屏幕',
+    1.0: '全屏',
+  };
+
   final TextEditingController _blockWordController = TextEditingController();
   bool _hasBlockWordError = false;
   String? _blockWordErrorMessage;
@@ -257,6 +278,92 @@ class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
         '${twoDigits(time.second)}';
   }
 
+  bool get _isNext2Kernel =>
+      DanmakuKernelFactory.getKernelType() == DanmakuRenderEngine.next2;
+
+  bool get _isDfmPlusKernel =>
+      DanmakuKernelFactory.getKernelType() == DanmakuRenderEngine.dfmPlus;
+
+  bool get _usesBinaryDanmakuEffectToggles =>
+      _isNext2Kernel || _isDfmPlusKernel;
+
+  String get _binaryDanmakuEffectKernelName =>
+      _isDfmPlusKernel ? 'DFM+' : 'Next2';
+
+  Future<void> _pickDanmakuFontFile(VideoPlayerState videoState) async {
+    final selected = await openFile(
+      acceptedTypeGroups: const [
+        XTypeGroup(
+          label: 'Font',
+          extensions: ['ttf', 'otf', 'ttc', 'otc'],
+        ),
+      ],
+    );
+    if (selected == null) return;
+
+    final success = await videoState.importDanmakuFontFile(selected.path);
+    if (!mounted) return;
+    if (success) {
+      BlurSnackBar.show(context, '已应用字体: ${p.basename(selected.path)}');
+    } else {
+      BlurSnackBar.show(context, '字体加载失败，请选择有效的字体文件');
+    }
+  }
+
+  Future<void> _resetDanmakuFont(VideoPlayerState videoState) async {
+    await videoState.resetDanmakuFont();
+    if (!mounted) return;
+    BlurSnackBar.show(context, '已恢复为系统默认字体');
+  }
+
+  String _danmakuFontLabel(VideoPlayerState videoState) {
+    final fontPath = videoState.danmakuFontFilePath.trim();
+    if (fontPath.isEmpty) return '系统默认字体';
+    return p.basename(fontPath);
+  }
+
+  String _shadowStyleLabel(DanmakuShadowStyle style) {
+    switch (style) {
+      case DanmakuShadowStyle.none:
+        return '无阴影';
+      case DanmakuShadowStyle.soft:
+        return '柔和阴影';
+      case DanmakuShadowStyle.medium:
+        return '标准阴影';
+      case DanmakuShadowStyle.strong:
+        return '增强阴影';
+    }
+  }
+
+  String _outlineStyleLabel(DanmakuOutlineStyle style) {
+    switch (style) {
+      case DanmakuOutlineStyle.none:
+        return '无描边';
+      case DanmakuOutlineStyle.stroke:
+        return '标准描边';
+      case DanmakuOutlineStyle.uniform:
+        return '均匀描边';
+    }
+  }
+
+  double _snapDanmakuDisplayArea(double value) {
+    double best = _danmakuDisplayAreaOptions.first;
+    double bestDiff = (value - best).abs();
+    for (final option in _danmakuDisplayAreaOptions.skip(1)) {
+      final diff = (value - option).abs();
+      if (diff < bestDiff) {
+        bestDiff = diff;
+        best = option;
+      }
+    }
+    return best;
+  }
+
+  String _danmakuDisplayAreaText(double value) {
+    final snapped = _snapDanmakuDisplayArea(value);
+    return _danmakuDisplayAreaLabels[snapped] ?? '全屏';
+  }
+
   // 检查是否是正则表达式规则格式: 规则名称/表达式/
   bool _isRegexRule(String word) {
     if (!word.contains('/')) return false;
@@ -335,6 +442,406 @@ class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
     );
   }
 
+  Widget _buildDanmakuStyleSection(VideoPlayerState videoState) {
+    final isErikaPlayerKernel =
+        PlayerFactory.getKernelType() == PlayerKernelType.erika;
+    final showBinaryDanmakuEffectToggles =
+        isErikaPlayerKernel || _usesBinaryDanmakuEffectToggles;
+    final binaryDanmakuEffectKernelName =
+        isErikaPlayerKernel ? 'Erika' : _binaryDanmakuEffectKernelName;
+    final showMergeToggle = isErikaPlayerKernel ||
+        DanmakuKernelFactory.getKernelType() != DanmakuRenderEngine.canvas;
+
+    return Padding(
+      padding: const EdgeInsets.only(left: 16, right: 16, top: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '弹幕样式',
+            style: TextStyle(
+              color: PlayerMenuTheme.colorsOf(context).foreground,
+              fontSize: 14,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 12),
+          _buildSliderSection(
+            label: '弹幕不透明度',
+            value: videoState.danmakuOpacity,
+            min: 0,
+            max: 1,
+            step: 0.01,
+            displayTextBuilder: (value) => '${(value * 100).round()}%',
+            onChanged: videoState.setDanmakuOpacity,
+            hint: '调整弹幕文字透明度',
+          ),
+          _buildSliderSection(
+            label: '弹幕字体大小',
+            value: videoState.danmakuFontSize <= 0
+                ? videoState.actualDanmakuFontSize
+                : videoState.danmakuFontSize,
+            min: 12,
+            max: 60,
+            step: 0.5,
+            displayTextBuilder: (value) => '${value.toStringAsFixed(1)}px',
+            onChanged: videoState.setDanmakuFontSize,
+            onChangeEnd: (value) =>
+                videoState.setDanmakuFontSize(value, commit: true),
+            hint: '调整弹幕文字大小，轨道间距会自动适配',
+          ),
+          _buildFontSection(videoState),
+          _buildOutlineSection(
+            videoState,
+            useBinaryToggle: showBinaryDanmakuEffectToggles,
+            kernelName: binaryDanmakuEffectKernelName,
+          ),
+          if (!isErikaPlayerKernel) _buildShadowSection(videoState),
+          _buildSliderSection(
+            label: '滚动弹幕速度',
+            value: videoState.danmakuSpeedMultiplier,
+            min: 0.5,
+            max: 2,
+            step: 0.05,
+            displayTextBuilder: (value) => '${value.toStringAsFixed(2)}x',
+            onChanged: videoState.setDanmakuSpeedMultiplier,
+            hint: '向左减慢滚动弹幕速度，向右加快',
+          ),
+          _buildDisplayAreaSection(videoState),
+          if (showMergeToggle)
+            _buildSwitchSection(
+              label: '合并相同弹幕',
+              value: videoState.mergeDanmaku,
+              onChanged: videoState.setMergeDanmaku,
+              hint: '将内容相同的弹幕合并为一条显示',
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDanmakuBlockModeSection(VideoPlayerState videoState) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 16, right: 16, top: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '弹幕屏蔽',
+            style: TextStyle(
+              color: PlayerMenuTheme.colorsOf(context).foreground,
+              fontSize: 14,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          _buildSwitchSection(
+            label: '屏蔽顶部弹幕',
+            value: videoState.blockTopDanmaku,
+            onChanged: videoState.setBlockTopDanmaku,
+            hint: '不显示顶部固定弹幕',
+          ),
+          _buildSwitchSection(
+            label: '屏蔽底部弹幕',
+            value: videoState.blockBottomDanmaku,
+            onChanged: videoState.setBlockBottomDanmaku,
+            hint: '不显示底部固定弹幕',
+          ),
+          _buildSwitchSection(
+            label: '屏蔽滚动弹幕',
+            value: videoState.blockScrollDanmaku,
+            onChanged: videoState.setBlockScrollDanmaku,
+            hint: '不显示从右向左滚动的弹幕',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSliderSection({
+    required String label,
+    required double value,
+    required double min,
+    required double max,
+    required double step,
+    required String Function(double) displayTextBuilder,
+    required ValueChanged<double> onChanged,
+    ValueChanged<double>? onChangeEnd,
+    required String hint,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SettingsSlider(
+            value: value,
+            onChanged: onChanged,
+            onChangeEnd: onChangeEnd,
+            label: label,
+            displayTextBuilder: displayTextBuilder,
+            min: min,
+            max: max,
+            step: step,
+          ),
+          const SizedBox(height: 4),
+          SettingsHintText(hint),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFontSection(VideoPlayerState videoState) {
+    final menuColors = PlayerMenuTheme.colorsOf(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '字体选择',
+            style: TextStyle(
+              color: menuColors.foreground,
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '当前字体：${_danmakuFontLabel(videoState)}',
+            style: TextStyle(
+              color: menuColors.secondaryForeground,
+              fontSize: 13,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: BlurButton(
+                  text: '选择字体文件',
+                  icon: Icons.folder_open,
+                  onTap: () => _pickDanmakuFontFile(videoState),
+                  expandHorizontally: true,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: BlurButton(
+                  text: '恢复默认',
+                  icon: Icons.restart_alt,
+                  onTap: () => _resetDanmakuFont(videoState),
+                  expandHorizontally: true,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          const SettingsHintText('支持 ttf、otf、ttc、otc 字体文件'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOutlineSection(
+    VideoPlayerState videoState, {
+    required bool useBinaryToggle,
+    required String kernelName,
+  }) {
+    if (useBinaryToggle) {
+      return _buildSwitchSection(
+        label: '弹幕描边',
+        value: videoState.next2DanmakuOutlineWidth > 0.0,
+        onChanged: (value) {
+          videoState.setNext2DanmakuOutlineWidth(value ? 1.0 : 0.0);
+        },
+        hint: '开启后为 $kernelName 弹幕添加描边',
+      );
+    }
+
+    final items = DanmakuOutlineStyle.values
+        .map(
+          (style) => DropdownMenuItemData<DanmakuOutlineStyle>(
+            title: _outlineStyleLabel(style),
+            value: style,
+            isSelected: videoState.danmakuOutlineStyle == style,
+          ),
+        )
+        .toList();
+
+    return _buildOptionButtonsSection(
+      title: '弹幕描边',
+      description: '选择弹幕文字外缘的描边方式',
+      items: items,
+      onSelected: videoState.setDanmakuOutlineStyle,
+    );
+  }
+
+  Widget _buildShadowSection(VideoPlayerState videoState) {
+    if (_usesBinaryDanmakuEffectToggles) {
+      return _buildSwitchSection(
+        label: '弹幕阴影',
+        value: videoState.danmakuShadowStyle != DanmakuShadowStyle.none,
+        onChanged: (value) {
+          videoState.setDanmakuShadowStyle(
+            value ? DanmakuShadowStyle.strong : DanmakuShadowStyle.none,
+          );
+        },
+        hint: '开启后为 $_binaryDanmakuEffectKernelName 弹幕添加阴影',
+      );
+    }
+
+    final items = DanmakuShadowStyle.values
+        .map(
+          (style) => DropdownMenuItemData<DanmakuShadowStyle>(
+            title: _shadowStyleLabel(style),
+            value: style,
+            isSelected: videoState.danmakuShadowStyle == style,
+          ),
+        )
+        .toList();
+
+    return _buildOptionButtonsSection(
+      title: '弹幕阴影',
+      description: '选择弹幕文字的阴影强度',
+      items: items,
+      onSelected: videoState.setDanmakuShadowStyle,
+    );
+  }
+
+  Widget _buildDisplayAreaSection(VideoPlayerState videoState) {
+    final selectedArea = _snapDanmakuDisplayArea(videoState.danmakuDisplayArea);
+    final items = _danmakuDisplayAreaOptions
+        .map(
+          (area) => DropdownMenuItemData<double>(
+            title: _danmakuDisplayAreaText(area),
+            value: area,
+            isSelected: selectedArea == area,
+          ),
+        )
+        .toList();
+
+    return _buildOptionButtonsSection(
+      title: '轨道显示区域',
+      description: '设置弹幕轨道在屏幕上的显示范围',
+      items: items,
+      onSelected: (value) {
+        videoState.setDanmakuDisplayArea(_snapDanmakuDisplayArea(value));
+      },
+    );
+  }
+
+  Widget _buildOptionButtonsSection<T>({
+    required String title,
+    required String description,
+    required List<DropdownMenuItemData<T>> items,
+    required ValueChanged<T> onSelected,
+  }) {
+    final menuColors = PlayerMenuTheme.colorsOf(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              color: menuColors.foreground,
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: items
+                .map((item) => _buildOptionButton(item, onSelected))
+                .toList(),
+          ),
+          const SizedBox(height: 4),
+          SettingsHintText(description),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOptionButton<T>(
+    DropdownMenuItemData<T> item,
+    ValueChanged<T> onSelected,
+  ) {
+    final menuColors = PlayerMenuTheme.colorsOf(context);
+    final isSelected = item.isSelected;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(8),
+        onTap: () => onSelected(item.value),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: isSelected
+                ? menuColors.selectedBackground
+                : menuColors.controlBackground,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: isSelected
+                  ? menuColors.selectedBorder
+                  : menuColors.controlBorder,
+              width: 1,
+            ),
+          ),
+          child: Text(
+            item.title,
+            style: TextStyle(
+              color: isSelected
+                  ? menuColors.selectedForeground
+                  : menuColors.foreground,
+              fontSize: 13,
+              fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSwitchSection({
+    required String label,
+    required bool value,
+    required ValueChanged<bool> onChanged,
+    required String hint,
+  }) {
+    final menuColors = PlayerMenuTheme.colorsOf(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Text(
+                  label,
+                  style: TextStyle(
+                    color: menuColors.foreground,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              FluentSettingsSwitch(value: value, onChanged: onChanged),
+            ],
+          ),
+          const SizedBox(height: 4),
+          SettingsHintText(hint),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer<VideoPlayerState>(
@@ -375,6 +882,8 @@ class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
                   ],
                 ),
               ),
+              _buildDanmakuStyleSection(videoState),
+              _buildDanmakuBlockModeSection(videoState),
               // 手动匹配弹幕
               Padding(
                 padding: const EdgeInsets.only(left: 16, right: 16, top: 8),
@@ -562,49 +1071,58 @@ class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
 
   Widget _buildDesktopBlockWordInput() {
     final menuColors = PlayerMenuTheme.colorsOf(context);
-    return Container(
+    final borderColor = _hasBlockWordError
+        ? Colors.redAccent.withOpacity(0.8)
+        : menuColors.controlBorder;
+
+    return SizedBox(
       height: 80,
-      decoration: BoxDecoration(
-        color: menuColors.controlBackground,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: _hasBlockWordError
-              ? Colors.redAccent.withOpacity(0.8)
-              : menuColors.controlBorder,
-          width: 1,
-        ),
-      ),
-      child: Center(
-        child: TextField(
-          controller: _blockWordController,
-          style: TextStyle(color: menuColors.foreground, fontSize: 13),
-          textAlignVertical: TextAlignVertical.center,
-          maxLines: 3,
-          decoration: InputDecoration(
-            hintText: '输入要屏蔽的关键词\n（支持正则，以"规则名称/表达式/"形式输入；支持逗号分隔批量添加）',
-            hintStyle: TextStyle(
-              color: menuColors.disabledForeground,
-              fontSize: 13,
-            ),
-            border: InputBorder.none,
-            contentPadding:
-                const EdgeInsets.symmetric(horizontal: 12, vertical: 0),
-            isDense: true,
-            suffixIcon: IconButton(
-              icon: Icon(
-                Icons.clear,
-                color: menuColors.secondaryForeground,
-                size: 18,
-              ),
-              onPressed: () => _blockWordController.clear(),
-              tooltip: '',
-              padding: EdgeInsets.zero,
-              visualDensity: VisualDensity.compact,
-              constraints: const BoxConstraints(),
-            ),
+      child: TextField(
+        controller: _blockWordController,
+        style: TextStyle(color: menuColors.foreground, fontSize: 13),
+        textAlignVertical: TextAlignVertical.center,
+        maxLines: 3,
+        decoration: InputDecoration(
+          hintText: '输入要屏蔽的关键词\n（支持正则，以"规则名称/表达式/"形式输入；支持逗号分隔批量添加）',
+          hintStyle: TextStyle(
+            color: menuColors.disabledForeground,
+            fontSize: 13,
           ),
-          onSubmitted: (_) => _addBlockWord(),
+          filled: true,
+          fillColor: menuColors.controlBackground,
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          isDense: true,
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: BorderSide(color: borderColor, width: 1),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: BorderSide(color: menuColors.accent, width: 1),
+          ),
+          errorBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: BorderSide(color: borderColor, width: 1),
+          ),
+          focusedErrorBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: BorderSide(color: borderColor, width: 1),
+          ),
+          suffixIcon: IconButton(
+            icon: Icon(
+              Icons.clear,
+              color: menuColors.secondaryForeground,
+              size: 18,
+            ),
+            onPressed: () => _blockWordController.clear(),
+            tooltip: '',
+            padding: EdgeInsets.zero,
+            visualDensity: VisualDensity.compact,
+            constraints: const BoxConstraints(),
+          ),
         ),
+        onSubmitted: (_) => _addBlockWord(),
       ),
     );
   }


### PR DESCRIPTION
## Summary

- Move danmaku display controls from the global danmaku settings page into the player danmaku settings menus.
- Add the moved controls to both NipaPlay and Cupertino player menus, including opacity, font size, font file selection, outline, shadow, scroll speed, display area, merge duplicates, and danmaku type blocking.
- Add random color back to the Cupertino danmaku settings page and simplify the NipaPlay block-word input so it no longer renders as nested containers.

## Why

These controls are playback-time adjustments and should be available directly from the player menu. Keeping them out of the global settings page reduces duplication and avoids harder-to-reach controls during playback.

## Validation

- `dart format lib/themes/nipaplay/widgets/danmaku_settings_menu.dart lib/themes/cupertino/widgets/player_menu/cupertino_danmaku_settings_pane.dart lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart lib/themes/cupertino/pages/settings/pages/cupertino_danmaku_settings_page.dart`
- `flutter analyze lib/themes/nipaplay/widgets/danmaku_settings_menu.dart lib/themes/cupertino/widgets/player_menu/cupertino_danmaku_settings_pane.dart lib/themes/nipaplay/pages/settings/danmaku_settings_page.dart lib/themes/cupertino/pages/settings/pages/cupertino_danmaku_settings_page.dart` (info-level existing lint only)
- `flutter build windows --release`