### PR TITLE
Polish player menus and progress thumb

### DIFF
--- a/lib/themes/nipaplay/widgets/video_progress_bar.dart
+++ b/lib/themes/nipaplay/widgets/video_progress_bar.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/physics.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/player_menu_theme.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/player_overlay_surface.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
@@ -44,14 +45,16 @@ class VideoProgressBar extends StatefulWidget {
   State<VideoProgressBar> createState() => _VideoProgressBarState();
 }
 
-class _VideoProgressBarState extends State<VideoProgressBar> {
+class _VideoProgressBarState extends State<VideoProgressBar>
+    with TickerProviderStateMixin {
   final GlobalKey _sliderKey = GlobalKey();
   Duration? _localHoverTime;
   bool _isHovering = false;
   bool _isThumbHovered = false;
   OverlayEntry? _overlayEntry;
-  DateTime? _lastSeekTime;
   Timer? _previewDebounceTimer;
+  late final AnimationController _thumbHoverController;
+  late final AnimationController _thumbDeformController;
 
   /// 当前 hover/tap 命中的章节分割线索引（-1=未命中任何分割线）。
   /// 用于 _ChapterTickMarks 高亮放大该分割线。
@@ -59,12 +62,40 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
 
   /// 章节分割线命中容差（像素）。点击/悬停在该像素范围内才触发章节跳转。
   static const double _chapterTickHitTolerance = 8.0;
+  static const SpringDescription _dragThumbSpring = SpringDescription(
+    mass: 1,
+    stiffness: 620,
+    damping: 22,
+  );
+  static const SpringDescription _releaseThumbSpring = SpringDescription(
+    mass: 1,
+    stiffness: 360,
+    damping: 7.2,
+  );
   String? _hoverThumbnailPath;
   int? _hoverBucket;
+  Offset? _lastDragLocalPosition;
+  DateTime? _lastDragUpdateTime;
+
+  Size get _thumbBaseSize =>
+      globals.isPhone ? const Size(34.0, 20.0) : const Size(28.0, 16.0);
+
+  @override
+  void initState() {
+    super.initState();
+    _thumbHoverController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 160),
+      reverseDuration: const Duration(milliseconds: 140),
+    );
+    _thumbDeformController = AnimationController.unbounded(vsync: this);
+  }
 
   @override
   void dispose() {
     _previewDebounceTimer?.cancel();
+    _thumbHoverController.dispose();
+    _thumbDeformController.dispose();
     _removeOverlay();
     super.dispose();
   }
