### PR TITLE
feat(android): add Erika native playback with SAF and HDR support

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -26,6 +26,11 @@ runs:
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
 
+    - name: Setup Rust for Android
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
+
     - name: Accept Android SDK licenses
       shell: bash
       run: |
@@ -33,11 +38,31 @@ runs:
         yes | sdkmanager --licenses >/dev/null
         set -o pipefail
 
-    - name: Install 7zip dependency
+    - name: Install Android native build dependencies
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends p7zip-full
+        sudo apt-get install -y --no-install-recommends \
+          build-essential \
+          cmake \
+          libclang-dev \
+          make \
+          meson \
+          nasm \
+          ninja-build \
+          p7zip-full \
+          pkg-config \
+          python3-venv
+
+    - name: Cache Erika Android native dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          ~/.pub-cache/git/Erika-*/third_party/cache
+          ~/.pub-cache/git/Erika-*/third_party/dist
+        key: android-erika-native-${{ runner.os }}-${{ env.ERIKA_SHA || hashFiles('pubspec.lock') }}-${{ hashFiles('android/build.gradle', 'android/app/build.gradle') }}-v2
 
     - name: Prefetch MDK SDK for fvp
       shell: bash
@@ -87,6 +112,9 @@ runs:
     - name: Configure Gradle
       shell: bash
       run: |
+        ERIKA_CARGO_TARGET_DIR="${RUNNER_TEMP}/erika-android-target"
+        mkdir -p "${ERIKA_CARGO_TARGET_DIR}"
+        echo "CARGO_TARGET_DIR=${ERIKA_CARGO_TARGET_DIR}" >> "$GITHUB_ENV"
         mkdir -p ~/.gradle
         cat > ~/.gradle/gradle.properties << EOF
         org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError
@@ -110,10 +138,14 @@ runs:
           exit 1
         fi
 
