### PR TITLE
feat:file name display

### DIFF
--- a/lib/pages/dashboard_home_page.dart
+++ b/lib/pages/dashboard_home_page.dart
@@ -57,6 +57,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:nipaplay/services/server_history_sync_service.dart';
 import 'package:nipaplay/models/shared_remote_library.dart';
+import 'package:nipaplay/providers/shared_remote_library_provider.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/themed_anime_detail.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_home_scope.dart';
 import 'package:nipaplay/utils/watch_history_auto_match_helper.dart';

--- a/lib/providers/appearance_settings_provider.dart
+++ b/lib/providers/appearance_settings_provider.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/painting.dart' show TextOverflow;
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
@@ -21,6 +22,12 @@ enum NipaplayWindowDisplayMode {
   filledScreen, // 铺满屏幕（保留少量边距）
 }
 
+// 定义媒体库管理中目录名称的显示模式
+enum FolderNameDisplayMode {
+  ellipsis, // 省略号截断（默认，当前机制）
+  multiline, // 多行完整显示
+}
+
 class AppearanceSettingsProvider extends ChangeNotifier {
   static const String _widgetBlurEffectKey = 'enable_widget_blur_effect';
   static const String _animeCardActionKey = 'anime_card_action';
@@ -30,6 +37,7 @@ class AppearanceSettingsProvider extends ChangeNotifier {
   static const String _showAnimeCardSummaryKey = 'show_anime_card_summary';
   static const String _windowDisplayModeKey = 'nipaplay_window_display_mode';
   static const String _accentColorPresetKey = 'app_accent_color_preset';
+  static const String _folderNameDisplayModeKey = 'folder_name_display_mode';
 
   static const double uiScaleMin = 1.0;
   static const double uiScaleMax = 1.3;
@@ -44,6 +52,7 @@ class AppearanceSettingsProvider extends ChangeNotifier {
   late bool _showAnimeCardSummary;
   late NipaplayWindowDisplayMode _windowDisplayMode;
   late AppAccentColorPreset _accentColorPreset;
+  late FolderNameDisplayMode _folderNameDisplayMode;
 
   // 获取设置值
   // 页面滑动动画始终启用
@@ -57,6 +66,17 @@ class AppearanceSettingsProvider extends ChangeNotifier {
   bool get showAnimeCardSummary => _showAnimeCardSummary;
   NipaplayWindowDisplayMode get windowDisplayMode => _windowDisplayMode;
   AppAccentColorPreset get accentColorPreset => _accentColorPreset;
+  FolderNameDisplayMode get folderNameDisplayMode => _folderNameDisplayMode;
+
+  /// 目录名称最大行数：省略号模式为 1，多行模式为 null（不限制，完整显示）
+  int? get folderNameMaxLines =>
+      _folderNameDisplayMode == FolderNameDisplayMode.ellipsis ? 1 : null;
+
+  /// 目录名称溢出处理：省略号模式为 ellipsis，多行模式为 visible
+  TextOverflow get folderNameOverflow =>
+      _folderNameDisplayMode == FolderNameDisplayMode.ellipsis
+          ? TextOverflow.ellipsis
+          : TextOverflow.visible;
 
   // 构造函数
   AppearanceSettingsProvider() {
@@ -68,6 +88,7 @@ class AppearanceSettingsProvider extends ChangeNotifier {
     _showAnimeCardSummary = true; // 默认显示番剧卡片简介
     _windowDisplayMode = _resolveDefaultWindowDisplayMode();
     _accentColorPreset = AppAccentColorPreset.rose;
+    _folderNameDisplayMode = FolderNameDisplayMode.ellipsis;
     AppAccentColors.setCurrent(_accentColorPreset);
     _loadSettings();
   }
@@ -96,6 +117,17 @@ class AppearanceSettingsProvider extends ChangeNotifier {
         prefs.getString(_accentColorPresetKey),
       );
       AppAccentColors.setCurrent(_accentColorPreset);
+
+      // 加载目录名称显示模式
+      final folderNameModeIndex = prefs.getInt(_folderNameDisplayModeKey);
+      if (folderNameModeIndex != null &&
+          folderNameModeIndex >= 0 &&
+          folderNameModeIndex < FolderNameDisplayMode.values.length) {
+        _folderNameDisplayMode =
+            FolderNameDisplayMode.values[folderNameModeIndex];
+      } else {
+        _folderNameDisplayMode = FolderNameDisplayMode.ellipsis;
+      }
       final savedUiScale = prefs.getDouble(_uiScaleKey);
       _uiScale = (savedUiScale ?? _resolveDefaultUiScale())
           .clamp(uiScaleMin, uiScaleMax)
@@ -243,6 +275,21 @@ class AppearanceSettingsProvider extends ChangeNotifier {
       await prefs.setString(_accentColorPresetKey, value.storageKey);
     } catch (e) {
       debugPrint('保存主题色设置时出错: $e');
+    }
+  }
+
+  // 设置目录名称显示模式
+  Future<void> setFolderNameDisplayMode(FolderNameDisplayMode value) async {
+    if (_folderNameDisplayMode == value) return;
+
+    _folderNameDisplayMode = value;
+    notifyListeners();
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(_folderNameDisplayModeKey, value.index);
+    } catch (e) {
+      debugPrint('保存目录名称显示模式设置时出错: $e');
     }
   }
 }

--- a/lib/settings/pages/appearance_settings_content.dart
+++ b/lib/settings/pages/appearance_settings_content.dart
@@ -268,66 +268,68 @@ class _AppearanceSettingsContentState extends State<AppearanceSettingsContent> {
       const SizedBox(height: 16),
       AdaptiveSettingsSection(
         children: [
-          AdaptiveSettingsTile<AnimeDetailDisplayMode>.dropdown(
-            title: context.l10n.appearanceAnimeDetailStyle,
-            subtitle: _text(
-              context,
-              '选择番剧详情页展示方式',
-              '選擇番劇詳情頁展示方式',
-              'Choose the anime detail page layout.',
+          if (globals.isPhone) ...[
+            AdaptiveSettingsTile<AnimeDetailDisplayMode>.dropdown(
+              title: context.l10n.appearanceAnimeDetailStyle,
+              subtitle: _text(
+                context,
+                '选择番剧详情页展示方式',
+                '選擇番劇詳情頁展示方式',
+                'Choose the anime detail page layout.',
+              ),
+              icon: Ionicons.albums_outline,
+              phoneIcon: cupertino.CupertinoIcons.rectangle_on_rectangle,
+              items: [
+                DropdownMenuItemData(
+                  title: context.l10n.appearanceDetailSimple,
+                  value: AnimeDetailDisplayMode.simple,
+                  isSelected: themeNotifier.animeDetailDisplayMode ==
+                      AnimeDetailDisplayMode.simple,
+                  description: context.l10n.appearanceDetailSimpleSubtitle,
+                ),
+                DropdownMenuItemData(
+                  title: context.l10n.appearanceDetailVivid,
+                  value: AnimeDetailDisplayMode.vivid,
+                  isSelected: themeNotifier.animeDetailDisplayMode ==
+                      AnimeDetailDisplayMode.vivid,
+                  description: context.l10n.appearanceDetailVividSubtitle,
+                ),
+              ],
+              onChanged: (mode) {
+                themeNotifier.animeDetailDisplayMode = mode;
+              },
+              dropdownKey: _detailModeDropdownKey,
             ),
-            icon: Ionicons.albums_outline,
-            phoneIcon: cupertino.CupertinoIcons.rectangle_on_rectangle,
-            items: [
-              DropdownMenuItemData(
-                title: context.l10n.appearanceDetailSimple,
-                value: AnimeDetailDisplayMode.simple,
-                isSelected: themeNotifier.animeDetailDisplayMode ==
-                    AnimeDetailDisplayMode.simple,
-                description: context.l10n.appearanceDetailSimpleSubtitle,
+            AdaptiveSettingsTile<RecentWatchingStyle>.dropdown(
+              title: context.l10n.appearanceRecentWatchingStyle,
+              subtitle: _text(
+                context,
+                '选择最近观看区域的展示方式',
+                '選擇最近觀看區域的展示方式',
+                'Choose how recently watched items are shown.',
               ),
-              DropdownMenuItemData(
-                title: context.l10n.appearanceDetailVivid,
-                value: AnimeDetailDisplayMode.vivid,
-                isSelected: themeNotifier.animeDetailDisplayMode ==
-                    AnimeDetailDisplayMode.vivid,
-                description: context.l10n.appearanceDetailVividSubtitle,
-              ),
-            ],
-            onChanged: (mode) {
-              themeNotifier.animeDetailDisplayMode = mode;
-            },
-            dropdownKey: _detailModeDropdownKey,
-          ),
-          AdaptiveSettingsTile<RecentWatchingStyle>.dropdown(
-            title: context.l10n.appearanceRecentWatchingStyle,
-            subtitle: _text(
-              context,
-              '选择最近观看区域的展示方式',
-              '選擇最近觀看區域的展示方式',
-              'Choose how recently watched items are shown.',
+              icon: Ionicons.time_outline,
+              phoneIcon: cupertino.CupertinoIcons.clock,
+              items: [
+                DropdownMenuItemData(
+                  title: context.l10n.appearanceRecentSimple,
+                  value: RecentWatchingStyle.simple,
+                  isSelected: appearanceSettings.recentWatchingStyle ==
+                      RecentWatchingStyle.simple,
+                  description: context.l10n.appearanceRecentSimpleSubtitle,
+                ),
+                DropdownMenuItemData(
+                  title: context.l10n.appearanceRecentDetailed,
+                  value: RecentWatchingStyle.detailed,
+                  isSelected: appearanceSettings.recentWatchingStyle ==
+                      RecentWatchingStyle.detailed,
+                  description: context.l10n.appearanceRecentDetailedSubtitle,
+                ),
+              ],
+              onChanged: appearanceSettings.setRecentWatchingStyle,
+              dropdownKey: _recentStyleDropdownKey,
             ),
-            icon: Ionicons.time_outline,
-            phoneIcon: cupertino.CupertinoIcons.clock,
-            items: [
-              DropdownMenuItemData(
-                title: context.l10n.appearanceRecentSimple,
-                value: RecentWatchingStyle.simple,
-                isSelected: appearanceSettings.recentWatchingStyle ==
-                    RecentWatchingStyle.simple,
-                description: context.l10n.appearanceRecentSimpleSubtitle,
-              ),
-              DropdownMenuItemData(
-                title: context.l10n.appearanceRecentDetailed,
-                value: RecentWatchingStyle.detailed,
-                isSelected: appearanceSettings.recentWatchingStyle ==
-                    RecentWatchingStyle.detailed,
-                description: context.l10n.appearanceRecentDetailedSubtitle,
-              ),
-            ],
-            onChanged: appearanceSettings.setRecentWatchingStyle,
-            dropdownKey: _recentStyleDropdownKey,
-          ),
+          ],
           AdaptiveSettingsTile<bool>.toggle(
             title: _text(
               context,

--- a/lib/settings/pages/appearance_settings_content.dart
+++ b/lib/settings/pages/appearance_settings_content.dart
@@ -40,6 +40,7 @@ class _AppearanceSettingsContentState extends State<AppearanceSettingsContent> {
   final GlobalKey _backgroundImageDropdownKey = GlobalKey();
   final GlobalKey _blurDropdownKey = GlobalKey();
   final GlobalKey _backgroundRenderModeDropdownKey = GlobalKey();
+  final GlobalKey _folderNameDisplayModeDropdownKey = GlobalKey();
 
   static const List<AdaptiveSettingsColorOption<int>>
       _playerControlColorOptions = [
@@ -344,6 +345,43 @@ class _AppearanceSettingsContentState extends State<AppearanceSettingsContent> {
             phoneIcon: cupertino.CupertinoIcons.doc_text,
             value: appearanceSettings.showAnimeCardSummary,
             onChanged: appearanceSettings.setShowAnimeCardSummary,
+          ),
+        ],
+      ),
+      const SizedBox(height: 16),
+      AdaptiveSettingsSection(
+        children: [
+          AdaptiveSettingsTile<FolderNameDisplayMode>.dropdown(
+            title: _text(
+              context,
+              '目录名称显示模式',
+              '目錄名稱顯示模式',
+              'Folder Name Display',
+            ),
+            subtitle: _text(
+              context,
+              '设置媒体库管理中过长目录名的显示方式',
+              '設定媒體庫管理中過長目錄名的顯示方式',
+              'Choose how long folder names are shown in library management.',
+            ),
+            icon: Ionicons.folder_outline,
+            phoneIcon: cupertino.CupertinoIcons.folder,
+            items: [
+              DropdownMenuItemData(
+                title: _text(context, '省略号截断', '省略號截斷', 'Ellipsis'),
+                value: FolderNameDisplayMode.ellipsis,
+                isSelected: appearanceSettings.folderNameDisplayMode ==
+                    FolderNameDisplayMode.ellipsis,
+              ),
+              DropdownMenuItemData(
+                title: _text(context, '多行显示', '多行顯示', 'Multiline'),
+                value: FolderNameDisplayMode.multiline,
+                isSelected: appearanceSettings.folderNameDisplayMode ==
+                    FolderNameDisplayMode.multiline,
+              ),
+            ],
+            onChanged: appearanceSettings.setFolderNameDisplayMode,
+            dropdownKey: _folderNameDisplayModeDropdownKey,
           ),
         ],
       ),

--- a/lib/themes/cupertino/pages/cupertino_home_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_home_page.dart
@@ -266,11 +266,10 @@ class _CupertinoHomePageState extends State<CupertinoHomePage> {
 
       final historyProvider = _watchHistoryProvider;
       if (historyProvider != null && historyProvider.isLoaded) {
+        // 本地 + WebDAV + SMB 观看记录（详情页已支持这些路径播放）
         final localHistory = historyProvider.history.where((item) {
           return !item.filePath.startsWith('jellyfin://') &&
               !item.filePath.startsWith('emby://') &&
-              !MediaSourceUtils.isSmbPath(item.filePath) &&
-              !MediaSourceUtils.isWebDavPath(item.filePath) &&
               !item.isDandanplayRemote;
         }).toList();
 
@@ -294,6 +293,20 @@ class _CupertinoHomePageState extends State<CupertinoHomePage> {
         final groups =
             List<DandanplayRemoteAnimeGroup>.from(dandanProvider.animeGroups);
         allCandidates.addAll(groups.take(20));
+      }
+
+      // 从远程共享库（NipaPlay Server）收集候选项目
+      SharedRemoteLibraryProvider? sharedRemoteProvider;
+      try {
+        sharedRemoteProvider = context.read<SharedRemoteLibraryProvider>();
+      } catch (_) {}
+      if (sharedRemoteProvider != null &&
+          sharedRemoteProvider.animeSummaries.isNotEmpty) {
+        final summaries =
+            List<SharedRemoteAnimeSummary>.from(
+                sharedRemoteProvider.animeSummaries);
+        summaries.shuffle(math.Random());
+        allCandidates.addAll(summaries.take(20));
       }
 
       if (allCandidates.isEmpty) {
@@ -413,6 +426,24 @@ class _CupertinoHomePageState extends State<CupertinoHomePage> {
             mediaServerItemId: null,
             mediaServerType: null,
             dandanGroup: candidate,
+          );
+        } else if (candidate is SharedRemoteAnimeSummary) {
+          final title = (candidate.nameCn?.isNotEmpty == true)
+              ? candidate.nameCn!
+              : candidate.name;
+          built = _CupertinoRecommendedItem(
+            id: 'shared_${candidate.animeId}',
+            title: title,
+            subtitle: (candidate.summary?.isNotEmpty == true)
+                ? candidate.summary!
+                : '远程共享媒体',
+            imageUrl: candidate.imageUrl,
+            source: _CupertinoRecommendedSource.sharedRemote,
+            rating: null,
+            animeId: candidate.animeId,
+            episodeCount: candidate.episodeCount,
+            mediaServerItemId: null,
+            mediaServerType: null,
           );
         }
 
@@ -2907,6 +2938,8 @@ class _CupertinoHomePageState extends State<CupertinoHomePage> {
         return '本地媒体';
       case _CupertinoRecommendedSource.dandanplay:
         return '弹弹play';
+      case _CupertinoRecommendedSource.sharedRemote:
+        return '共享库';
       case _CupertinoRecommendedSource.placeholder:
         return '';
     }
@@ -2922,6 +2955,8 @@ class _CupertinoHomePageState extends State<CupertinoHomePage> {
         return CupertinoIcons.tray_full;
       case _CupertinoRecommendedSource.dandanplay:
         return CupertinoIcons.chat_bubble_2_fill;
+      case _CupertinoRecommendedSource.sharedRemote:
+        return CupertinoIcons.cloud_fill;
       case _CupertinoRecommendedSource.placeholder:
         return CupertinoIcons.sparkles;
     }
@@ -3124,5 +3159,6 @@ enum _CupertinoRecommendedSource {
   emby,
   local,
   dandanplay,
+  sharedRemote,
   placeholder,
 }

--- a/lib/themes/cupertino/pages/cupertino_media_library_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_media_library_page.dart
@@ -12,6 +12,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
+import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'package:nipaplay/services/jellyfin_service.dart';
 import 'package:nipaplay/services/emby_service.dart';
 
@@ -3333,8 +3334,13 @@ class _CupertinoLibraryManagementSheetState
       context,
     );
 
+    final appearance = context.watch<AppearanceSettingsProvider>();
     return CupertinoListTile(
-      title: Text(p.basename(folderPath)),
+      title: Text(
+        p.basename(folderPath),
+        maxLines: appearance.folderNameMaxLines,
+        overflow: appearance.folderNameOverflow,
+      ),
       subtitle: Text(
         folderPath,
         style: TextStyle(color: subtitleColor, fontSize: 12),
@@ -3605,6 +3611,7 @@ class _CupertinoLibraryManagementSheetState
       final name = p.basename(dirPath);
       final isExpanded = _expandedLocalFolders.contains(dirPath);
       final isLoading = _loadingLocalFolders.contains(dirPath);
+      final appearance = context.watch<AppearanceSettingsProvider>();
       final labelColor =
           CupertinoDynamicColor.resolve(CupertinoColors.label, context);
       final subtitleColor = CupertinoDynamicColor.resolve(
@@ -3631,8 +3638,8 @@ class _CupertinoLibraryManagementSheetState
                   Expanded(
                     child: Text(
                       name,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+                      maxLines: appearance.folderNameMaxLines,
+                      overflow: appearance.folderNameOverflow,
                       style: TextStyle(
                         fontSize: 13,
                         color: labelColor,
@@ -6483,6 +6490,7 @@ class _SharedRemoteLibraryManagementContentState
         CupertinoDynamicColor.resolve(CupertinoColors.label, context);
     final secondaryLabelColor =
         CupertinoDynamicColor.resolve(CupertinoColors.secondaryLabel, context);
+    final appearance = context.watch<AppearanceSettingsProvider>();
 
     if (entries.isEmpty) {
       return [
@@ -6518,8 +6526,8 @@ class _SharedRemoteLibraryManagementContentState
                   Expanded(
                     child: Text(
                       entryName,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+                      maxLines: appearance.folderNameMaxLines,
+                      overflow: appearance.folderNameOverflow,
                       style: TextStyle(fontSize: 13, color: labelColor),
                     ),
                   ),

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_actions.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_actions.dart
@@ -38,6 +38,50 @@ extension DashboardHomePageActions on _DashboardHomePageState {
       } else {
         BlurSnackBar.show(context, '无法找到对应的弹弹play条目');
       }
+    } else if (item.source == RecommendedItemSource.sharedRemote) {
+      _onSharedRemoteRecommendedTap(item.id);
+    }
+  }
+
+  // 打开远程共享库（NipaPlay Server）推荐项的详情
+  Future<void> _onSharedRemoteRecommendedTap(String itemId) async {
+    final animeId = int.tryParse(itemId.replaceFirst('shared:', ''));
+    if (animeId == null) return;
+    SharedRemoteLibraryProvider? provider;
+    try {
+      provider =
+          Provider.of<SharedRemoteLibraryProvider>(context, listen: false);
+    } catch (_) {}
+    if (provider == null || provider.animeSummaries.isEmpty) {
+      if (!mounted) return;
+      BlurSnackBar.show(context, '未连接到远程共享库');
+      return;
+    }
+    final matches =
+        provider.animeSummaries.where((s) => s.animeId == animeId).toList();
+    if (matches.isEmpty) {
+      if (!mounted) return;
+      BlurSnackBar.show(context, '找不到该共享库番剧');
+      return;
+    }
+    final summary = matches.first;
+    final resolvedProvider = provider;
+    try {
+      await ThemedAnimeDetail.show(
+        context,
+        animeId,
+        sharedSummary: summary,
+        sharedEpisodeLoader: () =>
+            resolvedProvider.loadAnimeEpisodes(animeId, force: true),
+        sharedEpisodeBuilder: (episode) => resolvedProvider.buildPlayableItem(
+          anime: summary,
+          episode: episode,
+        ),
+        sharedSourceLabel: resolvedProvider.activeHost?.displayName,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      BlurSnackBar.show(context, '打开详情失败: $e');
     }
   }
 

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_build_hero.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_build_hero.dart
@@ -164,7 +164,7 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                   forceBlur: item.source != RecommendedItemSource.dandanplay
                       ? item.isLowRes
                       : false,
-                  lowResBlurSigma: 40,
+                  lowResBlurSigma: 3,
                   lowResMinScale: 0.8,
                   errorBuilder: (context, error) => Container(
                     color: Colors.white10,
@@ -425,7 +425,7 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
                   forceBlur: item.source != RecommendedItemSource.dandanplay
                       ? item.isLowRes
                       : false,
-                  lowResBlurSigma: 40,
+                  lowResBlurSigma: 3,
                   lowResMinScale: 0.8,
                   errorBuilder: (context, error) => Container(
                     color: Colors.white10,
@@ -643,6 +643,12 @@ extension DashboardHomePageHeroBuild on _DashboardHomePageState {
       case RecommendedItemSource.dandanplay:
         return Icon(
           Icons.cloud_outlined,
+          color: Colors.white,
+          size: size,
+        );
+      case RecommendedItemSource.sharedRemote:
+        return Icon(
+          Icons.cloud_done_outlined,
           color: Colors.white,
           size: size,
         );

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_data_loading.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_data_loading.dart
@@ -242,18 +242,16 @@ extension DashboardHomePageDataLoading on _DashboardHomePageState {
         }
       }
 
-      // 从本地媒体库收集候选项目
+      // 从本地媒体库收集候选项目（含 WebDAV/SMB 观看记录，详情页已支持这些路径播放）
       final watchHistoryProvider =
           Provider.of<WatchHistoryProvider>(context, listen: false);
       if (watchHistoryProvider.isLoaded) {
         try {
-          // 过滤掉Jellyfin和Emby的项目，只保留本地文件
+          // 本地 + WebDAV + SMB 的观看记录
           final localHistory = watchHistoryProvider.history
               .where((item) =>
                   !item.filePath.startsWith('jellyfin://') &&
                   !item.filePath.startsWith('emby://') &&
-                  !MediaSourceUtils.isSmbPath(item.filePath) &&
-                  !MediaSourceUtils.isWebDavPath(item.filePath) &&
                   !item.isDandanplayRemote)
               .toList();
 
@@ -301,6 +299,22 @@ extension DashboardHomePageDataLoading on _DashboardHomePageState {
           await _loadPersistedLocalImageUrls(dandanAnimeIds);
         }
         allCandidates.addAll(selectedGroups);
+      }
+
+      // 从远程共享库（NipaPlay Server）收集候选项目
+      SharedRemoteLibraryProvider? sharedRemoteProvider;
+      try {
+        sharedRemoteProvider =
+            Provider.of<SharedRemoteLibraryProvider>(context, listen: false);
+      } catch (_) {}
+      if (sharedRemoteProvider != null &&
+          sharedRemoteProvider.animeSummaries.isNotEmpty) {
+        final summaries = List<SharedRemoteAnimeSummary>.from(
+            sharedRemoteProvider.animeSummaries);
+        summaries.shuffle(math.Random());
+        final selectedSummaries =
+            summaries.take(math.min(30, summaries.length)).toList();
+        allCandidates.addAll(selectedSummaries);
       }
 
       // 第二步：从所有候选中随机选择7个（去重）
@@ -512,6 +526,25 @@ extension DashboardHomePageDataLoading on _DashboardHomePageState {
               isLowRes:
                   coverUrl != null ? !_looksHighQualityUrl(coverUrl) : false,
             );
+          } else if (item is SharedRemoteAnimeSummary) {
+            final title = (item.nameCn?.isNotEmpty == true)
+                ? item.nameCn!
+                : item.name;
+            final subtitle = (item.summary?.isNotEmpty == true)
+                ? item.summary!
+                : '远程共享媒体';
+            final coverUrl = _normalizeRecommendationImageUrl(item.imageUrl);
+            return RecommendedItem(
+              id: 'shared:${item.animeId}',
+              title: title,
+              subtitle: subtitle,
+              backgroundImageUrl: coverUrl,
+              logoImageUrl: null,
+              source: RecommendedItemSource.sharedRemote,
+              rating: null,
+              isLowRes:
+                  coverUrl != null ? !_looksHighQualityUrl(coverUrl) : false,
+            );
           }
         } catch (_) {
           return null;
@@ -704,6 +737,10 @@ extension DashboardHomePageDataLoading on _DashboardHomePageState {
         keys.add('anime:${candidate.animeId}');
       }
       _addTitleKey(keys, candidate.title);
+    } else if (candidate is SharedRemoteAnimeSummary) {
+      keys.add('anime:${candidate.animeId}');
+      _addTitleKey(keys, candidate.nameCn);
+      _addTitleKey(keys, candidate.name);
     }
 
     if (keys.length <= 1) return keys;

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_models.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_models.dart
@@ -47,6 +47,7 @@ enum RecommendedItemSource {
   emby,
   local,
   dandanplay,
+  sharedRemote,
   placeholder,
 }
 

--- a/lib/themes/nipaplay/widgets/large_screen_page_scaffold.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_page_scaffold.dart
@@ -140,11 +140,19 @@ class NipaplayLargeScreenSectionHeader extends StatelessWidget {
     required this.title,
     this.subtitle,
     this.trailing,
+    this.titleMaxLines = 1,
+    this.titleOverflow = TextOverflow.ellipsis,
   });
 
   final String title;
   final String? subtitle;
   final Widget? trailing;
+
+  /// 标题最大行数，默认 1（省略号截断）；传入 null 可多行完整显示
+  final int? titleMaxLines;
+
+  /// 标题溢出处理，默认省略号截断
+  final TextOverflow titleOverflow;
 
   @override
   Widget build(BuildContext context) {
@@ -159,8 +167,8 @@ class NipaplayLargeScreenSectionHeader extends StatelessWidget {
             children: [
               Text(
                 title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
+                maxLines: titleMaxLines,
+                overflow: titleOverflow,
                 style: TextStyle(
                   color: textColor,
                   fontSize: 22,

--- a/lib/themes/nipaplay/widgets/library_management_layout.dart
+++ b/lib/themes/nipaplay/widgets/library_management_layout.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'package:nipaplay/utils/globals.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
+import 'package:provider/provider.dart';
 
 const double _libraryManagementTreeBaseIndent = 12.0;
 const double _libraryManagementTreeIndentStep = 16.0;
@@ -211,6 +213,8 @@ class LibraryManagementFolderRow extends StatelessWidget {
     final Color resolvedSecondaryTextColor =
         secondaryTextColor ?? (isDark ? Colors.white70 : Colors.black54);
     final Color resolvedIconColor = iconColor ?? resolvedSecondaryTextColor;
+    // 根据外观设置决定目录名是省略号截断还是多行完整显示
+    final appearance = context.watch<AppearanceSettingsProvider>();
 
     return Padding(
       padding: const EdgeInsets.only(top: 2),
@@ -222,8 +226,8 @@ class LibraryManagementFolderRow extends StatelessWidget {
           title,
           locale: locale,
           style: TextStyle(color: resolvedTextColor, fontSize: 13),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
+          maxLines: appearance.folderNameMaxLines,
+          overflow: appearance.folderNameOverflow,
         ),
         trailing: loading
             ? SizedBox(

--- a/lib/themes/nipaplay/widgets/library_management_tab.dart
+++ b/lib/themes/nipaplay/widgets/library_management_tab.dart
@@ -2501,6 +2501,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
       future: _getDisplayPath(folderPath),
       builder: (context, snapshot) {
         final displayPath = snapshot.data ?? folderPath;
+        final appearance = context.read<AppearanceSettingsProvider>();
         return NipaplayLargeScreenFocusableAction(
           autofocus: autofocus,
           onActivate: () {
@@ -2529,8 +2530,8 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
                   Expanded(
                     child: Text(
                       p.basename(folderPath),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+                      maxLines: appearance.folderNameMaxLines,
+                      overflow: appearance.folderNameOverflow,
                       style: TextStyle(
                         color: textColor,
                         fontSize: 17,
@@ -2585,6 +2586,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
     String folderPath,
     ScanService scanService,
   ) {
+    final appearance = context.read<AppearanceSettingsProvider>();
     final isLoading = _loadingFolders.contains(folderPath);
     final files = _expandedFolderContents[folderPath] ?? const [];
     if (!isLoading && !_expandedFolderContents.containsKey(folderPath)) {
@@ -2599,6 +2601,8 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
           NipaplayLargeScreenSectionHeader(
             title: p.basename(folderPath),
             subtitle: folderPath,
+            titleMaxLines: appearance.folderNameMaxLines,
+            titleOverflow: appearance.folderNameOverflow,
             trailing: NipaplayLargeScreenActionButton(
               icon: Icons.refresh_rounded,
               label: '扫描',
@@ -3640,6 +3644,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
       future: _getDisplayPath(folderPath),
       builder: (context, snapshot) {
         final displayPath = snapshot.data ?? folderPath;
+        final appearance = context.read<AppearanceSettingsProvider>();
 
         return LibraryManagementCard(
           child: Theme(
@@ -3660,7 +3665,8 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
                     child: Text(
                       p.basename(folderPath),
                       style: TextStyle(color: textColor, fontSize: 16),
-                      overflow: TextOverflow.ellipsis,
+                      maxLines: appearance.folderNameMaxLines,
+                      overflow: appearance.folderNameOverflow,
                     ),
                   ),
                 ],


### PR DESCRIPTION
## Summary

- 在 设置-外观 中新增“**目录名称显示模式**”，可自选媒体库管理当中的目录名称为**省略号截断**还是**多行完整显示**
- 扩展了首页滚动推荐海报的数据来源（现已支持 WebDAV/SMB/共享媒体库），降低模糊遮罩的不透明度，提升观感质量
- 在 NipaplayUI 隐藏了“番剧详情样式”和“最近观看”两个暂不支持的设置项
