### PR TITLE
[Bug] 修复自适应设置组件中 ReorderableListView 的编译错误

### DIFF
--- a/lib/settings/adaptive_settings_widgets.dart
+++ b/lib/settings/adaptive_settings_widgets.dart
@@ -945,7 +945,7 @@ class AdaptiveSettingsDragList<T> extends material.StatelessWidget {
           physics: const material.NeverScrollableScrollPhysics(),
           buildDefaultDragHandles: false,
           itemCount: items.length,
-          onReorderItem: onReorder,
+          onReorder: onReorder,
           proxyDecorator: (child, index, animation) {
             return material.Material(
               color: material.Colors.transparent,


### PR DESCRIPTION
此前由 Codex 提交的 `adaptive_settings_widgets.dart` 在使用 `ReorderableListView.builder` 时使用了错误的参数 `onReorderItem`，而在 Flutter SDK 中对应的参数应为 `onReorder`。此 PR 将其修正为 `onReorder` 以解决打包构建失败的问题。