### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.10.14
+version: 1.11.0
 
 environment:
   sdk: ^3.5.3


### PR DESCRIPTION
## 变更说明

- 将应用版本从 `1.10.14` 更新为 `1.11.0`。
- Android、iOS、macOS、Windows、Linux 及发布工作流会继续从 `pubspec.yaml` 读取该版本。

## 验证

- `flutter pub get --offline` 成功。
- 已确认 `pubspec.yaml` 解析出的版本为 `1.11.0`。
- PR 差异仅包含预期的一行版本变更。
