### PR TITLE
refactor(danmaku): 集中管理弹幕样式枚举与设置键

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -69,4 +69,9 @@ class SettingsKeys {
   static const String githubProxyUrl = 'github_proxy_url';
 
   static const String danmakuSupersample = 'danmaku_supersample';
+
+
+  // 弹幕相关设置
+  static const String danmakuOpacity      = 'danmaku_opacity';       // 弹幕透明度设置
+  static const String danmakuOutlineStyle = 'danmaku_outline_style'; // 弹幕描边样式设置
 }

--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -71,7 +71,51 @@ class SettingsKeys {
   static const String danmakuSupersample = 'danmaku_supersample';
 
 
-  // 弹幕相关设置
-  static const String danmakuOpacity      = 'danmaku_opacity';       // 弹幕透明度设置
-  static const String danmakuOutlineStyle = 'danmaku_outline_style'; // 弹幕描边样式设置
+  // ===========================================================================
+  // ============================ 弹幕相关设置 =================================
+  // ===========================================================================
+
+  // 弹幕基本设置
+  static const String danmakuOpacity                    = 'danmaku_opacity';                        // 透明度设置
+  static const String danmakuOutlineStyle               = 'danmaku_outline_style';                  // 描边样式设置
+  static const String danmakuVisible                    = 'danmaku_visible';                        // 可见性设置
+  static const String mergeDanmaku                      = 'merge_danmaku';                          // 合并设置
+  static const String danmakuStacking                   = 'danmaku_stacking';                       // 堆叠设置
+  static const String danmakuRandomColorEnabled         = 'danmaku_random_color_enabled';           // 随机颜色设置
+  static const String blockTopDanmaku                   = 'block_top_danmaku';                      // 屏蔽设置
+  static const String blockBottomDanmaku                = 'block_bottom_danmaku';                   // 屏蔽设置
+  static const String blockScrollDanmaku                = 'block_scroll_danmaku';                   // 屏蔽设置
+  static const String timelineDanmakuEnabled            = 'timeline_danmaku_enabled';               // 时间轴弹幕设置
+  static const String danmakuBlockWords                 = 'danmaku_block_words';                    // 弹幕屏蔽词设置
+  static const String danmakuFontSize                   = 'danmaku_font_size';                      // 字体大小设置
+  static const String danmakuFontFilePath               = 'danmaku_font_file_path';                 // 字体文件路径设置
+  static const String danmakuFontFamily                 = 'danmaku_font_family';                    // 字体族设置
+  static const String danmakuShadowStyle                = 'danmaku_shadow_style';                   // 阴影样式设置
+  static const String next2DanmakuOutlineWidth          = 'next2_danmaku_outline_width';            // 描边宽度设置
+  static const String danmakuDisplayArea                = 'danmaku_display_area';                   // 显示区域设置
+  static const String danmakuSpeedMultiplier            = 'danmaku_speed_multiplier';               // 速度倍数设置
+  static const String danmakuDfmPlusTrackGap            = 'danmaku_dfm_plus_track_gap';             // 轨道间距设置
+  static const String rememberDanmakuOffset             = 'remember_danmaku_offset';                // 记住偏移设置
+  static const String danmakuConvertToSimplified        = 'danmaku_convert_to_simplified';          // 简繁转换设置
+  static const String danmakuRenderEngine               = 'danmaku_render_engine';                  // 渲染引擎设置
+  static const String legacyDanmakuKernel               = 'danmaku_kernel';                         // 内核设置（已废弃，保留用于迁移旧设置）
+  static const String showDanmakuDensityChart           = 'show_danmaku_density_chart';             // 密度图设置
+  static const String playerTopSendDanmakuButtonVisible = 'player_top_send_danmaku_button_visible'; // 播放器顶部发送按钮可见性设置
+
+  // 弹幕防剧透设置
+  static const String spoilerPreventionEnabled          = 'spoiler_prevention_enabled';
+  static const String spoilerAiUseCustomKey             = 'spoiler_ai_use_custom_key';
+  static const String spoilerAiApiFormat                = 'spoiler_ai_api_format';
+  static const String spoilerAiApiUrl                   = 'spoiler_ai_api_url';
+  static const String spoilerAiApiKey                   = 'spoiler_ai_api_key';
+  static const String spoilerAiModel                    = 'spoiler_ai_model';
+  static const String spoilerAiTemperature              = 'spoiler_ai_temperature';
+  static const String spoilerAiDebugPrintResponse       = 'spoiler_ai_debug_print_response';
+
+  // 弹幕开发调试设置
+  static const String showCanvasDanmakuCollisionBoxes   = 'show_canvas_danmaku_collision_boxes';
+  static const String showCanvasDanmakuTrackNumbers     = 'show_canvas_danmaku_track_numbers';
+  static const String showGpuDanmakuCollisionBoxes      = 'show_gpu_danmaku_collision_boxes';
+  static const String showGpuDanmakuTrackNumbers        = 'show_gpu_danmaku_track_numbers';
+
 }

