### PR TITLE
优化设置按钮悬浮交互与关于页面样式

### DIFF
--- a/lib/settings/pages/about_settings_content.dart
+++ b/lib/settings/pages/about_settings_content.dart
@@ -29,6 +29,7 @@ class _AboutSettingsContentState extends State<AboutSettingsContent> {
   bool _versionLoadFailed = false;
   UpdateInfo? _updateInfo;
   bool _isCheckingUpdate = false;
+  bool _isUpdateActionHovered = false;
 
   @override
   void initState() {
@@ -256,7 +257,7 @@ class _AboutSettingsContentState extends State<AboutSettingsContent> {
             runSpacing: 10,
             children: [
               for (final name in AboutSettingsData.sponsorNames)
-                _buildAcknowledgementBadge(context, name, accentColor),
+                _buildAcknowledgementItem(context, name, accentColor),
             ],
           ),
           _buildCanvasDivider(textColor),
@@ -286,36 +287,72 @@ class _AboutSettingsContentState extends State<AboutSettingsContent> {
     Color accentColor,
     Color secondaryColor,
   ) {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: _isCheckingUpdate ? null : _manualCheckForUpdates,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 2),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (_isCheckingUpdate)
-              SizedBox(
-                width: 16,
-                height: 16,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: accentColor,
-                ),
-              )
-            else
-              Icon(Icons.system_update_alt, size: 18, color: accentColor),
-            const SizedBox(width: 8),
-            Text(
-              _isCheckingUpdate
-                  ? context.l10n.aboutCheckingUpdates
-                  : context.l10n.aboutCheckUpdates,
-              style: TextStyle(
-                color: _isCheckingUpdate ? secondaryColor : accentColor,
-                fontWeight: FontWeight.w600,
+    final isHovered = !_isCheckingUpdate && _isUpdateActionHovered;
+
+    return MouseRegion(
+      cursor: _isCheckingUpdate
+          ? SystemMouseCursors.basic
+          : SystemMouseCursors.click,
+      onEnter: (_) {
+        if (_isCheckingUpdate || _isUpdateActionHovered) return;
+        setState(() => _isUpdateActionHovered = true);
+      },
+      onExit: (_) {
+        if (!_isUpdateActionHovered) return;
+        setState(() => _isUpdateActionHovered = false);
+      },
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: _isCheckingUpdate ? null : _manualCheckForUpdates,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 2),
+          child: AnimatedScale(
+            scale: isHovered ? 1.08 : 1,
+            duration: const Duration(milliseconds: 180),
+            curve: Curves.easeOutBack,
+            alignment: Alignment.centerLeft,
+            child: TweenAnimationBuilder<double>(
+              tween: Tween<double>(
+                begin: 0,
+                end: isHovered ? 1 : 0,
               ),
+              duration: const Duration(milliseconds: 150),
+              curve: Curves.easeOut,
+              builder: (context, hoverProgress, child) {
+                final color = Color.lerp(
+                  secondaryColor,
+                  accentColor,
+                  hoverProgress,
+                )!;
+                return Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (_isCheckingUpdate)
+                      SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: color,
+                        ),
+                      )
+                    else
+                      Icon(Icons.system_update_alt, size: 18, color: color),
+                    const SizedBox(width: 8),
+                    Text(
+                      _isCheckingUpdate
+                          ? context.l10n.aboutCheckingUpdates
+                          : context.l10n.aboutCheckUpdates,
+                      style: TextStyle(
+                        color: color,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                );
+              },
             ),
-          ],
+          ),
         ),
       ),
     );
@@ -347,7 +384,7 @@ class _AboutSettingsContentState extends State<AboutSettingsContent> {
     );
   }
 
