### PR TITLE
[Bug] fix(deps): downgrade liquid_glass_widgets constraint to ^0.18.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -97,7 +97,7 @@ dependencies:
   system_info2: ^3.0.1
   hotkey_manager: ^0.2.3
   adaptive_platform_ui: ^0.1.98
-  liquid_glass_widgets: ^0.21.3
+  liquid_glass_widgets: ^0.18.4
   dynamic_color: ^1.6.0
   fluent_ui: ^4.13.0
   ffi: ^2.1.3


### PR DESCRIPTION
Downgrade liquid_glass_widgets constraint from ^0.21.3 to ^0.18.4 to resolve pub solve conflict with flutter_test from Flutter 3.12.2 SDK which pins meta to 1.17.0.