### PR TITLE
Promote Next2 danmaku kernel defaults

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -38,13 +38,10 @@ class SettingsKeys {
   static const String labsShowRemoteAccessQrCode =
       'labs_show_remote_access_qr_code';
 
-  static const String labsEnableNext2DanmakuKernel =
-      'labs_enable_next2_danmaku_kernel';
-
   static const String labsEnableErikaPlayerKernel =
       'labs_enable_erika_player_kernel';
 
-  static const String labsEnableNextPlusPlusEngine =
+  static const String danmakuEnableNextPlusPlusEngine =
       'labs_enable_next_plus_plus_engine';
 
   static const String torrentDownloadDirectory = 'torrent_download_directory';

--- a/lib/danmaku_abstraction/danmaku_kernel_factory.dart
+++ b/lib/danmaku_abstraction/danmaku_kernel_factory.dart
@@ -1,5 +1,6 @@
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:async';
+import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/danmaku_next/next2_platform_support.dart';
 
 /// 弹幕渲染引擎枚举
@@ -26,19 +27,41 @@ enum DanmakuRenderEngine {
 /// 负责读写弹幕渲染引擎设置的工厂类
 class DanmakuKernelFactory {
   static const String _danmakuRenderEngineKey = 'danmaku_render_engine';
-  // Default to NipaPlay Next if no user setting exists
-  static DanmakuRenderEngine _cachedEngine = DanmakuRenderEngine.nipaplayNext;
+  // Default to Next2 where it is supported; fall back to NipaPlay Next on Web.
+  static DanmakuRenderEngine _cachedEngine = _defaultEngine;
   static bool _initialized = false;
 
-  /// Next++ 激进优化引擎开关（由 LabsSettingsProvider 同步）
+  /// Next++ 激进优化引擎开关
   static bool _enableNextPlusPlus = false;
 
-  /// 同步 Next++ 开关状态（由 LabsSettingsProvider 调用）
-  static void setEnableNextPlusPlus(bool enabled) {
+  static DanmakuRenderEngine get _defaultEngine =>
+      Next2PlatformSupport.isKernelSupported
+          ? DanmakuRenderEngine.next2
+          : DanmakuRenderEngine.nipaplayNext;
+
+  static bool get isNextPlusPlusEnabled => _enableNextPlusPlus;
+
+  static void _setEnableNextPlusPlus(bool enabled) {
     if (_enableNextPlusPlus == enabled) return;
     _enableNextPlusPlus = enabled;
-    // 通知 UI 更新显示名称（如开发者模式右上角）
+  }
+
+  /// 保存 Next++ 开关状态，并通知 UI 更新显示名称和渲染路径。
+  static Future<void> saveEnableNextPlusPlus(bool enabled) async {
+    if (_enableNextPlusPlus == enabled) return;
+
+    _setEnableNextPlusPlus(enabled);
     _kernelChangeController.add(DanmakuRenderEngine.nipaplayNext);
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(
+        SettingsKeys.danmakuEnableNextPlusPlusEngine,
+        enabled,
+      );
+    } catch (e) {
+      // ignore
+    }
   }
 
   /// 获取 NipaPlay Next 引擎的显示名称
@@ -64,6 +87,9 @@ class DanmakuKernelFactory {
     try {
       final prefs = await SharedPreferences.getInstance();
       final engineIndex = prefs.getInt(_danmakuRenderEngineKey);
+      _setEnableNextPlusPlus(
+        prefs.getBool(SettingsKeys.danmakuEnableNextPlusPlusEngine) ?? false,
+      );
 
       if (engineIndex != null &&
           engineIndex >= 0 &&
@@ -71,10 +97,10 @@ class DanmakuKernelFactory {
         _cachedEngine =
             _sanitizeEngine(DanmakuRenderEngine.values[engineIndex]);
       } else {
-        _cachedEngine = DanmakuRenderEngine.nipaplayNext; // 默认使用 NipaPlay Next
+        _cachedEngine = _defaultEngine;
       }
     } catch (e) {
-      _cachedEngine = DanmakuRenderEngine.nipaplayNext;
+      _cachedEngine = _defaultEngine;
     }
 
     _initialized = true;

--- a/lib/providers/labs_settings_provider.dart
+++ b/lib/providers/labs_settings_provider.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/utils/settings_storage.dart';
-import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 
 class LabsSettingsProvider extends ChangeNotifier {
   LabsSettingsProvider() {
@@ -9,15 +8,11 @@ class LabsSettingsProvider extends ChangeNotifier {
   }
 
   bool _enableLargeScreenMode = false;
-  bool _enableNext2DanmakuKernel = false;
   bool _enableErikaPlayerKernel = false;
-  bool _enableNextPlusPlusEngine = false; // 默认关闭：Next++ 激进优化引擎
   bool _isLoaded = false;
 
   bool get enableLargeScreenMode => _enableLargeScreenMode;
-  bool get enableNext2DanmakuKernel => _enableNext2DanmakuKernel;
   bool get enableErikaPlayerKernel => _enableErikaPlayerKernel;
-  bool get enableNextPlusPlusEngine => _enableNextPlusPlusEngine;
   bool get isLoaded => _isLoaded;
 
   Future<void> _loadSettings() async {
@@ -25,19 +20,10 @@ class LabsSettingsProvider extends ChangeNotifier {
       SettingsKeys.labsEnableLargeScreenMode,
       defaultValue: false,
     );
-    _enableNext2DanmakuKernel = await SettingsStorage.loadBool(
-      SettingsKeys.labsEnableNext2DanmakuKernel,
-      defaultValue: false,
-    );
     _enableErikaPlayerKernel = await SettingsStorage.loadBool(
       SettingsKeys.labsEnableErikaPlayerKernel,
       defaultValue: false,
     );
-    _enableNextPlusPlusEngine = await SettingsStorage.loadBool(
-      SettingsKeys.labsEnableNextPlusPlusEngine,
-      defaultValue: false, // 默认关闭：Next++ 激进优化引擎（回退至 Next 原始引擎路径）
-    );
-    DanmakuKernelFactory.setEnableNextPlusPlus(_enableNextPlusPlusEngine);
     _isLoaded = true;
     notifyListeners();
   }
@@ -52,33 +38,12 @@ class LabsSettingsProvider extends ChangeNotifier {
     );
   }
 
-  Future<void> setEnableNext2DanmakuKernel(bool enabled) async {
-    if (_enableNext2DanmakuKernel == enabled) return;
-    _enableNext2DanmakuKernel = enabled;
-    notifyListeners();
-    await SettingsStorage.saveBool(
-      SettingsKeys.labsEnableNext2DanmakuKernel,
-      enabled,
-    );
-  }
-
   Future<void> setEnableErikaPlayerKernel(bool enabled) async {
     if (_enableErikaPlayerKernel == enabled) return;
     _enableErikaPlayerKernel = enabled;
     notifyListeners();
     await SettingsStorage.saveBool(
       SettingsKeys.labsEnableErikaPlayerKernel,
-      enabled,
-    );
-  }
-
-  Future<void> setEnableNextPlusPlusEngine(bool enabled) async {
-    if (_enableNextPlusPlusEngine == enabled) return;
-    _enableNextPlusPlusEngine = enabled;
-    DanmakuKernelFactory.setEnableNextPlusPlus(enabled);
-    notifyListeners();
-    await SettingsStorage.saveBool(
-      SettingsKeys.labsEnableNextPlusPlusEngine,
       enabled,
     );
   }

--- a/lib/settings/pages/danmaku_settings_content.dart
+++ b/lib/settings/pages/danmaku_settings_content.dart
@@ -9,7 +9,6 @@ import 'package:nipaplay/l10n/l10n.dart';
 import 'package:nipaplay/models/danmaku_auto_load_strategy.dart';
 import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
-import 'package:nipaplay/providers/labs_settings_provider.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/settings/adaptive_settings_scope.dart';
 import 'package:nipaplay/settings/adaptive_settings_widgets.dart';
@@ -95,6 +94,14 @@ class _DanmakuSettingsContentState extends State<DanmakuSettingsContent> {
     });
   }
 
+  Future<void> _saveNextPlusPlusEngineSetting(bool enabled) async {
+    await DanmakuKernelFactory.saveEnableNextPlusPlus(enabled);
+
+    if (!mounted) return;
+    BlurSnackBar.show(context, enabled ? 'Next++ 已开启' : 'Next++ 已关闭');
+    setState(() {});
+  }
+
   Future<bool> _saveSpoilerAiSettings(VideoPlayerState videoState) async {
     if (_isSavingSpoilerAiSettings) return false;
 
@@ -163,7 +170,6 @@ class _DanmakuSettingsContentState extends State<DanmakuSettingsContent> {
 
   List<DropdownMenuItemData<DanmakuRenderEngine>>
       _buildDanmakuRenderEngineItems({
-    required bool showNext2,
     required bool next2Supported,
   }) {
     final items = <DropdownMenuItemData<DanmakuRenderEngine>>[
@@ -198,7 +204,7 @@ class _DanmakuSettingsContentState extends State<DanmakuSettingsContent> {
       ),
     ];
 
-    if (showNext2) {
+    if (next2Supported) {
       items.add(
         DropdownMenuItemData(
           title: 'NipaPlay Next2',
@@ -221,9 +227,7 @@ class _DanmakuSettingsContentState extends State<DanmakuSettingsContent> {
     } else if (_selectedDanmakuRenderEngine == DanmakuRenderEngine.next2) {
       items.add(
         DropdownMenuItemData(
-          title: next2Supported
-              ? 'NipaPlay Next2 (实验室关闭)'
-              : 'NipaPlay Next2 (当前平台不支持)',
+          title: 'NipaPlay Next2 (当前平台不支持)',
           value: DanmakuRenderEngine.next2,
           isSelected: true,
           enabled: false,
@@ -231,10 +235,13 @@ class _DanmakuSettingsContentState extends State<DanmakuSettingsContent> {
               _getDanmakuRenderEngineDescription(DanmakuRenderEngine.next2),
         ),
       );
-    } else if (_selectedDanmakuRenderEngine == DanmakuRenderEngine.dfmPlus) {
+    }
+
+    if (!next2Supported &&
+        _selectedDanmakuRenderEngine == DanmakuRenderEngine.dfmPlus) {
       items.add(
         DropdownMenuItemData(
-          title: next2Supported ? 'DFM+ (实验室关闭)' : 'DFM+ (当前平台不支持)',
+          title: 'DFM+ (当前平台不支持)',
           value: DanmakuRenderEngine.dfmPlus,
           isSelected: true,
           enabled: false,
@@ -721,13 +728,12 @@ class _DanmakuSettingsContentState extends State<DanmakuSettingsContent> {
     final isErikaPlayerKernel =
         PlayerFactory.getKernelType() == PlayerKernelType.erika;
     final next2Supported = Next2PlatformSupport.isKernelSupported;
-    final showNext2 = next2Supported &&
-        context.watch<LabsSettingsProvider>().enableNext2DanmakuKernel;
+    final showNextPlusPlusToggle =
+        _selectedDanmakuRenderEngine == DanmakuRenderEngine.nipaplayNext;
     final showRendererSupersample = !isErikaPlayerKernel &&
         (_selectedDanmakuRenderEngine == DanmakuRenderEngine.next2 ||
             _selectedDanmakuRenderEngine == DanmakuRenderEngine.dfmPlus);
     final renderEngineItems = _buildDanmakuRenderEngineItems(
-      showNext2: showNext2,
       next2Supported: next2Supported,
     );
 
@@ -745,13 +751,26 @@ class _DanmakuSettingsContentState extends State<DanmakuSettingsContent> {
                 items: renderEngineItems,
                 onChanged: (dynamic value) {
                   if (value is! DanmakuRenderEngine) return;
-                  if ((!showNext2 || !next2Supported) &&
-                      value == DanmakuRenderEngine.next2) {
+                  if (!next2Supported &&
+                      (value == DanmakuRenderEngine.next2 ||
+                          value == DanmakuRenderEngine.dfmPlus)) {
                     return;
                   }
                   _saveDanmakuRenderEngineSettings(value);
                 },
                 dropdownKey: _danmakuRenderEngineDropdownKey,
+              ),
+              Divider(
+                  color: colorScheme.onSurface.withValues(alpha: 0.12),
+                  height: 1),
+            ],
+            if (showNextPlusPlusToggle) ...[
+              AdaptiveSettingsTile.toggle(
+                title: 'Next++ 激进优化引擎',
+                subtitle: '开启后使用 Next++ 优化路径，关闭则回退至 Next 原始引擎路径',
+                icon: Ionicons.rocket_outline,
+                value: DanmakuKernelFactory.isNextPlusPlusEnabled,
+                onChanged: _saveNextPlusPlusEngineSetting,
               ),
               Divider(
                   color: colorScheme.onSurface.withValues(alpha: 0.12),

--- a/lib/settings/pages/labs_settings_content.dart
+++ b/lib/settings/pages/labs_settings_content.dart
@@ -38,24 +38,6 @@ class LabsSettingsContent extends StatelessWidget {
                   value: labsSettings.enableLargeScreenMode,
                   onChanged: labsSettings.setEnableLargeScreenMode,
                 ),
-                AdaptiveSettingsTile.toggle(
-                  title: _text(
-                    context,
-                    '显示 Next2和 DFM+ 弹幕内核',
-                    '顯示 Next2 和 DFM+ 彈幕內核',
-                    'Show Next2 and DFM+ Danmaku Kernels',
-                  ),
-                  subtitle: _text(
-                    context,
-                    '开启后，弹幕渲染引擎下拉菜单显示 NipaPlay Next2 和 DFM+',
-                    '開啟後，彈幕渲染引擎下拉選單顯示 NipaPlay Next2 和 DFM+',
-                    'Expose NipaPlay Next2 and DFM+ in danmaku renderer menus.',
-                  ),
-                  icon: Ionicons.flask_outline,
-                  phoneIcon: cupertino.CupertinoIcons.lab_flask,
-                  value: labsSettings.enableNext2DanmakuKernel,
-                  onChanged: labsSettings.setEnableNext2DanmakuKernel,
-                ),
                 if (PlayerFactory.isErikaKernelSupported)
                   AdaptiveSettingsTile.toggle(
                     title: _text(
@@ -75,24 +57,6 @@ class LabsSettingsContent extends StatelessWidget {
                     value: labsSettings.enableErikaPlayerKernel,
                     onChanged: labsSettings.setEnableErikaPlayerKernel,
                   ),
-                AdaptiveSettingsTile.toggle(
-                  title: _text(
-                    context,
-                    'Next++ 激进优化引擎',
-                    'Next++ 激進最佳化引擎',
-                    'Next++ Aggressive Engine',
-                  ),
-                  subtitle: _text(
-                    context,
-                    '激进优化，推荐。关闭则回退至 Next 原始引擎路径',
-                    '激進最佳化，推薦。關閉則回退至 Next 原始引擎路徑',
-                    'Recommended aggressive optimization. Disable to use the original Next engine path.',
-                  ),
-                  icon: Ionicons.rocket_outline,
-                  phoneIcon: cupertino.CupertinoIcons.bolt,
-                  value: labsSettings.enableNextPlusPlusEngine,
-                  onChanged: labsSettings.setEnableNextPlusPlusEngine,
-                ),
                 AdaptiveSettingsTile.button(
                   title: _text(
                     context,

--- a/lib/utils/player_kernel_manager.dart
+++ b/lib/utils/player_kernel_manager.dart
@@ -119,6 +119,7 @@ class PlayerKernelManager {
     }
 
     // 通知UI刷新，以便DanmakuOverlay可以重建
+    // ignore: invalid_use_of_protected_member, invalid_use_of_visible_for_testing_member
     videoPlayerState.notifyListeners();
   }
 
@@ -198,9 +199,15 @@ class PlayerKernelManager {
 
   /// 获取支持的弹幕内核列表
   static List<String> getSupportedDanmakuKernels() {
-    final kernels = <String>['Canvas 弹幕', 'GPU渲染', 'CPU渲染', DanmakuKernelFactory.nipaplayNextDisplayName];
+    final kernels = <String>[
+      'Canvas 弹幕',
+      'GPU渲染',
+      'CPU渲染',
+      DanmakuKernelFactory.nipaplayNextDisplayName,
+    ];
     if (Next2PlatformSupport.isKernelSupported) {
       kernels.add('NipaPlay Next2');
+      kernels.add('DFM+');
     }
     return kernels;
   }
@@ -208,7 +215,10 @@ class PlayerKernelManager {
   /// 获取当前弹幕内核
   static Future<String> getCurrentDanmakuKernel() async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getString('danmaku_kernel') ?? 'Canvas 弹幕';
+    return prefs.getString('danmaku_kernel') ??
+        (Next2PlatformSupport.isKernelSupported
+            ? 'NipaPlay Next2'
+            : 'NipaPlay Next');
   }
 
   /// 设置弹幕内核
@@ -234,6 +244,10 @@ class PlayerKernelManager {
       case 'NipaPlay Next2 (实验性)':
         engine = DanmakuRenderEngine.next2;
         break;
+      case 'DFM+':
+      case 'DFM+ (实验性)':
+        engine = DanmakuRenderEngine.dfmPlus;
+        break;
       case 'Canvas弹幕':
       case 'Canvas 弹幕':
         engine = DanmakuRenderEngine.canvas;
@@ -242,7 +256,8 @@ class PlayerKernelManager {
         engine = DanmakuRenderEngine.canvas;
     }
 
-    if (engine == DanmakuRenderEngine.next2 &&
+    if ((engine == DanmakuRenderEngine.next2 ||
+            engine == DanmakuRenderEngine.dfmPlus) &&
         !Next2PlatformSupport.isKernelSupported) {
       engine = DanmakuRenderEngine.canvas;
     }
@@ -268,8 +283,6 @@ class PlayerKernelManager {
       case PlayerKernelType.erika:
         playerKernelName = 'Erika';
         break;
-      default:
-        playerKernelName = 'Unknown';
     }
 
     return {

--- a/lib/widgets/danmaku_overlay.dart
+++ b/lib/widgets/danmaku_overlay.dart
@@ -11,7 +11,6 @@ import 'package:nipaplay/danmaku_next/next2_platform_support.dart';
 import 'package:nipaplay/danmaku_dfm/dfm_plus_overlay.dart';
 import 'package:provider/provider.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
-import 'package:nipaplay/providers/labs_settings_provider.dart';
 import '../danmaku_abstraction/danmaku_kernel_factory.dart';
 
 class DanmakuOverlay extends StatefulWidget {
@@ -131,10 +130,9 @@ class _DanmakuOverlayState extends State<DanmakuOverlay> {
         }
 
         if (kernelType == DanmakuRenderEngine.nipaplayNext) {
-          final labsSettings = context.watch<LabsSettingsProvider>();
           // Next++ ON → NipaPlayNextOverlay (C++ FFI V2 + atlas + vsync + Emoji bypass)
           // Next++ OFF → NipaPlayNextOldOverlay (d6592232版 C++ FFI + TextPainter逐条 + playbackTimeMs驱动)
-          if (labsSettings.enableNextPlusPlusEngine) {
+          if (DanmakuKernelFactory.isNextPlusPlusEnabled) {
             return NipaPlayNextOverlay(
               danmakuList: activeDanmakuList,
               playbackTimeMs: videoState.playbackTimeMs,


### PR DESCRIPTION
## Summary
- Remove the Labs toggles for exposing Next2/DFM+ and the Next++ aggressive engine.
- Show Next2 and DFM+ directly in danmaku renderer menus when the platform supports them.
- Move the Next++ toggle into Danmaku Settings when the NipaPlay Next renderer is selected.
- Default the danmaku renderer to Next2 on supported native platforms, falling back to NipaPlay Next where Next2 is unsupported.

## Validation
- `dart format` on changed Dart files
- `git diff --check`
- `flutter analyze lib/constants/settings_keys.dart lib/danmaku_abstraction/danmaku_kernel_factory.dart lib/providers/labs_settings_provider.dart lib/settings/pages/danmaku_settings_content.dart lib/settings/pages/labs_settings_content.dart lib/utils/player_kernel_manager.dart lib/widgets/danmaku_overlay.dart`

Note: full `flutter analyze` still reports existing issues from build artifacts and third-party/upstream directories unrelated to this PR.