-  Widget _buildAcknowledgementBadge(
+  Widget _buildAcknowledgementItem(
     BuildContext context,
     String name,
     Color accentColor,
@@ -358,27 +395,19 @@ class _AboutSettingsContentState extends State<AboutSettingsContent> {
             context,
           )
         : Theme.of(context).colorScheme.onSurface;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(999),
-        color: accentColor.withValues(alpha: 0.12),
-        border: Border.all(color: accentColor.withValues(alpha: 0.28)),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(Ionicons.ribbon_outline, size: 15, color: accentColor),
-          const SizedBox(width: 7),
-          Text(
-            name,
-            style: TextStyle(
-              color: textColor,
-              fontWeight: FontWeight.w600,
-            ),
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Ionicons.ribbon_outline, size: 15, color: accentColor),
+        const SizedBox(width: 7),
+        Text(
+          name,
+          style: TextStyle(
+            color: textColor,
+            fontWeight: FontWeight.w600,
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/lib/themes/nipaplay/widgets/large_screen_focusable_action.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_focusable_action.dart
@@ -40,6 +40,8 @@ class NipaplayLargeScreenFocusableAction extends StatefulWidget {
   final BorderRadius borderRadius;
   final EdgeInsetsGeometry? padding;
   final NipaplayLargeScreenFocusableStyle style;
+
+  /// Scale applied to the content while the button surface stays fixed.
   final double focusScale;
 
   @override
@@ -62,6 +64,39 @@ class _NipaplayLargeScreenFocusableActionState
     final Color backgroundColor = idleOverlay;
     final Color contentColor =
         isDarkMode ? style.contentColorDark : style.contentColorLight;
+
+    final scaledContent = AnimatedScale(
+      scale: isActive ? widget.focusScale : 1.0,
+      duration: const Duration(milliseconds: 140),
+      curve: Curves.easeOutCubic,
+      child: widget.child,
+    );
+    final buttonSurface = AnimatedContainer(
+      duration: const Duration(milliseconds: 120),
+      curve: Curves.easeOut,
+      padding: widget.padding,
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: widget.borderRadius,
+      ),
+      foregroundDecoration: BoxDecoration(
+        borderRadius: widget.borderRadius,
+        border: Border.all(
+          color: isActive
+              ? (style.focusStrokeColor ?? AppAccentColors.current)
+              : Colors.transparent,
+          width: style.focusStrokeWidth,
+          strokeAlign: BorderSide.strokeAlignInside,
+        ),
+      ),
+      child: IconTheme.merge(
+        data: IconThemeData(color: contentColor),
+        child: DefaultTextStyle.merge(
+          style: TextStyle(color: contentColor),
+          child: scaledContent,
+        ),
+      ),
+    );
 
     return FocusableActionDetector(
       focusNode: widget.focusNode,
@@ -95,37 +130,7 @@ class _NipaplayLargeScreenFocusableActionState
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: widget.onActivate,
-        child: AnimatedScale(
-          scale: isActive ? widget.focusScale : 1.0,
-          duration: const Duration(milliseconds: 140),
-          curve: Curves.easeOutCubic,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 120),
-            curve: Curves.easeOut,
-            padding: widget.padding,
-            decoration: BoxDecoration(
-              color: backgroundColor,
-              borderRadius: widget.borderRadius,
-            ),
-            foregroundDecoration: BoxDecoration(
-              borderRadius: widget.borderRadius,
-              border: Border.all(
-                color: isActive
-                    ? (style.focusStrokeColor ?? AppAccentColors.current)
-                    : Colors.transparent,
-                width: style.focusStrokeWidth,
-                strokeAlign: BorderSide.strokeAlignInside,
-              ),
-            ),
-            child: IconTheme.merge(
-              data: IconThemeData(color: contentColor),
-              child: DefaultTextStyle.merge(
-                style: TextStyle(color: contentColor),
-                child: widget.child,
-              ),
-            ),
-          ),
-        ),
+        child: buttonSurface,
       ),
     );
   }

