### PR TITLE
Fix/dfm optimize@8

### DIFF
--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -144,8 +144,13 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   /// latency from distorting the frame interval measurement.
   int _vsyncWallUs = 0;
 
-  /// Continuous media time used for layout. Advances by real wall-clock dt and
-  /// is gently corrected toward playbackTimeMs during normal playback.
+  /// Continuous media time used for layout. Advances by real wall-clock dt at
+  /// EXACTLY playbackRate — the rate is never modulated by drift correction,
+  /// so danmaku on-screen speed is always consistent. Drift against the
+  /// authoritative media clock is removed by one-shot position snaps, and
+  /// during media-clock stalls the display clock is held (see
+  /// _stallThresholdSec) so danmaku pause with the video instead of running
+  /// ahead and being yanked back.
   double _displayMediaTime = 0.0;
 
   /// Wall-clock microseconds of the previous display-time update.
@@ -154,19 +159,45 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   /// Whether _displayMediaTime has been initialized from playbackTimeMs.
   bool _displayTimeInitialized = false;
 
+  /// Last observed media-clock value (seconds). Used to detect whether
+  /// playbackTimeMs is currently advancing or frozen (stalled).
+  double _lastMediaTimeSec = double.nan;
+
+  /// Wall-clock microseconds of the last observed media-clock advancement.
+  /// If the media clock has not advanced for longer than _stallThresholdSec
+  /// while playing, the video is treated as stalled (buffering / seek-settle /
+  /// upstream hold) and the display clock is held too.
+  int _lastMediaAdvanceWallUs = 0;
+
   /// Per-frame wall dt cap. Prevents a long app stall/backgrounding event from
   /// jumping danmaku far ahead; playbackTimeMs will snap/correct us afterward.
   static const double _maxFrameDtSec = 0.2;
 
-  /// Normal playback drift below this is ignored to preserve perfectly smooth
-  /// wall-clock motion between coarse media-clock ticks.
-  static const double _driftCorrectionThresholdSec = 0.080;
+  /// Media-clock staleness threshold. If playbackTimeMs does not advance for
+  /// longer than this while isPlaying is true, the video is considered stalled
+  /// (buffering / seek-settle / upstream hold) and the display clock is held
+  /// too — danmaku pause with the video instead of running ahead of the frozen
+  /// media clock and being yanked back. Must stay below _snapThresholdSec so
+  /// stall-detection latency cannot accumulate enough drift to trigger a snap.
+  /// ~6 frames at 60Hz: well above normal vsync jitter (16ms) and the upstream
+  /// 50ms anchor-expire gap, well below a real buffer/seek stall.
+  static const double _stallThresholdSec = 0.10;
 
-  /// Drift correction rate once the threshold is exceeded. Small enough to be
-  /// visually smooth, large enough to converge without a long slow/fast period.
-  static const double _driftCorrectionRate = 0.15;
+  /// Drift above this (but below _hardResyncThresholdSec) is corrected by a
+  /// one-shot position snap to the media clock — NOT by modulating the rate.
+  /// Because layout is a pure function of time (x = width - speed * (t -
+  /// item.time)), a snap translates to a single-frame horizontal shift of
+  /// on-screen danmaku (sub-pixel-imperceptible for small drift at typical
+  /// scroll speeds) while the per-frame advance rate — i.e. the visible speed
+  /// — stays exactly playbackRate. Below this, drift is ignored to preserve
+  /// smooth per-vsync motion. This replaces the old proportional drift
+  /// correction which smeared the correction over many frames and produced the
+  /// noticeable slow-then-fast convergence after a seek / video open.
+  static const double _snapThresholdSec = 0.15;
 
-  /// Treat very large drift as seek / loop / stale clock and snap to media time.
+  /// Treat very large drift as seek / loop / stale clock and snap immediately,
+  /// unconditionally (even if the media clock currently looks stalled — a large
+  /// jump is a seek, not a stall).
   static const double _hardResyncThresholdSec = 1.0;
 
   // ── Submit-rate throttle (P1-4) ──
@@ -279,8 +310,13 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   /// wall-clock baseline. Used for first frame, seek, resume, and clock source
   /// changes. This is a hard reset, not the normal playback correction path.
   void _resetDisplayTimeToMedia() {
-    _displayMediaTime = widget.playbackTimeMs.value / 1000.0;
+    final mediaTime = widget.playbackTimeMs.value / 1000.0;
+    _displayMediaTime = mediaTime;
     _lastDisplayWallUs = _wallClock.elapsedMicroseconds;
+    // Reset stall-detection baseline alongside the display clock so a fresh
+    // play/resume/seek doesn't get misread as a stall on its first frames.
+    _lastMediaTimeSec = mediaTime;
+    _lastMediaAdvanceWallUs = _lastDisplayWallUs;
     _displayTimeInitialized = true;
   }
 
@@ -449,28 +485,60 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
         if (!_displayTimeInitialized) {
           _displayMediaTime = mediaTime;
           _lastDisplayWallUs = currentWallUs;
+          _lastMediaTimeSec = mediaTime;
+          _lastMediaAdvanceWallUs = currentWallUs;
           _displayTimeInitialized = true;
         }
 