--- a/lib/danmaku_abstraction/danmaku_kernel_factory.dart
+++ b/lib/danmaku_abstraction/danmaku_kernel_factory.dart
@@ -26,7 +26,6 @@ enum DanmakuRenderEngine {
 
 /// 负责读写弹幕渲染引擎设置的工厂类
 class DanmakuKernelFactory {
-  static const String _danmakuRenderEngineKey = 'danmaku_render_engine';
   // Default to Next2 where it is supported; fall back to NipaPlay Next on Web.
   static DanmakuRenderEngine _cachedEngine = _defaultEngine;
   static bool _initialized = false;
@@ -86,7 +85,7 @@ class DanmakuKernelFactory {
 
     try {
       final prefs = await SharedPreferences.getInstance();
-      final engineIndex = prefs.getInt(_danmakuRenderEngineKey);
+      final engineIndex = prefs.getInt(SettingsKeys.danmakuRenderEngine);
       _setEnableNextPlusPlus(
         prefs.getBool(SettingsKeys.danmakuEnableNextPlusPlusEngine) ?? false,
       );
@@ -116,7 +115,7 @@ class DanmakuKernelFactory {
     try {
       final sanitizedEngine = _sanitizeEngine(engine);
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setInt(_danmakuRenderEngineKey, sanitizedEngine.index);
+      await prefs.setInt(SettingsKeys.danmakuRenderEngine, sanitizedEngine.index);
       final oldEngine = _cachedEngine;
       _cachedEngine = sanitizedEngine;
 

--- a/lib/danmaku_dfm/dfm_plus_overlay.dart
+++ b/lib/danmaku_dfm/dfm_plus_overlay.dart
@@ -5,7 +5,7 @@ import 'package:nipaplay/danmaku_next/next2_emoji_pipeline.dart';
 import 'package:nipaplay/danmaku_next/next2_overlay_viewport.dart';
 import 'package:nipaplay/danmaku_next/next2_texture_bridge.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
-import 'package:nipaplay/utils/video_player_state.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 import 'package:provider/provider.dart';
 
 import 'dfm_plus_layout_bridge.dart';

--- a/lib/danmaku_next/danmaku_atlas_painter.dart
+++ b/lib/danmaku_next/danmaku_atlas_painter.dart
@@ -15,7 +15,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:nipaplay/danmaku_abstraction/danmaku_content_item.dart';
-import 'package:nipaplay/utils/video_player_state.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 
 import 'danmaku_sprite_atlas.dart';
 import 'nipaplay_next_engine.dart';

--- a/lib/danmaku_next/next2_texture_bridge.dart
+++ b/lib/danmaku_next/next2_texture_bridge.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:flutter/services.dart';
 import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
 import 'package:nipaplay/danmaku_next/next2_platform_support.dart';
-import 'package:nipaplay/utils/video_player_state.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 
 class Next2TextureInfo {
   const Next2TextureInfo({

--- a/lib/danmaku_next/nipaplay_next2_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next2_overlay.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
-import 'package:nipaplay/utils/video_player_state.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 import 'package:provider/provider.dart';
 
 import 'next2_emoji_pipeline.dart';

--- a/lib/danmaku_next/nipaplay_next_canvas_painter.dart
+++ b/lib/danmaku_next/nipaplay_next_canvas_painter.dart
@@ -5,7 +5,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:nipaplay/danmaku_abstraction/danmaku_content_item.dart';
-import 'package:nipaplay/utils/video_player_state.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 
 import 'nipaplay_next_engine.dart';
 

--- a/lib/danmaku_next/nipaplay_next_old_canvas_painter.dart
+++ b/lib/danmaku_next/nipaplay_next_old_canvas_painter.dart
@@ -15,7 +15,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:nipaplay/danmaku_abstraction/danmaku_content_item.dart';
-import 'package:nipaplay/utils/video_player_state.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 
 import 'nipaplay_next_old_engine.dart';
 

--- a/lib/danmaku_next/nipaplay_next_old_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next_old_overlay.dart
@@ -15,7 +15,7 @@ import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
 import 'package:nipaplay/danmaku_next/nipaplay_next_old_canvas_painter.dart';
 import 'package:nipaplay/danmaku_next/nipaplay_next_old_engine.dart';
 import 'package:nipaplay/danmaku_next/danmaku_next_log.dart';
-import 'package:nipaplay/utils/video_player_state.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 
 const Locale _danmakuOldLocale = Locale.fromSubtags(
   languageCode: 'zh',

--- a/lib/danmaku_next/nipaplay_next_overlay.dart
+++ b/lib/danmaku_next/nipaplay_next_overlay.dart
@@ -4,7 +4,7 @@ import 'package:nipaplay/danmaku_abstraction/positioned_danmaku_item.dart';
 import 'package:nipaplay/danmaku_next/danmaku_atlas_painter.dart';
 import 'package:nipaplay/danmaku_next/nipaplay_next_engine.dart';
 import 'package:nipaplay/danmaku_next/danmaku_next_log.dart';
-import 'package:nipaplay/utils/video_player_state.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 
 const Locale _danmakuLocale = Locale.fromSubtags(
   languageCode: 'zh',

--- a/lib/providers/appearance_settings_provider.dart
+++ b/lib/providers/appearance_settings_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/painting.dart' show TextOverflow;
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/app_accent_color.dart';
 
@@ -31,7 +32,6 @@ enum FolderNameDisplayMode {
 class AppearanceSettingsProvider extends ChangeNotifier {
   static const String _widgetBlurEffectKey = 'enable_widget_blur_effect';
   static const String _animeCardActionKey = 'anime_card_action';
-  static const String _showDanmakuDensityKey = 'show_danmaku_density_chart';
   static const String _recentWatchingStyleKey = 'recent_watching_style';
   static const String _uiScaleKey = 'ui_scale_factor';
   static const String _showAnimeCardSummaryKey = 'show_anime_card_summary';
@@ -111,7 +111,7 @@ class AppearanceSettingsProvider extends ChangeNotifier {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_widgetBlurEffectKey, false);
-      _showDanmakuDensityChart = prefs.getBool(_showDanmakuDensityKey) ?? true;
+      _showDanmakuDensityChart = prefs.getBool(SettingsKeys.showDanmakuDensityChart) ?? true;
       _showAnimeCardSummary = prefs.getBool(_showAnimeCardSummaryKey) ?? true;
       _accentColorPreset = AppAccentColorPreset.fromStorageKey(
         prefs.getString(_accentColorPresetKey),
@@ -199,7 +199,7 @@ class AppearanceSettingsProvider extends ChangeNotifier {
 
     try {
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(_showDanmakuDensityKey, value);
+      await prefs.setBool(SettingsKeys.showDanmakuDensityChart, value);
     } catch (e) {
       debugPrint('保存弹幕密度图设置时出错: $e');
     }

--- a/lib/providers/developer_options_provider.dart
+++ b/lib/providers/developer_options_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/utils/settings_storage.dart';
 import 'package:nipaplay/services/certificate_trust_service.dart';
 
@@ -76,22 +77,22 @@ class DeveloperOptionsProvider extends ChangeNotifier {
     );
     
     _showCanvasDanmakuCollisionBoxes = await SettingsStorage.loadBool(
-      'show_canvas_danmaku_collision_boxes',
+      SettingsKeys.showCanvasDanmakuCollisionBoxes,
       defaultValue: false
     );
     
     _showCanvasDanmakuTrackNumbers = await SettingsStorage.loadBool(
-      'show_canvas_danmaku_track_numbers',
+      SettingsKeys.showCanvasDanmakuTrackNumbers,
       defaultValue: false
     );
     
     _showGPUDanmakuCollisionBoxes = await SettingsStorage.loadBool(
-      'show_gpu_danmaku_collision_boxes',
+      SettingsKeys.showGpuDanmakuCollisionBoxes,
       defaultValue: false
     );
     
     _showGPUDanmakuTrackNumbers = await SettingsStorage.loadBool(
-      'show_gpu_danmaku_track_numbers',
+      SettingsKeys.showGpuDanmakuTrackNumbers,
       defaultValue: false
     );
 
@@ -139,7 +140,7 @@ class DeveloperOptionsProvider extends ChangeNotifier {
   Future<void> setShowCanvasDanmakuCollisionBoxes(bool value) async {
     if (_showCanvasDanmakuCollisionBoxes != value) {
       _showCanvasDanmakuCollisionBoxes = value;
-      await SettingsStorage.saveBool('show_canvas_danmaku_collision_boxes', _showCanvasDanmakuCollisionBoxes);
+      await SettingsStorage.saveBool(SettingsKeys.showCanvasDanmakuCollisionBoxes, _showCanvasDanmakuCollisionBoxes);
       notifyListeners();
     }
   }
@@ -148,7 +149,7 @@ class DeveloperOptionsProvider extends ChangeNotifier {
   Future<void> setShowCanvasDanmakuTrackNumbers(bool value) async {
     if (_showCanvasDanmakuTrackNumbers != value) {
       _showCanvasDanmakuTrackNumbers = value;
-      await SettingsStorage.saveBool('show_canvas_danmaku_track_numbers', _showCanvasDanmakuTrackNumbers);
+      await SettingsStorage.saveBool(SettingsKeys.showCanvasDanmakuTrackNumbers, _showCanvasDanmakuTrackNumbers);
       notifyListeners();
     }
   }
@@ -157,7 +158,7 @@ class DeveloperOptionsProvider extends ChangeNotifier {
   Future<void> setShowGPUDanmakuCollisionBoxes(bool value) async {
     if (_showGPUDanmakuCollisionBoxes != value) {
       _showGPUDanmakuCollisionBoxes = value;
-      await SettingsStorage.saveBool('show_gpu_danmaku_collision_boxes', _showGPUDanmakuCollisionBoxes);
+      await SettingsStorage.saveBool(SettingsKeys.showGpuDanmakuCollisionBoxes, _showGPUDanmakuCollisionBoxes);
       notifyListeners();
     }
   }
@@ -166,7 +167,7 @@ class DeveloperOptionsProvider extends ChangeNotifier {
   Future<void> setShowGPUDanmakuTrackNumbers(bool value) async {
     if (_showGPUDanmakuTrackNumbers != value) {
       _showGPUDanmakuTrackNumbers = value;
-      await SettingsStorage.saveBool('show_gpu_danmaku_track_numbers', _showGPUDanmakuTrackNumbers);
+      await SettingsStorage.saveBool(SettingsKeys.showGpuDanmakuTrackNumbers, _showGPUDanmakuTrackNumbers);
       notifyListeners();
     }
   }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -15,8 +15,6 @@ class SettingsProvider with ChangeNotifier {
 
   // 弹幕转换简体中文设置
   bool _danmakuConvertToSimplified = true; // 默认开启
-  static const String _danmakuConvertKey = 'danmaku_convert_to_simplified';
-
   // 哈希匹配失败后自动选择搜索第一个结果（避免弹窗）
   bool _autoMatchDanmakuFirstSearchResultOnHashFail = true; // 默认开启
 
@@ -60,7 +58,7 @@ class SettingsProvider with ChangeNotifier {
     // Load blur power, defaulting to 0.0 if not set (无模糊)
     _blurPower = _prefs.getDouble(_blurPowerKey) ?? _defaultBlur;
     // 当用户仍为“自动语言”且系统为繁中时，首次默认关闭“弹幕转简体”。
-    final savedDanmakuConvert = _prefs.getBool(_danmakuConvertKey);
+    final savedDanmakuConvert = _prefs.getBool(SettingsKeys.danmakuConvertToSimplified);
     if (savedDanmakuConvert != null) {
       _danmakuConvertToSimplified = savedDanmakuConvert;
     } else {
@@ -138,7 +136,7 @@ class SettingsProvider with ChangeNotifier {
   /// Sets the danmaku convert to simplified Chinese setting.
   Future<void> setDanmakuConvertToSimplified(bool enable) async {
     _danmakuConvertToSimplified = enable;
-    await _prefs.setBool(_danmakuConvertKey, _danmakuConvertToSimplified);
+    await _prefs.setBool(SettingsKeys.danmakuConvertToSimplified, _danmakuConvertToSimplified);
     notifyListeners();
   }
 

--- a/lib/services/dandanplay_service_io.dart
+++ b/lib/services/dandanplay_service_io.dart
@@ -1573,7 +1573,7 @@ class DandanplayService {
 
   static Future<int> _getDanmakuChConvertFlag() async {
     final prefs = await SharedPreferences.getInstance();
-    final convert = prefs.getBool('danmaku_convert_to_simplified') ?? true;
+    final convert = prefs.getBool(SettingsKeys.danmakuConvertToSimplified) ?? true;
     return convert ? 1 : 0;
   }
 

--- a/lib/services/dandanplay_service_stub.dart
+++ b/lib/services/dandanplay_service_stub.dart
@@ -2389,7 +2389,7 @@ class DandanplayService {
 
   static Future<int> _getDanmakuChConvertFlag() async {
     final prefs = await SharedPreferences.getInstance();
-    final convert = prefs.getBool('danmaku_convert_to_simplified') ?? true;
+    final convert = prefs.getBool(SettingsKeys.danmakuConvertToSimplified) ?? true;
     return convert ? 1 : 0;
   }
 

--- a/lib/services/external_player_service.dart
+++ b/lib/services/external_player_service.dart
@@ -14,6 +14,7 @@ import 'package:nipaplay/services/security_bookmark_service.dart';
 import 'package:nipaplay/src/rust/api/dfm_plus.dart' as rust_dfm;
 import 'package:nipaplay/src/rust/rust_init.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 import 'package:nipaplay/utils/danmaku_ass_converter.dart';
 import 'package:nipaplay/utils/danmaku_xml_utils.dart';
 import 'package:nipaplay/utils/video_player_state.dart';

--- a/lib/services/player_remote_control_bridge.dart
+++ b/lib/services/player_remote_control_bridge.dart
@@ -11,6 +11,7 @@ import 'package:nipaplay/services/dandanplay_service.dart';
 import 'package:nipaplay/services/emby_service.dart';
 import 'package:nipaplay/services/jellyfin_service.dart';
 import 'package:nipaplay/services/remote_control_settings.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
 
 class PlayerRemoteControlBridge {

--- a/lib/themes/cupertino/widgets/player_menu/cupertino_danmaku_settings_pane.dart
+++ b/lib/themes/cupertino/widgets/player_menu/cupertino_danmaku_settings_pane.dart
@@ -11,6 +11,7 @@ import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
 import 'package:nipaplay/themes/cupertino/widgets/player_menu/adaptive_player_menu_primitives.dart';
 import 'package:nipaplay/themes/cupertino/widgets/player_menu/cupertino_player_slider.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 import 'package:nipaplay/utils/danmaku_history_sync.dart';
 import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 import 'package:nipaplay/player_abstraction/player_factory.dart';

--- a/lib/themes/nipaplay/widgets/danmaku_settings_menu.dart
+++ b/lib/themes/nipaplay/widgets/danmaku_settings_menu.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 import 'package:nipaplay/player_abstraction/player_factory.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
 import 'base_settings_menu.dart';
 import 'player_menu_theme.dart';

--- a/lib/utils/danmaku/style.dart
+++ b/lib/utils/danmaku/style.dart
@@ -1,0 +1,19 @@
+
+// lib/utils/danmaku/style.dart
+// 定义弹幕样式相关的枚举类型
+
+
+/// 弹幕描边样式
+enum DanmakuOutlineStyle {
+  none,    // 无描边
+  stroke,  // 描边
+  uniform, // 均匀描边
+}
+
+/// 弹幕阴影样式
+enum DanmakuShadowStyle {
+  none,    // 无阴影
+  soft,    // 柔化阴影
+  medium,  // 中等阴影
+  strong,  // 强烈阴影
+}

--- a/lib/utils/player_kernel_manager.dart
+++ b/lib/utils/player_kernel_manager.dart
@@ -5,6 +5,7 @@ import '../player_abstraction/player_factory.dart';
 import '../player_abstraction/player_abstraction.dart';
 import '../danmaku_abstraction/danmaku_kernel_factory.dart';
 import '../danmaku_next/next2_platform_support.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'video_player_state.dart';
 import '../models/watch_history_model.dart';
@@ -215,7 +216,7 @@ class PlayerKernelManager {
   /// 获取当前弹幕内核
   static Future<String> getCurrentDanmakuKernel() async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getString('danmaku_kernel') ??
+    return prefs.getString(SettingsKeys.legacyDanmakuKernel) ??
         (Next2PlatformSupport.isKernelSupported
             ? 'NipaPlay Next2'
             : 'NipaPlay Next');
@@ -224,7 +225,7 @@ class PlayerKernelManager {
   /// 设置弹幕内核
   static Future<void> setDanmakuKernel(String kernel) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('danmaku_kernel', kernel);
+    await prefs.setString(SettingsKeys.legacyDanmakuKernel, kernel);
 
     // 转换为枚举值
     DanmakuRenderEngine engine;

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -254,8 +254,6 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   final String _instantHidePlayerUiEnabledKey =
       'instant_hide_player_ui_enabled';
   bool _instantHidePlayerUiEnabled = false; // 默认关闭（桌面端）
-  final String _playerTopSendDanmakuButtonVisibleKey =
-      'player_top_send_danmaku_button_visible';
   final String _playerTopSkipButtonVisibleKey =
       'player_top_skip_button_visible';
   final String _playerTopResizeButtonVisibleKey =
@@ -364,7 +362,6 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   bool _minimalProgressBarEnabled = false; // 默认关闭
   final String _minimalProgressBarColorKey = 'minimal_progress_bar_color';
   int _minimalProgressBarColor = 0xFFFF7274; // 默认颜色 #ff7274
-  final String _showDanmakuDensityChartKey = 'show_danmaku_density_chart';
   bool _showDanmakuDensityChart = false; // 默认关闭弹幕密度曲线图
   final String _precacheBufferSizeMbKey = 'player_precache_buffer_size_mb';
   int _precacheBufferSizeMb = PlayerFactory.defaultPrecacheBufferSizeMb;
@@ -404,13 +401,9 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   String? _timelinePreviewPlayerSource;
   Future<void> _timelinePreviewSerialTask = Future.value();
   double _danmakuOpacity = 1.0; // 默认透明度
-  final String _danmakuVisibleKey = 'danmaku_visible';
   bool _danmakuVisible = true; // 默认显示弹幕
-  final String _mergeDanmakuKey = 'merge_danmaku';
   bool _mergeDanmaku = false; // 默认不合并弹幕
-  final String _danmakuStackingKey = 'danmaku_stacking';
   bool _danmakuStacking = false; // 默认不启用弹幕堆叠
-  final String _danmakuRandomColorEnabledKey = 'danmaku_random_color_enabled';
   bool _danmakuRandomColorEnabled = false; // 默认关闭随机染色
 
   final String _anime4kProfileKey = 'anime4k_profile';
@@ -441,19 +434,14 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   List<String> _crtShaderPaths = const <String>[];
 
   // 弹幕类型屏蔽
-  final String _blockTopDanmakuKey = 'block_top_danmaku';
-  final String _blockBottomDanmakuKey = 'block_bottom_danmaku';
-  final String _blockScrollDanmakuKey = 'block_scroll_danmaku';
   bool _blockTopDanmaku = false; // 默认不屏蔽顶部弹幕
   bool _blockBottomDanmaku = false; // 默认不屏蔽底部弹幕
   bool _blockScrollDanmaku = false; // 默认不屏蔽滚动弹幕
 
   // 时间轴告知弹幕轨道状态
-  final String _timelineDanmakuEnabledKey = 'timeline_danmaku_enabled';
   bool _isTimelineDanmakuEnabled = true;
 
   // 弹幕屏蔽词
-  final String _danmakuBlockWordsKey = 'danmaku_block_words';
   List<String> _danmakuBlockWords = []; // 弹幕屏蔽词列表
   List<String> _pluginDanmakuBlockWords = [];
   VoidCallback? _pluginServiceListener;
@@ -461,7 +449,6 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   int _totalDanmakuCount = 0; // 添加一个字段来存储总弹幕数
 
   // 防剧透模式
-  final String _spoilerPreventionEnabledKey = 'spoiler_prevention_enabled';
   bool _spoilerPreventionEnabled = false;
   bool _isSpoilerDanmakuAnalyzing = false;
   String? _spoilerDanmakuAnalysisHash;
@@ -474,38 +461,25 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   String? _spoilerDanmakuPendingTargetVideoPath;
 
   // 防剧透 AI 设置
-  final String _spoilerAiUseCustomKeyKey = 'spoiler_ai_use_custom_key';
   bool _spoilerAiUseCustomKey = true; // 兼容旧设置，固定为自定义接口
-  final String _spoilerAiApiFormatKey = 'spoiler_ai_api_format';
   SpoilerAiApiFormat _spoilerAiApiFormat = SpoilerAiApiFormat.openai;
-  final String _spoilerAiApiUrlKey = 'spoiler_ai_api_url';
   String _spoilerAiApiUrl = '';
-  final String _spoilerAiApiKeyKey = 'spoiler_ai_api_key';
   String _spoilerAiApiKey = '';
-  final String _spoilerAiModelKey = 'spoiler_ai_model';
   String _spoilerAiModel = 'gpt-5';
-  final String _spoilerAiTemperatureKey = 'spoiler_ai_temperature';
   double _spoilerAiTemperature = 0.5;
-  final String _spoilerAiDebugPrintResponseKey =
-      'spoiler_ai_debug_print_response';
   bool _spoilerAiDebugPrintResponse = false;
 
   // 弹幕字体大小设置
-  final String _danmakuFontSizeKey = 'danmaku_font_size';
   double _danmakuFontSize = 0.0; // 默认为0表示使用系统默认值
   Timer? _danmakuFontSizePersistenceTimer;
-  final String _danmakuFontFilePathKey = 'danmaku_font_file_path';
   String _danmakuFontFilePath = '';
-  final String _danmakuFontFamilyKey = 'danmaku_font_family';
   String _danmakuFontFamily = '';
   DanmakuOutlineStyle _danmakuOutlineStyle = globals.isMobilePlatform
       ? DanmakuOutlineStyle.stroke
       : DanmakuOutlineStyle.uniform;
-  final String _danmakuShadowStyleKey = 'danmaku_shadow_style';
   DanmakuShadowStyle _danmakuShadowStyle = globals.isMobilePlatform
       ? DanmakuShadowStyle.none
       : DanmakuShadowStyle.strong;
-  final String _next2DanmakuOutlineWidthKey = 'next2_danmaku_outline_width';
   double _next2DanmakuOutlineWidth = 1.0;
   static const double minSubtitleScale = 0.5;
   static const double maxSubtitleScale = 2.5;
@@ -566,22 +540,18 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   SubtitleStyleOverrideMode _subtitleOverrideMode = defaultSubtitleOverrideMode;
 
   // 弹幕轨道显示区域设置
-  final String _danmakuDisplayAreaKey = 'danmaku_display_area';
   double _danmakuDisplayArea =
       1.0; // 默认全屏显示（0.0=单行，1.0=全屏，0.67=2/3，0.33=1/3，0.25=1/4，0.125=1/8）
 
   // 弹幕速度设置
-  final String _danmakuSpeedMultiplierKey = 'danmaku_speed_multiplier';
   final double _minDanmakuSpeedMultiplier = 0.5;
   final double _maxDanmakuSpeedMultiplier = 2.0;
   final double _baseDanmakuScrollDurationSeconds = 10.0;
   double _danmakuSpeedMultiplier = 1.0; // 默认标准速度
 
   // DFM+ 弹幕轨道间距比例设置
-  final String _danmakuDfmPlusTrackGapKey = 'danmaku_dfm_plus_track_gap';
   double _danmakuDfmPlusTrackGap = 0.15;
 
-  final String _rememberDanmakuOffsetKey = 'remember_danmaku_offset';
   bool _rememberDanmakuOffset = false; // 是否在切换视频时保留手动弹幕偏移
   double _manualDanmakuOffset = 0.0; // 手动设置的弹幕偏移
   double _autoDanmakuOffset = 0.0; // 弹弹Play自动匹配的时间偏移
@@ -790,7 +760,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   Future<void> _saveDanmakuFontSizePreference(double fontSize) async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setDouble(_danmakuFontSizeKey, fontSize);
+      await prefs.setDouble(SettingsKeys.danmakuFontSize, fontSize);
     } catch (e) {
       debugPrint('[VideoPlayerState] 保存弹幕字号失败: $e');
     }

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -4,6 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:nipaplay/utils/danmaku/style.dart';
 // import 'package:fvp/mdk.dart';  // Commented out
 import '../player_abstraction/player_abstraction.dart'; // <-- NEW IMPORT
 import '../player_abstraction/player_factory.dart';
@@ -115,10 +116,6 @@ enum SubtitleStyleOverrideMode { auto, none, scale, force }
 enum SubtitleAlignX { left, center, right }
 
 enum SubtitleAlignY { top, center, bottom }
-
-enum DanmakuOutlineStyle { none, stroke, uniform }
-
-enum DanmakuShadowStyle { none, soft, medium, strong }
 
 enum PlayerStatus {
   idle, // 空闲状态
@@ -406,7 +403,6 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   PlayerKernelType? _timelinePreviewPlayerKernel;
   String? _timelinePreviewPlayerSource;
   Future<void> _timelinePreviewSerialTask = Future.value();
-  final String _danmakuOpacityKey = 'danmaku_opacity';
   double _danmakuOpacity = 1.0; // 默认透明度
   final String _danmakuVisibleKey = 'danmaku_visible';
   bool _danmakuVisible = true; // 默认显示弹幕
@@ -502,7 +498,6 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   String _danmakuFontFilePath = '';
   final String _danmakuFontFamilyKey = 'danmaku_font_family';
   String _danmakuFontFamily = '';
-  final String _danmakuOutlineStyleKey = 'danmaku_outline_style';
   DanmakuOutlineStyle _danmakuOutlineStyle = globals.isMobilePlatform
       ? DanmakuOutlineStyle.stroke
       : DanmakuOutlineStyle.uniform;
@@ -951,7 +946,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   bool get showDanmakuDensityChart => _showDanmakuDensityChart;
   int get precacheBufferSizeMb => _precacheBufferSizeMb;
   int get precacheBufferDurationSeconds => _precacheBufferDurationSeconds;
-  double get danmakuOpacity => _danmakuOpacity;
+  double get danmakuOpacity => _danmakuOpacity; // 获取弹幕透明度
   bool get danmakuVisible => _danmakuVisible;
   bool get mergeDanmaku => _mergeDanmaku;
   double get danmakuFontSize => _danmakuFontSize;

--- a/lib/utils/video_player_state/video_player_state_danmaku.dart
+++ b/lib/utils/video_player_state/video_player_state_danmaku.dart
@@ -1666,7 +1666,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
 
     try {
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(_timelineDanmakuEnabledKey, enabled);
+      await prefs.setBool(SettingsKeys.timelineDanmakuEnabled, enabled);
     } catch (e) {
       debugPrint('保存时间轴告知开关失败: $e');
     }

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -313,7 +313,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   // 加载弹幕不透明度
   Future<void> _loadDanmakuOpacity() async {
     final prefs = await SharedPreferences.getInstance();
-    _danmakuOpacity = prefs.getDouble(_danmakuOpacityKey) ?? 1.0;
+    _danmakuOpacity = prefs.getDouble(SettingsKeys.danmakuOpacity) ?? 1.0;
     _notifyListeners();
   }
 
@@ -321,7 +321,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   Future<void> setDanmakuOpacity(double opacity) async {
     _danmakuOpacity = opacity;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setDouble(_danmakuOpacityKey, opacity);
+    await prefs.setDouble(SettingsKeys.danmakuOpacity, opacity);
     _syncErikaDanmakuConfig();
     _notifyListeners();
   }
@@ -1502,7 +1502,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     var loadedFontFamily =
         (prefs.getString(_danmakuFontFamilyKey) ?? '').trim();
     final loadedOutlineStyle = _resolveDanmakuOutlineStyle(
-      prefs.getInt(_danmakuOutlineStyleKey),
+      prefs.getInt(SettingsKeys.danmakuOutlineStyle),
     );
     final loadedShadowStyle = _resolveDanmakuShadowStyle(
       prefs.getInt(_danmakuShadowStyleKey),
@@ -1626,7 +1626,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _danmakuOutlineStyle = style;
     _next2DanmakuOutlineWidth = sanitizedWidth;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_danmakuOutlineStyleKey, style.index);
+    await prefs.setInt(SettingsKeys.danmakuOutlineStyle, style.index);
     await prefs.setDouble(
       _next2DanmakuOutlineWidthKey,
       sanitizedWidth,

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -57,7 +57,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _minimalProgressBarColor =
         prefs.getInt(_minimalProgressBarColorKey) ?? 0xFFFF7274;
     _showDanmakuDensityChart =
-        prefs.getBool(_showDanmakuDensityChartKey) ?? false;
+        prefs.getBool(SettingsKeys.showDanmakuDensityChart) ?? false;
     _notifyListeners();
   }
 
@@ -197,7 +197,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   Future<void> _loadPlayerTopButtonVisibilitySettings() async {
     final prefs = await SharedPreferences.getInstance();
     final sendDanmaku =
-        prefs.getBool(_playerTopSendDanmakuButtonVisibleKey) ?? true;
+        prefs.getBool(SettingsKeys.playerTopSendDanmakuButtonVisible) ?? true;
     final skip = prefs.getBool(_playerTopSkipButtonVisibleKey) ?? false;
     final resize = prefs.getBool(_playerTopResizeButtonVisibleKey) ?? false;
     final frameStep =
@@ -218,7 +218,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
 
   Future<void> setPlayerTopSendDanmakuButtonVisible(bool visible) =>
       _setPlayerTopButtonVisibility(
-        key: _playerTopSendDanmakuButtonVisibleKey,
+        key: SettingsKeys.playerTopSendDanmakuButtonVisible,
         currentValue: _playerTopSendDanmakuButtonVisible,
         newValue: visible,
         apply: () => _playerTopSendDanmakuButtonVisible = visible,
@@ -306,7 +306,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   Future<void> setShowDanmakuDensityChart(bool show) async {
     _showDanmakuDensityChart = show;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_showDanmakuDensityChartKey, show);
+    await prefs.setBool(SettingsKeys.showDanmakuDensityChart, show);
     _notifyListeners();
   }
 
@@ -335,7 +335,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   // 加载弹幕可见性
   Future<void> _loadDanmakuVisible() async {
     final prefs = await SharedPreferences.getInstance();
-    _danmakuVisible = prefs.getBool(_danmakuVisibleKey) ?? true;
+    _danmakuVisible = prefs.getBool(SettingsKeys.danmakuVisible) ?? true;
     _notifyListeners();
   }
 
@@ -343,7 +343,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     if (_danmakuVisible != visible) {
       _danmakuVisible = visible;
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(_danmakuVisibleKey, visible);
+      await prefs.setBool(SettingsKeys.danmakuVisible, visible);
       _syncErikaDanmakuConfig();
       _notifyListeners();
     }
@@ -356,7 +356,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   // 加载弹幕合并设置
   Future<void> _loadMergeDanmaku() async {
     final prefs = await SharedPreferences.getInstance();
-    _mergeDanmaku = prefs.getBool(_mergeDanmakuKey) ?? false;
+    _mergeDanmaku = prefs.getBool(SettingsKeys.mergeDanmaku) ?? false;
     _notifyListeners();
   }
 
@@ -365,7 +365,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     if (_mergeDanmaku != merge) {
       _mergeDanmaku = merge;
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(_mergeDanmakuKey, merge);
+      await prefs.setBool(SettingsKeys.mergeDanmaku, merge);
       _syncErikaDanmakuConfig();
       _notifyListeners();
     }
@@ -379,7 +379,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   // 加载弹幕堆叠设置
   Future<void> _loadDanmakuStacking() async {
     final prefs = await SharedPreferences.getInstance();
-    _danmakuStacking = prefs.getBool(_danmakuStackingKey) ?? false;
+    _danmakuStacking = prefs.getBool(SettingsKeys.danmakuStacking) ?? false;
     _notifyListeners();
   }
 
@@ -387,7 +387,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   Future<void> _loadDanmakuRandomColorEnabled() async {
     final prefs = await SharedPreferences.getInstance();
     _danmakuRandomColorEnabled =
-        prefs.getBool(_danmakuRandomColorEnabledKey) ?? false;
+        prefs.getBool(SettingsKeys.danmakuRandomColorEnabled) ?? false;
     _notifyListeners();
   }
 
@@ -395,7 +395,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   Future<void> _loadTimelineDanmakuEnabled() async {
     final prefs = await SharedPreferences.getInstance();
     _isTimelineDanmakuEnabled =
-        prefs.getBool(_timelineDanmakuEnabledKey) ?? true;
+        prefs.getBool(SettingsKeys.timelineDanmakuEnabled) ?? true;
     _notifyListeners();
   }
 
@@ -416,7 +416,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     if (_danmakuStacking != stacking) {
       _danmakuStacking = stacking;
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(_danmakuStackingKey, stacking);
+      await prefs.setBool(SettingsKeys.danmakuStacking, stacking);
       _syncErikaDanmakuConfig();
       _notifyListeners();
     }
@@ -429,7 +429,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     }
     _danmakuRandomColorEnabled = enabled;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_danmakuRandomColorEnabledKey, enabled);
+    await prefs.setBool(SettingsKeys.danmakuRandomColorEnabled, enabled);
     _updateMergedDanmakuList();
   }
 
@@ -1368,7 +1368,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   // 加载弹幕字体大小
   Future<void> _loadDanmakuFontSize() async {
     final prefs = await SharedPreferences.getInstance();
-    _danmakuFontSize = prefs.getDouble(_danmakuFontSizeKey) ?? 0.0;
+    _danmakuFontSize = prefs.getDouble(SettingsKeys.danmakuFontSize) ?? 0.0;
     _notifyListeners();
   }
 
@@ -1498,17 +1498,17 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   Future<void> _loadDanmakuDisplayEffectSettings() async {
     final prefs = await SharedPreferences.getInstance();
     final loadedFontFilePath =
-        (prefs.getString(_danmakuFontFilePathKey) ?? '').trim();
+        (prefs.getString(SettingsKeys.danmakuFontFilePath) ?? '').trim();
     var loadedFontFamily =
-        (prefs.getString(_danmakuFontFamilyKey) ?? '').trim();
+        (prefs.getString(SettingsKeys.danmakuFontFamily) ?? '').trim();
     final loadedOutlineStyle = _resolveDanmakuOutlineStyle(
       prefs.getInt(SettingsKeys.danmakuOutlineStyle),
     );
     final loadedShadowStyle = _resolveDanmakuShadowStyle(
-      prefs.getInt(_danmakuShadowStyleKey),
+      prefs.getInt(SettingsKeys.danmakuShadowStyle),
     );
     final loadedNext2OutlineWidth = _sanitizeNext2DanmakuOutlineWidth(
-      prefs.getDouble(_next2DanmakuOutlineWidthKey),
+      prefs.getDouble(SettingsKeys.next2DanmakuOutlineWidth),
     );
 
     var effectiveFontPath = loadedFontFilePath;
@@ -1542,16 +1542,16 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _next2DanmakuOutlineWidth = loadedNext2OutlineWidth;
 
     if (loadedFontFilePath != effectiveFontPath) {
-      await prefs.setString(_danmakuFontFilePathKey, effectiveFontPath);
+      await prefs.setString(SettingsKeys.danmakuFontFilePath, effectiveFontPath);
     }
-    if ((prefs.getString(_danmakuFontFamilyKey) ?? '').trim() !=
+    if ((prefs.getString(SettingsKeys.danmakuFontFamily) ?? '').trim() !=
         loadedFontFamily) {
-      await prefs.setString(_danmakuFontFamilyKey, loadedFontFamily);
+      await prefs.setString(SettingsKeys.danmakuFontFamily, loadedFontFamily);
     }
-    if ((prefs.getDouble(_next2DanmakuOutlineWidthKey) ?? -1.0) !=
+    if ((prefs.getDouble(SettingsKeys.next2DanmakuOutlineWidth) ?? -1.0) !=
         loadedNext2OutlineWidth) {
       await prefs.setDouble(
-        _next2DanmakuOutlineWidthKey,
+        SettingsKeys.next2DanmakuOutlineWidth,
         loadedNext2OutlineWidth,
       );
     }
@@ -1569,8 +1569,8 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _danmakuFontFilePath = '';
     _danmakuFontFamily = normalized;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_danmakuFontFilePathKey, '');
-    await prefs.setString(_danmakuFontFamilyKey, normalized);
+    await prefs.setString(SettingsKeys.danmakuFontFilePath, '');
+    await prefs.setString(SettingsKeys.danmakuFontFamily, normalized);
     _syncErikaDanmakuConfig();
     _notifyListeners();
   }
@@ -1595,8 +1595,8 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _danmakuFontFilePath = persistedPath;
     _danmakuFontFamily = runtimeFamily;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_danmakuFontFilePathKey, persistedPath);
-    await prefs.setString(_danmakuFontFamilyKey, runtimeFamily);
+    await prefs.setString(SettingsKeys.danmakuFontFilePath, persistedPath);
+    await prefs.setString(SettingsKeys.danmakuFontFamily, runtimeFamily);
     _syncErikaDanmakuConfig();
     _notifyListeners();
     return true;
@@ -1609,8 +1609,8 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _danmakuFontFilePath = '';
     _danmakuFontFamily = '';
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_danmakuFontFilePathKey, '');
-    await prefs.setString(_danmakuFontFamilyKey, '');
+    await prefs.setString(SettingsKeys.danmakuFontFilePath, '');
+    await prefs.setString(SettingsKeys.danmakuFontFamily, '');
     _syncErikaDanmakuConfig();
     _notifyListeners();
   }
@@ -1628,7 +1628,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(SettingsKeys.danmakuOutlineStyle, style.index);
     await prefs.setDouble(
-      _next2DanmakuOutlineWidthKey,
+      SettingsKeys.next2DanmakuOutlineWidth,
       sanitizedWidth,
     );
     _syncErikaDanmakuConfig();
@@ -1659,7 +1659,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     }
     _danmakuShadowStyle = style;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_danmakuShadowStyleKey, style.index);
+    await prefs.setInt(SettingsKeys.danmakuShadowStyle, style.index);
     _notifyListeners();
   }
 
@@ -2285,7 +2285,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   // 加载弹幕轨道显示区域
   Future<void> _loadDanmakuDisplayArea() async {
     final prefs = await SharedPreferences.getInstance();
-    _danmakuDisplayArea = prefs.getDouble(_danmakuDisplayAreaKey) ?? 1.0;
+    _danmakuDisplayArea = prefs.getDouble(SettingsKeys.danmakuDisplayArea) ?? 1.0;
     _notifyListeners();
   }
 
@@ -2294,7 +2294,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     if (_danmakuDisplayArea != area) {
       _danmakuDisplayArea = area;
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setDouble(_danmakuDisplayAreaKey, area);
+      await prefs.setDouble(SettingsKeys.danmakuDisplayArea, area);
       _syncErikaDanmakuConfig();
       _notifyListeners();
     }
@@ -2312,14 +2312,14 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
 
   Future<void> _loadDanmakuSpeedMultiplier() async {
     final prefs = await SharedPreferences.getInstance();
-    final stored = prefs.getDouble(_danmakuSpeedMultiplierKey);
+    final stored = prefs.getDouble(SettingsKeys.danmakuSpeedMultiplier);
     _danmakuSpeedMultiplier = _normalizeDanmakuSpeed(stored ?? 1.0);
     _notifyListeners();
   }
 
   Future<void> _loadRememberDanmakuOffset() async {
     final prefs = await SharedPreferences.getInstance();
-    final resolved = prefs.getBool(_rememberDanmakuOffsetKey) ?? false;
+    final resolved = prefs.getBool(SettingsKeys.rememberDanmakuOffset) ?? false;
     if (_rememberDanmakuOffset != resolved) {
       _rememberDanmakuOffset = resolved;
       _notifyListeners();
@@ -2333,7 +2333,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       return;
     }
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_rememberDanmakuOffsetKey, remember);
+    await prefs.setBool(SettingsKeys.rememberDanmakuOffset, remember);
     _rememberDanmakuOffset = remember;
     _notifyListeners();
   }
@@ -2345,7 +2345,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     }
     _danmakuSpeedMultiplier = normalized;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setDouble(_danmakuSpeedMultiplierKey, normalized);
+    await prefs.setDouble(SettingsKeys.danmakuSpeedMultiplier, normalized);
     _syncErikaDanmakuConfig();
     _notifyListeners();
   }
@@ -2353,7 +2353,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   Future<void> _loadDanmakuDfmPlusTrackGap() async {
     final prefs = await SharedPreferences.getInstance();
     _danmakuDfmPlusTrackGap =
-        prefs.getDouble(_danmakuDfmPlusTrackGapKey) ?? 0.15;
+        prefs.getDouble(SettingsKeys.danmakuDfmPlusTrackGap) ?? 0.15;
     _notifyListeners();
   }
 
@@ -2364,7 +2364,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     }
     _danmakuDfmPlusTrackGap = normalized;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setDouble(_danmakuDfmPlusTrackGapKey, normalized);
+    await prefs.setDouble(SettingsKeys.danmakuDfmPlusTrackGap, normalized);
     _syncErikaDanmakuConfig();
     _notifyListeners();
   }

--- a/lib/utils/video_player_state/video_player_state_subtitles.dart
+++ b/lib/utils/video_player_state/video_player_state_subtitles.dart
@@ -226,7 +226,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
   // 加载顶部弹幕屏蔽设置
   Future<void> _loadBlockTopDanmaku() async {
     final prefs = await SharedPreferences.getInstance();
-    _blockTopDanmaku = prefs.getBool(_blockTopDanmakuKey) ?? false;
+    _blockTopDanmaku = prefs.getBool(SettingsKeys.blockTopDanmaku) ?? false;
     _notifyListeners();
   }
 
@@ -235,7 +235,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
     if (_blockTopDanmaku != block) {
       _blockTopDanmaku = block;
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(_blockTopDanmakuKey, block);
+      await prefs.setBool(SettingsKeys.blockTopDanmaku, block);
       _updateMergedDanmakuList();
     }
   }
@@ -243,7 +243,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
   // 加载底部弹幕屏蔽设置
   Future<void> _loadBlockBottomDanmaku() async {
     final prefs = await SharedPreferences.getInstance();
-    _blockBottomDanmaku = prefs.getBool(_blockBottomDanmakuKey) ?? false;
+    _blockBottomDanmaku = prefs.getBool(SettingsKeys.blockBottomDanmaku) ?? false;
     _notifyListeners();
   }
 
@@ -252,7 +252,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
     if (_blockBottomDanmaku != block) {
       _blockBottomDanmaku = block;
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(_blockBottomDanmakuKey, block);
+      await prefs.setBool(SettingsKeys.blockBottomDanmaku, block);
       _updateMergedDanmakuList();
     }
   }
@@ -260,7 +260,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
   // 加载滚动弹幕屏蔽设置
   Future<void> _loadBlockScrollDanmaku() async {
     final prefs = await SharedPreferences.getInstance();
-    _blockScrollDanmaku = prefs.getBool(_blockScrollDanmakuKey) ?? false;
+    _blockScrollDanmaku = prefs.getBool(SettingsKeys.blockScrollDanmaku) ?? false;
     _notifyListeners();
   }
 
@@ -269,7 +269,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
     if (_blockScrollDanmaku != block) {
       _blockScrollDanmaku = block;
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(_blockScrollDanmakuKey, block);
+      await prefs.setBool(SettingsKeys.blockScrollDanmaku, block);
       _updateMergedDanmakuList();
     }
   }
@@ -277,7 +277,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
   // 加载弹幕屏蔽词列表
   Future<void> _loadDanmakuBlockWords() async {
     final prefs = await SharedPreferences.getInstance();
-    final blockWordsJson = prefs.getString(_danmakuBlockWordsKey);
+    final blockWordsJson = prefs.getString(SettingsKeys.danmakuBlockWords);
     if (blockWordsJson != null && blockWordsJson.isNotEmpty) {
       try {
         final List<dynamic> decodedList = json.decode(blockWordsJson);
@@ -301,7 +301,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
   Future<void> _loadSpoilerPreventionEnabled() async {
     final prefs = await SharedPreferences.getInstance();
     _spoilerPreventionEnabled =
-        prefs.getBool(_spoilerPreventionEnabledKey) ?? false;
+        prefs.getBool(SettingsKeys.spoilerPreventionEnabled) ?? false;
     _notifyListeners();
   }
 
@@ -316,7 +316,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
     _spoilerPreventionEnabled = enabled;
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_spoilerPreventionEnabledKey, enabled);
+    await prefs.setBool(SettingsKeys.spoilerPreventionEnabled, enabled);
 
     _isSpoilerDanmakuAnalyzing = false;
     _spoilerDanmakuAnalysisHash = null;
@@ -366,25 +366,25 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
 
   Future<void> _loadSpoilerAiSettings() async {
     final prefs = await SharedPreferences.getInstance();
-    final storedUseCustomKey = prefs.getBool(_spoilerAiUseCustomKeyKey);
+    final storedUseCustomKey = prefs.getBool(SettingsKeys.spoilerAiUseCustomKey);
     if (storedUseCustomKey != true) {
       _spoilerAiUseCustomKey = true;
-      await prefs.setBool(_spoilerAiUseCustomKeyKey, true);
+      await prefs.setBool(SettingsKeys.spoilerAiUseCustomKey, true);
     } else {
       _spoilerAiUseCustomKey = true;
     }
     _spoilerAiApiFormat =
-        _parseSpoilerAiApiFormat(prefs.getString(_spoilerAiApiFormatKey));
-    _spoilerAiApiUrl = prefs.getString(_spoilerAiApiUrlKey) ?? '';
-    _spoilerAiApiKey = prefs.getString(_spoilerAiApiKeyKey) ?? '';
-    _spoilerAiModel = prefs.getString(_spoilerAiModelKey) ?? 'gpt-5';
-    final temp = prefs.getDouble(_spoilerAiTemperatureKey) ?? 0.5;
+        _parseSpoilerAiApiFormat(prefs.getString(SettingsKeys.spoilerAiApiFormat));
+    _spoilerAiApiUrl = prefs.getString(SettingsKeys.spoilerAiApiUrl) ?? '';
+    _spoilerAiApiKey = prefs.getString(SettingsKeys.spoilerAiApiKey) ?? '';
+    _spoilerAiModel = prefs.getString(SettingsKeys.spoilerAiModel) ?? 'gpt-5';
+    final temp = prefs.getDouble(SettingsKeys.spoilerAiTemperature) ?? 0.5;
     _spoilerAiTemperature = temp.clamp(0.0, 2.0).toDouble();
     _spoilerAiDebugPrintResponse =
-        prefs.getBool(_spoilerAiDebugPrintResponseKey) ?? false;
+        prefs.getBool(SettingsKeys.spoilerAiDebugPrintResponse) ?? false;
     if (_spoilerPreventionEnabled && !spoilerAiConfigReady) {
       _spoilerPreventionEnabled = false;
-      await prefs.setBool(_spoilerPreventionEnabledKey, false);
+      await prefs.setBool(SettingsKeys.spoilerPreventionEnabled, false);
     }
     _notifyListeners();
   }
@@ -404,7 +404,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
 
     if (useCustomKey != null && _spoilerAiUseCustomKey != true) {
       _spoilerAiUseCustomKey = true;
-      await prefs.setBool(_spoilerAiUseCustomKeyKey, true);
+      await prefs.setBool(SettingsKeys.spoilerAiUseCustomKey, true);
       changed = true;
       shouldRestartAnalysis = true;
     }
@@ -412,7 +412,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
     if (apiFormat != null && _spoilerAiApiFormat != apiFormat) {
       _spoilerAiApiFormat = apiFormat;
       await prefs.setString(
-        _spoilerAiApiFormatKey,
+        SettingsKeys.spoilerAiApiFormat,
         _spoilerAiApiFormatToPrefs(apiFormat),
       );
       changed = true;
@@ -421,21 +421,21 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
 
     if (apiUrl != null && _spoilerAiApiUrl != apiUrl) {
       _spoilerAiApiUrl = apiUrl;
-      await prefs.setString(_spoilerAiApiUrlKey, apiUrl);
+      await prefs.setString(SettingsKeys.spoilerAiApiUrl, apiUrl);
       changed = true;
       shouldRestartAnalysis = true;
     }
 
     if (apiKey != null && _spoilerAiApiKey != apiKey) {
       _spoilerAiApiKey = apiKey;
-      await prefs.setString(_spoilerAiApiKeyKey, apiKey);
+      await prefs.setString(SettingsKeys.spoilerAiApiKey, apiKey);
       changed = true;
       shouldRestartAnalysis = true;
     }
 
     if (model != null && _spoilerAiModel != model) {
       _spoilerAiModel = model;
-      await prefs.setString(_spoilerAiModelKey, model);
+      await prefs.setString(SettingsKeys.spoilerAiModel, model);
       changed = true;
       shouldRestartAnalysis = true;
     }
@@ -444,7 +444,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
       final resolved = temperature.clamp(0.0, 2.0).toDouble();
       if ((_spoilerAiTemperature - resolved).abs() > 0.0001) {
         _spoilerAiTemperature = resolved;
-        await prefs.setDouble(_spoilerAiTemperatureKey, resolved);
+        await prefs.setDouble(SettingsKeys.spoilerAiTemperature, resolved);
         changed = true;
         shouldRestartAnalysis = true;
       }
@@ -453,7 +453,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
     if (debugPrintResponse != null &&
         _spoilerAiDebugPrintResponse != debugPrintResponse) {
       _spoilerAiDebugPrintResponse = debugPrintResponse;
-      await prefs.setBool(_spoilerAiDebugPrintResponseKey, debugPrintResponse);
+      await prefs.setBool(SettingsKeys.spoilerAiDebugPrintResponse, debugPrintResponse);
       changed = true;
     }
 
@@ -522,7 +522,7 @@ extension VideoPlayerStateSubtitles on VideoPlayerState {
   Future<void> _saveDanmakuBlockWords() async {
     final prefs = await SharedPreferences.getInstance();
     final blockWordsJson = json.encode(_danmakuBlockWords);
-    await prefs.setString(_danmakuBlockWordsKey, blockWordsJson);
+    await prefs.setString(SettingsKeys.danmakuBlockWords, blockWordsJson);
   }
 
   // 检查是否是正则表达式规则格式: 规则名称/表达式/


### PR DESCRIPTION
## 背景

弹幕描边和阴影样式枚举原本定义在 `video_player_state.dart`,
使独立的弹幕渲染器为了使用样式类型而依赖整个播放器状态文件.

弹幕持久化设置键同时分散在 `VideoPlayerState`, Provider, 弹幕内核工厂和服务层,
且部分读写位置直接使用字符串常量, 不利于统一检索和后续维护.

## 主要改动

### 集中弹幕样式枚举

- 新增 `lib/utils/danmaku/style.dart`
- 将 `DanmakuOutlineStyle` 和 `DanmakuShadowStyle` 移入独立样式文件
- 弹幕渲染器, 设置菜单, 外部播放器和远程控制服务改为直接引用样式文件
- 删除因仅使用样式枚举而引入的 `video_player_state.dart` 依赖
- 弹幕渲染引擎, 弹幕内容类型和轨道类型等非样式枚举保持原位置

### 集中弹幕设置键

将弹幕用户设置键统一放到 `lib/constants/settings_keys.dart`, 包括:

- 显示: 可见性, 透明度, 随机染色和弹幕密度图
- 布局: 合并, 堆叠, 显示区域, 速度, 轨道间距和偏移记忆
- 字体与样式: 字号, 字体文件, 字体族, 描边, 阴影和 Next2 描边宽度
- 过滤: 顶部, 底部, 滚动弹幕屏蔽及屏蔽词
- 内核: 弹幕渲染引擎和旧内核兼容设置
- 加载: 简繁转换及既有的自动加载, 自动匹配设置
- 防剧透: 启用状态, API 格式, URL, Key, 模型, 温度和调试输出
- 开发调试: Canvas/GPU 碰撞箱和轨道编号开关
- 播放器 UI: 顶部发送弹幕按钮可见性

## 其他

- 所有 SharedPreferences 字符串值保持不变
- 已有用户设置可直接按原 Key 读取, 无需数据迁移
- `VideoPlayerState` 的对外 getter/setter 保持不变
- 本 PR 仅涉及弹幕设置相关的枚举和键, 其他播放器状态和设置键保持原位置
- 没有修改或添加任何功能, 仅修改了样式枚举引用和设置键引用