@@ -125,7 +156,7 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
                               ClipRRect(
                                 borderRadius: BorderRadius.circular(6),
                                 child: _buildPreviewImage(
-                                  thumbnailPath!,
+                                  thumbnailPath,
                                   previewWidth,
                                   previewHeight,
                                 ),
@@ -193,25 +224,23 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
 
           final progressRect =
               Rect.fromLTWH(0, 0, width, sliderBox.size.height);
-          final thumbSize = globals.isPhone ? 20.0 : 12.0;
-          final thumbSizeHovered = globals.isPhone ? 24.0 : 16.0;
-          final currentThumbSize =
-              _isThumbHovered ? thumbSizeHovered : thumbSize;
-          final halfThumbSize = currentThumbSize / 2;
+          final trackHeight = globals.isPhone ? 6.0 : 4.0;
           final baseVerticalMargin = globals.isPhone ? 24.0 : 20.0;
           final hitPadding = globals.isPhone ? 12.0 : 8.0;
           final verticalMargin = baseVerticalMargin + hitPadding;
-          final trackHeight = globals.isPhone ? 6.0 : 4.0;
-          final thumbRect = Rect.fromLTWH(
-              (widget.videoState.progress * width) - halfThumbSize,
-              verticalMargin + (trackHeight / 2) - halfThumbSize,
-              currentThumbSize,
-              currentThumbSize);
+          final thumbProgress =
+              widget.videoState.progress.clamp(0.0, 1.0).toDouble();
+          final thumbRect = _thumbHitRect(
+            progress: thumbProgress,
+            trackWidth: width,
+            verticalMargin: verticalMargin,
+            trackHeight: trackHeight,
+          );
 
           // 章节分割线 hover 命中检测：命中则高亮放大该分割线，鼠标变 pointer
           final hitTick = _hitTestChapterTick(localPosition.dx, width);
+          _setThumbHovered(thumbRect.contains(localPosition));
           setState(() {
-            _isThumbHovered = thumbRect.contains(localPosition);
             _hitChapterTickIndex = hitTick;
           });
 
@@ -239,9 +268,9 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
         }
       },
       onExit: (_) {
+        _setThumbHovered(false);
         setState(() {
           _isHovering = false;
-          _isThumbHovered = false;
           _localHoverTime = null;
           _hitChapterTickIndex = -1;
         });
@@ -253,7 +282,7 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onHorizontalDragStart: (details) {
-          widget.onDraggingStateChange(true);
+          _beginThumbPress(details.localPosition, deformTarget: 0.62);
           _updateProgressFromPosition(details.localPosition);
           _showOverlay(
             context,
@@ -262,6 +291,7 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
           );
         },
         onHorizontalDragUpdate: (details) {
+          _updateThumbDragEffect(details.localPosition);
           _updateProgressFromPosition(details.localPosition);
           if (_overlayEntry != null) {
             _showOverlay(
@@ -271,32 +301,43 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
             );
           }
         },
-        onHorizontalDragEnd: (details) {
+        onHorizontalDragEnd: (_) {
+          if (_lastDragLocalPosition != null) {
+            _updateProgressFromPosition(_lastDragLocalPosition!);
+          }
           widget.onDraggingStateChange(false);
-          _updateProgressFromPosition(details.localPosition);
           widget.onPositionUpdate(Offset.zero);
+          _endThumbPress();
+          _removeOverlay();
+        },
+        onHorizontalDragCancel: () {
+          widget.onDraggingStateChange(false);
+          widget.onPositionUpdate(Offset.zero);
+          _endThumbPress();
           _removeOverlay();
         },
         onTapDown: (details) {
-          widget.onDraggingStateChange(true);
-          // isTapGesture: true → 命中章节分割线走 seekToChapter（keyframe 对齐）。
-          // drag 手势（onHorizontalDrag*）默认 false，始终走精确 seekTo，避免
-          // 在章节边界 ±8px 内拖拽被章节跳转劫持。
-          _updateProgressFromPosition(details.localPosition,
-              isTapGesture: true);
+          _beginThumbPress(details.localPosition, deformTarget: 0.34);
+          _updateProgressFromPosition(
+            details.localPosition,
+            isTapGesture: true,
+          );
           _showOverlay(
             context,
             widget.videoState.progress,
             displayTime: widget.videoState.position,
           );
         },
-        onTapUp: (details) {
+        onTapUp: (_) {
           widget.onDraggingStateChange(false);
-          // 不重复 seek：onTapDown 已完成定位（章节分割线命中跳转或普通 seek）。
-          // 若此处再次 _updateProgressFromPosition，tap down→up 间鼠标微动会
-          // 导致 up 时未命中分割线，普通 seekTo 覆盖 onTapDown 的章节跳转。
-          // drag 场景由 onHorizontalDragEnd 处理，不受影响。
           widget.onPositionUpdate(Offset.zero);
+          _endThumbPress();
+          _removeOverlay();
+        },
+        onTapCancel: () {
+          widget.onDraggingStateChange(false);
+          widget.onPositionUpdate(Offset.zero);
+          _endThumbPress();
           _removeOverlay();
         },
         child: LayoutBuilder(
@@ -329,227 +370,252 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
             final baseVerticalMargin = globals.isPhone ? 24.0 : 20.0;
             final hitPadding = globals.isPhone ? 12.0 : 8.0;
             final verticalMargin = baseVerticalMargin + hitPadding;
-            final thumbSize = globals.isPhone ? 20.0 : 12.0;
-            final thumbSizeHovered = globals.isPhone ? 24.0 : 16.0;
-            final currentThumbSize = _isThumbHovered || widget.isDragging
-                ? thumbSizeHovered
-                : thumbSize;
-            final halfThumbSize = currentThumbSize / 2;
             const trackBaseColor = Color.fromARGB(255, 160, 160, 160);
             const bufferTrackColor = Color.fromARGB(255, 225, 225, 225);
             const playedTrackColor = Color(0xFFFFFFFF);
-            return widget.isDragging
-                ? Stack(
-                    key: _sliderKey,
-                    clipBehavior: Clip.none,
-                    children: [
-                      // 背景轨道
-                      Padding(
-                        padding: EdgeInsets.symmetric(vertical: verticalMargin),
-                        child: Opacity(
-                          opacity: 0.3,
-                          child: ControlShadow(
-                            borderRadius:
-                                BorderRadius.circular(trackHeight / 2),
-                            child: Container(
-                              height: trackHeight,
-                              decoration: BoxDecoration(
-                                color: trackBaseColor,
-                                borderRadius:
-                                    BorderRadius.circular(trackHeight / 2),
-                              ),
-                            ),
-                          ),
+            final trackOpacity = widget.isDragging ? 0.3 : 0.5;
+
+            return Stack(
+              key: _sliderKey,
+              clipBehavior: Clip.none,
+              children: [
+                // 背景轨道
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: verticalMargin),
+                  child: Opacity(
+                    opacity: trackOpacity,
+                    child: ControlShadow(
+                      borderRadius: BorderRadius.circular(trackHeight / 2),
+                      child: Container(
+                        height: trackHeight,
+                        decoration: BoxDecoration(
+                          color: trackBaseColor,
+                          borderRadius: BorderRadius.circular(trackHeight / 2),
                         ),
                       ),
-                      // 章节标记 overlay（竖线标记 + 当前章节高亮段）
-                      // 公共方法 _buildChapterOverlayWidgets 消除两布局分支重复
-                      ..._buildChapterOverlayWidgets(
-                          verticalMargin, trackHeight),
-                      // 缓存轨道
-                      Positioned(
-                        left: 0,
-                        right: 0,
-                        top: verticalMargin,
-                        child: FractionallySizedBox(
-                          widthFactor: bufferProgress,
-                          alignment: Alignment.centerLeft,
-                          child: Opacity(
-                            opacity: 0.3,
-                            child: Container(
-                              height: trackHeight,
-                              decoration: BoxDecoration(
-                                color: bufferTrackColor,
-                                borderRadius:
-                                    BorderRadius.circular(trackHeight / 2),
-                              ),
-                            ),
-                          ),
+                    ),
+                  ),
+                ),
+                // 章节标记 overlay（竖线标记 + 当前章节高亮段）
+                // 公共方法 _buildChapterOverlayWidgets 消除两布局分支重复
+                ..._buildChapterOverlayWidgets(verticalMargin, trackHeight),
+                // 缓存轨道
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  top: verticalMargin,
+                  child: FractionallySizedBox(
+                    widthFactor: bufferProgress,
+                    alignment: Alignment.centerLeft,
+                    child: Opacity(
+                      opacity: trackOpacity,
+                      child: Container(
+                        height: trackHeight,
+                        decoration: BoxDecoration(
+                          color: bufferTrackColor,
+                          borderRadius: BorderRadius.circular(trackHeight / 2),
                         ),
                       ),
-                      // 进度轨道
-                      Positioned(
-                        left: 0,
-                        right: 0,
-                        top: verticalMargin,
-                        child: FractionallySizedBox(
-                          widthFactor: progress,
-                          alignment: Alignment.centerLeft,
-                          child: Container(
-                            height: trackHeight,
-                            decoration: BoxDecoration(
-                              color: playedTrackColor,
-                              borderRadius:
-                                  BorderRadius.circular(trackHeight / 2),
-                            ),
-                          ),
-                        ),
+                    ),
+                  ),
+                ),
+                // 进度轨道
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  top: verticalMargin,
+                  child: FractionallySizedBox(
+                    widthFactor: progress,
+                    alignment: Alignment.centerLeft,
+                    child: Container(
+                      height: trackHeight,
+                      decoration: BoxDecoration(
+                        color: playedTrackColor,
+                        borderRadius: BorderRadius.circular(trackHeight / 2),
                       ),
-                      // 滑块
-                      Positioned(
-                        left: (progress * constraints.maxWidth) - halfThumbSize,
-                        top: verticalMargin + (trackHeight / 2) - halfThumbSize,
-                        child: MouseRegion(
-                          cursor: SystemMouseCursors.click,
-                          child: AnimatedContainer(
-                            duration: const Duration(milliseconds: 200),
-                            curve: Curves.easeOutBack,
-                            width: currentThumbSize,
-                            height: currentThumbSize,
-                            decoration: BoxDecoration(
-                              color: Colors.white,
-                              shape: BoxShape.circle,
-                              boxShadow: [
-                                BoxShadow(
-                                  color: const Color.fromARGB(100, 0, 0, 0),
-                                  blurRadius:
-                                      _isThumbHovered || widget.isDragging
-                                          ? 12
-                                          : 8,
-                                  offset: const Offset(0, 2),
-                                ),
-                                BoxShadow(
-                                  color: const Color.fromARGB(100, 0, 0, 0),
-                                  blurRadius:
-                                      _isThumbHovered || widget.isDragging
-                                          ? 20
-                                          : 14,
-                                  offset: const Offset(0, 6),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  )
-                : Stack(
-                    key: _sliderKey,
-                    clipBehavior: Clip.none,
-                    children: [
-                      // 背景轨道
-                      Padding(
-                        padding: EdgeInsets.symmetric(vertical: verticalMargin),
-                        child: Opacity(
-                          opacity: 0.5,
-                          child: ControlShadow(
-                            borderRadius:
-                                BorderRadius.circular(trackHeight / 2),
-                            child: Container(
-                              height: trackHeight,
-                              decoration: BoxDecoration(
-                                color: trackBaseColor,
-                                borderRadius:
-                                    BorderRadius.circular(trackHeight / 2),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                      // 章节标记 overlay（竖线标记 + 当前章节高亮段）
-                      // 公共方法 _buildChapterOverlayWidgets 消除两布局分支重复
-                      ..._buildChapterOverlayWidgets(
-                          verticalMargin, trackHeight),
-                      // 缓存轨道
-                      Positioned(
-                        left: 0,
-                        right: 0,
-                        top: verticalMargin,
-                        child: FractionallySizedBox(
-                          widthFactor: bufferProgress,
-                          alignment: Alignment.centerLeft,
-                          child: Opacity(
-                            opacity: 0.5,
-                            child: Container(
-                              height: trackHeight,
-                              decoration: BoxDecoration(
-                                color: bufferTrackColor,
-                                borderRadius:
-                                    BorderRadius.circular(trackHeight / 2),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                      // 进度轨道
-                      Positioned(
-                        left: 0,
-                        right: 0,
-                        top: verticalMargin,
-                        child: FractionallySizedBox(
-                          widthFactor: progress,
-                          alignment: Alignment.centerLeft,
-                          child: Container(
-                            height: trackHeight,
-                            decoration: BoxDecoration(
-                              color: playedTrackColor,
-                              borderRadius:
-                                  BorderRadius.circular(trackHeight / 2),
-                            ),
-                          ),
-                        ),
-                      ),
-                      // 滑块
-                      Positioned(
-                        left: (progress * constraints.maxWidth) - halfThumbSize,
-                        top: verticalMargin + (trackHeight / 2) - halfThumbSize,
-                        child: MouseRegion(
-                          cursor: SystemMouseCursors.click,
-                          child: AnimatedContainer(
-                            duration: const Duration(milliseconds: 200),
-                            curve: Curves.easeOutBack,
-                            width: currentThumbSize,
-                            height: currentThumbSize,
-                            decoration: BoxDecoration(
-                              color: Colors.white,
-                              shape: BoxShape.circle,
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Color.fromARGB(100, 0, 0, 0),
-                                  blurRadius:
-                                      _isThumbHovered || widget.isDragging
-                                          ? 12
-                                          : 8,
-                                  offset: const Offset(0, 2),
-                                ),
-                                BoxShadow(
-                                  color: Color.fromARGB(100, 0, 0, 0),
-                                  blurRadius:
-                                      _isThumbHovered || widget.isDragging
-                                          ? 20
-                                          : 14,
-                                  offset: const Offset(0, 6),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  );
+                    ),
+                  ),
+                ),
+                _buildThumb(
+                  progress: progress,
+                  trackWidth: constraints.maxWidth,
+                  trackHeight: trackHeight,
+                  verticalMargin: verticalMargin,
+                ),
+              ],
+            );
           },
         ),
       ),
+    );
+  }
+
+  Widget _buildThumb({
+    required double progress,
+    required double trackWidth,
+    required double trackHeight,
+    required double verticalMargin,
+  }) {
+    return AnimatedBuilder(
+      animation: Listenable.merge([
+        _thumbHoverController,
+        _thumbDeformController,
+      ]),
+      builder: (context, child) {
+        final size = _thumbSizeForAnimation();
+        final centerX = progress.clamp(0.0, 1.0) * trackWidth;
+        final centerY = verticalMargin + (trackHeight / 2);
+        final emphasis = widget.isDragging ||
+            _isThumbHovered ||
+            _thumbDeformController.value.abs() > 0.05;
+
+        return Positioned(
+          left: centerX - (size.width / 2),
+          top: centerY - (size.height / 2),
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: Container(
+              width: size.width,
+              height: size.height,
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(size.height / 2),
+                boxShadow: [
+                  BoxShadow(
+                    color: const Color.fromARGB(100, 0, 0, 0),
+                    blurRadius: emphasis ? 12 : 8,
+                    offset: const Offset(0, 2),
+                  ),
+                  BoxShadow(
+                    color: const Color.fromARGB(100, 0, 0, 0),
+                    blurRadius: emphasis ? 20 : 14,
+                    offset: const Offset(0, 6),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Size _thumbSizeForAnimation() {
+    final hoverT = Curves.easeOutCubic.transform(_thumbHoverController.value);
+    final deform = _thumbDeformController.value.clamp(-0.95, 1.0);
+    final squeeze = deform > 0 ? deform : 0.0;
+    final rebound = deform < 0 ? -deform : 0.0;
+    final hoverScale = 1.0 + (hoverT * 0.08);
+    final widthScale = (hoverScale * (1.0 - squeeze * 0.42 + rebound * 0.34))
+        .clamp(0.56, 1.38);
+    final heightScale = (hoverScale * (1.0 + squeeze * 0.40 - rebound * 0.30))
+        .clamp(0.68, 1.42);
+
+    return Size(
+      _thumbBaseSize.width * widthScale,
+      _thumbBaseSize.height * heightScale,
+    );
+  }
+
+  Rect _thumbHitRect({
+    required double progress,
+    required double trackWidth,
+    required double verticalMargin,
+    required double trackHeight,
+  }) {
+    final center = Offset(
+      progress * trackWidth,
+      verticalMargin + (trackHeight / 2),
+    );
+    final size = _thumbBaseSize;
+    return Rect.fromCenter(
+      center: center,
+      width: size.width + 12,
+      height: size.height + 12,
+    );
+  }
+
+  void _setThumbHovered(bool isHovered) {
+    if (_isThumbHovered == isHovered) return;
+    setState(() {
+      _isThumbHovered = isHovered;
+    });
+    if (isHovered) {
+      _thumbHoverController.forward();
+    } else {
+      _thumbHoverController.reverse();
+    }
+  }
+
+  void _beginThumbPress(Offset localPosition, {required double deformTarget}) {
+    widget.onDraggingStateChange(true);
+    _lastDragLocalPosition = localPosition;
+    _lastDragUpdateTime = DateTime.now();
+    _springThumbDeformTo(deformTarget);
+  }
+
+  void _updateThumbDragEffect(Offset localPosition) {
+    final now = DateTime.now();
+    final lastPosition = _lastDragLocalPosition;
+    final lastTime = _lastDragUpdateTime;
+
+    double target = 0.48;
+    if (lastPosition != null && lastTime != null) {
+      final elapsedSeconds = now.difference(lastTime).inMicroseconds /
+          Duration.microsecondsPerSecond;
+      final velocity = elapsedSeconds > 0
+          ? (localPosition.dx - lastPosition.dx).abs() / elapsedSeconds
+          : 0.0;
+      target = (0.40 + velocity / 2200).clamp(0.40, 0.95).toDouble();
+    }
+
+    _lastDragLocalPosition = localPosition;
+    _lastDragUpdateTime = now;
+    _springThumbDeformTo(target);
+  }
+
+  void _endThumbPress() {
+    _lastDragLocalPosition = null;
+    _lastDragUpdateTime = null;
+    _releaseThumbDeform();
+  }
+
+  void _springThumbDeformTo(double target) {
+    _thumbDeformController.stop();
+    unawaited(
+      _thumbDeformController.animateWith(
+        SpringSimulation(
+          _dragThumbSpring,
+          _thumbDeformController.value,
+          target,
+          _thumbDeformController.velocity,
+        ),
+      ),
+    );
+  }
+
+  void _releaseThumbDeform() {
+    _thumbDeformController.stop();
+    unawaited(
+      _thumbDeformController
+          .animateTo(
+        -0.55,
+        duration: const Duration(milliseconds: 95),
+        curve: Curves.easeOutCubic,
+      )
+          .whenComplete(() {
+        if (!mounted) return;
+        unawaited(
+          _thumbDeformController.animateWith(
+            SpringSimulation(
+              _releaseThumbSpring,
+              _thumbDeformController.value,
+              0.0,
+              0.0,
+            ),
+          ),
+        );
+      }),
     );
   }
 

--- a/lib/themes/nipaplay/widgets/video_settings_menu.dart
+++ b/lib/themes/nipaplay/widgets/video_settings_menu.dart
@@ -50,7 +50,8 @@ class VideoSettingsMenuState extends State<VideoSettingsMenu>
   late final PlayerKernelType _currentKernelType;
   static const double _menuWidth = 300;
   static const double _menuRightOffset = 20;
-  static const double _menuHeight = 420;
+  static const double _paneMenuHeight = 420;
+  static const double _settingsItemHeight = 44;
   static const int _maxAnchorRefreshAttempts = 6;
   static const Duration _menuEnterDuration = Duration(milliseconds: 240);
   static const Duration _menuExitDuration = Duration(milliseconds: 170);
@@ -254,6 +255,7 @@ class VideoSettingsMenuState extends State<VideoSettingsMenu>
     required Widget child,
     bool forceShowHeader = false,
     bool? useBackButtonOverride,
+    double? height,
   }) {
     final bool showHeader = showBackItem || forceShowHeader;
     final bool useBackButton = useBackButtonOverride ?? showBackItem;
@@ -286,10 +288,17 @@ class VideoSettingsMenuState extends State<VideoSettingsMenu>
       lockControlsVisible: true,
       anchorRect: resolvedAnchorRect,
       showPointer: resolvedAnchorRect != null,
-      height: _menuHeight,
+      height: height ?? _paneMenuHeight,
       requestClose: requestClose,
       child: child,
     );
+  }
+
+  double _heightForSettingsItemCount(int itemCount) {
+    if (itemCount <= 0) {
+      return _settingsItemHeight;
+    }
+    return itemCount * _settingsItemHeight;
   }
 
   Widget _buildPane(
@@ -438,6 +447,7 @@ class VideoSettingsMenuState extends State<VideoSettingsMenu>
         final Widget menuContent = _activePaneId == null
             ? _wrapMenu(
                 showBackItem: false,
+                height: _heightForSettingsItemCount(menuItems.length),
                 child: BaseSettingsMenu(
                   title: '设置',
                   width: _menuWidth,

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,17 +1,7 @@
 PODS:
-  - battery_plus (0.0.1):
-    - FlutterMacOS
-  - desktop_drop (0.0.1):
-    - FlutterMacOS
   - desktop_multi_window (0.0.1):
     - FlutterMacOS
-  - dynamic_color (0.0.2):
-    - FlutterMacOS
   - erika_flutter (0.0.1):
-    - FlutterMacOS
-  - file_picker (0.0.1):
-    - FlutterMacOS
-  - file_selector_macos (0.0.1):
     - FlutterMacOS
   - flutter_js (0.0.1):
     - FlutterMacOS
@@ -31,42 +21,18 @@ PODS:
     - FlutterMacOS
   - nipaplay_smb2 (0.0.1):
     - FlutterMacOS
-  - package_info_plus (0.0.1):
-    - FlutterMacOS
   - rust_lib_nipaplay (0.0.1):
-    - FlutterMacOS
-  - screen_brightness_macos (0.1.0):
     - FlutterMacOS
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
-  - shared_preferences_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - sqflite_darwin (0.0.4):
-    - Flutter
-    - FlutterMacOS
   - tray_manager (0.0.1):
-    - FlutterMacOS
-  - url_launcher_macos (0.0.1):
-    - FlutterMacOS
-  - video_player_avfoundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - volume_controller (0.0.1):
-    - FlutterMacOS
-  - wakelock_plus (0.0.1):
     - FlutterMacOS
   - window_manager (0.2.0):
     - FlutterMacOS
 
 DEPENDENCIES:
-  - battery_plus (from `Flutter/ephemeral/.symlinks/plugins/battery_plus/macos`)
-  - desktop_drop (from `Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos`)
   - desktop_multi_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos`)
-  - dynamic_color (from `Flutter/ephemeral/.symlinks/plugins/dynamic_color/macos`)
   - erika_flutter (from `Flutter/ephemeral/.symlinks/plugins/erika_flutter/macos`)
-  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
-  - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - flutter_js (from `Flutter/ephemeral/.symlinks/plugins/flutter_js/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - fvp (from `Flutter/ephemeral/.symlinks/plugins/fvp/darwin`)
@@ -75,17 +41,9 @@ DEPENDENCIES:
   - media_kit_libs_macos_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos`)
   - media_kit_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos`)
   - nipaplay_smb2 (from `Flutter/ephemeral/.symlinks/plugins/nipaplay_smb2/macos`)
-  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - rust_lib_nipaplay (from `Flutter/ephemeral/.symlinks/plugins/rust_lib_nipaplay/macos`)
-  - screen_brightness_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_brightness_macos/macos`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
-  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - sqflite_darwin (from `Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin`)
   - tray_manager (from `Flutter/ephemeral/.symlinks/plugins/tray_manager/macos`)
-  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
-  - video_player_avfoundation (from `Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin`)
-  - volume_controller (from `Flutter/ephemeral/.symlinks/plugins/volume_controller/macos`)
-  - wakelock_plus (from `Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos`)
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 SPEC REPOS:
@@ -93,20 +51,10 @@ SPEC REPOS:
     - HotKey
 
 EXTERNAL SOURCES:
-  battery_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/battery_plus/macos
-  desktop_drop:
-    :path: Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos
   desktop_multi_window:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_multi_window/macos
-  dynamic_color:
-    :path: Flutter/ephemeral/.symlinks/plugins/dynamic_color/macos
   erika_flutter:
     :path: Flutter/ephemeral/.symlinks/plugins/erika_flutter/macos
-  file_picker:
-    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
-  file_selector_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   flutter_js:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_js/macos
   FlutterMacOS:
@@ -123,39 +71,18 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos
   nipaplay_smb2:
     :path: Flutter/ephemeral/.symlinks/plugins/nipaplay_smb2/macos
-  package_info_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   rust_lib_nipaplay:
     :path: Flutter/ephemeral/.symlinks/plugins/rust_lib_nipaplay/macos
-  screen_brightness_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/screen_brightness_macos/macos
   screen_retriever_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
-  shared_preferences_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
-  sqflite_darwin:
-    :path: Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin
   tray_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/tray_manager/macos
-  url_launcher_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
-  video_player_avfoundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin
-  volume_controller:
-    :path: Flutter/ephemeral/.symlinks/plugins/volume_controller/macos
-  wakelock_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos
   window_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
-  battery_plus: f51ad29136e025b714b96f7d096f44f604615da7
-  desktop_drop: 248706031734554504f939cab1ad4c5fbc9c9c72
   desktop_multi_window: 93667594ccc4b88d91a97972fd3b1b89667fa80a
-  dynamic_color: cb7c2a300ee67ed3bd96c3e852df3af0300bf610
   erika_flutter: f4d07f66427bf4e63bb5d242c3b78616c37a19f7
-  file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
-  file_selector_macos: 9e9e068e90ebee155097d00e89ae91edb2374db7
   flutter_js: 79c3c70d33ba464c67d8eb88639a61aa718cd8b8
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   fvp: ed100b827d10aff53789fb9cb9dfdd85a87d037d
@@ -165,17 +92,9 @@ SPEC CHECKSUMS:
   media_kit_libs_macos_video: 85a23e549b5f480e72cae3e5634b5514bc692f65
   media_kit_video: fa6564e3799a0a28bff39442334817088b7ca758
   nipaplay_smb2: da01641bec939e73001cd1934643d5c5d2acb866
-  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
-  rust_lib_nipaplay: 9282da9f4097bd2164268a5893ba2f13b117d00c
-  screen_brightness_macos: 1058c18b5e0570f48f93016487a5ed66d6977fe0
+  rust_lib_nipaplay: ad303ace8ae6c9e62d8ad4e8076ebfe4d1c64b74
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
-  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   tray_manager: a104b5c81b578d83f3c3d0f40a997c8b10810166
-  url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
-  video_player_avfoundation: 3453f792138786248960ca029747fcd9f318ef52
-  volume_controller: 5c068e6d085c80dadd33fc2c918d2114b775b3dd
-  wakelock_plus: 917609be14d812ddd9e9528876538b2263aaa03b
   window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
 
 PODFILE CHECKSUM: d8f651b9b24d21681d77d9cf5a55e67bfaa4a5a9


### PR DESCRIPTION
## Summary
- Make the player settings root menu height depend on the number of settings items to avoid empty bottom space.
- Replace the progress thumb with a compact pill-shaped custom thumb with hover animation and stronger drag squash/stretch rebound.
- Include the current macOS Podfile lock update from the working tree.

## Validation
- `flutter analyze --no-pub lib/themes/nipaplay/widgets/video_progress_bar.dart lib/themes/nipaplay/widgets/video_settings_menu.dart`
- `flutter test --no-pub test/player_menu_definition_builder_test.dart`
- `git diff --check`