### PR TITLE
chore: upgrade erika_flutter dependency to v0.1.2

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -291,8 +291,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: main
-      resolved-ref: b8694e8b9122f36679b8a3f6b71df43bc1a5d258
+      ref: v0.1.2
+      resolved-ref: 28e380039c61df9018a8a1604d5ffb3b492e5bb7
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,7 @@ dependencies:
   erika_flutter:
     git:
       url: https://github.com/AimesSoft/Erika.git
-      ref: main
+      ref: v0.1.2
       path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   mobile_scanner: ^7.2.0


### PR DESCRIPTION
Upgraded erika_flutter dependency to tag v0.1.2 and set the resolved ref to 28e380039c61df9018a8a1604d5ffb3b492e5bb7.