-        # 从项目配置读取 ndkVersion，避免 CI 与项目不一致导致找不到 clang
-        NDK_VERSION="$(grep -E '^[[:space:]]*ndkVersion[[:space:]]*=' -m 1 android/app/build.gradle | sed -E 's/.*['\''"]([^'\''"]+)['\''"].*/\1/')"
+        # Prefer the shared NDK declaration. Keep a literal app-level fallback
+        # for older branches that have not moved to android_ndk_version yet.
+        NDK_VERSION="$(sed -nE "s/^[[:space:]]*ext\.android_ndk_version[[:space:]]*=[[:space:]]*['\"]([^'\"]+)['\"].*/\1/p" android/build.gradle | head -n 1)"
         if [ -z "${NDK_VERSION}" ]; then
-          echo "错误：未能从 android/app/build.gradle 解析 ndkVersion。"
+          NDK_VERSION="$(sed -nE "s/^[[:space:]]*ndkVersion[[:space:]]*=[[:space:]]*['\"]([^'\"]+)['\"].*/\1/p" android/app/build.gradle | head -n 1)"
+        fi
+        if [ -z "${NDK_VERSION}" ]; then
+          echo "Unable to resolve the Android NDK version from Gradle configuration."
           exit 1
         fi
 

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -27,7 +27,10 @@ runs:
       with:
         path: |
           ~/.fvm
-          ~/.pub-cache
+          ~/.pub-cache/bin
+          ~/.pub-cache/git/cache
+          ~/.pub-cache/global_packages
+          ~/.pub-cache/hosted
         key: ${{ runner.os }}-fvm-${{ hashFiles('.fvmrc') }}-${{ hashFiles('**/pubspec.lock') }}-${{ hashFiles('**/gradle-wrapper.properties') }}-v1
         restore-keys: |
           ${{ runner.os }}-fvm-
@@ -38,7 +41,10 @@ runs:
       with:
         path: |
           ${{ env.USERPROFILE }}\.fvm
-          ${{ env.LOCALAPPDATA }}\Pub\Cache
+          ${{ env.LOCALAPPDATA }}\Pub\Cache\bin
+          ${{ env.LOCALAPPDATA }}\Pub\Cache\git\cache
+          ${{ env.LOCALAPPDATA }}\Pub\Cache\global_packages
+          ${{ env.LOCALAPPDATA }}\Pub\Cache\hosted
         key: ${{ runner.os }}-fvm-${{ hashFiles('.fvmrc') }}-${{ hashFiles('**/pubspec.lock') }}-${{ hashFiles('**/gradle-wrapper.properties') }}-v1
         restore-keys: |
           ${{ runner.os }}-fvm-
@@ -130,14 +136,27 @@ runs:
           exit 1
         fi
 
-        ERIKA_REF="${ERIKA_REF:-main}"
-        ERIKA_REMOTE="https://github.com/AimesSoft/Erika.git"
-        ERIKA_SHA="$(git ls-remote "${ERIKA_REMOTE}" "refs/heads/${ERIKA_REF}" | awk '{print $1}')"
-        if [ -z "${ERIKA_SHA}" ]; then
-          ERIKA_SHA="$(git ls-remote "${ERIKA_REMOTE}" "refs/tags/${ERIKA_REF}^{}" | awk '{print $1}')"
+        CONFIGURED_ERIKA_REF="$(awk '
+          /^  erika_flutter:/ {in_erika=1; next}
+          in_erika && /^      ref:/ {print $2; exit}
+          in_erika && /^  [^ ]/ {exit}
+        ' pubspec.yaml)"
+        ERIKA_REF="${ERIKA_REF:-${CONFIGURED_ERIKA_REF}}"
+        if [ -z "${ERIKA_REF}" ]; then
+          echo "Unable to resolve the Erika ref from pubspec.yaml."
+          exit 1
         fi
-        if [ -z "${ERIKA_SHA}" ]; then
-          ERIKA_SHA="$(git ls-remote "${ERIKA_REMOTE}" "refs/tags/${ERIKA_REF}" | awk '{print $1}')"
+        ERIKA_REMOTE="https://github.com/AimesSoft/Erika.git"
+        if [[ "${ERIKA_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+          ERIKA_SHA="$(printf '%s' "${ERIKA_REF}" | tr '[:upper:]' '[:lower:]')"
+        else
+          ERIKA_SHA="$(git ls-remote "${ERIKA_REMOTE}" "refs/heads/${ERIKA_REF}" | awk '{print $1}')"
+          if [ -z "${ERIKA_SHA}" ]; then
+            ERIKA_SHA="$(git ls-remote "${ERIKA_REMOTE}" "refs/tags/${ERIKA_REF}^{}" | awk '{print $1}')"
+          fi
+          if [ -z "${ERIKA_SHA}" ]; then
+            ERIKA_SHA="$(git ls-remote "${ERIKA_REMOTE}" "refs/tags/${ERIKA_REF}" | awk '{print $1}')"
+          fi
         fi
         if [ -z "${ERIKA_SHA}" ]; then
           echo "❌ 无法解析 Erika ref: ${ERIKA_REF}。"

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -69,6 +69,8 @@ jobs:
       - name: Setup Flutter Environment
         id: setup
         uses: ./.github/actions/setup-flutter
+        with:
+          java-version: '17'
 
       - name: Generate build info json
         shell: bash

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,21 +8,23 @@ plugins {
 android {
     namespace = "com.aimessoft.nipaplay"
     compileSdk = flutter.compileSdkVersion
-    // 多个插件要求 NDK 27.0.12077973，固定版本避免安装多版本导致磁盘耗尽
-    ndkVersion = "27.0.12077973"
+    // Erika、应用 C++ 模块与打包的 libc++_shared.so 统一使用同一 NDK。
+    ndkVersion = rootProject.ext.android_ndk_version
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 
     packagingOptions {
         jniLibs {
-            pickFirsts += ["**/*.so"]
+            // Native runtimes intentionally share one C++ runtime. Other duplicate
+            // libraries are build errors and must not be hidden by a broad *.so rule.
+            pickFirsts += ["**/libc++_shared.so"]
         }
         resources {
             pickFirsts += ["META-INF/*.version"]
@@ -35,7 +37,7 @@ android {
         applicationId = "com.aimessoft.nipaplay"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 26
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
@@ -113,8 +115,6 @@ flutter {
 }
 
 dependencies {
-    // Kotlin标准库
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10"
     implementation "androidx.multidex:multidex:2.0.1"
     
     // 添加Kotlin协程库

--- a/android/app/src/main/kotlin/com/aimessoft/nipaplay/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/aimessoft/nipaplay/MainActivity.kt
@@ -12,6 +12,7 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import java.io.File
 import android.content.ContentResolver
+import android.content.ClipData
 import android.content.Context
 import android.database.Cursor
 import android.provider.DocumentsContract
@@ -266,9 +267,19 @@ class MainActivity: FlutterActivity() {
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, FILE_SELECTOR_CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
                 "pickFilePathOnly" -> {
+                    if (filePickerResult != null) {
+                        result.error(
+                            "FILE_PICKER_BUSY",
+                            "Another file picker request is already active",
+                            null
+                        )
+                        return@setMethodCallHandler
+                    }
+
                     val params = call.arguments as? Map<*, *>
                     var fileType = "video/*"
                     var mimeTypes = mutableListOf<String>()
+                    val preserveContentUri = params?.get("preserveContentUri") as? Boolean ?: false
                     if (params != null) {
                         fileType = params["type"] as? String ?: "video/*"
                         params["extra_mime_types"]?.let { types ->
@@ -286,6 +297,10 @@ class MainActivity: FlutterActivity() {
                         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
                             type = fileType
                             addCategory(Intent.CATEGORY_OPENABLE)
+                            addFlags(
+                                Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                                    Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+                            )
                             putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false)
                         }
                         if(mimeTypes.isNotEmpty()) {
@@ -295,12 +310,15 @@ class MainActivity: FlutterActivity() {
                             )
                         }
                         
-                        // 启动文件选择器活动
-                        startActivityForResult(intent, FILE_PICKER_REQUEST_CODE)
-                        
                         // 保存结果回调
                         filePickerResult = result
+                        filePickerPreserveContentUri = preserveContentUri
+
+                        // 启动文件选择器活动
+                        startActivityForResult(intent, FILE_PICKER_REQUEST_CODE)
                     } catch (e: Exception) {
+                        filePickerResult = null
+                        filePickerPreserveContentUri = false
                         Log.e("MainActivity", "Error launching file picker", e)
                         result.error("FILE_PICKER_ERROR", e.message, null)
                     }
@@ -351,18 +369,33 @@ class MainActivity: FlutterActivity() {
 
                     var resolvedMimeType = explicitMimeType ?: "text/plain"
                     if (!filePath.isNullOrEmpty()) {
-                        val file = File(filePath)
-                        if (file.exists()) {
-                            val uri = FileProvider.getUriForFile(
-                                this@MainActivity,
-                                "${this@MainActivity.packageName}.fileprovider",
-                                file
-                            )
-                            intent.putExtra(Intent.EXTRA_STREAM, uri)
+                        val parsedUri = Uri.parse(filePath)
+                        if (ContentResolver.SCHEME_CONTENT == parsedUri.scheme) {
+                            intent.putExtra(Intent.EXTRA_STREAM, parsedUri)
+                            intent.clipData = ClipData.newRawUri("shared media", parsedUri)
                             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
 
                             if (explicitMimeType == null) {
-                                resolvedMimeType = guessMimeTypeFromPath(filePath) ?: "application/octet-stream"
+                                resolvedMimeType = contentResolver.getType(parsedUri)
+                                    ?: guessMimeTypeFromPath(filePath)
+                                    ?: "application/octet-stream"
+                            }
+                        } else {
+                            val file = File(filePath)
+                            if (file.exists()) {
+                                val uri = FileProvider.getUriForFile(
+                                    this@MainActivity,
+                                    "${this@MainActivity.packageName}.fileprovider",
+                                    file
+                                )
+                                intent.putExtra(Intent.EXTRA_STREAM, uri)
+                                intent.clipData = ClipData.newRawUri("shared media", uri)
+                                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+
+                                if (explicitMimeType == null) {
+                                    resolvedMimeType = guessMimeTypeFromPath(filePath)
+                                        ?: "application/octet-stream"
+                                }
                             }
                         }
                     }
@@ -439,6 +472,7 @@ class MainActivity: FlutterActivity() {
     private val FILE_PICKER_REQUEST_CODE = 9421
     private val SAF_DIRECTORY_PICKER_REQUEST_CODE = 9422
     private var filePickerResult: MethodChannel.Result? = null
+    private var filePickerPreserveContentUri = false
     private var safDirectoryPickerResult: MethodChannel.Result? = null
     
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -471,22 +505,45 @@ class MainActivity: FlutterActivity() {
         }
 
         if (requestCode == FILE_PICKER_REQUEST_CODE && filePickerResult != null) {
+            val pendingResult = filePickerResult
+            val preserveContentUri = filePickerPreserveContentUri
+            filePickerResult = null
+            filePickerPreserveContentUri = false
+
             if (resultCode == RESULT_OK && data != null && data.data != null) {
-                // 获取文件的真实路径
-                val filePath = getPathFromUri(this, data.data!!)
+                val uri = data.data!!
+                if (preserveContentUri && ContentResolver.SCHEME_CONTENT == uri.scheme) {
+                    // Preserve video SAF sources so native backends can open
+                    // the ContentResolver descriptor without copying media.
+                    if (!persistReadPermissionIfAvailable(uri, data.flags)) {
+                        Log.w(
+                            "MainActivity",
+                            "Selected media URI has only an ephemeral read grant; " +
+                                "reopening it from history after process restart may fail: $uri"
+                        )
+                    }
+                    pendingResult?.success(uri.toString())
+                    return
+                }
+                val filePath = if (ContentResolver.SCHEME_CONTENT == uri.scheme) {
+                    // Subtitle consumers still require an app-owned File path.
+                    // A persisted SAF grant does not make provider _data paths
+                    // readable under scoped storage, so copy these small files.
+                    saveContentToCache(this, uri)
+                } else {
+                    getPathFromUri(this, uri)
+                }
                 if (filePath != null) {
                     // 返回文件路径给Flutter
-                    filePickerResult?.success(filePath)
+                    pendingResult?.success(filePath)
                 } else {
                     // 如果无法获取路径，返回错误
-                    filePickerResult?.error("PATH_RESOLUTION_FAILED", "Failed to resolve file path", null)
+                    pendingResult?.error("PATH_RESOLUTION_FAILED", "Failed to resolve file path", null)
                 }
             } else {
                 // 用户取消选择
-                filePickerResult?.success(null)
+                pendingResult?.success(null)
             }
-            // 清除回调引用
-            filePickerResult = null
         }
     }
     
@@ -505,6 +562,20 @@ class MainActivity: FlutterActivity() {
             return null
         }
 
+        if (ContentResolver.SCHEME_CONTENT == uri.scheme) {
+            if (!persistReadPermissionIfAvailable(uri, intent.flags)) {
+                Log.w(
+                    "MainActivity",
+                    "File association URI has only an ephemeral read grant; " +
+                        "reopening it from history after process restart may fail: $uri"
+                )
+            }
+            val mediaSource = uri.toString()
+            Log.d("MainActivity", "File association: $mediaSource")
+            lastDeliveredOpenUri = mediaSource
+            return mediaSource
+        }
+
         val filePath = getPathFromUri(this@MainActivity, uri)
         if (filePath != null) {
             Log.d("MainActivity", "File association: $filePath")
@@ -514,6 +585,25 @@ class MainActivity: FlutterActivity() {
 
         Log.e("MainActivity", "Failed to resolve file path from URI: $uri")
         return null
+    }
+
+    private fun persistReadPermissionIfAvailable(uri: Uri, flags: Int): Boolean {
+        val hasReadGrant = flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0
+        val isPersistable = flags and Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION != 0
+        if (!hasReadGrant || !isPersistable) {
+            return false
+        }
+        try {
+            contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
+            Log.d("MainActivity", "Persisted read permission for $uri")
+            return true
+        } catch (e: Exception) {
+            Log.w("MainActivity", "Unable to persist read permission for $uri", e)
+            return false
+        }
     }
 
     private fun canAccessSafTree(treeUriString: String): Boolean {
@@ -683,7 +773,10 @@ class MainActivity: FlutterActivity() {
                     val type = split[0]
                     
                     if ("primary".equals(type, ignoreCase = true)) {
-                        return "${Environment.getExternalStorageDirectory()}/${split[1]}"
+                        val path = "${Environment.getExternalStorageDirectory()}/${split[1]}"
+                        if (File(path).exists()) {
+                            return path
+                        }
                     }
                     
                     // 处理SD卡和其他外部存储
@@ -692,7 +785,10 @@ class MainActivity: FlutterActivity() {
                     if (firstExternalDir != null) {
                         val storagePath = firstExternalDir.absolutePath
                         val storageId = storagePath.substringBefore("/Android")
-                        return "$storageId/${split[1]}"
+                        val path = "$storageId/${split[1]}"
+                        if (File(path).exists()) {
+                            return path
+                        }
                     }
                 }
             }
@@ -706,13 +802,17 @@ class MainActivity: FlutterActivity() {
                     
                     val contentUri = when (mediaType.lowercase()) {
                         "video" -> MediaStore.Video.Media.EXTERNAL_CONTENT_URI
-                        else -> return null
+                        else -> null
                     }
-                    
-                    val selection = "_id=?"
-                    val selectionArgs = arrayOf(mediaId)
-                    
-                    return getDataColumn(context, contentUri, selection, selectionArgs)
+
+                    if (contentUri != null) {
+                        val selection = "_id=?"
+                        val selectionArgs = arrayOf(mediaId)
+                        val path = getDataColumn(context, contentUri, selection, selectionArgs)
+                        if (path != null) {
+                            return path
+                        }
+                    }
                 }
             }
             
@@ -722,7 +822,15 @@ class MainActivity: FlutterActivity() {
                 val contentUri = ContentResolver.SCHEME_CONTENT + "://downloads/public_downloads"
                 val contentUriParsed = Uri.parse(contentUri)
                 
-                return getDataColumn(context, contentUriParsed, "_id=?", arrayOf(documentId))
+                val path = getDataColumn(
+                    context,
+                    contentUriParsed,
+                    "_id=?",
+                    arrayOf(documentId)
+                )
+                if (path != null) {
+                    return path
+                }
             }
         } catch (e: Exception) {
             Log.e("MainActivity", "Error resolving document URI", e)
@@ -734,6 +842,7 @@ class MainActivity: FlutterActivity() {
     
     // 保存内容URI指向的文件到缓存目录并返回路径
     private fun saveContentToCache(context: Context, uri: Uri): String? {
+        var outputFile: File? = null
         try {
             // 获取文件名
             var fileName: String? = null
@@ -746,28 +855,40 @@ class MainActivity: FlutterActivity() {
                 }
             }
             
-            if (fileName == null) {
-                fileName = "video_${System.currentTimeMillis()}.mp4"
-            }
-            
-            // 创建缓存文件
+            val extension = fileName
+                ?.substringAfterLast('.', "")
+                ?.takeIf { it.isNotBlank() }
+                ?.let { ".$it" }
+                ?: ".tmp"
+
+            // 创建唯一缓存文件，避免失败重试误用上一次选择的旧内容。
             val cacheDir = context.externalCacheDir ?: context.cacheDir
-            val outputFile = File(cacheDir, fileName)
+            val cacheFile = File.createTempFile("nipaplay_picker_", extension, cacheDir)
+            outputFile = cacheFile
             
             // 复制内容到缓存文件但不将整个文件加载到内存
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                outputFile.outputStream().use { output ->
+            val input = context.contentResolver.openInputStream(uri)
+                ?: throw IllegalStateException("Cannot open selected content: $uri")
+            input.use { source ->
+                cacheFile.outputStream().use { output ->
                     val buffer = ByteArray(8 * 1024) // 8KB缓冲区
                     var bytesRead: Int
-                    while (input.read(buffer).also { bytesRead = it } != -1) {
+                    while (source.read(buffer).also { bytesRead = it } != -1) {
                         output.write(buffer, 0, bytesRead)
                     }
                     output.flush()
                 }
             }
-            
-            return outputFile.absolutePath
+
+            if (!cacheFile.exists() || cacheFile.length() <= 0L) {
+                cacheFile.delete()
+                Log.e("MainActivity", "Selected content was empty: $uri")
+                return null
+            }
+
+            return cacheFile.absolutePath
         } catch (e: Exception) {
+            outputFile?.delete()
             Log.e("MainActivity", "Error saving content to cache", e)
             return null
         }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,7 @@
+ext.android_ndk_version = '29.0.14206865'
+
 buildscript {
-    ext.kotlin_version = '2.1.0'
+    ext.kotlin_version = '2.3.21'
     repositories {
         google()
         mavenCentral()
@@ -33,6 +35,14 @@ allprojects {
 rootProject.buildDir = "../build"
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
+}
+subprojects { subproject ->
+    subproject.afterEvaluate {
+        if (subproject.plugins.hasPlugin("com.android.application") ||
+                subproject.plugins.hasPlugin("com.android.library")) {
+            subproject.android.ndkVersion = rootProject.ext.android_ndk_version
+        }
+    }
 }
 subprojects {
     project.evaluationDependsOn(":app")

--- a/lib/player_abstraction/abstract_player.dart
+++ b/lib/player_abstraction/abstract_player.dart
@@ -3,6 +3,11 @@ import 'package:flutter/foundation.dart'; // For ValueListenable
 import './player_enums.dart';
 import './player_data_models.dart';
 
+/// Optional capability for backends whose native teardown must be awaited.
+abstract interface class AsyncDisposablePlayer {
+  Future<void> disposeAsync();
+}
+
 abstract class AbstractPlayer {
   // Properties
   double get volume;

--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -548,17 +548,30 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
     }
     switch (value) {
       case PlayerPlaybackState.playing:
-        unawaited(playDirectly());
+        _dispatchStateCommand('play', playDirectly);
         break;
       case PlayerPlaybackState.paused:
-        unawaited(pauseDirectly());
+        _dispatchStateCommand('pause', pauseDirectly);
         break;
       case PlayerPlaybackState.stopped:
         _state = PlayerPlaybackState.stopped;
         _lastPositionMs = 0;
-        unawaited(_player.stop());
+        _dispatchStateCommand('stop', _player.stop);
         break;
     }
+  }
+
+  void _dispatchStateCommand(
+    String operation,
+    Future<void> Function() command,
+  ) {
+    unawaited(
+      command().catchError((Object error, StackTrace stackTrace) {
+        final message = '$operation failed: $error';
+        _lastNativeError = message;
+        debugPrint('[Erika] $message');
+      }),
+    );
   }
 
   @override
@@ -834,9 +847,21 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
   @override
   Future<void> pauseDirectly() async {
     _ensureSupported();
+    if (_state != PlayerPlaybackState.playing) {
+      return;
+    }
     await _player.ensureCreated();
     _lastPositionMs = position;
-    await _player.pause();
+    try {
+      await _player.pause();
+    } catch (error) {
+      if (_state == PlayerPlaybackState.stopped) {
+        debugPrint(
+            '[Erika] pause ignored after native playback stopped: $error');
+        return;
+      }
+      rethrow;
+    }
     _state = PlayerPlaybackState.paused;
     _lastPositionUpdate = DateTime.now();
   }

--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -488,11 +488,13 @@ class ErikaPlayerAdapter implements AbstractPlayer {
       !kIsWeb &&
       (defaultTargetPlatform == TargetPlatform.macOS ||
           defaultTargetPlatform == TargetPlatform.iOS ||
-          defaultTargetPlatform == TargetPlatform.windows);
+          defaultTargetPlatform == TargetPlatform.windows ||
+          defaultTargetPlatform == TargetPlatform.android);
 
   bool get prefersPlatformVideoSurface => _isSupported;
 
-  bool get usesWindowOverlayVideoSurface => _isSupported;
+  bool get usesWindowOverlayVideoSurface =>
+      _isSupported && defaultTargetPlatform != TargetPlatform.android;
 
   @override
   double get volume => _volume;
@@ -945,6 +947,13 @@ class ErikaPlayerAdapter implements AbstractPlayer {
     ValueChanged<Rect?>? onFrameRectChanged,
   }) {
     _ensureSupported();
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      return ErikaVideoView(
+        player: _player,
+        debugLabel: debugLabel,
+        onPlatformViewIdChanged: onPlatformViewIdChanged,
+      );
+    }
     return _NipaplayErikaWindowOverlayVideoView(
       player: _player,
       debugLabel: debugLabel,
@@ -1224,6 +1233,40 @@ class ErikaPlayerAdapter implements AbstractPlayer {
   }
 
   void _handleEvent(ErikaPlayerEvent event) {
+    if (event.kind == ErikaEventKind.error) {
+      final errorMessage = _formatPlaybackError(event);
+      _mediaInfo = _mediaInfo.copyWith(specificErrorMessage: errorMessage);
+      debugPrint(
+        '[Erika] playback error '
+        'player=${event.playerId} state=${event.state.name} '
+        'status=${event.status} error=${event.error ?? '-'} '
+        'message=${event.message ?? '-'}',
+      );
+    }
+
+    if (event.kind == ErikaEventKind.videoDecoderChanged &&
+        event.decoder case final decoder?) {
+      debugPrint(
+        '[Erika] video decoder changed '
+        'stage=${decoder.stage} requested=${decoder.requestedBackend} '
+        'previous=${decoder.previousBackend ?? '-'} '
+        'active=${decoder.activeBackend} fallbacks=${decoder.fallbackCount} '
+        'codec=${decoder.codec ?? '-'} format=${decoder.pixelFormat ?? '-'} '
+        'reason=${decoder.reason ?? '-'}',
+      );
+    }
+
+    if (event.kind == ErikaEventKind.audioOutputChanged &&
+        event.audio case final audio?) {
+      debugPrint(
+        '[Erika] audio output changed '
+        'state=${audio.recoveryState} errorCode=${audio.lastErrorCode} '
+        'attempts=${audio.recoveryAttempts} recoveries=${audio.recoveryCount} '
+        'failures=${audio.recoveryFailures} '
+        'sequence=${audio.transitionSequence}',
+      );
+    }
+
     if (event.kind == ErikaEventKind.stateChanged ||
         event.kind == ErikaEventKind.error) {
       switch (event.state) {
@@ -1372,6 +1415,19 @@ class ErikaPlayerAdapter implements AbstractPlayer {
     _mediaInfo = updatedInfo;
   }
 
+  static String _formatPlaybackError(ErikaPlayerEvent event) {
+    final error = event.error?.trim();
+    final message = event.message?.trim();
+    final details = <String>[
+      if (error != null && error.isNotEmpty) error,
+      if (message != null && message.isNotEmpty && message != error) message,
+      if (event.status != 0) 'status=${event.status}',
+    ];
+    return details.isEmpty
+        ? 'Erika 播放失败（未返回详细原因）'
+        : 'Erika 播放失败：${details.join('；')}';
+  }
+
   static String _formatErikaVideoCodecParams(ErikaTrackInfo track) {
     final parts = <String>[
       if (track.codec != null) 'codec: ${track.codec}',
@@ -1434,7 +1490,8 @@ class ErikaPlayerAdapter implements AbstractPlayer {
   void _ensureSupported() {
     if (!_isSupported) {
       throw UnsupportedError(
-          'Erika is currently only wired on macOS/iOS/Windows.');
+        'Erika is currently only wired on Android/iOS/macOS/Windows.',
+      );
     }
   }
 }

--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -424,7 +424,7 @@ class _NipaplayErikaWindowOverlayVideoViewState
   }
 }
 
-class ErikaPlayerAdapter implements AbstractPlayer {
+class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
   ErikaPlayerAdapter() {
     if (_isSupported) {
       _eventSubscription = _player.events.listen(
@@ -447,6 +447,7 @@ class ErikaPlayerAdapter implements AbstractPlayer {
   final Map<String, String> _properties = <String, String>{};
 
   StreamSubscription<ErikaPlayerEvent>? _eventSubscription;
+  Future<void>? _disposeFuture;
   PlayerPlaybackState _state = PlayerPlaybackState.stopped;
   PlayerMediaInfo _mediaInfo = PlayerMediaInfo(duration: 0);
   String _media = '';
@@ -672,8 +673,18 @@ class ErikaPlayerAdapter implements AbstractPlayer {
 
   @override
   void dispose() {
-    if (_disposed) {
-      return;
+    unawaited(
+      disposeAsync().catchError((Object error, StackTrace stackTrace) {
+        debugPrint('Erika: asynchronous dispose failed: $error');
+      }),
+    );
+  }
+
+  @override
+  Future<void> disposeAsync() {
+    final existing = _disposeFuture;
+    if (existing != null) {
+      return existing;
     }
     _disposed = true;
     _danmakuConfigTimer?.cancel();
@@ -685,10 +696,20 @@ class ErikaPlayerAdapter implements AbstractPlayer {
     }
     _pendingDanmakuConfigCompleters.clear();
     _pendingDanmakuConfig = null;
-    unawaited(_eventSubscription?.cancel());
+    final eventSubscription = _eventSubscription;
     _eventSubscription = null;
-    unawaited(_player.dispose());
     _textureIdNotifier.dispose();
+    return _disposeFuture = _finishDispose(eventSubscription);
+  }
+
+  Future<void> _finishDispose(
+    StreamSubscription<ErikaPlayerEvent>? eventSubscription,
+  ) async {
+    try {
+      await eventSubscription?.cancel();
+    } finally {
+      await _player.dispose();
+    }
   }
 
   @override
@@ -1233,6 +1254,9 @@ class ErikaPlayerAdapter implements AbstractPlayer {
   }
 
   void _handleEvent(ErikaPlayerEvent event) {
+    if (_disposed) {
+      return;
+    }
     if (event.kind == ErikaEventKind.error) {
       final errorMessage = _formatPlaybackError(event);
       _mediaInfo = _mediaInfo.copyWith(specificErrorMessage: errorMessage);

--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -425,7 +425,12 @@ class _NipaplayErikaWindowOverlayVideoViewState
 }
 
 class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
-  ErikaPlayerAdapter() {
+  ErikaPlayerAdapter({
+    PlayerErikaAndroidOutputMode androidOutputMode =
+        PlayerErikaAndroidOutputMode.sdr,
+  }) : _player = ErikaPlayer(
+          outputMode: _resolveNativeOutputMode(androidOutputMode),
+        ) {
     if (_isSupported) {
       _eventSubscription = _player.events.listen(
         _handleEvent,
@@ -436,7 +441,7 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
     }
   }
 
-  final ErikaPlayer _player = ErikaPlayer();
+  final ErikaPlayer _player;
   final ValueNotifier<int?> _textureIdNotifier = ValueNotifier<int?>(null);
   final Map<PlayerMediaType, List<String>> _decoders = {
     PlayerMediaType.video: const <String>[],
@@ -455,6 +460,10 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
   double _playbackRate = 1.0;
   PlayerUpscalerStatus _lastUpscalerStatus = const PlayerUpscalerStatus.off();
   Map<String, dynamic> _lastPresenterStats = const <String, dynamic>{};
+  Map<String, dynamic> _lastOutputStatus = const <String, dynamic>{};
+  Map<String, dynamic> _lastDecoderStatus = const <String, dynamic>{};
+  Map<String, dynamic> _lastAudioOutputStatus = const <String, dynamic>{};
+  String? _lastNativeError;
   int _lastPositionMs = 0;
   DateTime _lastPositionUpdate = DateTime.now();
   int? _pendingSeekTargetMs;
@@ -484,6 +493,19 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
   static const bool _subtitleTraceEnabled = bool.fromEnvironment(
     'NIPAPLAY_ERIKA_SUBTITLE_TRACE',
   );
+
+  static ErikaOutputMode? _resolveNativeOutputMode(
+    PlayerErikaAndroidOutputMode mode,
+  ) {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return null;
+    }
+    return switch (mode) {
+      PlayerErikaAndroidOutputMode.sdr => ErikaOutputMode.sdr,
+      PlayerErikaAndroidOutputMode.extendedLinearHdr =>
+        ErikaOutputMode.extendedLinear,
+    };
+  }
 
   static bool get _isSupported =>
       !kIsWeb &&
@@ -644,6 +666,11 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
       _lastPositionMs = 0;
       _lastPositionUpdate = DateTime.now();
       _mediaInfo = PlayerMediaInfo(duration: 0);
+      _lastPresenterStats = const <String, dynamic>{};
+      _lastOutputStatus = const <String, dynamic>{};
+      _lastDecoderStatus = const <String, dynamic>{};
+      _lastAudioOutputStatus = const <String, dynamic>{};
+      _lastNativeError = null;
       _externalSubtitleTrackIds.clear();
       _externalSubtitleGeneration++;
     }
@@ -1171,6 +1198,10 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
       'duration': _mediaInfo.duration,
       'upscaler': _lastUpscalerStatus.toMap(),
       'presenterStats': _lastPresenterStats,
+      'outputStatus': _lastOutputStatus,
+      'decoder': _lastDecoderStatus,
+      'audioOutput': _lastAudioOutputStatus,
+      if (_lastNativeError != null) 'lastError': _lastNativeError,
       'tracks': <String, dynamic>{
         'video': _videoTrackInfos.map(_erikaTrackToDebugMap).toList(),
         'audio': _audioTrackInfos.map(_erikaTrackToDebugMap).toList(),
@@ -1201,6 +1232,30 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
     } catch (error) {
       debugPrint('Erika: get presenter stats failed: $error');
     }
+    try {
+      final output = await _player.getOutputStatus();
+      _lastOutputStatus = _outputStatusToMap(output);
+    } catch (error) {
+      debugPrint('Erika: get output status failed: $error');
+    }
+  }
+
+  static Map<String, dynamic> _outputStatusToMap(ErikaOutputStatus status) {
+    return <String, dynamic>{
+      'requestedMode': status.requestedMode.name,
+      'activeEncoding': status.activeEncoding.name,
+      'surfaceFormat': status.surfaceFormat.name,
+      'nativeDataSpace': status.nativeDataSpace,
+      'requestedHeadroom': status.requestedHeadroom,
+      'activeHeadroom': status.activeHeadroom,
+      'activeHeadroomKnown': status.activeHeadroomKnown,
+      'extendedLinearActive': status.extendedLinearActive,
+      'fallbackReason': status.fallbackReason.label,
+      'fallbackCount': status.fallbackCount,
+      'dataSpaceFailures': status.dataSpaceFailures,
+      'headroomUpdates': status.headroomUpdates,
+      'extendedLinearFrames': status.extendedLinearFrames,
+    };
   }
 
   ErikaUpscalerMode _toNativeUpscalerMode(PlayerUpscalerMode mode) {
@@ -1259,6 +1314,7 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
     }
     if (event.kind == ErikaEventKind.error) {
       final errorMessage = _formatPlaybackError(event);
+      _lastNativeError = errorMessage;
       _mediaInfo = _mediaInfo.copyWith(specificErrorMessage: errorMessage);
       debugPrint(
         '[Erika] playback error '
@@ -1268,8 +1324,19 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
       );
     }
 
-    if (event.kind == ErikaEventKind.videoDecoderChanged &&
-        event.decoder case final decoder?) {
+    final decoder = event.decoder;
+    if (event.kind == ErikaEventKind.videoDecoderChanged && decoder != null) {
+      _lastDecoderStatus = <String, dynamic>{
+        'stage': decoder.stage,
+        'requestedBackend': decoder.requestedBackend,
+        'previousBackend': decoder.previousBackend,
+        'activeBackend': decoder.activeBackend,
+        'fallbackCount': decoder.fallbackCount,
+        'codec': decoder.codec,
+        'pixelFormat': decoder.pixelFormat,
+        'lineSizes': decoder.lineSizes,
+        'reason': decoder.reason,
+      };
       debugPrint(
         '[Erika] video decoder changed '
         'stage=${decoder.stage} requested=${decoder.requestedBackend} '
@@ -1280,8 +1347,16 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
       );
     }
 
-    if (event.kind == ErikaEventKind.audioOutputChanged &&
-        event.audio case final audio?) {
+    final audio = event.audio;
+    if (event.kind == ErikaEventKind.audioOutputChanged && audio != null) {
+      _lastAudioOutputStatus = <String, dynamic>{
+        'recoveryState': audio.recoveryState,
+        'lastErrorCode': audio.lastErrorCode,
+        'recoveryAttempts': audio.recoveryAttempts,
+        'recoveryCount': audio.recoveryCount,
+        'recoveryFailures': audio.recoveryFailures,
+        'transitionSequence': audio.transitionSequence,
+      };
       debugPrint(
         '[Erika] audio output changed '
         'state=${audio.recoveryState} errorCode=${audio.lastErrorCode} '

--- a/lib/player_abstraction/player_abstraction.dart
+++ b/lib/player_abstraction/player_abstraction.dart
@@ -5,6 +5,7 @@ export './abstract_player.dart' show AbstractPlayer, AsyncDisposablePlayer;
 export './player_factory.dart'
     show PlayerKernelType; // Export PlayerKernelType enum
 
+import 'dart:async';
 import 'dart:ui' show Rect;
 
 import 'package:flutter/foundation.dart'; // For ValueListenable, used in AbstractPlayer
@@ -33,6 +34,8 @@ enum MediaType { unknown, video, audio, subtitle }
 /// obtained from the `PlayerFactory`.
 class Player {
   final core_player.AbstractPlayer _delegate;
+  Future<void>? _disposeFuture;
+  bool _disposeErrorHandlerAttached = false;
 
   /// Factory constructor that allows `Player()` to be called.
   /// This is what `VideoPlayerState` will use, e.g., `Player player = Player();`.
@@ -40,6 +43,9 @@ class Player {
     // PlayerFactory 会自动从 SharedPreferences 读取播放器内核设置
     return Player._internal(PlayerFactory().createPlayer());
   }
+
+  @visibleForTesting
+  Player.withDelegate(this._delegate);
 
   // Private internal constructor
   Player._internal(this._delegate);
@@ -129,15 +135,53 @@ class Player {
 
   void seek({required int position}) => _delegate.seek(position: position);
 
-  void dispose() => _delegate.dispose();
-
-  Future<void> disposeAsync() async {
-    final delegate = _delegate;
-    if (delegate is core_player.AsyncDisposablePlayer) {
-      await (delegate as core_player.AsyncDisposablePlayer).disposeAsync();
+  void dispose() {
+    final future = _startDispose();
+    if (_disposeErrorHandlerAttached) {
       return;
     }
-    delegate.dispose();
+    _disposeErrorHandlerAttached = true;
+    unawaited(
+      future.then<void>(
+        (_) {},
+        onError: (Object error, StackTrace stackTrace) {
+          debugPrint('[Player] asynchronous disposal failed: $error');
+        },
+      ),
+    );
+  }
+
+  Future<void> disposeAsync() => _startDispose();
+
+  Future<void> _startDispose() {
+    final existing = _disposeFuture;
+    if (existing != null) {
+      return existing;
+    }
+
+    // Publish the future before calling the delegate so a re-entrant or
+    // concurrent dispose call observes the same teardown operation.
+    final completer = Completer<void>();
+    _disposeFuture = completer.future;
+    final delegate = _delegate;
+    try {
+      if (delegate is core_player.AsyncDisposablePlayer) {
+        (delegate as core_player.AsyncDisposablePlayer)
+            .disposeAsync()
+            .then<void>(
+          (_) => completer.complete(),
+          onError: (Object error, StackTrace stackTrace) {
+            completer.completeError(error, stackTrace);
+          },
+        );
+      } else {
+        delegate.dispose();
+        completer.complete();
+      }
+    } catch (error, stackTrace) {
+      completer.completeError(error, stackTrace);
+    }
+    return completer.future;
   }
 
   Future<PlayerFrame?> snapshot({int width = 0, int height = 0}) =>

--- a/lib/player_abstraction/player_abstraction.dart
+++ b/lib/player_abstraction/player_abstraction.dart
@@ -1,8 +1,7 @@
 // Export all necessary enums, data models, and the abstract interface
 export './player_enums.dart' show PlayerPlaybackState, PlayerMediaType;
 export './player_data_models.dart';
-export './abstract_player.dart'
-    show AbstractPlayer; // Export only AbstractPlayer type
+export './abstract_player.dart' show AbstractPlayer, AsyncDisposablePlayer;
 export './player_factory.dart'
     show PlayerKernelType; // Export PlayerKernelType enum
 
@@ -131,6 +130,15 @@ class Player {
   void seek({required int position}) => _delegate.seek(position: position);
 
   void dispose() => _delegate.dispose();
+
+  Future<void> disposeAsync() async {
+    final delegate = _delegate;
+    if (delegate is core_player.AsyncDisposablePlayer) {
+      await (delegate as core_player.AsyncDisposablePlayer).disposeAsync();
+      return;
+    }
+    delegate.dispose();
+  }
 
   Future<PlayerFrame?> snapshot({int width = 0, int height = 0}) =>
       _delegate.snapshot(width: width, height: height);

--- a/lib/player_abstraction/player_data_models.dart
+++ b/lib/player_abstraction/player_data_models.dart
@@ -1,5 +1,10 @@
 import 'dart:typed_data';
 
+enum PlayerErikaAndroidOutputMode {
+  sdr,
+  extendedLinearHdr,
+}
+
 enum PlayerUpscalerMode {
   off,
   erikaArtCnnC4F16,

--- a/lib/player_abstraction/player_factory.dart
+++ b/lib/player_abstraction/player_factory.dart
@@ -3,6 +3,7 @@ import './mdk_player_adapter.dart';
 import './video_player_adapter.dart'; // 导入新的适配器
 import './media_kit_player_adapter.dart'; // 导入新的MediaKit适配器
 import './erika_player_adapter.dart';
+import './player_data_models.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/foundation.dart'; // 用于 debugPrint
 import 'package:nipaplay/constants/settings_keys.dart';
@@ -25,6 +26,7 @@ class PlayerFactory {
   static const String _macOSNativeVideoEnabledKey =
       'macos_native_video_enabled';
   static const String _androidAudioOutputKey = 'android_audio_output';
+  static const String _erikaAndroidOutputModeKey = 'erika_android_output_mode';
   static const int defaultPrecacheBufferSizeMb = 32;
   static const int minPrecacheBufferSizeMb = 4;
   static const int maxPrecacheBufferSizeMb = 512;
@@ -32,6 +34,8 @@ class PlayerFactory {
   static int _cachedPrecacheBufferSizeMb = defaultPrecacheBufferSizeMb;
   static bool _cachedMacOSNativeVideoEnabled = false;
   static String _cachedAndroidAudioOutput = 'opensles';
+  static PlayerErikaAndroidOutputMode _cachedErikaAndroidOutputMode =
+      PlayerErikaAndroidOutputMode.sdr;
   static String _cachedCustomPlayerUA = ''; // 自定义播放器 UA，空=用内核默认
   static String? _oneTimeUA; // 一次性 UA（仅下一次播放有效，不持久化，用后即清）
   static bool _hasLoadedSettings = false;
@@ -67,6 +71,8 @@ class PlayerFactory {
           prefs.getBool(_macOSNativeVideoEnabledKey) ?? false;
       final androidAudioOutput =
           prefs.getString(_androidAudioOutputKey) ?? 'opensles';
+      final erikaAndroidOutputModeIndex =
+          prefs.getInt(_erikaAndroidOutputModeKey);
 
       if (kernelTypeIndex != null &&
           kernelTypeIndex < PlayerKernelType.values.length) {
@@ -84,7 +90,10 @@ class PlayerFactory {
         _cachedMacOSNativeVideoEnabled,
       );
       _cachedAndroidAudioOutput = androidAudioOutput;
-      _cachedCustomPlayerUA = prefs.getString(SettingsKeys.customPlayerUA) ?? '';
+      _cachedErikaAndroidOutputMode =
+          _decodeErikaAndroidOutputMode(erikaAndroidOutputModeIndex);
+      _cachedCustomPlayerUA =
+          prefs.getString(SettingsKeys.customPlayerUA) ?? '';
 
       _hasLoadedSettings = true;
     } catch (e) {
@@ -93,6 +102,7 @@ class PlayerFactory {
       _cachedPrecacheBufferSizeMb = defaultPrecacheBufferSizeMb;
       _cachedMacOSNativeVideoEnabled = false;
       _cachedAndroidAudioOutput = 'opensles';
+      _cachedErikaAndroidOutputMode = PlayerErikaAndroidOutputMode.sdr;
       _cachedCustomPlayerUA = '';
       MediaKitPlayerAdapter.setMacOSNativeVideoPreference(false);
       _hasLoadedSettings = true;
@@ -107,6 +117,7 @@ class PlayerFactory {
       _cachedPrecacheBufferSizeMb = defaultPrecacheBufferSizeMb;
       _cachedMacOSNativeVideoEnabled = false;
       _cachedAndroidAudioOutput = 'opensles';
+      _cachedErikaAndroidOutputMode = PlayerErikaAndroidOutputMode.sdr;
       _cachedCustomPlayerUA = '';
       MediaKitPlayerAdapter.setMacOSNativeVideoPreference(false);
       _hasLoadedSettings = true;
@@ -119,6 +130,8 @@ class PlayerFactory {
             prefs.getBool(_macOSNativeVideoEnabledKey) ?? false;
         final androidAudioOutput =
             prefs.getString(_androidAudioOutputKey) ?? 'opensles';
+        final erikaAndroidOutputModeIndex =
+            prefs.getInt(_erikaAndroidOutputModeKey);
         if (kernelTypeIndex != null &&
             kernelTypeIndex < PlayerKernelType.values.length) {
           _cachedKernelType = PlayerKernelType.values[kernelTypeIndex];
@@ -134,7 +147,10 @@ class PlayerFactory {
           _cachedMacOSNativeVideoEnabled,
         );
         _cachedAndroidAudioOutput = androidAudioOutput;
-        _cachedCustomPlayerUA = prefs.getString(SettingsKeys.customPlayerUA) ?? '';
+        _cachedErikaAndroidOutputMode =
+            _decodeErikaAndroidOutputMode(erikaAndroidOutputModeIndex);
+        _cachedCustomPlayerUA =
+            prefs.getString(SettingsKeys.customPlayerUA) ?? '';
       });
 
       debugPrint('[PlayerFactory] 同步设置临时默认值: MDK');
@@ -143,6 +159,7 @@ class PlayerFactory {
       _cachedKernelType = PlayerKernelType.mdk;
       _cachedPrecacheBufferSizeMb = defaultPrecacheBufferSizeMb;
       _cachedAndroidAudioOutput = 'opensles';
+      _cachedErikaAndroidOutputMode = PlayerErikaAndroidOutputMode.sdr;
     }
   }
 
@@ -248,6 +265,42 @@ class PlayerFactory {
     }
   }
 
+  static PlayerErikaAndroidOutputMode getErikaAndroidOutputMode() {
+    if (!_hasLoadedSettings) {
+      _loadSettingsSync();
+    }
+    return _cachedErikaAndroidOutputMode;
+  }
+
+  static Future<void> saveErikaAndroidOutputMode(
+    PlayerErikaAndroidOutputMode mode,
+  ) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(_erikaAndroidOutputModeKey, mode.index);
+      final previous = _cachedErikaAndroidOutputMode;
+      _cachedErikaAndroidOutputMode = mode;
+      if (previous != mode &&
+          (_cachedKernelType ?? getKernelType()) == PlayerKernelType.erika) {
+        _kernelChangeController.add(PlayerKernelType.erika);
+      }
+    } catch (e) {
+      debugPrint(
+          '[PlayerFactory] Failed to save Erika Android output mode: $e');
+    }
+  }
+
+  static PlayerErikaAndroidOutputMode _decodeErikaAndroidOutputMode(
+    int? index,
+  ) {
+    if (index != null &&
+        index >= 0 &&
+        index < PlayerErikaAndroidOutputMode.values.length) {
+      return PlayerErikaAndroidOutputMode.values[index];
+    }
+    return PlayerErikaAndroidOutputMode.sdr;
+  }
+
   /// 保存自定义播放器 User-Agent。空字符串表示用内核默认 UA。
   /// 即时生效于"下一次打开视频"（当前正在播放的视频不会重新请求）。
   static Future<void> saveCustomPlayerUA(String ua) async {
@@ -288,7 +341,9 @@ class PlayerFactory {
         );
       case PlayerKernelType.erika:
         debugPrint('[PlayerFactory] 创建 Erika 播放器');
-        return ErikaPlayerAdapter();
+        return ErikaPlayerAdapter(
+          androidOutputMode: getErikaAndroidOutputMode(),
+        );
       // case PlayerKernelType.otherPlayer:
       //   // return OtherPlayerAdapter(ThirdPartyPlayerApi());
       //   throw UnimplementedError('Other player types not yet supported.');

--- a/lib/player_abstraction/player_factory.dart
+++ b/lib/player_abstraction/player_factory.dart
@@ -46,7 +46,8 @@ class PlayerFactory {
     if (kIsWeb) return false;
     return defaultTargetPlatform == TargetPlatform.macOS ||
         defaultTargetPlatform == TargetPlatform.iOS ||
-        defaultTargetPlatform == TargetPlatform.windows;
+        defaultTargetPlatform == TargetPlatform.windows ||
+        defaultTargetPlatform == TargetPlatform.android;
   }
 
   // 初始化方法，在应用启动时调用

--- a/lib/services/file_picker_service.dart
+++ b/lib/services/file_picker_service.dart
@@ -461,6 +461,7 @@ class FilePickerService {
           }
         ],
         'confirmButtonText': '选择视频文件',
+        'preserveContentUri': true,
       });
 
       if (result == null || result.isEmpty) {

--- a/lib/settings/pages/player_settings_content.dart
+++ b/lib/settings/pages/player_settings_content.dart
@@ -30,11 +30,14 @@ class _PlayerSettingsContentState extends State<PlayerSettingsContent> {
   PlayerKernelType _selectedKernelType = PlayerKernelType.mdk;
   bool _macOSNativeVideoEnabled = false;
   String _androidAudioOutput = 'opensles';
+  PlayerErikaAndroidOutputMode _erikaAndroidOutputMode =
+      PlayerErikaAndroidOutputMode.sdr;
 
   // 为BlurDropdown添加GlobalKey
   final GlobalKey _playerKernelDropdownKey = GlobalKey();
   final GlobalKey _androidAudioOutputDropdownKey = GlobalKey();
   final GlobalKey _erikaUpscalerDropdownKey = GlobalKey();
+  final GlobalKey _erikaAndroidOutputDropdownKey = GlobalKey();
   final GlobalKey _seekStepDropdownKey = GlobalKey();
   final GlobalKey _speedBoostDropdownKey = GlobalKey();
 
@@ -70,6 +73,7 @@ class _PlayerSettingsContentState extends State<PlayerSettingsContent> {
     _loadPlayerKernelSettings();
     _loadMacOSNativeVideoSettings();
     _loadAndroidAudioOutputSettings();
+    _loadErikaAndroidOutputSettings();
   }
 
   Future<void> _loadPlayerKernelSettings() async {
@@ -127,6 +131,30 @@ class _PlayerSettingsContentState extends State<PlayerSettingsContent> {
     });
     final displayName = output == 'audiotrack' ? 'AudioTrack' : 'OpenSL ES';
     BlurSnackBar.show(context, 'Android 音频后端已切换为 $displayName，需重启APP生效');
+  }
+
+  Future<void> _loadErikaAndroidOutputSettings() async {
+    final mode = PlayerFactory.getErikaAndroidOutputMode();
+    if (!mounted) return;
+    setState(() {
+      _erikaAndroidOutputMode = mode;
+    });
+  }
+
+  Future<void> _saveErikaAndroidOutputSettings(
+    PlayerErikaAndroidOutputMode mode,
+  ) async {
+    await PlayerFactory.saveErikaAndroidOutputMode(mode);
+    if (!mounted) return;
+    setState(() {
+      _erikaAndroidOutputMode = mode;
+    });
+    BlurSnackBar.show(
+      context,
+      mode == PlayerErikaAndroidOutputMode.extendedLinearHdr
+          ? 'Erika 已切换到扩展线性 HDR；不支持时会明确回退 SDR'
+          : 'Erika 已切换到 SDR 输出',
+    );
   }
 
   String _getPlayerKernelDescription(PlayerKernelType type) {
@@ -390,6 +418,38 @@ class _PlayerSettingsContentState extends State<PlayerSettingsContent> {
               Divider(
                   color: colorScheme.onSurface.withValues(alpha: 0.12),
                   height: 1),
+              if (!kIsWeb && Platform.isAndroid) ...[
+                AdaptiveSettingsTile.dropdown(
+                  title: 'Erika Android 输出',
+                  subtitle: '选择兼容 SDR，或在支持的 HDR 设备上启用扩展线性 scRGB',
+                  icon: Ionicons.color_filter_outline,
+                  items: [
+                    DropdownMenuItemData(
+                      title: 'SDR（兼容）',
+                      value: PlayerErikaAndroidOutputMode.sdr,
+                      isSelected: _erikaAndroidOutputMode ==
+                          PlayerErikaAndroidOutputMode.sdr,
+                      description: '8-bit sRGB 输出；HDR 视频会映射到 SDR',
+                    ),
+                    DropdownMenuItemData(
+                      title: '扩展线性 HDR（实验性）',
+                      value: PlayerErikaAndroidOutputMode.extendedLinearHdr,
+                      isSelected: _erikaAndroidOutputMode ==
+                          PlayerErikaAndroidOutputMode.extendedLinearHdr,
+                      description:
+                          '使用 Hybrid Composition 与 16-bit float scRGB；能力不足时明确回退 SDR',
+                    ),
+                  ],
+                  onChanged: (dynamic value) async {
+                    if (value is! PlayerErikaAndroidOutputMode) return;
+                    await _saveErikaAndroidOutputSettings(value);
+                  },
+                  dropdownKey: _erikaAndroidOutputDropdownKey,
+                ),
+                Divider(
+                    color: colorScheme.onSurface.withValues(alpha: 0.12),
+                    height: 1),
+              ],
             ],
             if (visibleKernelType == PlayerKernelType.mdk ||
                 visibleKernelType == PlayerKernelType.mediaKit) ...[

--- a/lib/settings/pages/player_settings_content.dart
+++ b/lib/settings/pages/player_settings_content.dart
@@ -138,7 +138,7 @@ class _PlayerSettingsContentState extends State<PlayerSettingsContent> {
       case PlayerKernelType.mediaKit:
         return 'MediaKit (Libmpv) 播放器\n基于MPV，功能强大，支持硬件解码，支持复杂媒体格式';
       case PlayerKernelType.erika:
-        return 'Erika Rust 播放器（实验性）\niOS/macOS 原生 Metal 输出，Windows 原生 D3D11 输出，播放、渲染和音频由 Rust 内核负责';
+        return 'Erika Rust 播放器（实验性）\niOS/macOS 使用 Metal，Windows 使用 D3D11，Android 使用 wgpu（Vulkan/GLES 回退）；播放、渲染和音频由 Rust 内核负责';
     }
   }
 

--- a/lib/themes/cupertino/cupertino_adaptive_platform_ui.dart
+++ b/lib/themes/cupertino/cupertino_adaptive_platform_ui.dart
@@ -469,6 +469,7 @@ class AdaptiveAlertDialog {
         oneTimeCode: oneTimeCode,
       );
     }
+    final navigator = Navigator.of(context, rootNavigator: true);
     await GlassDialog.show<void>(
       context: context,
       title: title,
@@ -480,7 +481,7 @@ class AdaptiveAlertDialog {
         iconColor: iconColor,
         oneTimeCode: oneTimeCode,
       ),
-      actions: _glassActions<void>(context, actions),
+      actions: _glassActions<void>(navigator, actions),
     );
   }
 
@@ -508,6 +509,7 @@ class AdaptiveAlertDialog {
       );
     }
 
+    final navigator = Navigator.of(context, rootNavigator: true);
     final controller = TextEditingController(text: input.initialValue);
     try {
       return await GlassDialog.show<String?>(
@@ -538,7 +540,7 @@ class AdaptiveAlertDialog {
           ],
         ),
         actions: _glassActions<String?>(
-          context,
+          navigator,
           actions,
           resultForAction: (action) {
             if (action.style == platform_ui.AlertActionStyle.cancel) {
@@ -586,7 +588,7 @@ class AdaptiveAlertDialog {
   }
 
   static List<GlassDialogAction> _glassActions<T>(
-    BuildContext context,
+    NavigatorState navigator,
     List<platform_ui.AlertAction> actions, {
     T Function(platform_ui.AlertAction action)? resultForAction,
   }) {
@@ -599,7 +601,8 @@ class AdaptiveAlertDialog {
               action.style == platform_ui.AlertActionStyle.destructive,
           onPressed: action.enabled
               ? () {
-                  Navigator.of(context).pop<T>(resultForAction?.call(action));
+                  if (!navigator.mounted) return;
+                  navigator.pop<T>(resultForAction?.call(action));
                   action.onPressed();
                 }
               : _noop,

--- a/lib/themes/nipaplay/widgets/network_media_server_dialog.dart
+++ b/lib/themes/nipaplay/widgets/network_media_server_dialog.dart
@@ -1037,86 +1037,95 @@ class _NetworkMediaServerDialogState extends State<NetworkMediaServerDialog> {
     return _subTextColor;
   }
 
+  void _toggleTranscodeSettings() {
+    setState(() {
+      _transcodeSettingsExpanded = !_transcodeSettingsExpanded;
+    });
+  }
+
   Widget _buildTranscodeSection() {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        InkWell(
-          onTap: () {
-            setState(() {
-              _transcodeSettingsExpanded = !_transcodeSettingsExpanded;
-            });
-          },
-          borderRadius: BorderRadius.circular(12),
-          splashFactory: NoSplash.splashFactory,
-          splashColor: Colors.transparent,
-          highlightColor: Colors.transparent,
-          hoverColor: Colors.transparent,
-          focusColor: Colors.transparent,
-          child: Container(
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: _panelColor,
-              borderRadius: _transcodeSettingsExpanded
-                  ? const BorderRadius.only(
-                      topLeft: Radius.circular(12),
-                      topRight: Radius.circular(12),
-                    )
-                  : BorderRadius.circular(12),
-              border: _transcodeSettingsExpanded
-                  ? Border(
-                      top: BorderSide(color: _borderColor),
-                      left: BorderSide(color: _borderColor),
-                      right: BorderSide(color: _borderColor),
-                    )
-                  : Border.all(color: _borderColor),
-            ),
-            child: Row(
-              children: [
-                Container(
-                  padding: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: _accentColor.withOpacity(0.2),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child:
-                      Icon(Icons.high_quality, color: _accentColor, size: 20),
+        Semantics(
+          button: true,
+          expanded: _transcodeSettingsExpanded,
+          onTap: _toggleTranscodeSettings,
+          child: KeyboardActivatable(
+            onActivate: _toggleTranscodeSettings,
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              excludeFromSemantics: true,
+              onTap: _toggleTranscodeSettings,
+              child: Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: _panelColor,
+                  borderRadius: _transcodeSettingsExpanded
+                      ? const BorderRadius.only(
+                          topLeft: Radius.circular(12),
+                          topRight: Radius.circular(12),
+                        )
+                      : BorderRadius.circular(12),
+                  border: _transcodeSettingsExpanded
+                      ? Border(
+                          top: BorderSide(color: _borderColor),
+                          left: BorderSide(color: _borderColor),
+                          right: BorderSide(color: _borderColor),
+                        )
+                      : Border.all(color: _borderColor),
                 ),
-                SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        '转码设置',
-                        locale: Locale("zh-Hans", "zh"),
-                        style: TextStyle(
-                          color: _textColor,
-                          fontSize: 16,
-                          fontWeight: FontWeight.w500,
-                        ),
+                child: Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(8),
+                      decoration: BoxDecoration(
+                        color: _accentColor.withOpacity(0.2),
+                        borderRadius: BorderRadius.circular(8),
                       ),
-                      SizedBox(height: 4),
-                      Text(
-                        '当前默认质量: ${_selectedQuality.displayName}',
-                        locale: Locale("zh-Hans", "zh"),
-                        style: TextStyle(
-                          color: _subTextColor,
-                          fontSize: 12,
-                        ),
+                      child: Icon(
+                        Icons.high_quality,
+                        color: _accentColor,
+                        size: 20,
                       ),
-                    ],
-                  ),
+                    ),
+                    SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '转码设置',
+                            locale: Locale("zh-Hans", "zh"),
+                            style: TextStyle(
+                              color: _textColor,
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                          SizedBox(height: 4),
+                          Text(
+                            '当前默认质量: ${_selectedQuality.displayName}',
+                            locale: Locale("zh-Hans", "zh"),
+                            style: TextStyle(
+                              color: _subTextColor,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    AnimatedRotation(
+                      turns: _transcodeSettingsExpanded ? 0.5 : 0,
+                      duration: const Duration(milliseconds: 200),
+                      child: Icon(
+                        Icons.expand_more,
+                        color: _subTextColor,
+                      ),
+                    ),
+                  ],
                 ),
-                AnimatedRotation(
-                  turns: _transcodeSettingsExpanded ? 0.5 : 0,
-                  duration: const Duration(milliseconds: 200),
-                  child: Icon(
-                    Icons.expand_more,
-                    color: _subTextColor,
-                  ),
-                ),
-              ],
+              ),
             ),
           ),
         ),

--- a/lib/themes/nipaplay/widgets/playback_info_menu.dart
+++ b/lib/themes/nipaplay/widgets/playback_info_menu.dart
@@ -81,6 +81,20 @@ class _PlaybackInfoMenuState extends State<PlaybackInfoMenu> {
     }
   }
 
+  Map<String, dynamic> _detailedInfoFor(VideoPlayerState videoState) {
+    final live = videoState.player.getDetailedMediaInfo();
+    final snapshot = _asyncDetailedInfo;
+    if (snapshot == null) {
+      return live;
+    }
+    if (!_isErikaKernel) {
+      return snapshot;
+    }
+    // The async snapshot refreshes presenter/output data. Runtime decoder,
+    // audio recovery, and error events continue updating the live adapter.
+    return <String, dynamic>{...snapshot, ...live};
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer<VideoPlayerState>(
@@ -428,8 +442,7 @@ class _PlaybackInfoMenuState extends State<PlaybackInfoMenu> {
       String colorSpace = '未知';
       String decodeMethod = '未知';
 
-      final detailedInfo =
-          _asyncDetailedInfo ?? videoState.player.getDetailedMediaInfo();
+      final detailedInfo = _detailedInfoFor(videoState);
       // 使用详细信息（若异步已填充，则优先）
       if (detailedInfo.isNotEmpty) {
         final mpvProps = detailedInfo['mpvProperties'] as Map?;
@@ -499,8 +512,7 @@ class _PlaybackInfoMenuState extends State<PlaybackInfoMenu> {
   }
 
   List<InfoItem> _getErikaUpscalerInfo(VideoPlayerState videoState) {
-    final detailedInfo =
-        _asyncDetailedInfo ?? videoState.player.getDetailedMediaInfo();
+    final detailedInfo = _detailedInfoFor(videoState);
     final rawUpscaler = detailedInfo['upscaler'];
     if (rawUpscaler is! Map) {
       return const <InfoItem>[];
@@ -535,10 +547,21 @@ class _PlaybackInfoMenuState extends State<PlaybackInfoMenu> {
     if (!_isErikaKernel) {
       return const <InfoItem>[];
     }
-    final detailedInfo =
-        _asyncDetailedInfo ?? videoState.player.getDetailedMediaInfo();
-    final stats = detailedInfo['presenterStats'];
-    if (stats is! Map || stats.isEmpty) {
+    final detailedInfo = _detailedInfoFor(videoState);
+    final rawStats = detailedInfo['presenterStats'];
+    final stats = rawStats is Map ? rawStats : const <dynamic, dynamic>{};
+    final rawOutput = detailedInfo['outputStatus'];
+    final output = rawOutput is Map ? rawOutput : const <dynamic, dynamic>{};
+    final rawDecoder = detailedInfo['decoder'];
+    final decoder = rawDecoder is Map ? rawDecoder : const <dynamic, dynamic>{};
+    final rawAudio = detailedInfo['audioOutput'];
+    final audio = rawAudio is Map ? rawAudio : const <dynamic, dynamic>{};
+    final lastError = _normalizeText(detailedInfo['lastError']);
+    if (stats.isEmpty &&
+        output.isEmpty &&
+        decoder.isEmpty &&
+        audio.isEmpty &&
+        lastError == null) {
       return const <InfoItem>[];
     }
     final rendered = _toNum(stats['renderedVideoFrames'])?.toInt() ?? 0;
@@ -552,17 +575,61 @@ class _PlaybackInfoMenuState extends State<PlaybackInfoMenu> {
     final audioQueued = _toNum(stats['audioClockQueuedFrames'])?.toInt() ?? 0;
     final renderMicros = _toNum(stats['lastRenderMicros'])?.toInt() ?? 0;
     final hdrActive = stats['hdr10OutputActive'] == true;
+    final activeEncoding =
+        _normalizeText(output['activeEncoding']) ?? 'unknown';
+    final surfaceFormat = _normalizeText(output['surfaceFormat']) ?? 'unknown';
+    final outputFallback = _normalizeText(output['fallbackReason']) ?? 'none';
+    final outputFallbackCount = _toNum(output['fallbackCount'])?.toInt() ?? 0;
+    final activeHeadroom = _toNum(output['activeHeadroom'])?.toDouble() ?? 1.0;
+    final decoderBackend =
+        _normalizeText(decoder['activeBackend']) ?? 'unknown';
+    final decoderFallbackCount = _toNum(decoder['fallbackCount'])?.toInt() ?? 0;
+    final decoderReason = _normalizeText(decoder['reason']);
+    final audioState = _normalizeText(audio['recoveryState']) ?? 'unknown';
+    final audioFailures = _toNum(audio['recoveryFailures'])?.toInt() ?? 0;
 
     return [
-      InfoItem('视频帧', 'decoded $decoded / rendered $rendered'),
-      InfoItem('硬解帧', '$hardware', hardware > 0),
-      InfoItem('软解帧', '$software'),
-      InfoItem('零拷贝', '$zeroCopy', zeroCopy > 0),
-      InfoItem('CPU回退', '$cpuFallback', cpuFallback == 0),
-      InfoItem('音频队列', 'queued $audioQueued / underflow $audioUnderflow',
-          audioUnderflow == 0),
-      InfoItem('最近渲染', _formatMicrosAsMs(renderMicros)),
-      InfoItem('HDR10输出', hdrActive ? '开启' : '关闭', hdrActive),
+      if (stats.isNotEmpty) ...[
+        InfoItem('视频帧', 'decoded $decoded / rendered $rendered'),
+        InfoItem('硬解帧', '$hardware', hardware > 0),
+        InfoItem('软解帧', '$software'),
+        InfoItem('零拷贝', '$zeroCopy', zeroCopy > 0),
+        InfoItem('CPU回退', '$cpuFallback', cpuFallback == 0),
+        InfoItem(
+          '音频队列',
+          'queued $audioQueued / underflow $audioUnderflow',
+          audioUnderflow == 0,
+        ),
+        InfoItem('最近渲染', _formatMicrosAsMs(renderMicros)),
+        InfoItem('HDR10输出', hdrActive ? '开启' : '关闭', hdrActive),
+      ],
+      if (output.isNotEmpty) ...[
+        InfoItem('输出编码', activeEncoding),
+        InfoItem('Surface格式', surfaceFormat),
+        InfoItem('输出余量', activeHeadroom.toStringAsFixed(2)),
+        InfoItem(
+          '输出回退',
+          '$outputFallback ($outputFallbackCount)',
+          outputFallback == 'none' && outputFallbackCount == 0,
+        ),
+      ],
+      if (decoder.isNotEmpty) ...[
+        InfoItem('解码后端', decoderBackend),
+        InfoItem(
+          '解码回退',
+          decoderReason == null
+              ? '$decoderFallbackCount'
+              : '$decoderFallbackCount · $decoderReason',
+          decoderFallbackCount == 0,
+        ),
+      ],
+      if (audio.isNotEmpty)
+        InfoItem(
+          '音频恢复',
+          '$audioState / failures $audioFailures',
+          audioFailures == 0,
+        ),
+      if (lastError != null) InfoItem('最近错误', lastError),
     ];
   }
 
@@ -676,8 +743,7 @@ class _PlaybackInfoMenuState extends State<PlaybackInfoMenu> {
       String channels = '未知';
       String bitRate = '未知';
 
-      final detailedInfo =
-          _asyncDetailedInfo ?? videoState.player.getDetailedMediaInfo();
+      final detailedInfo = _detailedInfoFor(videoState);
       // 使用详细信息（若异步已填充，则优先）
       if (detailedInfo.isNotEmpty) {
         final mpvProps = detailedInfo['mpvProperties'] as Map?;

--- a/lib/utils/audio_track_manager.dart
+++ b/lib/utils/audio_track_manager.dart
@@ -4,6 +4,7 @@ import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
 import '../player_abstraction/player_abstraction.dart';
 import '../services/remote_subtitle_service.dart';
+import 'media_source_utils.dart';
 
 /// 外部音频轨道管理器
 /// 负责自动检测同名MKA文件并加载为外部音频轨道
@@ -37,6 +38,7 @@ class AudioTrackManager {
   /// 支持本地文件和共享远程媒体库
   Future<String?> detectExternalAudioPath(String videoPath) async {
     if (kIsWeb) return null;
+    if (MediaSourceUtils.isContentUri(videoPath)) return null;
     if (kDebugMode) debugPrint('[MKA_DEBUG] detectExternalAudioPath: videoPath=$videoPath');
 
     // 检查是否来自共享远程媒体库

--- a/lib/utils/media_source_utils.dart
+++ b/lib/utils/media_source_utils.dart
@@ -11,6 +11,11 @@ class MediaSourceUtils {
     _remoteWebDavConnections = List<WebDAVConnection>.unmodifiable(connections);
   }
 
+  static bool isContentUri(String value) {
+    final uri = Uri.tryParse(value.trim());
+    return uri != null && uri.scheme.toLowerCase() == 'content';
+  }
+
   static bool isSmbPath(String filePath) {
     if (filePath.isEmpty) return false;
     final lower = filePath.toLowerCase();

--- a/lib/utils/player_kernel_manager.dart
+++ b/lib/utils/player_kernel_manager.dart
@@ -152,7 +152,11 @@ class PlayerKernelManager {
       return ['FVP', 'Video Player', 'Erika'];
     } else if (Platform.isAndroid) {
       // Android平台支持的内核
-      return ['FVP', 'Media Kit', 'Video Player'];
+      final androidKernels = ['FVP', 'Media Kit', 'Video Player'];
+      if (PlayerFactory.isErikaKernelSupported) {
+        androidKernels.add('Erika');
+      }
+      return androidKernels;
     } else if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
       // 桌面平台支持所有内核
       if (PlayerFactory.isErikaKernelSupported) {

--- a/lib/utils/player_kernel_manager.dart
+++ b/lib/utils/player_kernel_manager.dart
@@ -13,9 +13,14 @@ import '../models/watch_history_model.dart';
 /// 播放器内核管理器
 /// 提供多内核支持的静态工具方法
 class PlayerKernelManager {
+  static const Duration defaultHotSwapPlayerDisposalTimeout =
+      Duration(seconds: 5);
+
   /// 为VideoPlayerState执行播放器内核热切换
   static Future<void> performPlayerKernelHotSwap(
-      VideoPlayerState videoPlayerState) async {
+    VideoPlayerState videoPlayerState, {
+    Duration playerDisposalTimeout = defaultHotSwapPlayerDisposalTimeout,
+  }) async {
     if (videoPlayerState.isDisposed) {
       return;
     }
@@ -45,7 +50,10 @@ class PlayerKernelManager {
     if (currentPath == null) {
       debugPrint('[PlayerKernelManager] 没有正在播放的视频，仅创建新播放器实例');
       // 如果没有视频在播放，只需要创建一个新的播放器实例以备后用
-      await _disposePlayerForHotSwap(previousPlayer);
+      await _disposePlayerForHotSwap(
+        previousPlayer,
+        timeout: playerDisposalTimeout,
+      );
       if (videoPlayerState.isDisposed) {
         return;
       }
@@ -66,7 +74,10 @@ class PlayerKernelManager {
 
     // 2. 释放旧播放器资源
     await videoPlayerState.resetPlayer();
-    await _disposePlayerForHotSwap(previousPlayer);
+    await _disposePlayerForHotSwap(
+      previousPlayer,
+      timeout: playerDisposalTimeout,
+    );
     if (videoPlayerState.isDisposed) {
       return;
     }
@@ -120,14 +131,40 @@ class PlayerKernelManager {
     }
   }
 
-  static Future<void> _disposePlayerForHotSwap(Player player) async {
+  static Future<void> _disposePlayerForHotSwap(
+    Player player, {
+    required Duration timeout,
+  }) async {
+    final kernelName = player.getPlayerKernelName();
+    debugPrint(
+      '[PlayerKernelManager] Waiting for old player teardown before hot swap: '
+      'kernel=$kernelName timeoutMs=${timeout.inMilliseconds}',
+    );
     try {
-      await player.disposeAsync();
+      await player.disposeAsync().timeout(timeout);
+      debugPrint(
+        '[PlayerKernelManager] Old player teardown completed: '
+        'kernel=$kernelName',
+      );
+    } on TimeoutException catch (_, stackTrace) {
+      final error = TimeoutException(
+        'Old player teardown timed out after ${timeout.inMilliseconds}ms; '
+        'replacement creation was aborted to avoid overlapping resources.',
+        timeout,
+      );
+      debugPrint(
+        '[PlayerKernelManager] Native/backend player teardown timed out; '
+        'replacement creation aborted: kernel=$kernelName '
+        'timeoutMs=${timeout.inMilliseconds}\n$stackTrace',
+      );
+      Error.throwWithStackTrace(error, stackTrace);
     } catch (error, stackTrace) {
       debugPrint(
-        '[PlayerKernelManager] Native player disposal failed during hot swap: '
+        '[PlayerKernelManager] Native/backend player teardown failed; '
+        'replacement creation aborted: kernel=$kernelName '
         '$error\n$stackTrace',
       );
+      Error.throwWithStackTrace(error, stackTrace);
     }
   }
 

--- a/lib/utils/player_kernel_manager.dart
+++ b/lib/utils/player_kernel_manager.dart
@@ -16,6 +16,9 @@ class PlayerKernelManager {
   /// 为VideoPlayerState执行播放器内核热切换
   static Future<void> performPlayerKernelHotSwap(
       VideoPlayerState videoPlayerState) async {
+    if (videoPlayerState.isDisposed) {
+      return;
+    }
     debugPrint('[PlayerKernelManager] 开始执行播放器内核热切换...');
 
     // 1. 保存当前播放状态
@@ -26,6 +29,7 @@ class PlayerKernelManager {
     final currentVolume = videoPlayerState.player.volume;
     final currentPlaybackRate = videoPlayerState.playbackRate;
     final wasPlaying = videoPlayerState.status == PlayerStatus.playing;
+    final previousPlayer = videoPlayerState.player;
     final historyItem = WatchHistoryItem(
       filePath: currentPath ?? '',
       animeName: videoPlayerState.animeTitle ?? '',
@@ -41,14 +45,20 @@ class PlayerKernelManager {
     if (currentPath == null) {
       debugPrint('[PlayerKernelManager] 没有正在播放的视频，仅创建新播放器实例');
       // 如果没有视频在播放，只需要创建一个新的播放器实例以备后用
-      videoPlayerState.player.dispose();
+      await _disposePlayerForHotSwap(previousPlayer);
+      if (videoPlayerState.isDisposed) {
+        return;
+      }
       videoPlayerState.player = Player();
       videoPlayerState.subtitleManager.updatePlayer(videoPlayerState.player);
       videoPlayerState.audioTrackManager.updatePlayer(videoPlayerState.player);
       videoPlayerState.decoderManager.updatePlayer(videoPlayerState.player);
       await videoPlayerState.applyAnime4KProfileToCurrentPlayer();
+      if (videoPlayerState.isDisposed) return;
       await videoPlayerState.applyHardwareDecoderPreference();
+      if (videoPlayerState.isDisposed) return;
       await videoPlayerState.applyPrecacheBufferSettings();
+      if (videoPlayerState.isDisposed) return;
       await videoPlayerState.applySubtitleStylePreference();
       debugPrint('[PlayerKernelManager] 已创建新的空播放器实例');
       return;
@@ -56,6 +66,10 @@ class PlayerKernelManager {
 
     // 2. 释放旧播放器资源
     await videoPlayerState.resetPlayer();
+    await _disposePlayerForHotSwap(previousPlayer);
+    if (videoPlayerState.isDisposed) {
+      return;
+    }
 
     // 3. 创建新的播放器实例（Player()工厂会自动使用新的内核）
     videoPlayerState.player = Player();
@@ -63,9 +77,13 @@ class PlayerKernelManager {
     videoPlayerState.audioTrackManager.updatePlayer(videoPlayerState.player);
     videoPlayerState.decoderManager.updatePlayer(videoPlayerState.player);
     await videoPlayerState.applyAnime4KProfileToCurrentPlayer();
+    if (videoPlayerState.isDisposed) return;
     await videoPlayerState.applyHardwareDecoderPreference();
+    if (videoPlayerState.isDisposed) return;
     await videoPlayerState.applyPrecacheBufferSettings();
+    if (videoPlayerState.isDisposed) return;
     await videoPlayerState.applySubtitleStylePreference();
+    if (videoPlayerState.isDisposed) return;
 
     // 4. 重新初始化播放
     await videoPlayerState.initializePlayer(
@@ -73,6 +91,7 @@ class PlayerKernelManager {
       historyItem: historyItem,
       resetManualDanmakuOffset: false,
     );
+    if (videoPlayerState.isDisposed) return;
 
     // 5. 恢复播放状态
     if (videoPlayerState.hasVideo) {
@@ -98,6 +117,17 @@ class PlayerKernelManager {
       debugPrint('[PlayerKernelManager] 播放器内核热切换完成，已恢复播放状态');
     } else {
       debugPrint('[PlayerKernelManager] 播放器内核热切换完成，但未能恢复播放（可能视频加载失败）');
+    }
+  }
+
+  static Future<void> _disposePlayerForHotSwap(Player player) async {
+    try {
+      await player.disposeAsync();
+    } catch (error, stackTrace) {
+      debugPrint(
+        '[PlayerKernelManager] Native player disposal failed during hot swap: '
+        '$error\n$stackTrace',
+      );
     }
   }
 

--- a/lib/utils/subtitle_manager.dart
+++ b/lib/utils/subtitle_manager.dart
@@ -9,6 +9,7 @@ import 'subtitle_parser.dart';
 import 'storage_service.dart';
 import '../../player_abstraction/player_abstraction.dart';
 import 'package:nipaplay/services/remote_subtitle_service.dart';
+import 'package:nipaplay/utils/media_source_utils.dart';
 import 'package:nipaplay/utils/subtitle_file_utils.dart';
 import 'package:nipaplay/utils/subtitle_language_utils.dart';
 
@@ -877,6 +878,9 @@ class SubtitleManager extends ChangeNotifier {
   Future<void> autoDetectAndLoadSubtitle(String videoPath) async {
     if (kIsWeb) {
       debugPrint('SubtitleManager: Web平台跳过自动检测字幕文件');
+      return;
+    }
+    if (MediaSourceUtils.isContentUri(videoPath)) {
       return;
     }
     try {

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -1583,33 +1583,42 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   @override
   void onWindowEvent(String eventName) {
     if (eventName == 'enter-full-screen' || eventName == 'leave-full-screen') {
-      windowManager.isFullScreen().then((isFullscreen) {
-        if (isFullscreen != _isFullscreen) {
-          _isFullscreen = isFullscreen;
-          notifyListeners();
-        }
-      });
+      unawaited(_refreshFullscreenStateFromWindowManager());
     }
   }
 
   @override
   void onWindowEnterFullScreen() {
-    windowManager.isFullScreen().then((isFullscreen) {
-      if (isFullscreen != _isFullscreen) {
-        _isFullscreen = isFullscreen;
-        notifyListeners();
-      }
-    });
+    unawaited(_refreshFullscreenStateFromWindowManager());
   }
 
   @override
   void onWindowLeaveFullScreen() {
-    windowManager.isFullScreen().then((isFullscreen) {
-      if (!isFullscreen && _isFullscreen) {
-        _isFullscreen = false;
-        notifyListeners();
+    unawaited(
+      _refreshFullscreenStateFromWindowManager(onlyHandleExit: true),
+    );
+  }
+
+  Future<void> _refreshFullscreenStateFromWindowManager({
+    bool onlyHandleExit = false,
+  }) async {
+    try {
+      final isFullscreen = await windowManager.isFullScreen();
+      if (_isDisposed || (onlyHandleExit && isFullscreen)) {
+        return;
       }
-    });
+      if (isFullscreen != _isFullscreen) {
+        _isFullscreen = isFullscreen;
+        _notifyListeners();
+      }
+    } catch (error, stackTrace) {
+      if (!_isDisposed) {
+        debugPrint(
+          '[VideoPlayerState] Failed to refresh desktop fullscreen state: '
+          '$error\n$stackTrace',
+        );
+      }
+    }
   }
 
   @override

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -244,11 +244,17 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   int _playbackGeneration = 0;
 
   void _notifyListeners() {
+    if (_isDisposed) {
+      return;
+    }
     notifyListeners();
   }
 
   StreamSubscription? _playerKernelChangeSubscription; // 播放器内核切换事件订阅
   StreamSubscription? _danmakuKernelChangeSubscription; // 弹幕内核切换事件订阅
+  int _playerKernelSwapRequested = 0;
+  int _playerKernelSwapApplied = 0;
+  Future<void>? _playerKernelSwapDrain;
   PlayerStatus _status = PlayerStatus.idle;
   List<String> _statusMessages = []; // 修改为列表存储多个状态消息
   bool _showControls = true;
@@ -1502,7 +1508,14 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
     _systemVolumeSubscription = null;
     _systemVolumeController?.removeListener();
     _systemVolumeController = null;
-    player.dispose();
+    unawaited(
+      player.disposeAsync().catchError((Object error, StackTrace stackTrace) {
+        debugPrint(
+          '[VideoPlayerState] Native player disposal failed: '
+          '$error\n$stackTrace',
+        );
+      }),
+    );
     _focusNode.dispose();
     _uiUpdateTimer?.cancel(); // 清理UI更新定时器
 

--- a/lib/utils/video_player_state/video_player_state_danmaku.dart
+++ b/lib/utils/video_player_state/video_player_state_danmaku.dart
@@ -99,6 +99,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
 
     if (videoPath.startsWith('http://') ||
         videoPath.startsWith('https://') ||
+        MediaSourceUtils.isContentUri(videoPath) ||
         videoPath.startsWith('jellyfin://') ||
         videoPath.startsWith('emby://') ||
         SharedRemoteHistoryHelper.isSharedRemoteStreamPath(videoPath)) {

--- a/lib/utils/video_player_state/video_player_state_initialization.dart
+++ b/lib/utils/video_player_state/video_player_state_initialization.dart
@@ -109,7 +109,7 @@ extension VideoPlayerStateInitialization on VideoPlayerState {
     // 订阅播放器内核切换事件
     _playerKernelChangeSubscription = PlayerFactory.onKernelChanged.listen((_) {
       debugPrint('[VideoPlayerState] 收到播放器内核切换事件，执行热切换');
-      PlayerKernelManager.performPlayerKernelHotSwap(this);
+      _requestPlayerKernelHotSwap();
     });
 
     // 订阅弹幕内核切换事件
@@ -118,6 +118,48 @@ extension VideoPlayerStateInitialization on VideoPlayerState {
       debugPrint('[VideoPlayerState] 收到弹幕内核切换事件: $newKernel');
       PlayerKernelManager.performDanmakuKernelHotSwap(this, newKernel);
     });
+  }
+
+  void _requestPlayerKernelHotSwap() {
+    if (_isDisposed) {
+      return;
+    }
+    _playerKernelSwapRequested++;
+    _startPlayerKernelHotSwapDrain();
+  }
+
+  void _startPlayerKernelHotSwapDrain() {
+    if (_isDisposed || _playerKernelSwapDrain != null) {
+      return;
+    }
+    final drain = _drainPlayerKernelHotSwaps();
+    _playerKernelSwapDrain = drain;
+    unawaited(drain);
+  }
+
+  Future<void> _drainPlayerKernelHotSwaps() async {
+    try {
+      while (!_isDisposed &&
+          _playerKernelSwapApplied < _playerKernelSwapRequested) {
+        final targetGeneration = _playerKernelSwapRequested;
+        try {
+          await PlayerKernelManager.performPlayerKernelHotSwap(this);
+        } catch (error, stackTrace) {
+          debugPrint(
+            '[VideoPlayerState] Player hot swap failed '
+            'generation=$targetGeneration: $error\n$stackTrace',
+          );
+        } finally {
+          _playerKernelSwapApplied = targetGeneration;
+        }
+      }
+    } finally {
+      _playerKernelSwapDrain = null;
+      if (!_isDisposed &&
+          _playerKernelSwapApplied < _playerKernelSwapRequested) {
+        _startPlayerKernelHotSwapDrain();
+      }
+    }
   }
 
   Future<void> _loadInitialBrightness() async {

--- a/lib/utils/video_player_state/video_player_state_metadata.dart
+++ b/lib/utils/video_player_state/video_player_state_metadata.dart
@@ -544,6 +544,7 @@ extension VideoPlayerStateMetadata on VideoPlayerState {
     }
     if (filePath.startsWith('http://') ||
         filePath.startsWith('https://') ||
+        MediaSourceUtils.isContentUri(filePath) ||
         filePath.startsWith('jellyfin://') ||
         filePath.startsWith('emby://')) {
       return md5.convert(utf8.encode(filePath)).toString();

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -10,6 +10,8 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
     PlaybackDetailContext? playbackDetailContext,
     bool resetManualDanmakuOffset = true,
   }) async {
+    var mediaPrepareStarted = false;
+    var mediaPrepareCompleted = false;
     // 每次切换新视频时，重置自动连播倒计时状态，防止高强度测试下卡死
     try {
       AutoNextEpisodeService.instance.cancelAutoNext();
@@ -69,6 +71,9 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
     // 检查是否为网络URL (HTTP或HTTPS)
     bool isNetworkUrl =
         videoPath.startsWith('http://') || videoPath.startsWith('https://');
+    final bool isAndroidContentUri = !kIsWeb &&
+        Platform.isAndroid &&
+        MediaSourceUtils.isContentUri(videoPath);
 
     // 检查是否是流媒体（jellyfin://协议、emby://协议）
     bool isJellyfinStream = videoPath.startsWith('jellyfin://');
@@ -77,8 +82,11 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
     String? resolvedActualPlayUrl = actualPlayUrl;
 
     // 对于本地文件才检查存在性，网络URL和流媒体默认认为"存在"
-    bool fileExists =
-        isNetworkUrl || isJellyfinStream || isEmbyStream || kIsWeb;
+    bool fileExists = isNetworkUrl ||
+        isJellyfinStream ||
+        isEmbyStream ||
+        isAndroidContentUri ||
+        kIsWeb;
 
     // 为网络URL添加特定日志
     if (isNetworkUrl) {
@@ -101,7 +109,12 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
 
     if (!kIsWeb && !isNetworkUrl && !isJellyfinStream && !isEmbyStream) {
       // 使用FilePickerService处理文件路径问题
-      if (Platform.isIOS) {
+      if (isAndroidContentUri) {
+        // Erika resolves SAF sources through Android's ContentResolver and
+        // transfers an owned file descriptor to Rust. Treating this as a
+        // normal File path would reject it before the player can open it.
+        fileExists = true;
+      } else if (Platform.isIOS) {
         final filePickerService = FilePickerService();
 
         // 首先检查文件是否存在
@@ -277,7 +290,11 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
         _context?.read<SettingsProvider>().fastPlaybackStartup ?? false;
 
     // 检测本地 fonts 文件夹
-    if (!kIsWeb && !isNetworkUrl && !isJellyfinStream && !isEmbyStream) {
+    if (!kIsWeb &&
+        !isNetworkUrl &&
+        !isJellyfinStream &&
+        !isEmbyStream &&
+        !isAndroidContentUri) {
       final localFontsFolder = await _detectLocalFontsFolder(videoPath);
       debugPrint('[VideoPlayerState] 自动检测本地fonts结果: $localFontsFolder');
       if (localFontsFolder != null) {
@@ -386,7 +403,9 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
 
       //debugPrint('4. 准备播放器...');
       // 准备播放器
-      player.prepare();
+      mediaPrepareStarted = true;
+      await player.prepare();
+      mediaPrepareCompleted = true;
 
       // 针对Jellyfin流媒体，给予更长的初始化时间
       final bool isJellyfinStreaming =
@@ -902,12 +921,14 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
       }
 
       // 尝试自动检测和加载字幕
-      await _subtitleManager.autoDetectAndLoadSubtitle(videoPath);
+      if (!isAndroidContentUri) {
+        await _subtitleManager.autoDetectAndLoadSubtitle(videoPath);
+      }
 
       // 尝试自动检测和加载同名MKA外部音频
       // MediaKit已通过audio-add在主媒体加载后添加外部音频，此处仅处理MDK内核
       _audioTrackManager.setCurrentVideoPath(videoPath);
-      if (!isMediaKitKernel) {
+      if (!isAndroidContentUri && !isMediaKitKernel) {
         await _audioTrackManager.autoDetectAndLoadExternalAudio(videoPath);
       }
 
@@ -966,6 +987,15 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
           _setStatus(PlayerStatus.error, message: message);
           return;
         }
+      }
+      if (mediaPrepareStarted && !mediaPrepareCompleted) {
+        final message = '播放器打开媒体失败: $e';
+        debugPrint(
+          '[VideoPlayerState] Media prepare failed for $videoPath: $e',
+        );
+        _error = message;
+        _setStatus(PlayerStatus.error, message: message);
+        return;
       }
       _error = '初始化视频播放器时出错: $e';
       _setStatus(PlayerStatus.error, message: '播放器初始化失败');

--- a/packages/nipaplay_smb2/android/build.gradle
+++ b/packages/nipaplay_smb2/android/build.gradle
@@ -31,7 +31,7 @@ android {
     compileSdk = 34
 
     // Match the host project's NDK version (see android/app/build.gradle).
-    ndkVersion = "27.0.12077973"
+    ndkVersion = "29.0.14206865"
 
     // Invoke the shared CMake build.
     externalNativeBuild {
@@ -41,8 +41,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -291,8 +291,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: "34aa39fd5e8583fe2b69a748d4873d3ace2aaf91"
-      resolved-ref: "34aa39fd5e8583fe2b69a748d4873d3ace2aaf91"
+      ref: "25cfde9d940dc6cd8dbfff21cf1366c53fdecac8"
+      resolved-ref: "25cfde9d940dc6cd8dbfff21cf1366c53fdecac8"
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
     version: "0.1.2"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -291,11 +291,11 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: v0.1.2
-      resolved-ref: 28e380039c61df9018a8a1604d5ffb3b492e5bb7
+      ref: "686314d83bd968979ba52321a7ca81c8db9e8d14"
+      resolved-ref: "686314d83bd968979ba52321a7ca81c8db9e8d14"
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
-    version: "0.0.1"
+    version: "0.1.2"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -291,8 +291,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: "686314d83bd968979ba52321a7ca81c8db9e8d14"
-      resolved-ref: "686314d83bd968979ba52321a7ca81c8db9e8d14"
+      ref: "34aa39fd5e8583fe2b69a748d4873d3ace2aaf91"
+      resolved-ref: "34aa39fd5e8583fe2b69a748d4873d3ace2aaf91"
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
     version: "0.1.2"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -291,8 +291,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: "25cfde9d940dc6cd8dbfff21cf1366c53fdecac8"
-      resolved-ref: "25cfde9d940dc6cd8dbfff21cf1366c53fdecac8"
+      ref: be8192d223f32a1bec512b935446999d3694ddff
+      resolved-ref: be8192d223f32a1bec512b935446999d3694ddff
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
     version: "0.1.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -86,7 +86,7 @@ dependencies:
       url: https://github.com/AimesSoft/Erika.git
       # Keep Nipa reproducible while Erika Android support is under review.
       # Move this back to main after AimesSoft/Erika#42 is merged.
-      ref: 25cfde9d940dc6cd8dbfff21cf1366c53fdecac8
+      ref: be8192d223f32a1bec512b935446999d3694ddff
       path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   mobile_scanner: ^7.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,9 @@ dependencies:
   erika_flutter:
     git:
       url: https://github.com/AimesSoft/Erika.git
-      ref: v0.1.2
+      # Keep Nipa reproducible while Erika Android support is under review.
+      # Move this back to main after AimesSoft/Erika#42 is merged.
+      ref: 686314d83bd968979ba52321a7ca81c8db9e8d14
       path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   mobile_scanner: ^7.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -86,7 +86,7 @@ dependencies:
       url: https://github.com/AimesSoft/Erika.git
       # Keep Nipa reproducible while Erika Android support is under review.
       # Move this back to main after AimesSoft/Erika#42 is merged.
-      ref: 34aa39fd5e8583fe2b69a748d4873d3ace2aaf91
+      ref: 25cfde9d940dc6cd8dbfff21cf1366c53fdecac8
       path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   mobile_scanner: ^7.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -86,7 +86,7 @@ dependencies:
       url: https://github.com/AimesSoft/Erika.git
       # Keep Nipa reproducible while Erika Android support is under review.
       # Move this back to main after AimesSoft/Erika#42 is merged.
-      ref: 686314d83bd968979ba52321a7ca81c8db9e8d14
+      ref: 34aa39fd5e8583fe2b69a748d4873d3ace2aaf91
       path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   mobile_scanner: ^7.2.0

--- a/test/cupertino_adaptive_alert_dialog_test.dart
+++ b/test/cupertino_adaptive_alert_dialog_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:nipaplay/app/app_display_surface.dart';
+import 'package:nipaplay/app/app_display_surface_scope.dart';
+import 'package:nipaplay/themes/cupertino/cupertino_adaptive_platform_ui.dart';
+
+void main() {
+  setUp(() {
+    PlatformInfo.setPlatformOverride(PlatformOverride.android);
+    PlatformInfo.setPreferCupertinoControls(true);
+  });
+
+  tearDown(() {
+    PlatformInfo.setPreferCupertinoControls(false);
+    PlatformInfo.clearPlatformOverride();
+  });
+
+  testWidgets(
+      'liquid glass input dialog closes the root route after its caller unmounts',
+      (tester) async {
+    final nestedNavigatorKey = GlobalKey<NavigatorState>();
+    String? dialogResult;
+    var primaryActionCount = 0;
+    var callerVisible = true;
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: AppDisplaySurfaceScope(
+          surface: AppDisplaySurface.phone,
+          child: Navigator(
+            key: nestedNavigatorKey,
+            onGenerateRoute: (_) => CupertinoPageRoute<void>(
+              builder: (_) => const CupertinoPageScaffold(
+                child: Center(child: Text('Nested home')),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    nestedNavigatorKey.currentState!.push(
+      CupertinoPageRoute<void>(
+        builder: (_) => StatefulBuilder(
+          builder: (context, setState) => CupertinoPageScaffold(
+            child: Center(
+              child: callerVisible
+                  ? Builder(
+                      builder: (callerContext) => CupertinoButton(
+                        onPressed: () async {
+                          final result = AdaptiveAlertDialog.inputShow(
+                            context: callerContext,
+                            title: 'Connect to Jellyfin Server',
+                            actions: [
+                              AlertAction(
+                                title: 'Cancel',
+                                style: AlertActionStyle.cancel,
+                                onPressed: () {},
+                              ),
+                              AlertAction(
+                                title: 'Next',
+                                style: AlertActionStyle.primary,
+                                onPressed: () => primaryActionCount++,
+                              ),
+                            ],
+                            input: const AdaptiveAlertDialogInput(
+                              placeholder: 'Server URL',
+                              initialValue: '192.168.3.49:8096',
+                            ),
+                          );
+                          setState(() => callerVisible = false);
+                          dialogResult = await result;
+                        },
+                        child: const Text('Open input'),
+                      ),
+                    )
+                  : const Text('Caller removed'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Open input'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Caller removed'), findsOneWidget);
+    expect(find.byType(GlassDialog), findsOneWidget);
+
+    await tester.tap(find.text('Next'));
+    await tester.pumpAndSettle();
+
+    expect(dialogResult, '192.168.3.49:8096');
+    expect(primaryActionCount, 1);
+    expect(find.byType(GlassDialog), findsNothing);
+    expect(find.text('Caller removed'), findsOneWidget);
+    expect(nestedNavigatorKey.currentState!.canPop(), isTrue);
+  });
+}

--- a/test/media_source_utils_test.dart
+++ b/test/media_source_utils_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/utils/media_source_utils.dart';
+
+void main() {
+  group('MediaSourceUtils.isContentUri', () {
+    test('accepts Android SAF media sources', () {
+      expect(
+        MediaSourceUtils.isContentUri(
+          'content://com.android.providers.media.documents/document/video%3A42',
+        ),
+        isTrue,
+      );
+      expect(
+          MediaSourceUtils.isContentUri('  CONTENT://provider/item  '), isTrue);
+    });
+
+    test('does not classify file and network sources as content URIs', () {
+      expect(MediaSourceUtils.isContentUri('/storage/emulated/0/video.mkv'),
+          isFalse);
+      expect(MediaSourceUtils.isContentUri('file:///tmp/video.mkv'), isFalse);
+      expect(MediaSourceUtils.isContentUri('https://example.test/video.mkv'),
+          isFalse);
+    });
+  });
+}

--- a/test/network_media_server_dialog_test.dart
+++ b/test/network_media_server_dialog_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/app/app_display_surface.dart';
+import 'package:nipaplay/app/app_display_surface_scope.dart';
+import 'package:nipaplay/providers/jellyfin_provider.dart';
+import 'package:nipaplay/providers/jellyfin_transcode_provider.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/network_media_server_dialog.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  testWidgets('phone Jellyfin settings builds in a Cupertino-only tree',
+      (tester) async {
+    SharedPreferences.setMockInitialValues(const {});
+    tester.view.physicalSize = const Size(430, 932);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final jellyfinProvider = JellyfinProvider();
+    addTearDown(jellyfinProvider.dispose);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<JellyfinProvider>.value(
+            value: jellyfinProvider,
+          ),
+          ChangeNotifierProvider<JellyfinTranscodeProvider>.value(
+            value: JellyfinTranscodeProvider(),
+          ),
+        ],
+        child: const CupertinoApp(
+          home: AppDisplaySurfaceScope(
+            surface: AppDisplaySurface.phone,
+            child: CupertinoPageScaffold(
+              child: NetworkMediaServerDialog(
+                serverType: MediaServerType.jellyfin,
+                embedded: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(ErrorWidget), findsNothing);
+    expect(find.text('转码设置'), findsOneWidget);
+
+    await tester.tap(find.text('转码设置'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(ErrorWidget), findsNothing);
+    expect(find.text('启用转码'), findsOneWidget);
+  });
+}

--- a/test/player_lifecycle_test.dart
+++ b/test/player_lifecycle_test.dart
@@ -1,0 +1,209 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/player_abstraction/player_abstraction.dart';
+import 'package:nipaplay/utils/player_kernel_manager.dart';
+import 'package:nipaplay/utils/video_player_state.dart';
+
+class _SyncPlayerDelegate extends Fake implements AbstractPlayer {
+  int disposeCalls = 0;
+
+  @override
+  double get volume => 0.5;
+
+  @override
+  set volume(double value) {}
+
+  @override
+  void dispose() {
+    disposeCalls++;
+  }
+}
+
+class _ControlledAsyncPlayerDelegate extends Fake
+    implements AbstractPlayer, AsyncDisposablePlayer {
+  final Completer<void> _disposeCompleter = Completer<void>();
+  int disposeCalls = 0;
+  int disposeAsyncCalls = 0;
+
+  @override
+  double get volume => 0.5;
+
+  @override
+  set volume(double value) {}
+
+  @override
+  void dispose() {
+    disposeCalls++;
+  }
+
+  @override
+  Future<void> disposeAsync() {
+    disposeAsyncCalls++;
+    return _disposeCompleter.future;
+  }
+
+  void completeDisposal() {
+    if (!_disposeCompleter.isCompleted) {
+      _disposeCompleter.complete();
+    }
+  }
+
+  void failDisposal(Object error) {
+    if (!_disposeCompleter.isCompleted) {
+      _disposeCompleter.completeError(error);
+    }
+  }
+}
+
+class _HotSwapVideoPlayerState extends Fake implements VideoPlayerState {
+  _HotSwapVideoPlayerState(this._player);
+
+  Player _player;
+  int replacementAssignments = 0;
+
+  @override
+  bool get isDisposed => false;
+
+  @override
+  String? get currentVideoPath => null;
+
+  @override
+  Duration get position => Duration.zero;
+
+  @override
+  Duration get duration => Duration.zero;
+
+  @override
+  double get progress => 0;
+
+  @override
+  double get playbackRate => 1;
+
+  @override
+  PlayerStatus get status => PlayerStatus.idle;
+
+  @override
+  Player get player => _player;
+
+  @override
+  set player(Player value) {
+    replacementAssignments++;
+    _player = value;
+  }
+
+  @override
+  String? get animeTitle => null;
+
+  @override
+  String? get episodeTitle => null;
+
+  @override
+  int? get animeId => null;
+
+  @override
+  int? get episodeId => null;
+}
+
+void main() {
+  group('Player disposal lifecycle', () {
+    test('synchronous delegates are disposed exactly once', () async {
+      final delegate = _SyncPlayerDelegate();
+      final player = Player.withDelegate(delegate);
+
+      player.dispose();
+      player.dispose();
+      await player.disposeAsync();
+
+      expect(delegate.disposeCalls, 1);
+    });
+
+    test('async and sync entry points share one teardown future', () async {
+      final delegate = _ControlledAsyncPlayerDelegate();
+      final player = Player.withDelegate(delegate);
+
+      final firstDisposal = player.disposeAsync();
+      player.dispose();
+      final secondDisposal = player.disposeAsync();
+
+      expect(identical(firstDisposal, secondDisposal), isTrue);
+      expect(delegate.disposeAsyncCalls, 1);
+      expect(delegate.disposeCalls, 0);
+
+      delegate.completeDisposal();
+      await Future.wait(<Future<void>>[firstDisposal, secondDisposal]);
+    });
+
+    test('failed async disposal remains memoized', () async {
+      final delegate = _ControlledAsyncPlayerDelegate();
+      final player = Player.withDelegate(delegate);
+      final firstDisposal = player.disposeAsync();
+      final expectation = expectLater(firstDisposal, throwsStateError);
+
+      delegate.failDisposal(StateError('teardown failed'));
+      await expectation;
+      await expectLater(player.disposeAsync(), throwsStateError);
+
+      expect(delegate.disposeAsyncCalls, 1);
+      expect(delegate.disposeCalls, 0);
+    });
+  });
+
+  group('hot-swap teardown gate', () {
+    test('timeout aborts before assigning a replacement player', () async {
+      final delegate = _ControlledAsyncPlayerDelegate();
+      final player = Player.withDelegate(delegate);
+      final state = _HotSwapVideoPlayerState(player);
+
+      await expectLater(
+        PlayerKernelManager.performPlayerKernelHotSwap(
+          state,
+          playerDisposalTimeout: const Duration(milliseconds: 10),
+        ),
+        throwsA(isA<TimeoutException>()),
+      );
+
+      expect(delegate.disposeAsyncCalls, 1);
+      expect(state.replacementAssignments, 0);
+      delegate.completeDisposal();
+      await player.disposeAsync();
+    });
+
+    test('teardown failure aborts before assigning a replacement player',
+        () async {
+      final delegate = _ControlledAsyncPlayerDelegate();
+      final player = Player.withDelegate(delegate);
+      final state = _HotSwapVideoPlayerState(player);
+      final swap = PlayerKernelManager.performPlayerKernelHotSwap(
+        state,
+        playerDisposalTimeout: const Duration(seconds: 1),
+      );
+      final expectation = expectLater(swap, throwsStateError);
+
+      delegate.failDisposal(StateError('native teardown failed'));
+      await expectation;
+
+      expect(delegate.disposeAsyncCalls, 1);
+      expect(state.replacementAssignments, 0);
+    });
+  });
+
+  test('desktop fullscreen callback checks disposal after awaiting', () {
+    final source = File('lib/utils/video_player_state.dart').readAsStringSync();
+    const signature = 'Future<void> _refreshFullscreenStateFromWindowManager({';
+    final methodStart = source.indexOf(signature);
+    final methodEnd = source.indexOf('void onWindowBlur()', methodStart);
+
+    expect(methodStart, greaterThanOrEqualTo(0));
+    expect(methodEnd, greaterThan(methodStart));
+    final method = source.substring(methodStart, methodEnd);
+    final awaitIndex = method.indexOf('await windowManager.isFullScreen()');
+    final disposedGuardIndex = method.indexOf('if (_isDisposed');
+    final notifyIndex = method.indexOf('_notifyListeners()');
+
+    expect(awaitIndex, greaterThanOrEqualTo(0));
+    expect(disposedGuardIndex, greaterThan(awaitIndex));
+    expect(notifyIndex, greaterThan(disposedGuardIndex));
+  });
+}

--- a/test/unified_app_architecture_test.dart
+++ b/test/unified_app_architecture_test.dart
@@ -33,6 +33,7 @@ import 'package:nipaplay/pages/torrent_download_page.dart';
 import 'package:nipaplay/pages/webdav_browser_page.dart';
 import 'package:nipaplay/playback/adaptive_playback_entry_view.dart';
 import 'package:nipaplay/playback/unified_playback_entry_model.dart';
+import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'package:nipaplay/providers/bottom_bar_provider.dart';
 import 'package:nipaplay/providers/home_sections_settings_provider.dart';
 import 'package:nipaplay/settings/adaptive_settings_scope.dart';
@@ -1207,6 +1208,8 @@ void main() {
 
   testWidgets('phone library management renders one item model in both views',
       (tester) async {
+    final appearanceSettings = AppearanceSettingsProvider();
+    addTearDown(appearanceSettings.dispose);
     const items = <UnifiedLibraryManagementItem>[
       UnifiedLibraryManagementItem(
         id: 'library-a',
@@ -1219,13 +1222,16 @@ void main() {
 
     Future<void> pump(LibraryManagementViewMode viewMode) {
       return tester.pumpWidget(
-        CupertinoApp(
-          home: CupertinoPageScaffold(
-            child: CupertinoLibraryManagementOverview(
-              items: items,
-              viewMode: viewMode,
-              emptyTitle: '没有目录',
-              emptySubtitle: '请添加目录',
+        ChangeNotifierProvider<AppearanceSettingsProvider>.value(
+          value: appearanceSettings,
+          child: CupertinoApp(
+            home: CupertinoPageScaffold(
+              child: CupertinoLibraryManagementOverview(
+                items: items,
+                viewMode: viewMode,
+                emptyTitle: '没有目录',
+                emptySubtitle: '请添加目录',
+              ),
             ),
           ),
         ),
@@ -1243,35 +1249,41 @@ void main() {
 
   testWidgets('desktop library management honors the shared view mode',
       (tester) async {
+    final appearanceSettings = AppearanceSettingsProvider();
+    addTearDown(appearanceSettings.dispose);
+
     Future<void> pump(LibraryManagementViewMode viewMode) {
       return tester.pumpWidget(
-        MaterialApp(
-          home: AppDisplaySurfaceScope(
-            surface: AppDisplaySurface.desktopTablet,
-            child: SizedBox(
-              width: 900,
-              height: 600,
-              child: AdaptiveLibraryManagementOverview(
-                items: const [
-                  UnifiedLibraryManagementItem(
-                    id: 'a',
-                    title: '目录 A',
-                    subtitle: '/media/a',
-                    icon: LibraryManagementIcon.folder,
-                    onOpen: null,
+        ChangeNotifierProvider<AppearanceSettingsProvider>.value(
+          value: appearanceSettings,
+          child: MaterialApp(
+            home: AppDisplaySurfaceScope(
+              surface: AppDisplaySurface.desktopTablet,
+              child: SizedBox(
+                width: 900,
+                height: 600,
+                child: AdaptiveLibraryManagementOverview(
+                  items: const [
+                    UnifiedLibraryManagementItem(
+                      id: 'a',
+                      title: '目录 A',
+                      subtitle: '/media/a',
+                      icon: LibraryManagementIcon.folder,
+                      onOpen: null,
+                    ),
+                    UnifiedLibraryManagementItem(
+                      id: 'b',
+                      title: '目录 B',
+                      subtitle: '/media/b',
+                      icon: LibraryManagementIcon.folder,
+                      onOpen: null,
+                    ),
+                  ],
+                  viewMode: viewMode,
+                  emptyContent: const LibraryManagementEmptyContent(
+                    title: '没有目录',
+                    subtitle: '请添加目录',
                   ),
-                  UnifiedLibraryManagementItem(
-                    id: 'b',
-                    title: '目录 B',
-                    subtitle: '/media/b',
-                    icon: LibraryManagementIcon.folder,
-                    onOpen: null,
-                  ),
-                ],
-                viewMode: viewMode,
-                emptyContent: const LibraryManagementEmptyContent(
-                  title: '没有目录',
-                  subtitle: '请添加目录',
                 ),
               ),
             ),

--- a/test/unified_app_architecture_test.dart
+++ b/test/unified_app_architecture_test.dart
@@ -50,6 +50,8 @@ import 'package:nipaplay/utils/theme_notifier.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+String _portablePath(String path) => path.replaceAll('\\', '/');
+
 void main() {
   group('unified application pages', () {
     testWidgets('application chrome inherits the selected display surface',
@@ -528,7 +530,7 @@ void main() {
         .whereType<File>()
         .where((file) => file.path.endsWith('.dart'))
         .where(
-          (file) => !file.path.endsWith(
+          (file) => !_portablePath(file.path).endsWith(
             'themes/cupertino/widgets/cupertino_bottom_sheet.dart',
           ),
         );


### PR DESCRIPTION
## Summary

- Integrate Erika's Android PlatformView and native video surface into Nipa.
- Add Erika player selection, SDR / Extended Linear HDR output control, and live decoder, audio, presenter, output, and error diagnostics.
- Support Android SAF `content://` video sources through Erika's owned file-descriptor path without copying media; selected SAF subtitles remain file-backed through an app-owned cache copy.
- Serialize player hot swaps and await native teardown so old and replacement players cannot overlap.
- Make backend disposal idempotent, add a bounded teardown gate with explicit timeout/failure logs, and harden asynchronous fullscreen/dialog lifecycle callbacks.
- Handle EOF pause races and deterministic media-open failures without unbounded recovery loops.
- Build the pinned Erika Android runtime from source in CI for every supported ABI.

## Dependency

This PR depends on AimesSoft/Erika#42:

- https://github.com/AimesSoft/Erika/pull/42
- Erika is pinned to `be8192d223f32a1bec512b935446999d3694ddff` for reproducible review builds.
- Do not merge this PR before the Erika dependency and final pin/update strategy are reviewed.

## Runtime validation

Validated on a Pixel 8 / API 36 x86_64 emulator with the current Erika pin lineage:

- Connected to the local Jellyfin server and successfully played episode 11 through MediaCodec + wgpu + AAudio.
- Loaded and rendered 2,877 danmaku items through Erika.
- Default 20 logical-pixel danmaku renders at about 52.5 physical pixels with DPR 2.625; Nipa `fontSize` / `isMe` payload compatibility is covered by Erika.
- No native attach, resize, or surface-recovery errors were observed during the playback smoke test.
- SAF playback reaches Erika through its owned descriptor path; unsupported hardware/output cases emit explicit diagnostics and use the configured fallback path.

## Checks

- Full Flutter suite on Windows: 129 passed, 10 skipped.
- `flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings lib test`: exit code 0; remaining warnings/info are pre-existing repository diagnostics.
- The two library-management widget failures introduced by upstream PR #744 are fixed in a separate test-only commit by supplying the new `AppearanceSettingsProvider` dependency.
- Erika dependency head: all 8 CI checks pass, including macOS Rust, iOS staticlib, Windows x64, and all four Android ABIs.
- Android Kotlin/native assemble, install, startup, SAF, software fallback, rendering, screenshot, Jellyfin playback, and danmaku smoke paths have been exercised during development.

## Cross-platform review status

- Android output mode arguments are only sent on Android; macOS/iOS/Windows retain Erika's previous output behavior.
- Android SAF and Kotlin activity code are platform-isolated.
- Shared disposal/hot-swap changes prevent duplicate backend teardown and abort replacement creation after a teardown failure or timeout.
- Shared Flutter changes have passed the full Windows-hosted test suite; native Apple/Windows behavior is also protected by Erika's macOS, iOS, and Windows CI jobs.
- Erika review follow-ups make `play` non-blocking, bound stalled subtitle subscribers with structured diagnostics, remove a D3D11 panic path, and document the C API physical-pixel migration.

## Known limitation

Some providers opening files through Android `ACTION_VIEW` grant only temporary read access and do not offer a persistable URI grant. Playback works while that grant remains valid, but reopening the item from history after a process restart may fail. Nipa logs this condition explicitly. Files selected through `ACTION_OPEN_DOCUMENT` retain permission when the provider supports persistable grants.

Do not merge this PR until review is complete.
