### PR TITLE
Fix Windows mdk-sdk fallback download

### DIFF
--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -174,6 +174,18 @@ runs:
           return $true
         }
 
+        function Get-MdkSdkReleaseAsset {
+          param(
+            [object]$Release,
+            [string[]]$Patterns
+          )
+          foreach ($pattern in $Patterns) {
+            $asset = $Release.assets | Where-Object { $_.name -match $pattern } | Select-Object -First 1
+            if ($asset) { return $asset }
+          }
+          return $null
+        }
+
         $candidates = @(
           "https://sourceforge.net/projects/mdk-sdk/files/nightly/$mdkSdkPkg/download",
           "https://downloads.sourceforge.net/project/mdk-sdk/nightly/$mdkSdkPkg",
@@ -204,10 +216,35 @@ runs:
         }
 
         if (-not $downloaded) {
-          $ghPkg = "mdk-sdk-windows-x64.7z"
-          $ghUrl = "https://github.com/wang-bin/mdk-sdk/releases/latest/download/$ghPkg"
+          $releaseApi = "https://api.github.com/repos/wang-bin/mdk-sdk/releases/latest"
+          $headers = @{
+            "User-Agent" = "NipaPlay-Build"
+            "Accept" = "application/vnd.github+json"
+          }
+          if ($env:GITHUB_TOKEN) {
+            $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
+          }
+          try {
+            $release = Invoke-RestMethod -Uri $releaseApi -Headers $headers -UseBasicParsing -TimeoutSec 60
+          } catch {
+            throw "Unable to query mdk-sdk latest release: $($_.Exception.Message)"
+          }
+          $assetPatterns = @(
+            "^mdk-sdk-windows-x64-vs[0-9]+\.7z$",
+            "^mdk-sdk-windows-vs[0-9]+\.7z$",
+            "^mdk-sdk-windows-x64\.7z$",
+            "^mdk-sdk-windows\.7z$",
+            "^mdk-sdk-windows-vs[0-9]+-ltl\.7z$"
+          )
+          $asset = Get-MdkSdkReleaseAsset -Release $release -Patterns $assetPatterns
+          if (-not $asset) {
+            $available = ($release.assets | ForEach-Object { $_.name }) -join ", "
+            throw "No compatible Windows mdk-sdk asset found in $($release.tag_name). Available assets: $available"
+          }
+          $ghPkg = $asset.name
+          $ghUrl = $asset.browser_download_url
           $archivePath = Join-Path $fvpDir "windows\$ghPkg"
-          Write-Host "SourceForge mirrors unavailable; falling back to GitHub release $ghUrl ..."
+          Write-Host "SourceForge mirrors unavailable; falling back to GitHub release $($release.tag_name) asset $ghPkg ..."
           Invoke-WebRequest -Uri $ghUrl -OutFile $archivePath -UseBasicParsing -TimeoutSec 180 -Headers $ua
           if (-not (Test-SevenZip $archivePath)) {
             throw "GitHub fallback download was not a valid 7z archive: $archivePath"


### PR DESCRIPTION
## Summary
- keep the existing SourceForge mirror attempts for FVP mdk-sdk
- replace the hardcoded GitHub fallback asset `mdk-sdk-windows-x64.7z` with latest-release asset discovery
- prefer MSVC/x64 Windows assets such as `mdk-sdk-windows-x64-vs2026.7z`, with compatibility fallbacks for older names

## Why
The latest `wang-bin/mdk-sdk` release no longer publishes `mdk-sdk-windows-x64.7z`, so the Windows CI fallback downloaded GitHub 404 HTML and failed before the Flutter build.

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/actions/build-windows/action.yml")'\n- git diff --check\n- verified the release asset selection against `wang-bin/mdk-sdk` latest release; it selects `v0.37.0 mdk-sdk-windows-x64-vs2026.7z`