### PR TITLE
[codex] Restore iOS IPA release build

### DIFF
--- a/.github/actions/build-ios/action.yml
+++ b/.github/actions/build-ios/action.yml
@@ -19,6 +19,12 @@ runs:
         echo "CPU架构: $(uname -m)"
         echo "可用磁盘空间:"
         df -h
+
+        MACOS_VERSION="$(sw_vers -productVersion)"
+        if [[ "${MACOS_VERSION}" != 26.* ]]; then
+          echo "❌ 错误：iOS IPA 构建必须运行在 macOS 26，当前系统为 ${MACOS_VERSION}"
+          exit 1
+        fi
         
         echo "=== Xcode环境检查 ==="
         if command -v xcodebuild &> /dev/null; then

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: Build iOS IPA
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 60
     outputs:
       version: ${{ steps.setup.outputs.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,12 @@ jobs:
       ALIAS: ${{ secrets.ALIAS }}
       KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
+  Build-iOS:
+    name: Build iOS
+    needs: Gatekeeper
+    if: needs.Gatekeeper.outputs.triggered == 'true'
+    uses: ./.github/workflows/build-ios.yml
+
   Build-macOS:
     name: Build macOS
     needs: Gatekeeper
@@ -80,7 +86,7 @@ jobs:
 
   Publish:
     name: Publish Release
-    needs: [Gatekeeper, Build-Android, Build-macOS, Build-Windows, Build-Linux]
+    needs: [Gatekeeper, Build-Android, Build-iOS, Build-macOS, Build-Windows, Build-Linux]
     if: needs.Gatekeeper.outputs.triggered == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -356,7 +362,7 @@ jobs:
           name: Release v${{ needs.Build-Android.outputs.version }}
           bodyFile: "release_notes.md"
           allowUpdates: true
-          artifacts: /tmp/artifacts/release-Android/*.apk,/tmp/artifacts/release-macOS/*.dmg,/tmp/artifacts/release-macOS/*.zip,/tmp/artifacts/release-macOS/*.pkg,/tmp/artifacts/release-Windows-x64/*.zip,/tmp/artifacts/release-Windows-x64/*.exe,/tmp/artifacts/release-Windows-x64/*.msix,/tmp/artifacts/release-Linux-amd64/*.deb,/tmp/artifacts/release-Linux-amd64/*.AppImage,/tmp/artifacts/release-Linux-amd64/*.tar.gz,/tmp/artifacts/release-Linux-amd64/*.rpm,/tmp/artifacts/release-Linux-arm64/*.deb,/tmp/artifacts/release-Linux-arm64/*.tar.gz,/tmp/artifacts/release-Linux-arm64/*.rpm
+          artifacts: /tmp/artifacts/release-Android/*.apk,/tmp/artifacts/release-iOS/*.ipa,/tmp/artifacts/release-macOS/*.dmg,/tmp/artifacts/release-macOS/*.zip,/tmp/artifacts/release-macOS/*.pkg,/tmp/artifacts/release-Windows-x64/*.zip,/tmp/artifacts/release-Windows-x64/*.exe,/tmp/artifacts/release-Windows-x64/*.msix,/tmp/artifacts/release-Linux-amd64/*.deb,/tmp/artifacts/release-Linux-amd64/*.AppImage,/tmp/artifacts/release-Linux-amd64/*.tar.gz,/tmp/artifacts/release-Linux-amd64/*.rpm,/tmp/artifacts/release-Linux-arm64/*.deb,/tmp/artifacts/release-Linux-arm64/*.tar.gz,/tmp/artifacts/release-Linux-arm64/*.rpm
           artifactErrorsFailBuild: true
           replacesArtifacts: true
           token: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}


### PR DESCRIPTION
## Summary

- Restore the iOS IPA build job in the modular release workflow.
- Publish generated `.ipa` files as release artifacts again.
- Require the iOS IPA build to run on the `macos-26` GitHub-hosted runner and fail fast if the runtime macOS version is not 26.x.

## Validation

- Ran `git diff --check` for the touched workflow/action files.
- Verified the remote workflow with `gh workflow view build-ios.yml --ref codex/restore-ipa-build --yaml` and confirmed `runs-on: macos-26`.

## Notes

This PR targets `codex/unify-settings-ui` because the branch was created from that branch; targeting `main` directly would include the existing `Unify adaptive settings UI` commit as unrelated scope.