### PR TITLE
Fix scaled dropdown menu positioning

### DIFF
--- a/lib/themes/nipaplay/widgets/blur_dropdown.dart
+++ b/lib/themes/nipaplay/widgets/blur_dropdown.dart
@@ -239,7 +239,7 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
                     _getSelectedItemText(),
                     style: getTitleTextStyle(context),
                   ),
-                  SizedBox(width: 10),
+                  const SizedBox(width: 10),
                   RotationTransition(
                     turns: Tween(begin: 0.0, end: 0.5)
                         .animate(_animationController),
@@ -425,11 +425,24 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
     return KeyEventResult.ignored;
   }
 
+  RenderBox? _overlayRenderBox(OverlayState overlay) {
+    final renderObject = overlay.context.findRenderObject();
+    if (renderObject is RenderBox && renderObject.hasSize) {
+      return renderObject;
+    }
+    return null;
+  }
+
   void _openDropdown({bool requestMenuFocus = false}) {
     if (_isDropdownOpen || _animationController.isAnimating) {
       return;
     }
     _removeOverlay();
+
+    final overlay = Overlay.maybeOf(context);
+    if (overlay == null) {
+      return;
+    }
 
     final RenderBox? renderBox =
         widget.dropdownKey.currentContext?.findRenderObject() as RenderBox?;
@@ -437,10 +450,14 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
       return;
     }
 
+    final overlayBox = _overlayRenderBox(overlay);
     final size = renderBox.size;
-    final position = renderBox.localToGlobal(Offset.zero);
-    final screenHeight = MediaQuery.of(context).size.height;
-    final screenWidth = MediaQuery.of(context).size.width;
+    final position = overlayBox == null
+        ? renderBox.localToGlobal(Offset.zero)
+        : renderBox.localToGlobal(Offset.zero, ancestor: overlayBox);
+    final overlaySize = overlayBox?.size ?? MediaQuery.of(context).size;
+    final screenHeight = overlaySize.height;
+    final screenWidth = overlaySize.width;
 
     double top = position.dy + size.height + 5;
     double estimatedHeight = widget.items.length * 50.0;
@@ -594,7 +611,7 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
       },
     );
 
-    Overlay.of(context).insert(_overlayEntry!);
+    overlay.insert(_overlayEntry!);
     _setExpandedTracked(true);
     setState(() {
       _isDropdownOpen = true;

--- a/test/blur_dropdown_test.dart
+++ b/test/blur_dropdown_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/ui_scale_wrapper.dart';
+
+void main() {
+  testWidgets('positions dropdown in overlay coordinates when UI is scaled', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1000, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final dropdownKey = GlobalKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (context, child) {
+          return UiScaleWrapper(
+            scale: 1.25,
+            child: child ?? const SizedBox.shrink(),
+          );
+        },
+        home: Scaffold(
+          body: Stack(
+            children: [
+              Positioned(
+                left: 200,
+                top: 120,
+                child: BlurDropdown<String>(
+                  dropdownKey: dropdownKey,
+                  items: [
+                    DropdownMenuItemData(
+                      title: 'One',
+                      value: 'one',
+                      isSelected: true,
+                    ),
+                    DropdownMenuItemData(title: 'Two', value: 'two'),
+                  ],
+                  onItemSelected: (_) {},
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('One'));
+    await tester.pump();
+
+    expect(find.text('Two'), findsOneWidget);
+
+    final renderBox =
+        dropdownKey.currentContext!.findRenderObject()! as RenderBox;
+    final overlayBox = tester.renderObject<RenderBox>(find.byType(Overlay));
+    final anchorPosition = renderBox.localToGlobal(
+      Offset.zero,
+      ancestor: overlayBox,
+    );
+    final positionedFinder = find.ancestor(
+      of: find.text('Two'),
+      matching: find.byType(Positioned),
+    );
+    final dropdownPositioned = tester.widget<Positioned>(positionedFinder);
+
+    expect(
+      dropdownPositioned.top,
+      closeTo(anchorPosition.dy + renderBox.size.height + 5, 1),
+    );
+    expect(
+      dropdownPositioned.right,
+      closeTo(
+        overlayBox.size.width - anchorPosition.dx - renderBox.size.width,
+        1,
+      ),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Position BlurDropdown menus in the active Overlay coordinate space instead of scaled global screen coordinates.
- Use the Overlay size for menu bounds so UI scale no longer pushes menus down and right.
- Add a widget test covering dropdown placement under UiScaleWrapper.

## Root Cause
UiScaleWrapper lays the app out in reduced logical coordinates and then applies Transform.scale. BlurDropdown previously used RenderBox.localToGlobal without an Overlay ancestor, so the already-scaled global position was reused as an Overlay-local Positioned value.

## Validation
- flutter analyze --no-pub lib/themes/nipaplay/widgets/blur_dropdown.dart test/blur_dropdown_test.dart
- flutter test --no-pub test/blur_dropdown_test.dart