### PR TITLE
ci: restore Flutter dependency resolution

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,5 +1,5 @@
 {
-  "flutterSdkVersion": "3.41.9",
-  "flutter": "3.41.9",
+  "flutterSdkVersion": "3.44.6",
+  "flutter": "3.44.6",
   "flavors": {}
 }

--- a/test/unified_app_architecture_test.dart
+++ b/test/unified_app_architecture_test.dart
@@ -386,13 +386,15 @@ void main() {
       ).existsSync(),
       isFalse,
     );
-    expect(
-      Directory('lib/themes/cupertino/pages/network_media')
-          .listSync()
-          .whereType<File>()
-          .where((file) => file.path.endsWith('.dart')),
-      isEmpty,
-    );
+    final legacyNetworkMediaDirectory =
+        Directory('lib/themes/cupertino/pages/network_media');
+    final legacyNetworkMediaPages = legacyNetworkMediaDirectory.existsSync()
+        ? legacyNetworkMediaDirectory
+            .listSync()
+            .whereType<File>()
+            .where((file) => file.path.endsWith('.dart'))
+        : const <File>[];
+    expect(legacyNetworkMediaPages, isEmpty);
     final appRegistry =
         File('lib/app/adaptive_app_page_content.dart').readAsStringSync();
     expect(appRegistry, isNot(contains('forSurface')));


### PR DESCRIPTION
## Summary

- update the FVM-pinned Flutter SDK from 3.41.9 to 3.44.6
- make the legacy Cupertino network-media removal test accept the directory being absent

## Root cause

`liquid_glass_widgets ^0.21.3` requires `meta ^1.18.0`, while Flutter 3.41.9 pins `flutter_test` to `meta 1.17.0`. Every release platform therefore failed during `Setup Flutter Environment` before reaching its build step.

After upgrading Flutter, the PR test suite reached an existing architecture assertion that called `listSync()` on an intentionally removed directory. The test now treats a missing legacy directory as the expected empty state.

## Impact

This restores dependency resolution for PR validation and the modular Linux, Windows, Android, iOS, and macOS release builds.

## Validation

- `flutter pub get`
- `flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings lib`
- `flutter test --no-pub --reporter compact` — 104 passed, 7 skipped
- `git diff --check`