### PR TITLE
feat:player custom UA

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -21,6 +21,9 @@ class SettingsKeys {
   static const String externalPlayerDanmakuOverlay =
       'external_player_danmaku_overlay';
 
+  /// 自定义播放器请求视频的 User-Agent（空字符串 = 用内核默认 UA）。
+  static const String customPlayerUA = 'custom_player_ua';
+
   static const String autoCheckUpdatesInBackground =
       'auto_check_updates_in_background';
 

--- a/lib/player_abstraction/abstract_player.dart
+++ b/lib/player_abstraction/abstract_player.dart
@@ -51,6 +51,10 @@ abstract class AbstractPlayer {
   List<String> getDecoders(PlayerMediaType type);
   String? getProperty(String key);
   void setProperty(String key, String value);
+
+  /// 设置 HTTP User-Agent（播放器请求视频时使用）。默认空实现，各内核按需 override。
+  /// 空字符串 [ua] = 用内核默认 UA。在打开媒体前调用。
+  void setUserAgent(String ua) {}
   Future<void> setVideoSurfaceSize({int? width, int? height});
 
   /// 跳转到指定索引的章节（使用 mpv 原生 `chapter` 属性，keyframe 对齐）。

--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -760,6 +760,11 @@ class ErikaPlayerAdapter implements AbstractPlayer {
   }
 
   @override
+  void setUserAgent(String ua) {
+    // erika_flutter 暂未暴露设置 HTTP User-Agent 的接口，留空实现。
+  }
+
+  @override
   Future<void> setVideoSurfaceSize({int? width, int? height}) async {}
 
   @override

--- a/lib/player_abstraction/mdk_player_adapter_io.dart
+++ b/lib/player_abstraction/mdk_player_adapter_io.dart
@@ -507,6 +507,15 @@ class MdkPlayerAdapter implements AbstractPlayer {
   }
 
   @override
+  void setUserAgent(String ua) {
+    if (ua.isEmpty) return;
+    // mdk-sdk: avio.user_agent 是 AVIOContext/URLProtocol 选项，对 HTTP 请求生效。
+    // setProperty 内部用 sticky property，对后续所有媒体生效。
+    setProperty('avio.user_agent', ua);
+    debugPrint('MDK: 已设置自定义 user-agent: $ua');
+  }
+
+  @override
   void setProperty(String key, String value) {
     try {
       _setStickyProperty(key, value);

--- a/lib/player_abstraction/media_kit_player_adapter.dart
+++ b/lib/player_abstraction/media_kit_player_adapter.dart
@@ -2431,6 +2431,19 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
   }
 
   @override
+  void setUserAgent(String ua) {
+    if (ua.isEmpty) return;
+    try {
+      // mpv 的 user-agent 属性，对所有 HTTP 请求生效。须在打开媒体前设置。
+      unawaited((_player.platform as dynamic).setProperty('user-agent', ua));
+      _properties['user-agent'] = ua;
+      debugPrint('MediaKit: 已设置自定义 user-agent: $ua');
+    } catch (e) {
+      debugPrint('MediaKit: 设置 user-agent 失败: $e');
+    }
+  }
+
+  @override
   void setProperty(String name, String value) {
     var resolvedValue = value;
     final diagnosticHwdecOverride = _mpvDiagnosticsEnabled && name == 'hwdec'

--- a/lib/player_abstraction/player_abstraction.dart
+++ b/lib/player_abstraction/player_abstraction.dart
@@ -179,6 +179,9 @@ class Player {
   void setProperty(String key, String value) =>
       _delegate.setProperty(key, value);
 
+  /// 设置 HTTP User-Agent（播放器请求视频时）。空字符串 = 用内核默认 UA。
+  void setUserAgent(String ua) => _delegate.setUserAgent(ua);
+
   Future<void> setVideoSurfaceSize({int? width, int? height}) =>
       _delegate.setVideoSurfaceSize(width: width, height: height);
 

--- a/lib/player_abstraction/player_factory.dart
+++ b/lib/player_abstraction/player_factory.dart
@@ -5,6 +5,7 @@ import './media_kit_player_adapter.dart'; // 导入新的MediaKit适配器
 import './erika_player_adapter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/foundation.dart'; // 用于 debugPrint
+import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/utils/system_resource_monitor.dart'; // 导入系统资源监控器
 import 'dart:async'; // 导入dart:async库
 
@@ -31,6 +32,8 @@ class PlayerFactory {
   static int _cachedPrecacheBufferSizeMb = defaultPrecacheBufferSizeMb;
   static bool _cachedMacOSNativeVideoEnabled = false;
   static String _cachedAndroidAudioOutput = 'opensles';
+  static String _cachedCustomPlayerUA = ''; // 自定义播放器 UA，空=用内核默认
+  static String? _oneTimeUA; // 一次性 UA（仅下一次播放有效，不持久化，用后即清）
   static bool _hasLoadedSettings = false;
 
   // 添加一个StreamController来广播内核切换事件
@@ -80,6 +83,7 @@ class PlayerFactory {
         _cachedMacOSNativeVideoEnabled,
       );
       _cachedAndroidAudioOutput = androidAudioOutput;
+      _cachedCustomPlayerUA = prefs.getString(SettingsKeys.customPlayerUA) ?? '';
 
       _hasLoadedSettings = true;
     } catch (e) {
@@ -88,6 +92,7 @@ class PlayerFactory {
       _cachedPrecacheBufferSizeMb = defaultPrecacheBufferSizeMb;
       _cachedMacOSNativeVideoEnabled = false;
       _cachedAndroidAudioOutput = 'opensles';
+      _cachedCustomPlayerUA = '';
       MediaKitPlayerAdapter.setMacOSNativeVideoPreference(false);
       _hasLoadedSettings = true;
     }
@@ -101,6 +106,7 @@ class PlayerFactory {
       _cachedPrecacheBufferSizeMb = defaultPrecacheBufferSizeMb;
       _cachedMacOSNativeVideoEnabled = false;
       _cachedAndroidAudioOutput = 'opensles';
+      _cachedCustomPlayerUA = '';
       MediaKitPlayerAdapter.setMacOSNativeVideoPreference(false);
       _hasLoadedSettings = true;
 
@@ -127,6 +133,7 @@ class PlayerFactory {
           _cachedMacOSNativeVideoEnabled,
         );
         _cachedAndroidAudioOutput = androidAudioOutput;
+        _cachedCustomPlayerUA = prefs.getString(SettingsKeys.customPlayerUA) ?? '';
       });
 
       debugPrint('[PlayerFactory] 同步设置临时默认值: MDK');
@@ -145,6 +152,31 @@ class PlayerFactory {
     }
     return _cachedKernelType ?? PlayerKernelType.mdk;
   }
+
+  /// 获取自定义播放器 User-Agent（空字符串 = 用内核默认 UA）。
+  static String getCustomPlayerUA() {
+    if (!_hasLoadedSettings) {
+      _loadSettingsSync();
+    }
+    return _cachedCustomPlayerUA;
+  }
+
+  /// 设置一次性 User-Agent（仅下一次打开视频时生效，不持久化，用后即清）。
+  /// 优先级高于 [getCustomPlayerUA] 的持久 UA。空字符串清除一次性 UA。
+  static void setOneTimeUA(String ua) {
+    final resolved = ua.trim();
+    _oneTimeUA = resolved.isEmpty ? null : resolved;
+  }
+
+  /// 消费一次性 UA：返回并清除。未设置返回 null（调用方回退到持久 UA）。
+  static String? consumeOneTimeUA() {
+    final v = _oneTimeUA;
+    _oneTimeUA = null;
+    return v;
+  }
+
+  /// 获取一次性 UA（不消费，供 UI 预填）。未设置返回 null。
+  static String? getOneTimeUA() => _oneTimeUA;
 
   static int _clampPrecacheBufferSizeMb(int value) {
     return value
@@ -212,6 +244,21 @@ class PlayerFactory {
       _cachedAndroidAudioOutput = resolved;
     } catch (e) {
       debugPrint('[PlayerFactory] 保存 Android 音频后端设置出错: $e');
+    }
+  }
+
+  /// 保存自定义播放器 User-Agent。空字符串表示用内核默认 UA。
+  /// 即时生效于"下一次打开视频"（当前正在播放的视频不会重新请求）。
+  static Future<void> saveCustomPlayerUA(String ua) async {
+    final resolved = ua.trim();
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(SettingsKeys.customPlayerUA, resolved);
+      _cachedCustomPlayerUA = resolved;
+      debugPrint('[PlayerFactory] 已保存自定义播放器 UA: '
+          '${resolved.isEmpty ? "(空=默认)" : resolved}');
+    } catch (e) {
+      debugPrint('[PlayerFactory] 保存自定义播放器 UA 出错: $e');
     }
   }
 

--- a/lib/player_abstraction/video_player_adapter.dart
+++ b/lib/player_abstraction/video_player_adapter.dart
@@ -821,6 +821,11 @@ class VideoPlayerAdapter implements AbstractPlayer, TickerProvider {
   }
 
   @override
+  void setUserAgent(String ua) {
+    // video_player 插件无设置 HTTP User-Agent 的能力，留空实现。
+  }
+
+  @override
   Future<void> setVideoSurfaceSize({int? width, int? height}) async {
     // video_player 插件使用 Flutter 纹理，由外层控制，保持空实现。
   }

--- a/lib/services/external_player_service.dart
+++ b/lib/services/external_player_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter/widgets.dart';
 import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/models/media_server_playback.dart';
 import 'package:nipaplay/models/playable_item.dart';
+import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/services/security_bookmark_service.dart';
 import 'package:nipaplay/src/rust/api/dfm_plus.dart' as rust_dfm;
@@ -115,6 +116,24 @@ class ExternalPlayerService {
     }
   }
 
+  /// 按播放器类型构造自定义 User-Agent 参数（用户在 PlayerFactory 设置的 UA）。
+  /// 空 UA 或不支持的播放器返回空列表。须在打开媒体前传入，对所有 HTTP 请求生效。
+  static List<String> _buildUAArgs(String playerPath) {
+    final ua = PlayerFactory.getCustomPlayerUA();
+    if (ua.isEmpty) return const [];
+    switch (detectPlayer(playerPath)) {
+      case ExternalPlayerType.mpv:
+      case ExternalPlayerType.mpvNet:
+        return ['--user-agent=$ua'];
+      case ExternalPlayerType.vlc:
+        return ['--http-user-agent=$ua'];
+      case ExternalPlayerType.potPlayer:
+      case ExternalPlayerType.generic:
+        // PotPlayer / 未知播放器：CLI 不支持自定义 UA
+        return const [];
+    }
+  }
+
   /// 安全显示 snackbar。
   ///
   /// 服务层拿到的 context 可能缺少 Overlay 祖先（如 PlaybackService 传入的
@@ -205,6 +224,13 @@ class ExternalPlayerService {
     } else {
       debugPrint('[ExtPlayer] 跳过弹幕外挂 '
           '(enabled=$danmakuEnabled, episodeId="$episodeId")');
+    }
+
+    // 自定义 User-Agent（mpv/mpv.net/vlc 支持；与弹幕参数合并）
+    final uaArgs = _buildUAArgs(playerPath);
+    if (uaArgs.isNotEmpty) {
+      extraArgs = [...extraArgs, ...uaArgs];
+      debugPrint('[ExtPlayer] 注入自定义 UA 参数: $uaArgs');
     }
 
     debugPrint('[ExtPlayer] 调用 launch: path="$playerPath", '

--- a/lib/services/external_player_service.dart
+++ b/lib/services/external_player_service.dart
@@ -134,6 +134,34 @@ class ExternalPlayerService {
     }
   }
 
+  /// 按播放器类型构造弹幕平滑参数（仅原版 mpv）。
+  ///
+  /// 两个配套参数，缺一不可：
+  /// - `--blend-subtitles=video`：把弹幕混入视频层。是下面 vf 滤镜让弹幕
+  ///   按 60fps 重新定位的前提——若字幕留在 OSD 层，vf 不影响其刷新率。
+  ///   通过 CLI 强制设值，不依赖用户外部 mpv 的 mpv.conf 已配置此项。
+  /// - `--vf-add=lavfi=[fps=fps=60:round=down]`：把视频复制帧到 60fps，
+  ///   混入视频层的弹幕随之按 60fps 重新计算 \move 位置 → 滚动清晰不卡顿
+  ///   （mpv 字幕刷新率随视频帧率，24fps 视频下弹幕步进大、看不清）。
+  ///
+  /// 仅原版 mpv 需要：mpv.net 原生弹幕渲染已足够平滑，无需此滤镜。
+  /// `--vf-add` 追加而非 `--vf=` 覆盖，避免冲掉用户 mpv.conf 已有的 vf
+  /// 滤镜。PotPlayer/VLC/未知播放器不认这些选项，跳过。
+  static List<String> _buildDanmakuSmoothArgs(String playerPath) {
+    switch (detectPlayer(playerPath)) {
+      case ExternalPlayerType.mpv:
+        return [
+          '--blend-subtitles=video',
+          '--vf-add=lavfi=[fps=fps=60:round=down]',
+        ];
+      case ExternalPlayerType.mpvNet:
+      case ExternalPlayerType.potPlayer:
+      case ExternalPlayerType.vlc:
+      case ExternalPlayerType.generic:
+        return const [];
+    }
+  }
+
   /// 安全显示 snackbar。
   ///
   /// 服务层拿到的 context 可能缺少 Overlay 祖先（如 PlaybackService 传入的
@@ -215,6 +243,14 @@ class ExternalPlayerService {
           'assPath=${assets?.assPath}, luaPath=${assets?.luaPath}, 耗时=${dt}ms');
       if (assets != null) {
         extraArgs = _buildSubArgs(playerPath, assets);
+        // 弹幕平滑参数：仅原版 mpv（mpv.net 原生弹幕渲染已足够平滑）。
+        // blend-subtitles=video 把弹幕混入视频层，是 vf fps=60 让弹幕
+        // 按 60fps 重新定位的前提；二者配套，不依赖用户 mpv.conf。
+        final smoothArgs = _buildDanmakuSmoothArgs(playerPath);
+        if (smoothArgs.isNotEmpty) {
+          extraArgs = [...extraArgs, ...smoothArgs];
+          debugPrint('[ExtPlayer] 注入弹幕平滑参数: $smoothArgs');
+        }
         debugPrint('[ExtPlayer] 注入弹幕参数: extraArgs=$extraArgs, '
             'playerType=${detectPlayer(playerPath)}');
       } else {

--- a/lib/themes/nipaplay/pages/settings/network_settings_page.dart
+++ b/lib/themes/nipaplay/pages/settings/network_settings_page.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/l10n/l10n.dart';
+import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/utils/network_settings.dart';
 import 'package:nipaplay/services/server_connectivity_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_item.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_button.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/text_input_dialog.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 
 class NetworkSettingsPage extends StatefulWidget {
@@ -167,6 +169,39 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
     });
 
     BlurSnackBar.show(context, 'Bangumi 服务器已切换到自定义服务器');
+  }
+
+  String _persistentUASubtitle() {
+    final ua = PlayerFactory.getCustomPlayerUA();
+    if (ua.isEmpty) return '未设置（使用内核默认 UA）';
+    return ua.length > 60 ? '${ua.substring(0, 60)}…' : ua;
+  }
+
+  Future<void> _editPersistentUA() async {
+    final result = await TextInputDialog.show(
+      context,
+      title: '自定义 User-Agent',
+      subtitle: '播放器请求视频时使用，长期有效。重新输入可覆盖原值。',
+      hintText: 'Mozilla/5.0 ...',
+      initialValue: PlayerFactory.getCustomPlayerUA(),
+      minLines: 2,
+    );
+    // 对话框空输入返回 null（等同取消），故 result 必为非空字符串。
+    if (result == null) return;
+    await PlayerFactory.saveCustomPlayerUA(result);
+    if (!mounted) return;
+    setState(() {}); // 刷新 subtitle
+    BlurSnackBar.show(context, '已保存自定义 UA');
+  }
+
+  bool _persistentUAHasValue() =>
+      PlayerFactory.getCustomPlayerUA().isNotEmpty;
+
+  Future<void> _resetPersistentUA() async {
+    await PlayerFactory.saveCustomPlayerUA('');
+    if (!mounted) return;
+    setState(() {}); // 刷新 subtitle + 恢复默认按钮禁用态
+    BlurSnackBar.show(context, '已恢复默认 UA');
   }
 
   String _getServerDisplayName(BuildContext context, String serverUrl) {
@@ -600,6 +635,84 @@ class _NetworkSettingsPageState extends State<NetworkSettingsPage> {
                   style: TextStyle(
                     color: colorScheme.onSurface.withOpacity(0.7),
                     fontSize: 12,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(height: 16),
+          Divider(color: colorScheme.onSurface.withOpacity(0.12), height: 1),
+
+          // 播放器请求 User-Agent
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+            child: Row(
+              children: [
+                Icon(
+                  Ionicons.globe_outline,
+                  color: colorScheme.onSurface,
+                  size: 16,
+                ),
+                SizedBox(width: 6),
+                Text(
+                  '播放器请求',
+                  style: TextStyle(
+                    color: colorScheme.onSurface.withOpacity(0.6),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          ListTile(
+            leading: Icon(
+              Ionicons.person_outline,
+              color: colorScheme.onSurface.withOpacity(0.7),
+            ),
+            title: Text(
+              '自定义 User-Agent',
+              locale: const Locale('zh-Hans', 'zh'),
+              style: TextStyle(
+                color: colorScheme.onSurface,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            subtitle: Text(
+              _persistentUASubtitle(),
+              locale: const Locale('zh-Hans', 'zh'),
+              style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
+            ),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                BlurButton(
+                  icon: Ionicons.create_outline,
+                  text: '编辑',
+                  onTap: _editPersistentUA,
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+                  fontSize: 13,
+                  iconSize: 16,
+                  foregroundColor: colorScheme.onSurface,
+                  hoverForegroundColor: AppAccentColors.current,
+                ),
+                const SizedBox(width: 8),
+                Opacity(
+                  opacity: _persistentUAHasValue() ? 1.0 : 0.4,
+                  child: IgnorePointer(
+                    ignoring: !_persistentUAHasValue(),
+                    child: BlurButton(
+                      icon: Ionicons.refresh_outline,
+                      text: '恢复默认',
+                      onTap: _resetPersistentUA,
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 14, vertical: 8),
+                      fontSize: 13,
+                      iconSize: 16,
+                      foregroundColor: colorScheme.onSurface,
+                      hoverForegroundColor: AppAccentColors.current,
+                    ),
                   ),
                 ),
               ],

--- a/lib/themes/nipaplay/widgets/video_upload_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_upload_ui.dart
@@ -7,9 +7,11 @@ import 'package:nipaplay/utils/video_player_state.dart';
 import 'dart:io' as io;
 import 'package:image_picker/image_picker.dart';
 import 'package:nipaplay/models/playable_item.dart';
+import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/text_input_dialog.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:permission_handler/permission_handler.dart';
 import 'package:nipaplay/services/file_picker_service.dart';
@@ -407,6 +409,10 @@ class _VideoUploadUIState extends State<VideoUploadUI>
             onSubmitted: (_) => _handlePlayFromUrl(),
             decoration: InputDecoration(
               hintText: 'https://example.com/video.mp4 或签名下载直链',
+              hintStyle: TextStyle(
+                color: textColor.withOpacity(0.35),
+                fontSize: 14,
+              ),
               filled: true,
               fillColor: colorScheme.surface.withOpacity(
                 isDarkMode ? 0.58 : 0.94,
@@ -422,24 +428,35 @@ class _VideoUploadUIState extends State<VideoUploadUI>
             ),
           ),
           SizedBox(height: 10),
-          Wrap(
-            alignment: WrapAlignment.end,
-            spacing: 8,
-            runSpacing: 8,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               HoverScaleTextButton(
-                onPressed: _isSubmittingUrl ? null : _pasteUrlFromClipboard,
-                child: Text('粘贴', style: TextStyle(color: textColor)),
-              ),
-              HoverScaleTextButton(
-                onPressed: _isSubmittingUrl ? null : _handlePlayFromUrl,
+                onPressed: _isSubmittingUrl ? null : _showOneTimeUADialog,
                 child: Text(
-                  _isSubmittingUrl ? '处理中...' : '播放链接',
-                  style: TextStyle(
-                    color: AppAccentColors.current,
-                    fontWeight: FontWeight.w700,
-                  ),
+                  '自定义UA(仅一次)',
+                  style: TextStyle(color: textColor),
                 ),
+              ),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  HoverScaleTextButton(
+                    onPressed: _isSubmittingUrl ? null : _pasteUrlFromClipboard,
+                    child: Text('粘贴', style: TextStyle(color: textColor)),
+                  ),
+                  HoverScaleTextButton(
+                    onPressed: _isSubmittingUrl ? null : _handlePlayFromUrl,
+                    child: Text(
+                      _isSubmittingUrl ? '处理中...' : '播放链接',
+                      style: TextStyle(
+                        color: AppAccentColors.current,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ],
           ),
@@ -465,6 +482,27 @@ class _VideoUploadUIState extends State<VideoUploadUI>
       if (!mounted) return;
       BlurSnackBar.show(context, '读取剪贴板失败: $e');
     }
+  }
+
+  /// 串流播放的"自定义UA(仅一次)"：设置仅对下一次播放这条链接生效的一次性 UA。
+  Future<void> _showOneTimeUADialog() async {
+    final result = await TextInputDialog.show(
+      context,
+      title: '自定义 User-Agent（仅本次播放）',
+      subtitle: '仅对下一次播放生效，不影响长期设置。',
+      hintText: 'Mozilla/5.0 ...',
+      initialValue: PlayerFactory.getOneTimeUA() ?? '',
+      minLines: 2,
+    );
+    if (result == null) return; // 用户取消
+    PlayerFactory.setOneTimeUA(result);
+    if (!mounted) return;
+    BlurSnackBar.show(
+      context,
+      result.isEmpty
+          ? '已清除一次性 UA，本次将使用长期/默认 UA'
+          : '已设置一次性 UA，本次播放生效',
+    );
   }
 
   Future<bool> _handlePlayFromUrl() async {

--- a/lib/utils/danmaku_ass_converter.dart
+++ b/lib/utils/danmaku_ass_converter.dart
@@ -134,7 +134,7 @@ String convertDanmakuToAss(
         final line =
             '{\\an4\\move($kAssPlayResX,${yCenter.toStringAsFixed(1)},'
             '${xEnd.toStringAsFixed(1)},${yCenter.toStringAsFixed(1)})'
-            '${_colorOverride(d.color)}\\1a$alphaHex}'
+            '${_colorOverride(d.color)}${_outlineColorOverride(d.color)}\\1a$alphaHex}'
             '${_escapeAssText(d.content)}';
         _writeDialogue(
           buffer,
@@ -151,7 +151,7 @@ String convertDanmakuToAss(
         final yTop = (lane * laneHeight + 2).toDouble();
         final line =
             '{\\an8\\pos(${(kAssPlayResX ~/ 2)},${yTop.toStringAsFixed(1)})'
-            '${_colorOverride(d.color)}\\1a$alphaHex}'
+            '${_colorOverride(d.color)}${_outlineColorOverride(d.color)}\\1a$alphaHex}'
             '${_escapeAssText(d.content)}';
         _writeDialogue(
           buffer,
@@ -168,7 +168,7 @@ String convertDanmakuToAss(
         final yBottom = (kAssPlayResY - lane * laneHeight - 2).toDouble();
         final line =
             '{\\an2\\pos(${(kAssPlayResX ~/ 2)},${yBottom.toStringAsFixed(1)})'
-            '${_colorOverride(d.color)}\\1a$alphaHex}'
+            '${_colorOverride(d.color)}${_outlineColorOverride(d.color)}\\1a$alphaHex}'
             '${_escapeAssText(d.content)}';
         _writeDialogue(
           buffer,
@@ -303,6 +303,19 @@ String _colorOverride(int rgb) {
   final b = rgb & 0xFF;
   final bgr = (b << 16) | (g << 8) | r;
   return '\\c&H${bgr.toRadixString(16).toUpperCase().padLeft(6, '0')}&';
+}
+
+/// 暗色弹幕（近黑）用白描边，其余沿用样式黑描边。
+/// 与 Next2/DFM+ 渲染管线 `stroke_color` 一致：r/g/b 均 ≤ 8 视为黑 → 白描边。
+/// 返回 ASS `\3c` 覆盖（空 = 沿用样式黑描边）。
+String _outlineColorOverride(int rgb) {
+  final r = (rgb >> 16) & 0xFF;
+  final g = (rgb >> 8) & 0xFF;
+  final b = rgb & 0xFF;
+  if (r <= 8 && g <= 8 && b <= 8) {
+    return r'\3c&HFFFFFF&';
+  }
+  return '';
 }
 
 // ---------- 宽度估算 ----------
@@ -557,6 +570,7 @@ String convertDanmakuToAssFromPrepared(
         : (it.isScroll ? 10.0 : kAssFixedDanmakuDurationSeconds);
     final end = start + duration;
     final colorOverride = _colorOverride(it.colorRgb);
+    final outlineOverride = _outlineColorOverride(it.colorRgb);
     final escaped = _escapeAssText(it.text);
     final yStr = it.yPosition.toStringAsFixed(1);
 
@@ -573,7 +587,7 @@ String convertDanmakuToAssFromPrepared(
         x2 = (-it.width).toStringAsFixed(1);
       }
       final line =
-          '{\\an7\\move($x1,$yStr,$x2,$yStr)$colorOverride\\1a$alphaHex}$escaped';
+          '{\\an7\\move($x1,$yStr,$x2,$yStr)$colorOverride$outlineOverride\\1a$alphaHex}$escaped';
       _writeDialogue(buffer,
           layer: 0, start: start, end: end, style: 'Danmaku', text: line);
     } else {
@@ -581,7 +595,7 @@ String convertDanmakuToAssFromPrepared(
       // 顶/底部居中：用 \an8 顶中对齐 + \pos(PlayResX/2, y)，让 libass 按自身
       // 字体度量居中，避免 DFM+ paint_width 与 libass 渲染宽度不一致导致长弹幕偏移。
       final line =
-          '{\\an8\\pos($centerX,$yStr)$colorOverride\\1a$alphaHex}$escaped';
+          '{\\an8\\pos($centerX,$yStr)$colorOverride$outlineOverride\\1a$alphaHex}$escaped';
       _writeDialogue(
         buffer,
         layer: isBottom ? 2 : 1,

--- a/lib/utils/danmaku_ass_converter.dart
+++ b/lib/utils/danmaku_ass_converter.dart
@@ -305,7 +305,7 @@ String _colorOverride(int rgb) {
   return '\\c&H${bgr.toRadixString(16).toUpperCase().padLeft(6, '0')}&';
 }
 
-/// 暗色弹幕（近黑）用白描边，其余沿用样式黑描边。
+/// 暗色弹幕（近纯黑）用白描边，其余沿用样式黑描边。
 /// 与 Next2/DFM+ 渲染管线 `stroke_color` 一致：r/g/b 均 ≤ 8 视为黑 → 白描边。
 /// 返回 ASS `\3c` 覆盖（空 = 沿用样式黑描边）。
 String _outlineColorOverride(int rgb) {

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -349,6 +349,14 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
         }
       }
 
+      // 应用自定义 User-Agent（须在打开媒体前设置；空字符串 = 用内核默认 UA）。
+      // 优先用一次性 UA（串流菜单设置，仅本次有效，用后即清），否则用持久 UA。
+      final customUA =
+          PlayerFactory.consumeOneTimeUA() ?? PlayerFactory.getCustomPlayerUA();
+      if (customUA.isNotEmpty) {
+        player.setUserAgent(customUA);
+      }
+
       player.media = playUrl;
       await applyErikaUpscalerModeToCurrentPlayer();
 


### PR DESCRIPTION
## Summary

- 修复了生成外挂ASS弹幕时深色填充弹幕未使用白色描边的问题
- 支持自定义User-Agent，分别有两处入口：
    1. 视频播放-输入链接 串流播放处可自定义UA(仅一次)
    2. 设置-网络设置 中可配置长期有效的UA
 
自定义UA目前仅支持 libmpv、mdk 内核，同时支持外部播放器中的 mpv/mpv.net 和 vlc

## Related Issue

- #641 

## Test

已通过python搭建的简易UA限制server测试
```python
import http.server
import mimetypes
import os
import socketserver
import sys
from urllib.parse import unquote

PORT = 8000
REQUIRED_UA = "hello"
DIRECTORY = os.path.dirname(os.path.abspath(__file__))


class Handler(http.server.BaseHTTPRequestHandler):
    server_version = "UAProtected/1.0"

    # ---- UA 校验 ----
    def _ua_ok(self) -> bool:
        ua = self.headers.get("User-Agent", "")
        if ua == REQUIRED_UA:
            return True
        body = (
            f"403 Forbidden: User-Agent 必须为 '{REQUIRED_UA}'，"
            f"收到 '{ua}'\n"
        ).encode("utf-8")
        self.send_response(403)
        self.send_header("Content-Type", "text/plain; charset=utf-8")
        self.send_header("Content-Length", str(len(body)))
        self.end_headers()
        if self.command != "HEAD":
            self.wfile.write(body)
        return False

    # ---- 路径解析（防穿越）----
    def _translate(self, urlpath: str):
        path = unquote(urlpath.split("?")[0].split("#")[0]).lstrip("/")
        full = os.path.normpath(os.path.join(DIRECTORY, path))
        if not full.startswith(os.path.abspath(DIRECTORY) + os.sep) and full != os.path.abspath(DIRECTORY):
            return None
        return full

    # ---- 入口 ----
    def do_HEAD(self):
        self._serve(head_only=True)

    def do_GET(self):
        self._serve(head_only=False)

    def _serve(self, head_only: bool):
        if not self._ua_ok():
            return
        full = self._translate(self.path)
        if full is None or not os.path.isfile(full):
            self.send_error(404, "Not Found")
            return

        size = os.path.getsize(full)
        ctype = mimetypes.guess_type(full)[0] or "application/octet-stream"
        range_header = self.headers.get("Range")

        if range_header and range_header.startswith("bytes="):
            try:
                spec = range_header[6:].split(",")[0].strip()
                start_s, end_s = spec.split("-", 1)
                start = int(start_s) if start_s else 0
                end = int(end_s) if end_s else size - 1
                if end >= size:
                    end = size - 1
                if start > end or start >= size:
                    self.send_response(416)
                    self.send_header("Content-Range", f"bytes */{size}")
                    self.end_headers()
                    return
                length = end - start + 1
                self.send_response(206)
                self.send_header("Content-Type", ctype)
                self.send_header("Content-Length", str(length))
                self.send_header("Content-Range", f"bytes {start}-{end}/{size}")
                self.send_header("Accept-Ranges", "bytes")
                self.end_headers()
                if not head_only:
                    self._send_file(full, start, length)
            except Exception as e:  # noqa
                self.send_error(400, f"Bad Range: {e}")
        else:
            self.send_response(200)
            self.send_header("Content-Type", ctype)
            self.send_header("Content-Length", str(size))
            self.send_header("Accept-Ranges", "bytes")
            self.end_headers()
            if not head_only:
                self._send_file(full, 0, size)

    def _send_file(self, full: str, start: int, length: int):
        remaining = length
        with open(full, "rb") as f:
            f.seek(start)
            while remaining > 0:
                chunk = f.read(min(1024 * 1024, remaining))
                if not chunk:
                    break
                self.wfile.write(chunk)
                remaining -= len(chunk)

    def log_message(self, fmt, *args):
        ua = self.headers.get("User-Agent", "")
        status = args[1] if len(args) >= 2 else ""
        print(f"[{self.command}] {self.path}  UA='{ua}'  -> {status}")


class ThreadingServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
    daemon_threads = True


def main():
    port = int(sys.argv[1]) if len(sys.argv) > 1 else PORT
    socketserver.TCPServer.allow_reuse_address = True
    with ThreadingServer(("0.0.0.0", port), Handler) as httpd:
        print("=" * 56)
        print(" UA-protected video test server")
        print(f"   directory   : {DIRECTORY}")
        print(f"   required UA : '{REQUIRED_UA}'")
        print(f"   listening   : http://0.0.0.0:{port}")
        print(f"   LAN URL     : http://127.0.0.1:{port}/testvideo.mp4")
        print("   Ctrl+C to stop.")
        print("=" * 56)
        try:
            httpd.serve_forever()
        except KeyboardInterrupt:
            print("\n停止。")


if __name__ == "__main__":
    main()
```