### PR TITLE
降低播放器右键菜单间距并添加来源感知的番剧详情

### DIFF
--- a/lib/models/playback_detail_context.dart
+++ b/lib/models/playback_detail_context.dart
@@ -74,4 +74,26 @@ class PlaybackDetailContext {
       sourceKind == PlaybackSourceKind.localLibrary &&
       animeId != null &&
       animeId! > 0;
+
+  PlaybackDetailContext withAnimeMatch({
+    required int animeId,
+    String? title,
+  }) {
+    assert(animeId > 0);
+    final matchedTitle = title?.trim();
+    final isLocalFile = sourceKind == PlaybackSourceKind.localFile;
+
+    return PlaybackDetailContext(
+      sourceKind: isLocalFile ? PlaybackSourceKind.localLibrary : sourceKind,
+      sourceLabel: isLocalFile ? '本地媒体库' : sourceLabel,
+      sourceKey: '$sourceKey:anime:$animeId',
+      title: matchedTitle?.isNotEmpty == true ? matchedTitle! : this.title,
+      subtitle: subtitle,
+      summary: summary,
+      imageUrl: imageUrl,
+      animeId: animeId,
+      isIdentified: true,
+      episodeLoader: episodeLoader,
+    );
+  }
 }

--- a/lib/pages/anime_detail_page.dart
+++ b/lib/pages/anime_detail_page.dart
@@ -99,7 +99,8 @@ class AnimeDetailPage extends StatefulWidget {
     String? sharedSourceLabel,
     PlaybackDetailContext? playbackDetailContext,
   }) {
-    if (NipaplayLargeScreenModeScope.isActiveOf(context)) {
+    if (NipaplayLargeScreenModeScope.isActiveOf(context) &&
+        playbackDetailContext == null) {
       return Navigator.of(context).push<WatchHistoryItem>(
         NipaplayLargeScreenWindowPageRoute<WatchHistoryItem>(
           enableAnimation: true,

--- a/lib/themes/nipaplay/widgets/themed_anime_detail.dart
+++ b/lib/themes/nipaplay/widgets/themed_anime_detail.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart' as material;
 import 'package:nipaplay/pages/anime_detail_page.dart';
 import 'package:nipaplay/models/playable_item.dart';
+import 'package:nipaplay/models/playback_detail_context.dart';
 import 'package:nipaplay/models/shared_remote_library.dart';
 import 'package:nipaplay/models/watch_history_model.dart';
 
@@ -14,6 +15,7 @@ class ThemedAnimeDetail {
     Future<List<SharedRemoteEpisode>> Function()? sharedEpisodeLoader,
     PlayableItem Function(SharedRemoteEpisode episode)? sharedEpisodeBuilder,
     String? sharedSourceLabel,
+    PlaybackDetailContext? playbackDetailContext,
   }) {
     return AnimeDetailPage.show(
       context,
@@ -22,6 +24,7 @@ class ThemedAnimeDetail {
       sharedEpisodeLoader: sharedEpisodeLoader,
       sharedEpisodeBuilder: sharedEpisodeBuilder,
       sharedSourceLabel: sharedSourceLabel,
+      playbackDetailContext: playbackDetailContext,
     );
   }
 }

--- a/lib/themes/nipaplay/widgets/video_player_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_player_ui.dart
@@ -13,6 +13,7 @@ import 'package:nipaplay/widgets/context_menu/context_menu.dart';
 import 'package:nipaplay/widgets/danmaku_overlay.dart';
 import 'package:nipaplay/widgets/external_subtitle_overlay.dart';
 import 'package:nipaplay/widgets/macos_native_video_view.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/themed_anime_detail.dart';
 import 'package:provider/provider.dart';
 import 'brightness_gesture_area.dart';
 import 'volume_gesture_area.dart';
@@ -834,6 +835,22 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
     }
   }
 
+  Future<void> _showAnimeDetail(VideoPlayerState videoState) async {
+    final detailContext = videoState.animeDetailContext;
+    if (detailContext == null) return;
+
+    try {
+      await ThemedAnimeDetail.show(
+        context,
+        detailContext.animeId ?? 0,
+        playbackDetailContext: detailContext,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      BlurSnackBar.show(context, '打开番剧详情失败: $e');
+    }
+  }
+
   List<ContextMenuAction> _buildContextMenuActions(
     VideoPlayerState videoState,
   ) {
@@ -850,6 +867,12 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
         enabled: videoState.canPlayNextEpisode,
         onPressed: () => unawaited(videoState.playNextEpisode()),
       ),
+      if (videoState.animeDetailContext != null)
+        ContextMenuAction(
+          icon: Icons.movie_outlined,
+          label: '番剧详情',
+          onPressed: () => unawaited(_showAnimeDetail(videoState)),
+        ),
       ContextMenuAction(
         icon: Icons.fast_forward_rounded,
         label: '快进 ${videoState.seekStepDisplayLabel}',

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -1280,6 +1280,18 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   int? get animeId => _animeId; // 添加动画ID getter
   int? get episodeId => _episodeId; // 添加剧集ID getter
   PlaybackDetailContext? get playbackDetailContext => _playbackDetailContext;
+  PlaybackDetailContext? get animeDetailContext {
+    final detailContext = _playbackDetailContext;
+    if (detailContext == null) return null;
+    if (detailContext.isIdentified) return detailContext;
+
+    final matchedAnimeId = _animeId;
+    if (matchedAnimeId == null || matchedAnimeId <= 0) return null;
+    return detailContext.withAnimeMatch(
+      animeId: matchedAnimeId,
+      title: _animeTitle,
+    );
+  }
 
   bool hasJellyfinServerAudioSelection(String itemId) =>
       _jellyfinServerAudioSelections.containsKey(itemId);

--- a/lib/widgets/context_menu/src/context_menu_styles.dart
+++ b/lib/widgets/context_menu/src/context_menu_styles.dart
@@ -13,7 +13,7 @@ class ContextMenuStyles {
 
     return ContextMenuStyle(
       width: 196,
-      itemHeight: 44,
+      itemHeight: 36,
       borderRadius: 8,
       itemPadding: const EdgeInsets.symmetric(horizontal: 14),
       iconSize: 18,

--- a/test/player_control_style_test.dart
+++ b/test/player_control_style_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/control_shadow.dart';
+import 'package:nipaplay/widgets/context_menu/context_menu.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/shadow_action_button.dart';
 
 void main() {
@@ -25,6 +26,22 @@ void main() {
       shadow.shadows.every((item) => item.offset == Offset.zero),
       isTrue,
     );
+  });
+
+  testWidgets('player context menu uses compact item spacing', (tester) async {
+    ContextMenuStyle? style;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            style = ContextMenuStyles.playerOverlay(context);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    expect(style?.itemHeight, 36);
   });
 
   test('portrait controls rebuild unscaled and danmaku keeps phone size', () {

--- a/test/unified_app_architecture_test.dart
+++ b/test/unified_app_architecture_test.dart
@@ -872,15 +872,71 @@ void main() {
     expect(recognizedItem.detailContext, isNull);
   });
 
+  test('anime matching preserves source-specific detail episodes', () async {
+    var loadCount = 0;
+    final localFile = PlaybackDetailContext(
+      sourceKind: PlaybackSourceKind.localFile,
+      sourceLabel: '本地文件',
+      sourceKey: 'local:/media/Anime',
+      title: '01',
+      isIdentified: false,
+      episodeLoader: () async {
+        loadCount += 1;
+        return const <PlaybackDetailEpisode>[
+          PlaybackDetailEpisode(
+            id: 'episode-1',
+            videoPath: '/media/Anime/01.mkv',
+            title: '01',
+          ),
+        ];
+      },
+    );
+
+    final matched = localFile.withAnimeMatch(
+      animeId: 42,
+      title: 'Example',
+    );
+    final episodes = await matched.episodeLoader();
+
+    expect(matched.sourceKind, PlaybackSourceKind.localLibrary);
+    expect(matched.sourceLabel, '本地媒体库');
+    expect(matched.sourceKey, 'local:/media/Anime:anime:42');
+    expect(matched.title, 'Example');
+    expect(matched.animeId, 42);
+    expect(matched.isIdentified, isTrue);
+    expect(matched.usesLocalLibraryDetail, isTrue);
+    expect(episodes.single.videoPath, '/media/Anime/01.mkv');
+    expect(loadCount, 1);
+
+    final webDav = PlaybackDetailContext(
+      sourceKind: PlaybackSourceKind.webDav,
+      sourceLabel: 'WebDAV',
+      sourceKey: 'webdav:example:/Anime',
+      title: '01',
+      isIdentified: false,
+      episodeLoader: () async => const <PlaybackDetailEpisode>[],
+    ).withAnimeMatch(animeId: 42);
+
+    expect(webDav.sourceKind, PlaybackSourceKind.webDav);
+    expect(webDav.sourceLabel, 'WebDAV');
+    expect(webDav.usesLocalLibraryDetail, isFalse);
+  });
+
   test('playback sources reuse the canonical anime detail renderer', () {
     final player = File('lib/pages/play_video_page.dart').readAsStringSync();
     final detail = File('lib/pages/anime_detail_page.dart').readAsStringSync();
+    final contextMenu = File(
+      'lib/themes/nipaplay/widgets/video_player_ui.dart',
+    ).readAsStringSync();
 
     expect(player, contains('AnimeDetailPage('));
     expect(player, contains('playbackDetailContext: detailContext'));
     expect(detail, contains('PlaybackDetailContext? playbackDetailContext'));
     expect(detail, contains('NipaplayAnimeDetailLayout('));
     expect(detail, contains('BangumiCommentsWidget('));
+    expect(contextMenu, contains("label: '番剧详情'"));
+    expect(contextMenu, contains('videoState.animeDetailContext'));
+    expect(contextMenu, contains('playbackDetailContext: detailContext'));
     expect(
       File('lib/playback/adaptive_playback_detail_view.dart').existsSync(),
       isFalse,


### PR DESCRIPTION
## 改动

- 将播放器右键菜单项目高度从 44 调整为 36，降低上下留白。
- 在当前视频存在已识别详情时添加“番剧详情”入口。
- 打开详情时透传当前播放来源上下文，保留本地、WebDAV、Emby、Jellyfin 等来源各自的剧集加载方式。
- 支持本地文件在播放期间完成番剧匹配后显示详情入口。
- 大屏模式下携带来源上下文时复用完整的通用番剧详情渲染器。

## 原因与影响

此前播放器右键菜单偏松散，也没有直接进入当前番剧详情的入口。若仅按番剧 ID 打开详情，远程媒体来源可能错误复用本地剧集列表。本改动将播放来源上下文一并传入详情窗口，避免不同媒体库之间的剧集数据串用。

## 验证

- `flutter test --no-pub test/player_control_style_test.dart`
- `flutter test --no-pub test/unified_app_architecture_test.dart --plain-name 'anime matching preserves source-specific detail episodes'`
- `flutter test --no-pub test/unified_app_architecture_test.dart --plain-name 'playback sources reuse the canonical anime detail renderer'`
- `flutter test --no-pub test/unified_app_architecture_test.dart --plain-name 'only identified local media may mount the local anime detail'`
- 变更文件定向 `dart analyze` 未发现新增诊断。

完整架构测试仍有两个既有的媒体库 Provider 装配失败；完整仓库分析也会扫描构建产物与第三方源码并报告大量既有问题，均与本改动无关。