-        // Advance by real wall-clock frame time. This is what gives 120Hz
-        // panels 120 distinct positions instead of re-anchoring to a coarser
-        // playbackTimeMs tick and making motion look sticky/60Hz-like.
-        if (widget.isPlaying && currentWallUs > _lastDisplayWallUs) {
+        // ── Media-clock freshness / stall detection ──
+        // playbackTimeMs is the authoritative clock. While the video is really
+        // playing it advances every vsync; if it stops advancing while isPlaying
+        // is true, the video is stalled (buffering / seek-settle / upstream
+        // hold). In that case the display clock must NOT run ahead of the
+        // frozen media clock — doing so is exactly what produced the old
+        // "drift correction slows the danmaku" symptom.
+        if ((mediaTime - _lastMediaTimeSec).abs() > 1e-6) {
+          _lastMediaTimeSec = mediaTime;
+          _lastMediaAdvanceWallUs = currentWallUs;
+        }
+        final bool mediaStalled = widget.isPlaying &&
+            currentWallUs - _lastMediaAdvanceWallUs >
+                (_stallThresholdSec * 1000000).toInt();
+
+        // Advance by real wall-clock frame time at EXACTLY playbackRate — never
+        // modulated by drift. This is what gives 120Hz panels 120 distinct
+        // positions and, crucially, keeps danmaku speed constant in every
+        // situation. When the media clock is stalled, hold the display clock
+        // too so danmaku pause with the video instead of drifting ahead.
+        if (widget.isPlaying &&
+            !mediaStalled &&
+            currentWallUs > _lastDisplayWallUs) {
           final deltaUs = currentWallUs - _lastDisplayWallUs;
           final dt = (deltaUs / 1000000.0).clamp(0.0, _maxFrameDtSec);
           _displayMediaTime += dt * widget.playbackRate;
         }
         _lastDisplayWallUs = currentWallUs;
 
-        // Correct against the authoritative media clock only when needed.
-        // Small drift is ignored to preserve smooth per-vsync motion; larger
-        // drift is corrected gently; seek/loop-sized drift snaps immediately.
+        // ── Drift correction: position snaps only, never rate modulation ──
+        // A snap is a single-frame position jump; the per-frame advance rate
+        // (the visible speed) stays at playbackRate. This replaces the old
+        // proportional correction (displayMediaTime += drift * rate) which
+        // smeared correction across many frames and made danmaku visibly
+        // slow-then-fast whenever the media clock was held (seek / buffer).
         final drift = mediaTime - _displayMediaTime;
         if (drift.abs() >= _hardResyncThresholdSec) {
+          // Seek / loop / stale clock — snap immediately, even mid-stall.
           _displayMediaTime = mediaTime;
           _lastDisplayWallUs = currentWallUs;
-        } else if (drift.abs() > _driftCorrectionThresholdSec) {
-          _displayMediaTime += drift * _driftCorrectionRate;
+          _lastMediaTimeSec = mediaTime;
+          _lastMediaAdvanceWallUs = currentWallUs;
+        } else if (drift.abs() > _snapThresholdSec && !mediaStalled) {
+          // Fresh media clock with accumulated drift (small seek / skew) —
+          // snap to it. Skipped during stalls: the media clock is frozen and
+          // the display clock is held, so drift is bounded and clears when
+          // playback resumes; snapping toward a frozen clock would yank
+          // danmaku backward and reintroduce the jitter/slowdown symptom.
+          _displayMediaTime = mediaTime;
         }
 
         final double interpolatedTime = _displayMediaTime + widget.timeOffset;

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -145,12 +145,11 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   int _vsyncWallUs = 0;
 
   /// Continuous media time used for layout. Advances by real wall-clock dt at
-  /// EXACTLY playbackRate — the rate is never modulated by drift correction,
-  /// so danmaku on-screen speed is always consistent. Drift against the
-  /// authoritative media clock is removed by one-shot position snaps, and
-  /// during media-clock stalls the display clock is held (see
-  /// _stallThresholdSec) so danmaku pause with the video instead of running
-  /// ahead and being yanked back.
+  /// EXACTLY playbackRate — the rate is never modulated, so danmaku on-screen
+  /// speed is always consistent. It is kept from running ahead of the
+  /// authoritative media clock by a ceiling (see _aheadToleranceSec) so that
+  /// during buffering the danmaku follow the (slowed/held) media clock instead
+  /// of running ahead and snapping back, and it snaps forward on seeks.
   double _displayMediaTime = 0.0;
 
   /// Wall-clock microseconds of the previous display-time update.
@@ -159,45 +158,37 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   /// Whether _displayMediaTime has been initialized from playbackTimeMs.
   bool _displayTimeInitialized = false;
 
-  /// Last observed media-clock value (seconds). Used to detect whether
-  /// playbackTimeMs is currently advancing or frozen (stalled).
-  double _lastMediaTimeSec = double.nan;
-
-  /// Wall-clock microseconds of the last observed media-clock advancement.
-  /// If the media clock has not advanced for longer than _stallThresholdSec
-  /// while playing, the video is treated as stalled (buffering / seek-settle /
-  /// upstream hold) and the display clock is held too.
-  int _lastMediaAdvanceWallUs = 0;
-
   /// Per-frame wall dt cap. Prevents a long app stall/backgrounding event from
   /// jumping danmaku far ahead; playbackTimeMs will snap/correct us afterward.
   static const double _maxFrameDtSec = 0.2;
 
-  /// Media-clock staleness threshold. If playbackTimeMs does not advance for
-  /// longer than this while isPlaying is true, the video is considered stalled
-  /// (buffering / seek-settle / upstream hold) and the display clock is held
-  /// too — danmaku pause with the video instead of running ahead of the frozen
-  /// media clock and being yanked back. Must stay below _snapThresholdSec so
-  /// stall-detection latency cannot accumulate enough drift to trigger a snap.
-  /// ~6 frames at 60Hz: well above normal vsync jitter (16ms) and the upstream
-  /// 50ms anchor-expire gap, well below a real buffer/seek stall.
-  static const double _stallThresholdSec = 0.10;
+  /// Ceiling tolerance: the display clock may run ahead of the authoritative
+  /// media clock by at most this much. During buffering / seek-settle the media
+  /// clock advances slower than wall-clock (the upstream smooth clock is pulled
+  /// back toward the stalled player position), so the display clock would
+  /// otherwise race ahead and then get yanked back by a backward snap every
+  /// ~150ms — the visible "forward a bit, back a little" oscillation. The
+  /// ceiling makes the display clock gently follow the media clock's actual
+  /// (slowed) rate instead: danmaku slow / freeze with the video. Must exceed
+  /// one frame of wall-clock advance (dt*rate ≈ 17ms at 60Hz) so it never
+  /// binds during normal in-sync playback, and stay below _snapThresholdSec.
+  static const double _aheadToleranceSec = 0.05;
 
-  /// Drift above this (but below _hardResyncThresholdSec) is corrected by a
-  /// one-shot position snap to the media clock — NOT by modulating the rate.
-  /// Because layout is a pure function of time (x = width - speed * (t -
+  /// Forward drift above this (but below _hardResyncThresholdSec) is corrected
+  /// by a one-shot position snap to the media clock — NOT by modulating the
+  /// rate. Because layout is a pure function of time (x = width - speed * (t -
   /// item.time)), a snap translates to a single-frame horizontal shift of
   /// on-screen danmaku (sub-pixel-imperceptible for small drift at typical
   /// scroll speeds) while the per-frame advance rate — i.e. the visible speed
-  /// — stays exactly playbackRate. Below this, drift is ignored to preserve
-  /// smooth per-vsync motion. This replaces the old proportional drift
-  /// correction which smeared the correction over many frames and produced the
-  /// noticeable slow-then-fast convergence after a seek / video open.
+  /// — stays exactly playbackRate. Backward drift (display ahead of media) is
+  /// NOT snapped — the _aheadToleranceSec ceiling handles it continuously, and
+  /// a backward snap was the source of the buffering oscillation. Below this
+  /// threshold, drift is ignored to preserve smooth per-vsync motion.
   static const double _snapThresholdSec = 0.15;
 
-  /// Treat very large drift as seek / loop / stale clock and snap immediately,
-  /// unconditionally (even if the media clock currently looks stalled — a large
-  /// jump is a seek, not a stall).
+  /// Treat very large forward drift as seek and snap immediately (resets the
+  /// wall-clock baseline too). Large backward drift (loop restart) is handled
+  /// by the ceiling pulling the display clock back to mediaTime + tolerance.
   static const double _hardResyncThresholdSec = 1.0;
 
   // ── Submit-rate throttle (P1-4) ──
@@ -310,13 +301,8 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   /// wall-clock baseline. Used for first frame, seek, resume, and clock source
   /// changes. This is a hard reset, not the normal playback correction path.
   void _resetDisplayTimeToMedia() {
-    final mediaTime = widget.playbackTimeMs.value / 1000.0;
-    _displayMediaTime = mediaTime;
+    _displayMediaTime = widget.playbackTimeMs.value / 1000.0;
     _lastDisplayWallUs = _wallClock.elapsedMicroseconds;
-    // Reset stall-detection baseline alongside the display clock so a fresh
-    // play/resume/seek doesn't get misread as a stall on its first frames.
-    _lastMediaTimeSec = mediaTime;
-    _lastMediaAdvanceWallUs = _lastDisplayWallUs;
     _displayTimeInitialized = true;
   }
 
@@ -485,59 +471,45 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
         if (!_displayTimeInitialized) {
           _displayMediaTime = mediaTime;
           _lastDisplayWallUs = currentWallUs;
-          _lastMediaTimeSec = mediaTime;
-          _lastMediaAdvanceWallUs = currentWallUs;
           _displayTimeInitialized = true;
         }
 
-        // ── Media-clock freshness / stall detection ──
-        // playbackTimeMs is the authoritative clock. While the video is really
-        // playing it advances every vsync; if it stops advancing while isPlaying
-        // is true, the video is stalled (buffering / seek-settle / upstream
-        // hold). In that case the display clock must NOT run ahead of the
-        // frozen media clock — doing so is exactly what produced the old
-        // "drift correction slows the danmaku" symptom.
-        if ((mediaTime - _lastMediaTimeSec).abs() > 1e-6) {
-          _lastMediaTimeSec = mediaTime;
-          _lastMediaAdvanceWallUs = currentWallUs;
-        }
-        final bool mediaStalled = widget.isPlaying &&
-            currentWallUs - _lastMediaAdvanceWallUs >
-                (_stallThresholdSec * 1000000).toInt();
-
         // Advance by real wall-clock frame time at EXACTLY playbackRate — never
         // modulated by drift. This is what gives 120Hz panels 120 distinct
-        // positions and, crucially, keeps danmaku speed constant in every
-        // situation. When the media clock is stalled, hold the display clock
-        // too so danmaku pause with the video instead of drifting ahead.
-        if (widget.isPlaying &&
-            !mediaStalled &&
-            currentWallUs > _lastDisplayWallUs) {
+        // positions and keeps danmaku speed constant during normal playback.
+        if (widget.isPlaying && currentWallUs > _lastDisplayWallUs) {
           final deltaUs = currentWallUs - _lastDisplayWallUs;
           final dt = (deltaUs / 1000000.0).clamp(0.0, _maxFrameDtSec);
           _displayMediaTime += dt * widget.playbackRate;
         }
         _lastDisplayWallUs = currentWallUs;
 
-        // ── Drift correction: position snaps only, never rate modulation ──
+        // ── Ceiling: don't let the display clock run ahead of the media clock ──
+        // During buffering / seek-settle the media clock advances SLOWER than
+        // wall-clock (the upstream smooth clock is periodically pulled back
+        // toward the stalled player position). Without this ceiling the display
+        // clock races ahead, drift passes _snapThresholdSec, and the backward
+        // snap yanks it back — repeating every ~150ms as a visible "forward a
+        // bit, back a little" oscillation. The ceiling makes the display clock
+        // gently follow the media clock's actual rate instead, so danmaku slow
+        // or freeze with the video. Never binds during normal in-sync playback
+        // (drift stays within one frame ≪ _aheadToleranceSec).
+        if (_displayMediaTime > mediaTime + _aheadToleranceSec) {
+          _displayMediaTime = mediaTime + _aheadToleranceSec;
+        }
+
+        // ── Forward snap only (seek catch-up) — never a backward snap ──
         // A snap is a single-frame position jump; the per-frame advance rate
-        // (the visible speed) stays at playbackRate. This replaces the old
-        // proportional correction (displayMediaTime += drift * rate) which
-        // smeared correction across many frames and made danmaku visibly
-        // slow-then-fast whenever the media clock was held (seek / buffer).
-        final drift = mediaTime - _displayMediaTime;
-        if (drift.abs() >= _hardResyncThresholdSec) {
-          // Seek / loop / stale clock — snap immediately, even mid-stall.
+        // (the visible speed) stays at playbackRate. Only forward drift (media
+        // clock jumped ahead) is snapped; backward drift is already bounded by
+        // the ceiling above, and a backward snap was the oscillation source.
+        final drift = mediaTime - _displayMediaTime; // >= -_aheadToleranceSec
+        if (drift >= _hardResyncThresholdSec) {
+          // Large seek — snap and reset the wall-clock baseline.
           _displayMediaTime = mediaTime;
           _lastDisplayWallUs = currentWallUs;
-          _lastMediaTimeSec = mediaTime;
-          _lastMediaAdvanceWallUs = currentWallUs;
-        } else if (drift.abs() > _snapThresholdSec && !mediaStalled) {
-          // Fresh media clock with accumulated drift (small seek / skew) —
-          // snap to it. Skipped during stalls: the media clock is frozen and
-          // the display clock is held, so drift is bounded and clears when
-          // playback resumes; snapping toward a frozen clock would yank
-          // danmaku backward and reintroduce the jitter/slowdown symptom.
+        } else if (drift > _snapThresholdSec) {
+          // Small/medium forward seek — snap to the media clock.
           _displayMediaTime = mediaTime;
         }
 

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -146,10 +146,13 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
 
   /// Continuous media time used for layout. Advances by real wall-clock dt at
   /// EXACTLY playbackRate — the rate is never modulated, so danmaku on-screen
-  /// speed is always consistent. It is kept from running ahead of the
-  /// authoritative media clock by a ceiling (see _aheadToleranceSec) so that
-  /// during buffering the danmaku follow the (slowed/held) media clock instead
-  /// of running ahead and snapping back, and it snaps forward on seeks.
+  /// speed is always consistent and matches the decoder (which always plays at
+  /// playbackRate). The authoritative media clock (playbackTimeMs) is used only
+  /// to (a) snap forward on seeks and (b) hold the display clock when the media
+  /// clock itself is stalled (frozen) — NOT to pace the display clock, because
+  /// the upstream progressively corrects playbackTimeMs toward the decoder
+  /// (slowing it after a seek/buffer), and following that slowed rate was the
+  /// "danmaku move slowly until the video catches up" symptom.
   double _displayMediaTime = 0.0;
 
   /// Wall-clock microseconds of the previous display-time update.
@@ -158,37 +161,48 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   /// Whether _displayMediaTime has been initialized from playbackTimeMs.
   bool _displayTimeInitialized = false;
 
+  /// Last observed media-clock value (seconds), for stall detection.
+  double _lastMediaTimeSec = double.nan;
+
+  /// Wall-clock microseconds of the last observed media-clock advancement.
+  int _lastMediaAdvanceWallUs = 0;
+
   /// Per-frame wall dt cap. Prevents a long app stall/backgrounding event from
   /// jumping danmaku far ahead; playbackTimeMs will snap/correct us afterward.
   static const double _maxFrameDtSec = 0.2;
 
-  /// Ceiling tolerance: the display clock may run ahead of the authoritative
-  /// media clock by at most this much. During buffering / seek-settle the media
-  /// clock advances slower than wall-clock (the upstream smooth clock is pulled
-  /// back toward the stalled player position), so the display clock would
-  /// otherwise race ahead and then get yanked back by a backward snap every
-  /// ~150ms — the visible "forward a bit, back a little" oscillation. The
-  /// ceiling makes the display clock gently follow the media clock's actual
-  /// (slowed) rate instead: danmaku slow / freeze with the video. Must exceed
-  /// one frame of wall-clock advance (dt*rate ≈ 17ms at 60Hz) so it never
-  /// binds during normal in-sync playback, and stay below _snapThresholdSec.
-  static const double _aheadToleranceSec = 0.05;
+  /// Media-clock stall threshold. If playbackTimeMs does not advance for longer
+  /// than this while isPlaying is true, the media clock is stalled (the upstream
+  /// smooth clock is held by monotonicity during a big backward correction, or
+  /// the player is frozen). In that state the display clock is held too and
+  /// pulled back to mediaTime + _stallAheadToleranceSec so danmaku pause with
+  /// the video instead of racing ahead of the frozen clock. ~6 frames at 60Hz:
+  /// above normal vsync jitter (16ms) and the upstream 50ms anchor-expire gap,
+  /// below any real stall.
+  static const double _stallThresholdSec = 0.10;
+
+  /// While stalled, the display clock may sit at most this far ahead of the
+  /// (frozen) media clock. Pulls back any run-ahead that accumulated during
+  /// stall-detection latency, then holds. Small, so the post-stall resync is a
+  /// sub-pixel nudge rather than a visible jump.
+  static const double _stallAheadToleranceSec = 0.05;
 
   /// Forward drift above this (but below _hardResyncThresholdSec) is corrected
   /// by a one-shot position snap to the media clock — NOT by modulating the
   /// rate. Because layout is a pure function of time (x = width - speed * (t -
   /// item.time)), a snap translates to a single-frame horizontal shift of
-  /// on-screen danmaku (sub-pixel-imperceptible for small drift at typical
-  /// scroll speeds) while the per-frame advance rate — i.e. the visible speed
-  /// — stays exactly playbackRate. Backward drift (display ahead of media) is
-  /// NOT snapped — the _aheadToleranceSec ceiling handles it continuously, and
-  /// a backward snap was the source of the buffering oscillation. Below this
-  /// threshold, drift is ignored to preserve smooth per-vsync motion.
+  /// on-screen danmaku while the per-frame advance rate — the visible speed —
+  /// stays exactly playbackRate. Backward drift is NOT snapped: while the media
+  /// clock is advancing (normal play / upstream drift correction) danmaku just
+  /// advance at playbackRate and the bounded zero-sum correction drift keeps
+  /// them aligned; while it is stalled the _stallAheadToleranceSec ceiling
+  /// handles it. Below this threshold, drift is ignored (smooth per-vsync
+  /// motion).
   static const double _snapThresholdSec = 0.15;
 
   /// Treat very large forward drift as seek and snap immediately (resets the
-  /// wall-clock baseline too). Large backward drift (loop restart) is handled
-  /// by the ceiling pulling the display clock back to mediaTime + tolerance.
+  /// wall-clock baseline too). Large backward drift (loop restart) is pulled
+  /// back by the stall ceiling / forward-advancing media clock.
   static const double _hardResyncThresholdSec = 1.0;
 
   // ── Submit-rate throttle (P1-4) ──
@@ -301,8 +315,12 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   /// wall-clock baseline. Used for first frame, seek, resume, and clock source
   /// changes. This is a hard reset, not the normal playback correction path.
   void _resetDisplayTimeToMedia() {
-    _displayMediaTime = widget.playbackTimeMs.value / 1000.0;
+    final mediaTime = widget.playbackTimeMs.value / 1000.0;
+    _displayMediaTime = mediaTime;
     _lastDisplayWallUs = _wallClock.elapsedMicroseconds;
+    // Reset stall baseline so a fresh play/resume/seek isn't misread as a stall.
+    _lastMediaTimeSec = mediaTime;
+    _lastMediaAdvanceWallUs = _lastDisplayWallUs;
     _displayTimeInitialized = true;
   }
 
@@ -471,41 +489,66 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
         if (!_displayTimeInitialized) {
           _displayMediaTime = mediaTime;
           _lastDisplayWallUs = currentWallUs;
+          _lastMediaTimeSec = mediaTime;
+          _lastMediaAdvanceWallUs = currentWallUs;
           _displayTimeInitialized = true;
         }
 
-        // Advance by real wall-clock frame time at EXACTLY playbackRate — never
-        // modulated by drift. This is what gives 120Hz panels 120 distinct
-        // positions and keeps danmaku speed constant during normal playback.
-        if (widget.isPlaying && currentWallUs > _lastDisplayWallUs) {
+        // ── Media-clock stall detection ──
+        // The upstream smooth clock keeps advancing playbackTimeMs at ~1x even
+        // while the decoder is frozen (buffering), so a stall can't be detected
+        // from "mediaTime stopped". But the upstream DOES freeze playbackTimeMs
+        // (monotonicity hold) during a big backward drift correction after a
+        // seek/buffer — and that frozen state is what we detect here to hold
+        // the display clock.
+        if ((mediaTime - _lastMediaTimeSec).abs() > 1e-6) {
+          _lastMediaTimeSec = mediaTime;
+          _lastMediaAdvanceWallUs = currentWallUs;
+        }
+        final bool mediaStalled = widget.isPlaying &&
+            currentWallUs - _lastMediaAdvanceWallUs >
+                (_stallThresholdSec * 1000000).toInt();
+
+        // Advance at EXACTLY playbackRate — never modulated by drift. This is
+        // the decoder's rate, so danmaku stay aligned with the actual video
+        // frame even while the upstream is progressively correcting
+        // playbackTimeMs (slowing it), which was the "danmaku creep slowly
+        // until the video catches up" symptom. The bounded, zero-sum upstream
+        // corrections keep drift small without any rate modulation here. When
+        // the media clock is stalled (frozen), hold the display clock too.
+        if (widget.isPlaying &&
+            !mediaStalled &&
+            currentWallUs > _lastDisplayWallUs) {
           final deltaUs = currentWallUs - _lastDisplayWallUs;
           final dt = (deltaUs / 1000000.0).clamp(0.0, _maxFrameDtSec);
           _displayMediaTime += dt * widget.playbackRate;
         }
         _lastDisplayWallUs = currentWallUs;
 
-        // ── Ceiling: don't let the display clock run ahead of the media clock ──
-        // During buffering / seek-settle the media clock advances SLOWER than
-        // wall-clock (the upstream smooth clock is periodically pulled back
-        // toward the stalled player position). Without this ceiling the display
-        // clock races ahead, drift passes _snapThresholdSec, and the backward
-        // snap yanks it back — repeating every ~150ms as a visible "forward a
-        // bit, back a little" oscillation. The ceiling makes the display clock
-        // gently follow the media clock's actual rate instead, so danmaku slow
-        // or freeze with the video. Never binds during normal in-sync playback
-        // (drift stays within one frame ≪ _aheadToleranceSec).
-        if (_displayMediaTime > mediaTime + _aheadToleranceSec) {
-          _displayMediaTime = mediaTime + _aheadToleranceSec;
+        // ── Stall ceiling (active ONLY while the media clock is stalled) ──
+        // While playbackTimeMs is frozen, pull the display clock back to
+        // mediaTime + tolerance (clearing any run-ahead from the
+        // stall-detection latency) and hold it there so danmaku pause with the
+        // video. This is the ONLY backward correction — it is inactive while
+        // the media clock is advancing, so it never makes danmaku follow the
+        // upstream's slowed correction rate (the slow-movement symptom).
+        if (mediaStalled &&
+            _displayMediaTime > mediaTime + _stallAheadToleranceSec) {
+          _displayMediaTime = mediaTime + _stallAheadToleranceSec;
         }
 
-        // ── Forward snap only (seek catch-up) — never a backward snap ──
+        // ── Snaps: position jumps only, never rate modulation ──
         // A snap is a single-frame position jump; the per-frame advance rate
-        // (the visible speed) stays at playbackRate. Only forward drift (media
-        // clock jumped ahead) is snapped; backward drift is already bounded by
-        // the ceiling above, and a backward snap was the oscillation source.
-        final drift = mediaTime - _displayMediaTime; // >= -_aheadToleranceSec
-        if (drift >= _hardResyncThresholdSec) {
-          // Large seek — snap and reset the wall-clock baseline.
+        // (the visible speed) stays at playbackRate. Forward seek and large
+        // backward jumps (loop restart / backward seek) snap. Small/medium
+        // backward drift is NOT snapped — while the media clock advances it is
+        // handled by danmaku advancing at playbackRate (bounded zero-sum
+        // upstream corrections), and while stalled by the ceiling above; a
+        // small backward snap was the buffering-oscillation source.
+        final drift = mediaTime - _displayMediaTime;
+        if (drift >= _hardResyncThresholdSec ||
+            drift <= -_hardResyncThresholdSec) {
+          // Large seek / loop / backward seek — snap and reset baseline.
           _displayMediaTime = mediaTime;
           _lastDisplayWallUs = currentWallUs;
         } else if (drift > _snapThresholdSec) {

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -145,14 +145,14 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   int _vsyncWallUs = 0;
 
   /// Continuous media time used for layout. Advances by real wall-clock dt at
-  /// EXACTLY playbackRate — the rate is never modulated, so danmaku on-screen
-  /// speed is always consistent and matches the decoder (which always plays at
-  /// playbackRate). The authoritative media clock (playbackTimeMs) is used only
-  /// to (a) snap forward on seeks and (b) hold the display clock when the media
-  /// clock itself is stalled (frozen) — NOT to pace the display clock, because
-  /// the upstream progressively corrects playbackTimeMs toward the decoder
-  /// (slowing it after a seek/buffer), and following that slowed rate was the
-  /// "danmaku move slowly until the video catches up" symptom.
+  /// EXACTLY playbackRate — monotonic non-decreasing between snaps, never
+  /// modulated, so danmaku on-screen speed is always consistent and matches the
+  /// decoder (which always plays at playbackRate). The authoritative media
+  /// clock (playbackTimeMs) is used only to snap on seeks/loops — NOT to pace
+  /// the display clock, because the upstream progressively corrects
+  /// playbackTimeMs toward the decoder (slowing/freezing it after a
+  /// seek/buffer), and following or yanking back to that held clock caused the
+  /// "creep slowly" and "scroll-to-middle-then-snap-back" (twitch) symptoms.
   double _displayMediaTime = 0.0;
 
   /// Wall-clock microseconds of the previous display-time update.
@@ -161,48 +161,29 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
   /// Whether _displayMediaTime has been initialized from playbackTimeMs.
   bool _displayTimeInitialized = false;
 
-  /// Last observed media-clock value (seconds), for stall detection.
+  /// Last observed media-clock value (seconds). Used to detect actual mediaTime
+  /// *jumps* (seek / loop / backward seek) as opposed to mere drift, so the
+  /// backward snap only fires on a real backward jump — never on accumulated
+  /// backward drift, which is just the display clock pacing the decoder while
+  /// the media clock is held during an upstream correction.
   double _lastMediaTimeSec = double.nan;
-
-  /// Wall-clock microseconds of the last observed media-clock advancement.
-  int _lastMediaAdvanceWallUs = 0;
 
   /// Per-frame wall dt cap. Prevents a long app stall/backgrounding event from
   /// jumping danmaku far ahead; playbackTimeMs will snap/correct us afterward.
   static const double _maxFrameDtSec = 0.2;
 
-  /// Media-clock stall threshold. If playbackTimeMs does not advance for longer
-  /// than this while isPlaying is true, the media clock is stalled (the upstream
-  /// smooth clock is held by monotonicity during a big backward correction, or
-  /// the player is frozen). In that state the display clock is held too and
-  /// pulled back to mediaTime + _stallAheadToleranceSec so danmaku pause with
-  /// the video instead of racing ahead of the frozen clock. ~6 frames at 60Hz:
-  /// above normal vsync jitter (16ms) and the upstream 50ms anchor-expire gap,
-  /// below any real stall.
-  static const double _stallThresholdSec = 0.10;
-
-  /// While stalled, the display clock may sit at most this far ahead of the
-  /// (frozen) media clock. Pulls back any run-ahead that accumulated during
-  /// stall-detection latency, then holds. Small, so the post-stall resync is a
-  /// sub-pixel nudge rather than a visible jump.
-  static const double _stallAheadToleranceSec = 0.05;
-
-  /// Forward drift above this (but below _hardResyncThresholdSec) is corrected
-  /// by a one-shot position snap to the media clock — NOT by modulating the
-  /// rate. Because layout is a pure function of time (x = width - speed * (t -
-  /// item.time)), a snap translates to a single-frame horizontal shift of
-  /// on-screen danmaku while the per-frame advance rate — the visible speed —
-  /// stays exactly playbackRate. Backward drift is NOT snapped: while the media
-  /// clock is advancing (normal play / upstream drift correction) danmaku just
-  /// advance at playbackRate and the bounded zero-sum correction drift keeps
-  /// them aligned; while it is stalled the _stallAheadToleranceSec ceiling
-  /// handles it. Below this threshold, drift is ignored (smooth per-vsync
-  /// motion).
+  /// Drift / mediaTime-jump threshold for a one-shot position snap. Because
+  /// layout is a pure function of time (x = width - speed * (t - item.time)),
+  /// a snap is a single-frame horizontal shift of on-screen danmaku while the
+  /// per-frame advance rate — the visible speed — stays exactly playbackRate.
+  /// Forward snaps fire on drift (displayTime fell behind mediaTime = seek);
+  /// backward snaps fire only on a mediaTime backward *jump* (loop / backward
+  /// seek), never on accumulated backward drift. Below this, drift is ignored
+  /// (smooth per-vsync motion).
   static const double _snapThresholdSec = 0.15;
 
-  /// Treat very large forward drift as seek and snap immediately (resets the
-  /// wall-clock baseline too). Large backward drift (loop restart) is pulled
-  /// back by the stall ceiling / forward-advancing media clock.
+  /// Large seek/loop threshold: a snap of this magnitude also resets the
+  /// wall-clock baseline (the overlay may not have ticked during the seek).
   static const double _hardResyncThresholdSec = 1.0;
 
   // ── Submit-rate throttle (P1-4) ──
@@ -318,9 +299,7 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
     final mediaTime = widget.playbackTimeMs.value / 1000.0;
     _displayMediaTime = mediaTime;
     _lastDisplayWallUs = _wallClock.elapsedMicroseconds;
-    // Reset stall baseline so a fresh play/resume/seek isn't misread as a stall.
     _lastMediaTimeSec = mediaTime;
-    _lastMediaAdvanceWallUs = _lastDisplayWallUs;
     _displayTimeInitialized = true;
   }
 
@@ -490,71 +469,53 @@ class _DfmPlusOverlayState extends State<DfmPlusOverlay>
           _displayMediaTime = mediaTime;
           _lastDisplayWallUs = currentWallUs;
           _lastMediaTimeSec = mediaTime;
-          _lastMediaAdvanceWallUs = currentWallUs;
           _displayTimeInitialized = true;
         }
 
-        // ── Media-clock stall detection ──
-        // The upstream smooth clock keeps advancing playbackTimeMs at ~1x even
-        // while the decoder is frozen (buffering), so a stall can't be detected
-        // from "mediaTime stopped". But the upstream DOES freeze playbackTimeMs
-        // (monotonicity hold) during a big backward drift correction after a
-        // seek/buffer — and that frozen state is what we detect here to hold
-        // the display clock.
-        if ((mediaTime - _lastMediaTimeSec).abs() > 1e-6) {
-          _lastMediaTimeSec = mediaTime;
-          _lastMediaAdvanceWallUs = currentWallUs;
-        }
-        final bool mediaStalled = widget.isPlaying &&
-            currentWallUs - _lastMediaAdvanceWallUs >
-                (_stallThresholdSec * 1000000).toInt();
-
-        // Advance at EXACTLY playbackRate — never modulated by drift. This is
-        // the decoder's rate, so danmaku stay aligned with the actual video
-        // frame even while the upstream is progressively correcting
-        // playbackTimeMs (slowing it), which was the "danmaku creep slowly
-        // until the video catches up" symptom. The bounded, zero-sum upstream
-        // corrections keep drift small without any rate modulation here. When
-        // the media clock is stalled (frozen), hold the display clock too.
-        if (widget.isPlaying &&
-            !mediaStalled &&
-            currentWallUs > _lastDisplayWallUs) {
+        // Advance at EXACTLY playbackRate — monotonic non-decreasing, never
+        // modulated. This is the decoder's rate, so danmaku stay aligned with
+        // the actual video frame even while the upstream is progressively
+        // correcting playbackTimeMs (slowing / freezing it toward the
+        // decoder). Because the display clock paces the decoder, any drift
+        // accumulated while the media clock is held returns to 0 on its own
+        // when the decoder catches up — no backward correction needed.
+        if (widget.isPlaying && currentWallUs > _lastDisplayWallUs) {
           final deltaUs = currentWallUs - _lastDisplayWallUs;
           final dt = (deltaUs / 1000000.0).clamp(0.0, _maxFrameDtSec);
           _displayMediaTime += dt * widget.playbackRate;
         }
         _lastDisplayWallUs = currentWallUs;
 
-        // ── Stall ceiling (active ONLY while the media clock is stalled) ──
-        // While playbackTimeMs is frozen, pull the display clock back to
-        // mediaTime + tolerance (clearing any run-ahead from the
-        // stall-detection latency) and hold it there so danmaku pause with the
-        // video. This is the ONLY backward correction — it is inactive while
-        // the media clock is advancing, so it never makes danmaku follow the
-        // upstream's slowed correction rate (the slow-movement symptom).
-        if (mediaStalled &&
-            _displayMediaTime > mediaTime + _stallAheadToleranceSec) {
-          _displayMediaTime = mediaTime + _stallAheadToleranceSec;
-        }
-
-        // ── Snaps: position jumps only, never rate modulation ──
+        // ── Snaps: one-shot position jumps, never rate modulation ──
         // A snap is a single-frame position jump; the per-frame advance rate
-        // (the visible speed) stays at playbackRate. Forward seek and large
-        // backward jumps (loop restart / backward seek) snap. Small/medium
-        // backward drift is NOT snapped — while the media clock advances it is
-        // handled by danmaku advancing at playbackRate (bounded zero-sum
-        // upstream corrections), and while stalled by the ceiling above; a
-        // small backward snap was the buffering-oscillation source.
+        // (the visible speed) stays at playbackRate.
+        //
+        // Forward snap on DRIFT: displayTime fell behind mediaTime (seek /
+        // scrub forward). Drift-based is correct here because forward drift
+        // only grows when mediaTime genuinely moved ahead.
+        //
+        // Backward snap on mediaTime JUMP (not drift): a real backward jump
+        // (loop restart / backward seek). Backward drift is NOT snapped — it
+        // accumulates when the display clock paces the decoder while mediaTime
+        // is held during an upstream correction, and yanking it back repeatedly
+        // was the "scroll to middle, jump back to right edge" twitch. Letting
+        // it resolve on its own (decoder catches up) keeps displayMediaTime
+        // monotonic between snaps.
         final drift = mediaTime - _displayMediaTime;
-        if (drift >= _hardResyncThresholdSec ||
-            drift <= -_hardResyncThresholdSec) {
-          // Large seek / loop / backward seek — snap and reset baseline.
+        if (drift > _snapThresholdSec) {
           _displayMediaTime = mediaTime;
-          _lastDisplayWallUs = currentWallUs;
-        } else if (drift > _snapThresholdSec) {
-          // Small/medium forward seek — snap to the media clock.
-          _displayMediaTime = mediaTime;
+          if (drift >= _hardResyncThresholdSec) {
+            _lastDisplayWallUs = currentWallUs;
+          }
         }
+        final double mediaDelta = mediaTime - _lastMediaTimeSec;
+        if (mediaDelta < -_snapThresholdSec) {
+          _displayMediaTime = mediaTime;
+          if (mediaDelta <= -_hardResyncThresholdSec) {
+            _lastDisplayWallUs = currentWallUs;
+          }
+        }
+        _lastMediaTimeSec = mediaTime;
 
         final double interpolatedTime = _displayMediaTime + widget.timeOffset;
 

--- a/rust/src/next2_engine/engine/renderer_core.rs
+++ b/rust/src/next2_engine/engine/renderer_core.rs
@@ -317,8 +317,8 @@ impl Next2Renderer {
             mapped_at_creation: false,
         });
 
-        let shadow_width = width.max(1).saturating_mul(SHADOW_RENDER_SCALE);
-        let shadow_height = height.max(1).saturating_mul(SHADOW_RENDER_SCALE);
+        let shadow_width = ((width.max(1) as f32) * SHADOW_RENDER_SCALE).max(1.0) as u32;
+        let shadow_height = ((height.max(1) as f32) * SHADOW_RENDER_SCALE).max(1.0) as u32;
         let shadow_mask_texture = create_render_texture_with_usage(
             ctx.device.as_ref(),
             shadow_width,
@@ -395,8 +395,8 @@ impl Next2Renderer {
     fn resize(&mut self, width: u32, height: u32) -> bool {
         self.width = width.max(1);
         self.height = height.max(1);
-        self.shadow_width = self.width.saturating_mul(SHADOW_RENDER_SCALE);
-        self.shadow_height = self.height.saturating_mul(SHADOW_RENDER_SCALE);
+        self.shadow_width = ((self.width as f32) * SHADOW_RENDER_SCALE).max(1.0) as u32;
+        self.shadow_height = ((self.height as f32) * SHADOW_RENDER_SCALE).max(1.0) as u32;
         self.shadow_mask_texture = create_render_texture_with_usage(
             self.ctx.device.as_ref(),
             self.shadow_width,

--- a/rust/src/next2_engine/engine/renderer_draw.rs
+++ b/rust/src/next2_engine/engine/renderer_draw.rs
@@ -506,10 +506,10 @@ impl Next2Renderer {
 
                             if shadow.opacity > 0.0 {
                                 self.push_shadow_quad(
-                                    (glyph_left + shadow.offset_x) * SHADOW_RENDER_SCALE as f32,
-                                    (glyph_top + shadow.offset_y) * SHADOW_RENDER_SCALE as f32,
-                                    (glyph_right + shadow.offset_x) * SHADOW_RENDER_SCALE as f32,
-                                    (glyph_bottom + shadow.offset_y) * SHADOW_RENDER_SCALE as f32,
+                                    (glyph_left + shadow.offset_x) * SHADOW_RENDER_SCALE,
+                                    (glyph_top + shadow.offset_y) * SHADOW_RENDER_SCALE,
+                                    (glyph_right + shadow.offset_x) * SHADOW_RENDER_SCALE,
+                                    (glyph_bottom + shadow.offset_y) * SHADOW_RENDER_SCALE,
                                     entry.uv_min,
                                     entry.uv_max,
                                     entry.uv_min,
@@ -552,10 +552,10 @@ impl Next2Renderer {
 
                         if shadow.opacity > 0.0 {
                             self.push_shadow_quad(
-                                (glyph_left + shadow.offset_x) * SHADOW_RENDER_SCALE as f32,
-                                (glyph_top + shadow.offset_y) * SHADOW_RENDER_SCALE as f32,
-                                (glyph_right + shadow.offset_x) * SHADOW_RENDER_SCALE as f32,
-                                (glyph_bottom + shadow.offset_y) * SHADOW_RENDER_SCALE as f32,
+                                (glyph_left + shadow.offset_x) * SHADOW_RENDER_SCALE,
+                                (glyph_top + shadow.offset_y) * SHADOW_RENDER_SCALE,
+                                (glyph_right + shadow.offset_x) * SHADOW_RENDER_SCALE,
+                                (glyph_bottom + shadow.offset_y) * SHADOW_RENDER_SCALE,
                                 entry.uv_min,
                                 entry.uv_max,
                                 entry.mask_uv_min,

--- a/rust/src/next2_engine/engine/renderer_draw.rs
+++ b/rust/src/next2_engine/engine/renderer_draw.rs
@@ -588,41 +588,11 @@ impl Next2Renderer {
         // Restore the frame_items taken before the loop.
         self.frame_items = frame_items;
 
-        if !self.frame_items.is_empty() {
-            self.atlas_bind_group = self
-                .ctx
-                .device
-                .create_bind_group(&wgpu::BindGroupDescriptor {
-                    label: Some("next2 atlas bg"),
-                    layout: &self.atlas_bind_group_layout,
-                    entries: &[
-                        wgpu::BindGroupEntry {
-                            binding: 0,
-                            resource: wgpu::BindingResource::TextureView(&self.atlas.texture_view),
-                        },
-                        wgpu::BindGroupEntry {
-                            binding: 1,
-                            resource: wgpu::BindingResource::Sampler(&self.atlas.sampler),
-                        },
-                        wgpu::BindGroupEntry {
-                            binding: 2,
-                            resource: wgpu::BindingResource::TextureView(
-                                &self.emoji_atlas.color_texture_view,
-                            ),
-                        },
-                        wgpu::BindGroupEntry {
-                            binding: 3,
-                            resource: wgpu::BindingResource::TextureView(
-                                &self.emoji_atlas.mask_texture_view,
-                            ),
-                        },
-                        wgpu::BindGroupEntry {
-                            binding: 4,
-                            resource: wgpu::BindingResource::Sampler(&self.emoji_atlas.sampler),
-                        },
-                    ],
-                });
-        }
+        // atlas_bind_group is created at construction and rebuilt only on font
+        // switch via rebuild_atlas_bind_group (renderer_core.rs). The glyph and
+        // emoji atlases reuse the same texture objects across uploads (clear()
+        // only resets the cursor, never recreates the texture), so the bind
+        // group stays valid between frames — no per-frame rebuild needed.
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/rust/src/next2_engine/engine/renderer_draw.rs
+++ b/rust/src/next2_engine/engine/renderer_draw.rs
@@ -459,7 +459,13 @@ impl Next2Renderer {
         self.interp_dt = if elapsed < 0.050 { elapsed } else { 0.0 };
         let interp_dt = self.interp_dt as f64;
 
-        for item in self.frame_items.clone().iter() {
+        // Take `frame_items` out of `self` so the loop body can borrow `self`
+        // mutably (push_quad / push_shadow_quad / atlas.entry_for all need
+        // &mut self) without contending with a shared borrow of self.frame_items.
+        // The Vec move is O(1) (pointer swap); previously this cloned the whole
+        // Vec plus every token's String on every frame.
+        let frame_items = std::mem::take(&mut self.frame_items);
+        for item in &frame_items {
             let outline_px = resolve_outline_px(item.font_size, item.outline_width);
             let shadow = resolve_shadow(item.font_size, item.shadow_style);
             let fill_color = argb_to_linear(item.color_argb, item.opacity);
@@ -474,7 +480,7 @@ impl Next2Renderer {
             let mut cursor_x = (item.x + item.scroll_speed as f64 * interp_dt) as f32;
             let quantized_size = item.font_size.round().clamp(8.0, 256.0) as u32;
             let baseline_y = item.y as f32 + self.atlas.line_ascent(quantized_size);
-            let tokens = item.tokens.clone();
+            let tokens = &item.tokens;
 
             for token in tokens {
                 match token {
@@ -531,7 +537,7 @@ impl Next2Renderer {
                         }
                     }
                     FrameToken::Emoji(id) => {
-                        let Some(entry) = self.emoji_atlas.entry_for(&id).cloned() else {
+                        let Some(entry) = self.emoji_atlas.entry_for(id).cloned() else {
                             cursor_x += quantized_size as f32;
                             continue;
                         };
@@ -578,6 +584,9 @@ impl Next2Renderer {
                 }
             }
         }
+
+        // Restore the frame_items taken before the loop.
+        self.frame_items = frame_items;
 
         if !self.frame_items.is_empty() {
             self.atlas_bind_group = self

--- a/rust/src/next2_engine/engine/rendering.rs
+++ b/rust/src/next2_engine/engine/rendering.rs
@@ -359,6 +359,71 @@ impl Next2EmojiAtlas {
     }
 }
 
+// Persistent MSDF rasterization worker pool.
+//
+// `glyph_msdf_from_face` used to spawn a fresh OS thread per new glyph; under a
+// burst of new glyphs (new font / episode) that formed a thread-creation storm.
+// The pool keeps one persistent worker fed by an mpsc channel of boxed
+// closures, so only the first miss pays the thread-spawn cost.
+//
+// fdsm 0.8.0's generate_mtsdf / correct_sign_mtsdf can deadlock on certain
+// glyphs, so every task carries a 2s recv_timeout. On timeout the worker is
+// abandoned (it stays stuck — the same thread leak as the old spawn-per-glyph
+// path) and a fresh worker is spawned lazily on the next call.
+struct MsdfTask {
+    work: Box<dyn FnOnce() -> Vec<u8> + Send + 'static>,
+    result_tx: std::sync::mpsc::Sender<Vec<u8>>,
+}
+
+struct MsdfWorkerPool {
+    task_tx: Option<std::sync::mpsc::Sender<MsdfTask>>,
+}
+
+impl MsdfWorkerPool {
+    fn new() -> Self {
+        Self { task_tx: None }
+    }
+
+    fn rasterize<F>(&mut self, work: F) -> Option<Vec<u8>>
+    where
+        F: FnOnce() -> Vec<u8> + Send + 'static,
+    {
+        if self.task_tx.is_none() {
+            let (tx, rx) = std::sync::mpsc::channel::<MsdfTask>();
+            let _ = std::thread::Builder::new()
+                .name("next2-msdf".into())
+                .spawn(move || msdf_worker_loop(rx));
+            self.task_tx = Some(tx);
+        }
+        let (result_tx, result_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+        let task = MsdfTask {
+            work: Box::new(work),
+            result_tx,
+        };
+        if self.task_tx.as_ref().unwrap().send(task).is_err() {
+            // worker died / channel closed
+            self.task_tx = None;
+            return None;
+        }
+        match result_rx.recv_timeout(std::time::Duration::from_secs(2)) {
+            Ok(pixels) => Some(pixels),
+            Err(_) => {
+                // Timeout or disconnect: worker likely stuck on this glyph.
+                // Abandon it; a fresh worker spawns on the next call.
+                self.task_tx = None;
+                None
+            }
+        }
+    }
+}
+
+fn msdf_worker_loop(task_rx: std::sync::mpsc::Receiver<MsdfTask>) {
+    while let Ok(task) = task_rx.recv() {
+        let pixels = (task.work)();
+        let _ = task.result_tx.send(pixels);
+    }
+}
+
 struct Next2GlyphAtlas {
     font_key: String,
     fonts: Vec<FontFaceHandle>,
@@ -376,6 +441,9 @@ struct Next2GlyphAtlas {
     free_list: Vec<FreeRect>,
     /// Monotonically increasing frame counter for LRU eviction.
     frame_counter: u64,
+    /// Persistent MSDF rasterization worker (lazily spawned). Avoids spawning a
+    /// thread per new glyph; see `MsdfWorkerPool`.
+    msdf_worker: MsdfWorkerPool,
 }
 
 impl Next2GlyphAtlas {
@@ -427,6 +495,7 @@ impl Next2GlyphAtlas {
             line_ascent_cache: HashMap::new(),
             free_list: Vec::new(),
             frame_counter: 0,
+            msdf_worker: MsdfWorkerPool::new(),
         })
     }
 
@@ -608,12 +677,12 @@ impl Next2GlyphAtlas {
         ch
     }
 
-    fn glyph_from_fonts(&self, ch: char, px: f32) -> Option<GlyphMsdfData> {
+    fn glyph_from_fonts(&mut self, ch: char, px: f32) -> Option<GlyphMsdfData> {
         for font in &self.fonts {
             let Some(glyph_id) = font.face.glyph_index(ch) else {
                 continue;
             };
-            let data = glyph_msdf_from_face(&font.face, glyph_id, px)?;
+            let data = glyph_msdf_from_face(&mut self.msdf_worker, &font.face, glyph_id, px)?;
             return Some(data);
         }
         None
@@ -848,7 +917,12 @@ fn load_faces_from_owned_bytes(
     Ok(())
 }
 
-fn glyph_msdf_from_face(face: &Face<'static>, glyph_id: GlyphId, px: f32) -> Option<GlyphMsdfData> {
+fn glyph_msdf_from_face(
+    pool: &mut MsdfWorkerPool,
+    face: &Face<'static>,
+    glyph_id: GlyphId,
+    px: f32,
+) -> Option<GlyphMsdfData> {
     #[cfg(debug_assertions)]
     n2log(&format!("glyph_msdf: glyph_id={}, px={}", glyph_id.0, px));
     let advance_units = face
@@ -911,50 +985,39 @@ fn glyph_msdf_from_face(face: &Face<'static>, glyph_id: GlyphId, px: f32) -> Opt
     n2log("glyph_msdf: edge colored");
     let prepared_colored_shape = colored_shape.prepare();
 
-    // fdsm 0.8.0 generate_mtsdf / correct_sign_mtsdf can hang on certain glyphs.
-    // Run in a separate thread with a timeout to prevent permanent deadlock.
+    // fdsm 0.8.0 generate_mtsdf / correct_sign_mtsdf can hang on certain
+    // glyphs. Run on the persistent MSDF worker (see `MsdfWorkerPool`) with a
+    // 2s timeout; on timeout/worker-death the worker is abandoned (same thread
+    // leak as the old spawn-per-glyph path) and a fresh worker spawns next call.
     #[cfg(debug_assertions)]
     n2log(&format!("glyph_msdf: generating {}x{}", width, height));
-    let (tx, rx) = std::sync::mpsc::channel();
-    let _worker = std::thread::Builder::new()
-        .name("next2-msdf".into())
-        .spawn(move || {
-            let mut mtsdf_f32 = Rgba32FImage::new(width, height);
-            generate_mtsdf(&prepared_colored_shape, MSDF_RANGE, &mut mtsdf_f32);
-            correct_sign_mtsdf(&mut mtsdf_f32, &prepared_colored_shape, FillRule::Nonzero);
+    let rgba = match pool.rasterize(move || {
+        let mut mtsdf_f32 = Rgba32FImage::new(width, height);
+        generate_mtsdf(&prepared_colored_shape, MSDF_RANGE, &mut mtsdf_f32);
+        correct_sign_mtsdf(&mut mtsdf_f32, &prepared_colored_shape, FillRule::Nonzero);
 
-            let mtsdf_u8: RgbaImage = mtsdf_f32.convert();
-            let raw_rgba = mtsdf_u8.into_raw();
-            let mut rgba = Vec::with_capacity((width * height * 4) as usize);
-            for y in 0..height {
-                let src_y = height - 1 - y;
-                let row_start = (src_y * width * 4) as usize;
-                let row_end = row_start + (width * 4) as usize;
-                for chunk in raw_rgba[row_start..row_end].chunks_exact(4) {
-                    rgba.extend_from_slice(chunk);
-                }
+        let mtsdf_u8: RgbaImage = mtsdf_f32.convert();
+        let raw_rgba = mtsdf_u8.into_raw();
+        let mut rgba = Vec::with_capacity((width * height * 4) as usize);
+        for y in 0..height {
+            let src_y = height - 1 - y;
+            let row_start = (src_y * width * 4) as usize;
+            let row_end = row_start + (width * 4) as usize;
+            for chunk in raw_rgba[row_start..row_end].chunks_exact(4) {
+                rgba.extend_from_slice(chunk);
             }
-            let _ = tx.send(rgba);
-        });
-
-    let result = match rx.recv_timeout(std::time::Duration::from_secs(2)) {
-        Ok(pixels) => {
+        }
+        rgba
+    }) {
+        Some(pixels) => {
             #[cfg(debug_assertions)]
             n2log("glyph_msdf: done");
-            Some(pixels)
+            pixels
         }
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-            n2log(&format!("glyph_msdf: TIMEOUT glyph_id={}", glyph_id.0));
-            None
+        None => {
+            n2log(&format!("glyph_msdf: TIMEOUT/CRASH glyph_id={}", glyph_id.0));
+            return None;
         }
-        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-            n2log(&format!("glyph_msdf: CRASH glyph_id={}", glyph_id.0));
-            None
-        }
-    };
-
-    let Some(rgba) = result else {
-        return None;
     };
 
     let side_bearing = face.glyph_hor_side_bearing(glyph_id).unwrap_or(0) as f32;

--- a/rust/src/next2_engine/engine/rendering.rs
+++ b/rust/src/next2_engine/engine/rendering.rs
@@ -849,6 +849,7 @@ fn load_faces_from_owned_bytes(
 }
 
 fn glyph_msdf_from_face(face: &Face<'static>, glyph_id: GlyphId, px: f32) -> Option<GlyphMsdfData> {
+    #[cfg(debug_assertions)]
     n2log(&format!("glyph_msdf: glyph_id={}, px={}", glyph_id.0, px));
     let advance_units = face
         .glyph_hor_advance(glyph_id)
@@ -897,6 +898,7 @@ fn glyph_msdf_from_face(face: &Face<'static>, glyph_id: GlyphId, px: f32) -> Opt
     ));
 
     let mut shape: Shape<Contour> = fdsm_ttf_parser::load_shape_from_face(face, glyph_id)?;
+    #[cfg(debug_assertions)]
     n2log("glyph_msdf: shape loaded");
     shape.transform(&transform);
 
@@ -905,11 +907,13 @@ fn glyph_msdf_from_face(face: &Face<'static>, glyph_id: GlyphId, px: f32) -> Opt
 
     let colored_shape =
         Shape::edge_coloring_simple(shape, EDGE_COLORING_CORNER_THRESHOLD, EDGE_COLORING_SEED);
+    #[cfg(debug_assertions)]
     n2log("glyph_msdf: edge colored");
     let prepared_colored_shape = colored_shape.prepare();
 
     // fdsm 0.8.0 generate_mtsdf / correct_sign_mtsdf can hang on certain glyphs.
     // Run in a separate thread with a timeout to prevent permanent deadlock.
+    #[cfg(debug_assertions)]
     n2log(&format!("glyph_msdf: generating {}x{}", width, height));
     let (tx, rx) = std::sync::mpsc::channel();
     let _worker = std::thread::Builder::new()
@@ -935,6 +939,7 @@ fn glyph_msdf_from_face(face: &Face<'static>, glyph_id: GlyphId, px: f32) -> Opt
 
     let result = match rx.recv_timeout(std::time::Duration::from_secs(2)) {
         Ok(pixels) => {
+            #[cfg(debug_assertions)]
             n2log("glyph_msdf: done");
             Some(pixels)
         }

--- a/rust/src/next2_engine/engine/runtime.rs
+++ b/rust/src/next2_engine/engine/runtime.rs
@@ -19,7 +19,10 @@ pub(crate) fn n2log(msg: &str) {
     });
     if let Ok(mut f) = file.lock() {
         let _ = writeln!(f, "[next2] {}", msg);
-        let _ = f.flush();
+        // Don't flush per-call: a synchronous fsync on every log line was a
+        // stall source on the MSDF rasterization hot path (5+ logs per new
+        // glyph). The OS buffers the write and flushes on drop/close. Error
+        // and panic paths still log, just without forcing an fsync.
     }
 }
 

--- a/rust/src/next2_engine/engine/runtime.rs
+++ b/rust/src/next2_engine/engine/runtime.rs
@@ -71,7 +71,11 @@ const EMOJI_SIDE_BEARING_RATIO: f32 = 0.08;
 const GLYPH_MODE_TEXT: f32 = 0.0;
 const GLYPH_MODE_EMOJI: f32 = 1.0;
 const SHADOW_ALPHA_SCALE: f32 = 1.0;
-const SHADOW_RENDER_SCALE: u32 = 1;
+/// Shadow render texture scale relative to the screen. 0.5 renders the shadow
+/// mask/blur at half resolution (1/4 the pixel area); the shadow is blurred
+/// anyway so the visual difference is negligible while GPU pixel load on the
+/// shadow passes drops ~75%.
+const SHADOW_RENDER_SCALE: f32 = 0.5;
 const MISSING_GLYPH_FALLBACK: char = '□';
 const FALLBACK_GLYPH_ADVANCE_RATIO: f32 = 0.58;
 


### PR DESCRIPTION
## Summary

- 去除了 DFM+ 引擎的弹幕慢速时间校准机制，改为直接跳变
- 对 DFM+ 进行了多项性能优化：
1. P0-1 去每帧深拷贝 — build_vertices 用 std::mem::take + 引用遍历替代 frame_items.clone() 和 tokens.clone()，每帧省掉整 Vec + 每条弹幕 String 的堆分配。
2. P0-3 日志同步 I/O 治理 — n2log 去掉每条日志的 flush() 同步 fsync；5 处 MSDF 过程日志加 #[cfg(debug_assertions)] 守卫，release 完全消除（含 format! 分配），TIMEOUT/CRASH 错误日志保留。
3. P1-6 阴影降分辨率 — SHADOW_RENDER_SCALE 从 1 降到 0.5，阴影 mask/blur 纹理面积减 75%，shadow pass GPU 像素负载显著下降，视觉差异极小。
4. P0-4 MSDF worker 线程池化 — 持久 worker 线程 + mpsc channel 替代每个新字形 spawn 线程，密集新字形时省去线程风暴；保留 2s 超时防 fdsm 0.8.0 死锁，hang 时丢弃 worker 懒重建。
5. P0-2 atlas bind group 去每帧重建 — 删除 build_vertices 每帧 create_bind_group，改由构造时创建 + 字体切换 rebuild_atlas_bind_group 维护（emoji 上传复用同一 texture 对象，bind_group 帧间有效）。

## Test

```
flutter build macos
flutter build ipa --release --no-codesign
```

## What Changed

### rust/src/next2_engine/engine/renderer_draw.rs

- P0-1: build_vertices 用 std::mem::take 取出 frame_items 后引用遍历，去掉每帧 frame_items.clone() 整 Vec 深拷贝
- P0-1: tokens 改引用遍历（&item.tokens），去掉每条弹幕 item.tokens.clone()；emoji 分支 entry_for(&id) 改 entry_for(id)
- P0-1: 循环结束后 self.frame_items = frame_items 还回
- P1-6: 8 处阴影坐标缩放 `SHADOW_RENDER_SCALE as f32` 改为 `SHADOW_RENDER_SCALE`（常量已改 f32）
- P0-2: 删除 build_vertices 末尾每帧 create_bind_group 重建 atlas_bind_group，改由构造 + 字体切换 rebuild_atlas_bind_group 维护

### rust/src/next2_engine/engine/runtime.rs

- P0-3: n2log 去掉每条日志的 f.flush() 同步磁盘 fsync
- P1-6: SHADOW_RENDER_SCALE 常量 u32=1 改 f32=0.5，阴影 mask/blur 纹理半分辨率

### rust/src/next2_engine/engine/rendering.rs

- P0-3: 5 处 MSDF 过程日志（glyph_id/shape loaded/edge colored/generating/done）加 #[cfg(debug_assertions)] 守卫，release 完全消除
- P0-4: 新增 MsdfWorkerPool / MsdfTask / msdf_worker_loop，持久 worker 线程 + mpsc channel 替代每个新字形 spawn 线程
- P0-4: Next2GlyphAtlas 加 msdf_worker 字段，new() 初始化 MsdfWorkerPool::new()
- P0-4: glyph_from_fonts &self 改 &mut self，传 &mut self.msdf_worker 给 glyph_msdf_from_face
- P0-4: glyph_msdf_from_face 签名加 pool 参数，spawn-per-glyph 改 pool.rasterize 闭包，保留 2s recv_timeout 防 fdsm 死锁
- P0-4: TIMEOUT/CRASH 日志合并为一条（pool.rasterize 返回 Option 不区分）

### rust/src/next2_engine/engine/renderer_core.rs

- P1-6: shadow_width/shadow_height 计算 2 处（构造 + resize）saturating_mul(SHADOW_RENDER_SCALE) 改为 f32 乘法转 u32
