### PR TITLE
[codex] Remove AUR update instructions from docs

### DIFF
--- a/Documentation/release-channels.md
+++ b/Documentation/release-channels.md
@@ -29,32 +29,6 @@ brew upgrade nipaplay-reload
 - 通过 Homebrew 更新时，系统不会再次要求在"隐私与安全性"中手动允许应用
 - 自动处理依赖关系和清理旧版本
 
-## Arch Linux - AUR
-
-**包名**：`nipaplay-reload-bin`
-
-**更新方式**：
-
-使用 `paru`：
-
-```bash
-# 检查可更新的 AUR 包
-paru -Sua
-
-# 更新 NipaPlay
-paru -S nipaplay-reload-bin
-```
-
-使用 `yay`：
-
-```bash
-# 检查可更新的 AUR 包  
-yay -Sua
-
-# 更新 NipaPlay
-yay -S nipaplay-reload-bin
-```
-
 ## Windows
 
 **更新方式**：


### PR DESCRIPTION
## Summary

- Remove the Arch Linux AUR update/install instructions from the release channels documentation.
- Keep the existing AUR safety warnings in the README and installation guide so users are still told not to install the compromised package.

## Validation

- Ran `rg -n "\b(paru|yay)\b|paru -S|yay -S|Arch Linux - AUR" Documentation README.md || true` and confirmed no AUR helper update instructions remain.
- Ran `git diff --check -- Documentation/release-channels.md`.

## Scope

Only `Documentation/release-channels.md` is included in this PR.