--- a/test/about_settings_content_test.dart
+++ b/test/about_settings_content_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('sponsor acknowledgements render without badge containers', () {
+    final source = File(
+      'lib/settings/pages/about_settings_content.dart',
+    ).readAsStringSync();
+    final methodStart = source.indexOf('Widget _buildAcknowledgementItem(');
+    final methodEnd = source.indexOf(
+      '\n  Future<void> _loadVersion()',
+      methodStart,
+    );
+
+    expect(methodStart, greaterThanOrEqualTo(0));
+    expect(methodEnd, greaterThan(methodStart));
+
+    final method = source.substring(methodStart, methodEnd);
+    expect(method, contains('return Row('));
+    expect(method, isNot(contains('Container(')));
+    expect(method, isNot(contains('BoxDecoration(')));
+    expect(method, isNot(contains('BorderRadius.')));
+  });
+
+  test('update action changes color and scales only while hovered', () {
+    final source = File(
+      'lib/settings/pages/about_settings_content.dart',
+    ).readAsStringSync();
+    final methodStart = source.indexOf('Widget _buildCanvasUpdateAction(');
+    final methodEnd = source.indexOf(
+      '\n  Widget _buildCanvasRichText(',
+      methodStart,
+    );
+
+    expect(methodStart, greaterThanOrEqualTo(0));
+    expect(methodEnd, greaterThan(methodStart));
+
+    final method = source.substring(methodStart, methodEnd);
+    expect(method, contains('Color.lerp('));
+    expect(method, contains('secondaryColor,'));
+    expect(method, contains('accentColor,'));
+    expect(method, contains('AnimatedScale('));
+    expect(method, contains('scale: isHovered ? 1.08 : 1'));
+    expect(method, contains('TweenAnimationBuilder<double>('));
+    expect(
+      method.indexOf('Padding('),
+      lessThan(method.indexOf('AnimatedScale(')),
+    );
+  });
+}

--- a/test/large_screen_focusable_action_test.dart
+++ b/test/large_screen_focusable_action_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_focusable_action.dart';
+
+void main() {
+  testWidgets('hover scaling keeps every button surface unscaled',
+      (tester) async {
+    final previousHighlightStrategy = FocusManager.instance.highlightStrategy;
+    FocusManager.instance.highlightStrategy =
+        FocusHighlightStrategy.alwaysTraditional;
+    addTearDown(() {
+      FocusManager.instance.highlightStrategy = previousHighlightStrategy;
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 220,
+            height: 56,
+            child: NipaplayLargeScreenFocusableAction(
+              onActivate: () {},
+              focusScale: 1.1,
+              padding: const EdgeInsets.symmetric(horizontal: 14),
+              child: const Row(
+                children: [
+                  Icon(Icons.settings),
+                  SizedBox(width: 8),
+                  Text('设置'),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final hoverRegion = tester.widget<MouseRegion>(
+      find.descendant(
+        of: find.byType(FocusableActionDetector),
+        matching: find.byType(MouseRegion),
+      ),
+    );
+    hoverRegion.onEnter?.call(const PointerEnterEvent());
+    await tester.pumpAndSettle();
+
+    final contentScale = tester.widget<AnimatedScale>(
+      find.descendant(
+        of: find.byType(AnimatedContainer),
+        matching: find.byType(AnimatedScale),
+      ),
+    );
+    expect(contentScale.scale, 1.1);
+    expect(
+      find.ancestor(
+        of: find.byType(AnimatedContainer),
+        matching: find.byType(AnimatedScale),
+      ),
+      findsNothing,
+    );
+  });
+}


### PR DESCRIPTION
## 改动

- 调整公共 `NipaplayLargeScreenFocusableAction`，悬浮或聚焦时只缩放内部图标和文字，按钮背景、边框、布局与点击区域保持固定。
- 移除关于页面赞助用户名称外层的圆角胶囊背景和边框，保留图标、文字与自动换行布局。
- 将“检查更新”按钮默认色改为中性次要文字色，悬浮时只放大内部内容并平滑过渡为主题色。

## 原因与影响

此前公共可聚焦按钮会整体放大，导致设置页左侧导航按钮超出可用区域后被裁剪。由于这是公共组件行为，其他调用方也存在相同风险。现在按钮表面尺寸始终稳定，缩放只用于内容反馈。

关于页面的赞助名单去除了不必要的圆角矩形包裹；检查更新操作也改为更克制的默认视觉，仅在悬浮时强调。

## 验证

- `dart analyze lib/settings/pages/about_settings_content.dart test/about_settings_content_test.dart lib/themes/nipaplay/widgets/large_screen_focusable_action.dart test/large_screen_focusable_action_test.dart`
- `flutter test --no-pub test/about_settings_content_test.dart test/large_screen_focusable_action_test.dart`
- `git diff --check`