### PR TITLE
Fix iOS downloads, media libraries, and portrait playback

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -52,6 +52,9 @@ class SettingsKeys {
   static const String torrentRecentDownloadDirectoriesMigrated =
       'torrent_recent_download_directories_migrated';
 
+  static const String mediaLibrarySelectedSection =
+      'media_library_selected_section';
+
   static const String downloaderEnabled = 'downloader_enabled';
 
   static const String downloaderCreateFolderForTask =

--- a/lib/media_library/adaptive_media_library_page.dart
+++ b/lib/media_library/adaptive_media_library_page.dart
@@ -10,6 +10,7 @@ import 'package:nipaplay/app/app_display_surface_scope.dart';
 import 'package:nipaplay/app/app_page_ids.dart';
 import 'package:nipaplay/app/unified_app_view_presenter.dart';
 import 'package:nipaplay/app/unified_media_library_sections.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/media_library/adaptive_media_library_controls.dart';
 import 'package:nipaplay/media_library/unified_library_management_model.dart';
 import 'package:nipaplay/models/media_server_playback.dart';
@@ -45,6 +46,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/smb_connection_dialog.dart'
     as desktop_smb;
 import 'package:nipaplay/themes/nipaplay/widgets/webdav_connection_dialog.dart'
     as desktop_webdav;
+import 'package:nipaplay/utils/settings_storage.dart';
 import 'package:nipaplay/utils/tab_change_notifier.dart';
 
 class AdaptiveMediaLibraryPage extends StatefulWidget {
@@ -62,10 +64,12 @@ class _AdaptiveMediaLibraryPageState extends State<AdaptiveMediaLibraryPage> {
   TabChangeNotifier? _tabChangeNotifier;
   CupertinoPageActionsController? _pageActionsController;
   bool _connectionsInitialized = false;
+  int _selectionRevision = 0;
 
   @override
   void initState() {
     super.initState();
+    unawaited(_restoreSelectedSection());
     if (!kIsWeb) {
       unawaited(_initializeConnections());
     }
@@ -120,12 +124,51 @@ class _AdaptiveMediaLibraryPageState extends State<AdaptiveMediaLibraryPage> {
     setState(() => _connectionsInitialized = true);
   }
 
+  Future<void> _restoreSelectedSection() async {
+    final revisionAtStart = _selectionRevision;
+    final saved = await SettingsStorage.loadString(
+      SettingsKeys.mediaLibrarySelectedSection,
+    );
+    if (!mounted || saved.trim().isEmpty) return;
+    if (_selectionRevision != revisionAtStart) return;
+    setState(() => _selectedSectionId = saved.trim());
+  }
+
+  void _selectSection(String sectionId) {
+    final normalized = sectionId.trim();
+    if (normalized.isEmpty) return;
+    _selectionRevision++;
+    if (normalized != _selectedSectionId) {
+      setState(() => _selectedSectionId = normalized);
+    }
+    unawaited(_persistSelectedSection(normalized));
+  }
+
+  Future<void> _persistSelectedSection(String sectionId) async {
+    try {
+      await SettingsStorage.saveString(
+        SettingsKeys.mediaLibrarySelectedSection,
+        sectionId,
+      );
+    } catch (error) {
+      debugPrint('保存媒体库分区失败: $error');
+    }
+  }
+
+  void _selectMountedMediaLibrarySection(String sectionId) {
+    if (!mounted ||
+        AppDisplaySurfaceScope.of(context) != AppDisplaySurface.phone) {
+      return;
+    }
+    _selectSection(sectionId);
+  }
+
   void _handleRequestedSection() {
     final requested = _tabChangeNotifier?.targetMediaLibrarySectionId;
     if (requested == null) return;
     _tabChangeNotifier?.clearSubTabIndex();
     if (requested != _selectedSectionId && mounted) {
-      setState(() => _selectedSectionId = requested);
+      _selectSection(requested);
     }
   }
 
@@ -191,22 +234,11 @@ class _AdaptiveMediaLibraryPageState extends State<AdaptiveMediaLibraryPage> {
           _selectedSectionId,
         );
         final selectedSection = sections[selectedIndex < 0 ? 0 : selectedIndex];
-        if (selectedSection.id != _selectedSectionId) {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (mounted) {
-              setState(() => _selectedSectionId = selectedSection.id);
-            }
-          });
-        }
 
         return AdaptiveMediaLibraryScaffold(
           sections: sections,
           selectedSection: selectedSection,
-          onSectionSelected: (id) {
-            if (id != _selectedSectionId) {
-              setState(() => _selectedSectionId = id);
-            }
-          },
+          onSectionSelected: _selectSection,
           onRemoteAccess: _openRemoteAccessSettings,
           onAddMedia: _showAddMedia,
           child: AdaptiveMediaLibrarySectionContent(
@@ -359,6 +391,7 @@ class _AdaptiveMediaLibraryPageState extends State<AdaptiveMediaLibraryPage> {
       directory,
       skipPreviouslyMatchedUnwatched: false,
     );
+    _selectMountedMediaLibrarySection(MediaLibrarySectionIds.localManagement);
     if (mounted) _showMessage('已开始扫描：${path.basename(directory)}');
   }
 
@@ -370,6 +403,8 @@ class _AdaptiveMediaLibraryPageState extends State<AdaptiveMediaLibraryPage> {
         : await desktop_webdav.WebDAVConnectionDialog.show(context);
     if (result == true && mounted) {
       setState(() => _connectionsInitialized = true);
+      _selectMountedMediaLibrarySection(
+          MediaLibrarySectionIds.webdavManagement);
     }
   }
 
@@ -381,11 +416,18 @@ class _AdaptiveMediaLibraryPageState extends State<AdaptiveMediaLibraryPage> {
         : await desktop_smb.SMBConnectionDialog.show(context);
     if (result == true && mounted) {
       setState(() => _connectionsInitialized = true);
+      _selectMountedMediaLibrarySection(MediaLibrarySectionIds.smbManagement);
     }
   }
 
   Future<void> _configureNetworkServer(MediaServerType type) async {
-    await NetworkMediaServerDialog.show(context, type);
+    final result = await NetworkMediaServerDialog.show(context, type);
+    if (result != true || !mounted) return;
+    _selectMountedMediaLibrarySection(
+      type == MediaServerType.jellyfin
+          ? MediaLibrarySectionIds.jellyfin
+          : MediaLibrarySectionIds.emby,
+    );
   }
 
   Future<void> _configureDandanplay() async {
@@ -401,6 +443,7 @@ class _AdaptiveMediaLibraryPageState extends State<AdaptiveMediaLibraryPage> {
       );
       if (config == null) return;
       await provider.connect(config.baseUrl, token: config.apiToken);
+      _selectMountedMediaLibrarySection(MediaLibrarySectionIds.dandanplay);
       return;
     }
 
@@ -434,11 +477,21 @@ class _AdaptiveMediaLibraryPageState extends State<AdaptiveMediaLibraryPage> {
         }
       },
     );
-    if (result == true && mounted) setState(() {});
+    if (result == true && mounted) {
+      setState(() {});
+      _selectMountedMediaLibrarySection(MediaLibrarySectionIds.dandanplay);
+    }
   }
 
   Future<void> _addSharedHost() async {
+    final provider = context.read<SharedRemoteLibraryProvider>();
+    final previousHostId = provider.activeHostId;
     await SharedRemoteHostSelectionSheet.show(context);
+    if (!mounted) return;
+    final activeHostId = provider.activeHostId;
+    if (activeHostId != null && activeHostId != previousHostId) {
+      _selectMountedMediaLibrarySection(MediaLibrarySectionIds.shared);
+    }
   }
 
   Future<void> _playHistoryItem(WatchHistoryItem item) async {

--- a/lib/pages/play_video_page.dart
+++ b/lib/pages/play_video_page.dart
@@ -443,15 +443,18 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
       fit: StackFit.expand,
       clipBehavior: Clip.hardEdge,
       children: [
-        Positioned.fill(
-          child: VideoPlayerWidget(danmakuScale: portraitUiScale),
+        const Positioned.fill(
+          child: VideoPlayerWidget(),
         ),
         if (videoState.hasVideo)
           NipaplayLargeScreenModeScope.isActiveOf(context)
               ? _buildLargeScreenMaterialControls(videoState)
-              : _buildMaterialControls(
-                  videoState,
-                  portraitUiScale: portraitUiScale,
+              : KeyedSubtree(
+                  key: ValueKey<bool>(portraitUiScale < 0.999),
+                  child: _buildMaterialControls(
+                    videoState,
+                    portraitUiScale: portraitUiScale,
+                  ),
                 ),
       ],
     );
@@ -869,6 +872,7 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
     double portraitUiScale = 1.0,
   }) {
     final bool isCompactPortrait = portraitUiScale < 0.999;
+    final double topControlsScale = isCompactPortrait ? 1.0 : portraitUiScale;
     final bool uiLocked =
         globals.isMobilePlatform && !isCompactPortrait ? _isUiLocked : false;
     final bool showLockButton = globals.isMobilePlatform &&
@@ -885,7 +889,7 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
         (showScreenshotButton ? 1 : 0) +
         (showShareButton ? 1 : 0);
     final double rightButtonsWidth = rightButtonCount > 0
-        ? rightButtonCount * 42.0 + (rightButtonCount - 1) * 12.0
+        ? rightButtonCount * 44.0 + (rightButtonCount - 1) * 12.0
         : 0.0;
     final double availableTitleWidth = (MediaQuery.of(context).size.width -
             (16.0 + horizontalCutoutInset) -
@@ -914,7 +918,7 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
             child: IgnorePointer(
               ignoring: !videoState.showControls,
               child: Transform.scale(
-                scale: portraitUiScale,
+                scale: topControlsScale,
                 alignment: Alignment.topLeft,
                 child: Padding(
                   padding: EdgeInsets.only(
@@ -1039,7 +1043,7 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
             child: IgnorePointer(
               ignoring: !videoState.showControls,
               child: Transform.scale(
-                scale: portraitUiScale,
+                scale: topControlsScale,
                 alignment: Alignment.topRight,
                 child: Padding(
                   padding: EdgeInsets.only(

--- a/lib/providers/shared_remote_library_provider.dart
+++ b/lib/providers/shared_remote_library_provider.dart
@@ -299,10 +299,16 @@ class SharedRemoteLibraryProvider extends ChangeNotifier {
 
       debugPrint('✅ [共享媒体] 成功获取 ${items.length} 个番剧');
 
-      _animeSummaries = items
-          .map((item) =>
-              SharedRemoteAnimeSummary.fromJson(item as Map<String, dynamic>))
-          .toList();
+      _animeSummaries = items.map((item) {
+        final data = Map<String, dynamic>.from(item as Map<String, dynamic>);
+        if (!kIsWeb) {
+          data['imageUrl'] = _resolveRemoteImageUrl(
+            host.baseUrl,
+            data['imageUrl'],
+          );
+        }
+        return SharedRemoteAnimeSummary.fromJson(data);
+      }).toList();
       _animeSummaries
           .sort((a, b) => b.lastWatchTime.compareTo(a.lastWatchTime));
       _episodeCache.clear();
@@ -361,6 +367,21 @@ class SharedRemoteLibraryProvider extends ChangeNotifier {
       notifyListeners();
       await _persistHosts();
     }
+  }
+
+  String? _resolveRemoteImageUrl(String baseUrl, dynamic rawImageUrl) {
+    final imageUrl = rawImageUrl?.toString().trim() ?? '';
+    if (imageUrl.isEmpty) return null;
+    if (imageUrl.startsWith('http://') ||
+        imageUrl.startsWith('https://') ||
+        imageUrl.startsWith('data:') ||
+        imageUrl.startsWith('blob:')) {
+      return imageUrl;
+    }
+
+    final encoded = base64Url.encode(utf8.encode(imageUrl));
+    return '${_normalizeBaseUrl(baseUrl)}/api/image_proxy?url='
+        '${Uri.encodeQueryComponent(encoded)}';
   }
 
   Future<List<SharedRemoteEpisode>> loadAnimeEpisodes(int animeId,

--- a/lib/services/local_media_share_service.dart
+++ b/lib/services/local_media_share_service.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:shelf/shelf.dart';
 
 import 'package:nipaplay/models/bangumi_model.dart';
@@ -105,6 +106,8 @@ class LocalMediaShareService {
   }
 
   static final LocalMediaShareService instance = LocalMediaShareService._internal();
+  static const String _mediaLibraryImagePrefsKeyPrefix =
+      'media_library_image_url_';
   static const Map<String, int> _subtitleExtensionPriority = {
     '.ass': 0,
     '.ssa': 1,
@@ -192,21 +195,30 @@ class LocalMediaShareService {
     final bundles = _animeBundleMap.values.toList()
       ..sort((a, b) => b.latestWatchTime.compareTo(a.latestWatchTime));
 
-    // 预取部分番剧详情（异步，不阻塞 API），避免一次性触发过多请求
-    for (final bundle in bundles.take(24)) {
+    // BangumiService 已在应用启动时将持久化详情载入内存。先复用这些
+    // 缓存，再为确实缺失的条目后台补齐，避免首次共享时整页灰色封面。
+    for (final bundle in bundles) {
       _prefetchAnimeDetail(bundle.animeId);
     }
 
+    final prefs = await SharedPreferences.getInstance();
     final List<Map<String, dynamic>> summaries = [];
     for (final bundle in bundles) {
       final detail = _peekAnimeDetail(bundle.animeId);
       final fallbackName = bundle.episodes.first.historyItem.animeName;
+      final persistedImageUrl = prefs.getString(
+        '$_mediaLibraryImagePrefsKeyPrefix${bundle.animeId}',
+      );
       summaries.add({
         'animeId': bundle.animeId,
         'name': detail?.name ?? fallbackName,
         'nameCn': detail?.nameCn ?? fallbackName,
         'summary': detail?.summary ?? '',
-        'imageUrl': detail?.imageUrl,
+        'imageUrl': _firstNonEmptyString([
+          detail?.imageUrl,
+          persistedImageUrl,
+          bundle.episodes.first.historyItem.thumbnailPath,
+        ]),
         'tags': detail?.tags ?? const <dynamic>[],
         'totalEpisodes': detail?.totalEpisodes,
         'lastWatchTime': bundle.latestWatchTime.toIso8601String(),
@@ -266,14 +278,16 @@ class LocalMediaShareService {
     final episodes = _shareEpisodeMap.values.toList()
       ..sort((a, b) => b.historyItem.lastWatchTime.compareTo(a.historyItem.lastWatchTime));
 
-    // 预取部分番剧详情（异步，不阻塞 API）
-    for (final entry in episodes.take(sanitizedLimit).take(24)) {
+    // 与番剧摘要保持一致，预取本次返回范围内的全部详情，避免观看历史
+    // 超过 24 项后封面永久停留在占位图。
+    for (final entry in episodes.take(sanitizedLimit)) {
       final animeId = entry.historyItem.animeId;
       if (animeId != null) {
         _prefetchAnimeDetail(animeId);
       }
     }
 
+    final prefs = await SharedPreferences.getInstance();
     final List<Map<String, dynamic>> items = [];
     for (final entry in episodes.take(sanitizedLimit)) {
       final baseJson = await entry.toJson();
@@ -287,7 +301,13 @@ class LocalMediaShareService {
       items.add({
         ...baseJson,
         'animeName': resolvedName,
-        'imageUrl': detail?.imageUrl ?? entry.historyItem.thumbnailPath,
+        'imageUrl': _firstNonEmptyString([
+          detail?.imageUrl,
+          animeId == null
+              ? null
+              : prefs.getString('$_mediaLibraryImagePrefsKeyPrefix$animeId'),
+          entry.historyItem.thumbnailPath,
+        ]),
       });
     }
 
@@ -299,12 +319,29 @@ class LocalMediaShareService {
   }
 
   BangumiAnime? _peekAnimeDetail(int animeId) {
-    if (!_animeDetailCache.containsKey(animeId)) return null;
-    return _animeDetailCache[animeId];
+    if (_animeDetailCache.containsKey(animeId)) {
+      return _animeDetailCache[animeId];
+    }
+
+    final sharedDetail =
+        BangumiService.instance.getAnimeDetailsFromMemory(animeId);
+    if (sharedDetail != null) {
+      _animeDetailCache[animeId] = sharedDetail;
+    }
+    return sharedDetail;
+  }
+
+  String? _firstNonEmptyString(Iterable<String?> values) {
+    for (final value in values) {
+      final normalized = value?.trim() ?? '';
+      if (normalized.isNotEmpty) return normalized;
+    }
+    return null;
   }
 
   void _prefetchAnimeDetail(int animeId) {
-    if (_animeDetailCache.containsKey(animeId)) {
+    if (_peekAnimeDetail(animeId) != null ||
+        _animeDetailCache.containsKey(animeId)) {
       return;
     }
     if (_animeDetailFetching.contains(animeId)) {

--- a/lib/services/torrent_download_service.dart
+++ b/lib/services/torrent_download_service.dart
@@ -13,11 +13,36 @@ import 'package:nipaplay/utils/storage_service.dart';
 import 'package:path/path.dart' as p;
 
 class TorrentDownloadService {
-  TorrentDownloadService._();
+  TorrentDownloadService._({
+    bool Function()? isIos,
+    Future<io.Directory> Function()? getDownloadsDirectory,
+    Future<bool> Function(String path)? directoryExists,
+  })  : _isIos = isIos ?? (() => io.Platform.isIOS),
+        _getDownloadsDirectory =
+            getDownloadsDirectory ?? StorageService.getDownloadsDirectory,
+        _directoryExists =
+            directoryExists ?? ((path) => io.Directory(path).exists());
 
   static final TorrentDownloadService instance = TorrentDownloadService._();
 
+  @visibleForTesting
+  factory TorrentDownloadService.forTesting({
+    required bool Function() isIos,
+    required Future<io.Directory> Function() getDownloadsDirectory,
+    required Future<bool> Function(String path) directoryExists,
+  }) {
+    return TorrentDownloadService._(
+      isIos: isIos,
+      getDownloadsDirectory: getDownloadsDirectory,
+      directoryExists: directoryExists,
+    );
+  }
+
   static const int _maxRecentDownloadDirectories = 8;
+
+  final bool Function() _isIos;
+  final Future<io.Directory> Function() _getDownloadsDirectory;
+  final Future<bool> Function(String path) _directoryExists;
 
   bool _sessionInitialized = false;
   String _sessionDownloadDir = '';
@@ -27,14 +52,65 @@ class TorrentDownloadService {
       SettingsKeys.torrentDownloadDirectory,
     );
     if (saved.trim().isNotEmpty) {
-      return _resolveDownloadDirectoryAccess(saved.trim());
+      final savedDirectory = saved.trim();
+      final resolved = await _resolveDownloadDirectoryAccess(savedDirectory);
+      if (!_isIos() || await _directoryExists(resolved)) {
+        return resolved;
+      }
+
+      return _recoverInvalidIosDownloadDirectory(
+        savedDirectory: savedDirectory,
+        resolvedDirectory: resolved,
+      );
     }
-    final defaultDir = await StorageService.getDownloadsDirectory();
+    final defaultDir = await _getDownloadsDirectory();
     await SettingsStorage.saveString(
       SettingsKeys.torrentDownloadDirectory,
       defaultDir.path,
     );
     return defaultDir.path;
+  }
+
+  Future<String> _recoverInvalidIosDownloadDirectory({
+    required String savedDirectory,
+    required String resolvedDirectory,
+  }) async {
+    final defaultDirectory = await _getDownloadsDirectory();
+    final defaultPath = defaultDirectory.path;
+    _log(
+      'saved iOS download directory no longer exists; '
+      'recovering from "$savedDirectory" to "$defaultPath"',
+    );
+
+    await SettingsStorage.saveString(
+      SettingsKeys.torrentDownloadDirectory,
+      defaultPath,
+    );
+
+    final invalidDirectories = <String>{
+      savedDirectory,
+      resolvedDirectory,
+    };
+    final recentDirectories = await SettingsStorage.loadStringList(
+      SettingsKeys.torrentRecentDownloadDirectories,
+    );
+    final updatedRecentDirectories = <String>[
+      defaultPath,
+      ...recentDirectories.where(
+        (directory) =>
+            directory != defaultPath && !invalidDirectories.contains(directory),
+      ),
+    ].take(_maxRecentDownloadDirectories).toList(growable: false);
+    await SettingsStorage.saveStringList(
+      SettingsKeys.torrentRecentDownloadDirectories,
+      updatedRecentDirectories,
+    );
+    await SettingsStorage.saveBool(
+      SettingsKeys.torrentRecentDownloadDirectoriesMigrated,
+      true,
+    );
+
+    return defaultPath;
   }
 
   Future<void> setDownloadDirectory(String directory) async {

--- a/lib/themes/nipaplay/widgets/control_shadow.dart
+++ b/lib/themes/nipaplay/widgets/control_shadow.dart
@@ -52,12 +52,12 @@ class ControlIconShadow extends StatelessWidget {
       Shadow(
         color: Color.fromARGB(100, 0, 0, 0),
         blurRadius: 10,
-        offset: Offset(0, 2),
+        offset: Offset.zero,
       ),
       Shadow(
         color: Color.fromARGB(100, 0, 0, 0),
         blurRadius: 18,
-        offset: Offset(0, 4),
+        offset: Offset.zero,
       ),
     ],
   });

--- a/lib/themes/nipaplay/widgets/shadow_action_button.dart
+++ b/lib/themes/nipaplay/widgets/shadow_action_button.dart
@@ -15,7 +15,7 @@ class ShadowActionButton extends StatefulWidget {
     required this.tooltip,
     required this.icon,
     required this.onPressed,
-    this.iconSize = 26,
+    this.iconSize = 28,
     this.padding = const EdgeInsets.all(8.0),
   });
 

--- a/test/player_control_style_test.dart
+++ b/test/player_control_style_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/control_shadow.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/shadow_action_button.dart';
+
+void main() {
+  test('top action buttons match the 28px back icon', () {
+    final button = ShadowActionButton(
+      tooltip: 'test',
+      icon: Icons.share,
+      onPressed: () {},
+    );
+
+    expect(button.iconSize, 28);
+    expect(button.padding, const EdgeInsets.all(8));
+  });
+
+  test('player icon shadows stay centered on the glyph', () {
+    const shadow = ControlIconShadow(child: SizedBox.shrink());
+
+    expect(shadow.shadows, isNotEmpty);
+    expect(
+      shadow.shadows.every((item) => item.offset == Offset.zero),
+      isTrue,
+    );
+  });
+
+  test('portrait controls rebuild unscaled and danmaku keeps phone size', () {
+    final player = File('lib/pages/play_video_page.dart').readAsStringSync();
+
+    expect(
+      player,
+      contains('key: ValueKey<bool>(portraitUiScale < 0.999)'),
+    );
+    expect(
+      player,
+      contains('isCompactPortrait ? 1.0 : portraitUiScale'),
+    );
+    expect(
+      RegExp(r'scale: topControlsScale').allMatches(player).length,
+      2,
+    );
+    expect(player, contains('const Positioned.fill('));
+    expect(player, contains('child: VideoPlayerWidget()'));
+    expect(
+      player,
+      isNot(contains('VideoPlayerWidget(danmakuScale: portraitUiScale)')),
+    );
+  });
+}

--- a/test/torrent_download_service_test.dart
+++ b/test/torrent_download_service_test.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
+import 'package:nipaplay/services/torrent_download_service.dart';
+import 'package:nipaplay/utils/settings_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TorrentDownloadService.getDownloadDirectory', () {
+    const staleDirectory = '/old/Application/CONTAINER/Documents/downloads';
+    const currentDirectory =
+        '/current/Application/CONTAINER/Documents/downloads';
+
+    test('repairs a stale saved iOS sandbox directory', () async {
+      SharedPreferences.setMockInitialValues({
+        SettingsKeys.torrentDownloadDirectory: staleDirectory,
+        SettingsKeys.torrentRecentDownloadDirectories: <String>[
+          staleDirectory,
+          '/another/downloads',
+        ],
+        SettingsKeys.torrentRecentDownloadDirectoriesMigrated: true,
+      });
+      final service = TorrentDownloadService.forTesting(
+        isIos: () => true,
+        getDownloadsDirectory: () async => Directory(currentDirectory),
+        directoryExists: (_) async => false,
+      );
+
+      final result = await service.getDownloadDirectory();
+
+      expect(result, currentDirectory);
+      expect(
+        await SettingsStorage.loadString(
+          SettingsKeys.torrentDownloadDirectory,
+        ),
+        currentDirectory,
+      );
+      expect(
+        await SettingsStorage.loadStringList(
+          SettingsKeys.torrentRecentDownloadDirectories,
+        ),
+        <String>[currentDirectory, '/another/downloads'],
+      );
+    });
+
+    test('keeps an existing saved iOS directory', () async {
+      SharedPreferences.setMockInitialValues({
+        SettingsKeys.torrentDownloadDirectory: currentDirectory,
+      });
+      var requestedDefaultDirectory = false;
+      final service = TorrentDownloadService.forTesting(
+        isIos: () => true,
+        getDownloadsDirectory: () async {
+          requestedDefaultDirectory = true;
+          return Directory('/unused');
+        },
+        directoryExists: (_) async => true,
+      );
+
+      expect(await service.getDownloadDirectory(), currentDirectory);
+      expect(requestedDefaultDirectory, isFalse);
+    });
+
+    test('does not reset missing saved directories on other platforms',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        SettingsKeys.torrentDownloadDirectory: staleDirectory,
+      });
+      var checkedDirectory = false;
+      final service = TorrentDownloadService.forTesting(
+        isIos: () => false,
+        getDownloadsDirectory: () async => Directory('/unused'),
+        directoryExists: (_) async {
+          checkedDirectory = true;
+          return false;
+        },
+      );
+
+      expect(await service.getDownloadDirectory(), staleDirectory);
+      expect(checkedDirectory, isFalse);
+    });
+  });
+}

--- a/test/unified_app_architecture_test.dart
+++ b/test/unified_app_architecture_test.dart
@@ -1450,6 +1450,36 @@ void main() {
     );
   });
 
+  test('phone media library selection is restored and follows new mounts', () {
+    final page = File(
+      'lib/media_library/adaptive_media_library_page.dart',
+    ).readAsStringSync();
+    final keys = File('lib/constants/settings_keys.dart').readAsStringSync();
+
+    expect(keys, contains('mediaLibrarySelectedSection'));
+    expect(page, contains('_restoreSelectedSection'));
+    expect(page, contains('onSectionSelected: _selectSection'));
+    expect(page, contains('_selectMountedMediaLibrarySection'));
+    expect(page, contains('MediaLibrarySectionIds.localManagement'));
+    expect(page, contains('MediaLibrarySectionIds.webdavManagement'));
+    expect(page, contains('MediaLibrarySectionIds.smbManagement'));
+  });
+
+  test('shared media summaries hydrate covers without a 24 item cap', () {
+    final service = File(
+      'lib/services/local_media_share_service.dart',
+    ).readAsStringSync();
+    final provider = File(
+      'lib/providers/shared_remote_library_provider.dart',
+    ).readAsStringSync();
+
+    expect(service, isNot(contains('.take(24)')));
+    expect(service, contains('getAnimeDetailsFromMemory'));
+    expect(service, contains('_mediaLibraryImagePrefsKeyPrefix'));
+    expect(provider, contains('_resolveRemoteImageUrl'));
+    expect(provider, contains('/api/image_proxy?url='));
+  });
+
   test('playback entry host delegates controls to the adaptive renderer', () {
     final source = File(
       'lib/themes/nipaplay/widgets/video_upload_ui.dart',


### PR DESCRIPTION
## What changed

- Recover stale iOS torrent download directories after the app sandbox container changes.
- Persist the selected phone media-library section and automatically switch to newly mounted libraries.
- Hydrate shared-library covers without the previous 24-item cap and normalize remote cover URLs.
- Rebuild portrait player controls on orientation changes, keep top actions at full size, center icon shadows, and keep portrait danmaku readable with fewer tracks.

## Root causes

- Persisted iOS sandbox paths become invalid after reinstall/rebuild.
- Media-library selection was held only in transient widget state.
- Shared cover hydration was capped at 24 items and relative cover URLs were not normalized for remote clients.
- Portrait playback reused the landscape control subtree and scaled both top controls and danmaku with the compact UI scale.

## Validation

- `flutter test test/torrent_download_service_test.dart test/player_control_style_test.dart` (6 tests passed)
- `flutter test test/unified_app_architecture_test.dart --plain-name 'phone media library selection is restored and follows new mounts'`
- `flutter test test/unified_app_architecture_test.dart --plain-name 'shared media summaries hydrate covers without a 24 item cap'`
- `flutter analyze` for the modified player control widgets and regression test (no issues)