### PR TITLE
fix: 分离 Linux 外部播放器进程, 防止未被读取的 stdout/stderr 管道阻塞子进程

### DIFF
--- a/lib/services/external_player_service.dart
+++ b/lib/services/external_player_service.dart
@@ -657,8 +657,18 @@ end)
       }
 
       // Linux
-      debugPrint('[ExtPlayer] launch: Linux 直启 + extraArgs=$extraArgs');
-      await Process.start(resolvedPath, [mediaPath, ...extraArgs]);
+      debugPrint('[ExtPlayer] launch: Linux 直启 + extraArgs=$extraArgs, mode=detached',);
+
+      // 外部播放器改为独立进程
+      final proc = await Process.start(
+        resolvedPath,
+        [mediaPath, ...extraArgs],
+        mode: ProcessStartMode.detached,
+      );
+
+      // 打印派生进程 PID，方便调试
+      debugPrint('[ExtPlayer] launch: 已派生 pid=${proc.pid}');
+
       return true;
     } catch (e, st) {
       debugPrint('[ExtPlayer] launch: 启动异常: $e');


### PR DESCRIPTION
## Summary

- 修复了 Linux 上外部播放器长时间播放后卡顿的问题
- 防止未被读取的 stdout/stderr 管道阻塞子进程

## Related Issue

- Closes #726

## What Changed

- 使用 `ProcessStartMode.detached` 启动 Linux 外部播放器
- 保持现有的参数和播放器检测行为不变
