### PR TITLE
fix(windows): 恢复退出询问与托盘最小化

### DIFF
--- a/lib/services/desktop_exit_handler.dart
+++ b/lib/services/desktop_exit_handler.dart
@@ -41,6 +41,22 @@ class DesktopExitHandler
 
   static final DesktopExitHandler instance = DesktopExitHandler._();
 
+  @visibleForTesting
+  static bool supportsWindowCloseInterception({
+    required bool isWindows,
+    required bool isMacOS,
+    required bool isLinux,
+  }) {
+    return isWindows || isMacOS || isLinux;
+  }
+
+  static bool get _supportsWindowCloseInterception =>
+      supportsWindowCloseInterception(
+        isWindows: Platform.isWindows,
+        isMacOS: Platform.isMacOS,
+        isLinux: Platform.isLinux,
+      );
+
   material.GlobalKey<material.NavigatorState>? _navigatorKey;
 
   bool _bindingHooked = false;
@@ -63,7 +79,7 @@ class DesktopExitHandler
       _bindingHooked = true;
     }
 
-    if ((Platform.isMacOS || Platform.isLinux) && !_windowListenerHooked) {
+    if (_supportsWindowCloseInterception && !_windowListenerHooked) {
       try {
         await windowManager.setPreventClose(true);
         _preventCloseEnabled = true;
@@ -107,7 +123,7 @@ class DesktopExitHandler
 
   @override
   void onWindowClose() async {
-    if (!(Platform.isMacOS || Platform.isLinux)) return;
+    if (!_supportsWindowCloseInterception) return;
     if (_closingWindow) return;
     if (_quitting) {
       await _closeWindowSafely();

--- a/test/desktop_exit_handler_test.dart
+++ b/test/desktop_exit_handler_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/services/desktop_exit_handler.dart';
+
+void main() {
+  group('DesktopExitHandler window close interception', () {
+    test('supports every desktop operating system', () {
+      expect(
+        DesktopExitHandler.supportsWindowCloseInterception(
+          isWindows: true,
+          isMacOS: false,
+          isLinux: false,
+        ),
+        isTrue,
+      );
+      expect(
+        DesktopExitHandler.supportsWindowCloseInterception(
+          isWindows: false,
+          isMacOS: true,
+          isLinux: false,
+        ),
+        isTrue,
+      );
+      expect(
+        DesktopExitHandler.supportsWindowCloseInterception(
+          isWindows: false,
+          isMacOS: false,
+          isLinux: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not enable desktop hooks on unsupported platforms', () {
+      expect(
+        DesktopExitHandler.supportsWindowCloseInterception(
+          isWindows: false,
+          isMacOS: false,
+          isLinux: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 变更说明

- 将 Windows 纳入桌面窗口关闭拦截，确保 `setPreventClose` 在 Windows 上启用。
- 统一初始化和关闭回调的平台判定，避免两个入口再次出现支持范围不一致。
- 添加 Windows、macOS、Linux 平台判定回归测试。

## 根因

退出处理器仅为 macOS 和 Linux 注册窗口关闭拦截，导致 Windows 直接退出，无法进入“每次询问”或“最小化到系统托盘”的既有流程。

## 验证

- `flutter test --no-pub`：94 通过，6 跳过。
- `flutter test --no-pub test/desktop_exit_handler_test.dart`：2 通过。
- `flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings lib`：无错误（仓库现有 warning/info 保持不变）。

Fixes #652
