### PR TITLE
ci: automate iOS App Store publishing

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -2,6 +2,33 @@ name: Build iOS
 
 on:
   workflow_call:
+    inputs:
+      upload-to-app-store:
+        description: '是否构建签名 IPA，供 GitHub Release 发布成功后上传到 App Store Connect'
+        required: false
+        default: false
+        type: boolean
+      app-store-connect-api-key-id:
+        description: 'App Store Connect API Key ID'
+        required: false
+        type: string
+      app-store-connect-issuer-id:
+        description: 'App Store Connect API Issuer ID'
+        required: false
+        type: string
+    secrets:
+      IOS_DISTRIBUTION_CERTIFICATE_BASE64:
+        description: '包含 Apple Distribution 证书和私钥的 P12（Base64）'
+        required: false
+      IOS_DISTRIBUTION_CERTIFICATE_PASSWORD:
+        description: 'iOS Distribution P12 密码'
+        required: false
+      APPLE_TEAM_ID:
+        description: 'Apple Developer Team ID'
+        required: false
+      APP_STORE_CONNECT_API_PRIVATE_KEY:
+        description: 'App Store Connect API 私钥（AuthKey_*.p8 完整内容）'
+        required: false
     outputs:
       version:
         description: '应用版本号'
@@ -9,15 +36,30 @@ on:
       artifact-name:
         description: '构建产物名称'
         value: ${{ jobs.build.outputs.artifact-name }}
+      app-store-artifact-name:
+        description: 'App Store 签名 IPA 的 Actions artifact 名称'
+        value: ${{ jobs.build.outputs.app-store-artifact-name }}
+      app-store-build-number:
+        description: 'App Store 构建号'
+        value: ${{ jobs.build.outputs.app-store-build-number }}
+      app-store-version:
+        description: 'App Store 版本号（不含 pubspec build metadata）'
+        value: ${{ jobs.build.outputs.app-store-version }}
+
+permissions:
+  contents: read
 
 jobs:
   build:
     name: Build iOS IPA
     runs-on: macos-26
-    timeout-minutes: 60
+    timeout-minutes: 90
     outputs:
       version: ${{ steps.setup.outputs.version }}
       artifact-name: release-iOS
+      app-store-artifact-name: app-store-iOS
+      app-store-build-number: ${{ steps.app_store_build.outputs.build-number }}
+      app-store-version: ${{ steps.app_store_build.outputs.version }}
     env:
       FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
       FVP_DEPS_LATEST: 1
@@ -35,8 +77,39 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Validate App Store Connect configuration
+        if: inputs.upload-to-app-store
+        shell: bash
+        env:
+          IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ inputs.app-store-connect-api-key-id }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ inputs.app-store-connect-issuer-id }}
+          APP_STORE_CONNECT_API_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for variable_name in \
+            IOS_DISTRIBUTION_CERTIFICATE_BASE64 \
+            IOS_DISTRIBUTION_CERTIFICATE_PASSWORD \
+            APPLE_TEAM_ID \
+            APP_STORE_CONNECT_API_KEY_ID \
+            APP_STORE_CONNECT_ISSUER_ID \
+            APP_STORE_CONNECT_API_PRIVATE_KEY; do
+            if [ -z "${!variable_name:-}" ]; then
+              missing+=("$variable_name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "缺少 App Store Connect 发布配置：${missing[*]}" >&2
+            exit 1
+          fi
+
       - name: Cache iOS Pods
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ios/Pods
           key: ios-pods-${{ hashFiles('ios/Podfile.lock', 'pubspec.lock') }}
@@ -51,16 +124,140 @@ jobs:
         shell: bash
         run: python3 .github/workflows/scripts/generate-build-info-json.py assets/build_info.json
       
-      - name: Build iOS IPA
+      - name: Build unsigned iOS IPA
+        id: unsigned_build
         uses: ./.github/actions/build-ios
         with:
           app-version: ${{ steps.setup.outputs.version }}
+
+      - name: Import iOS distribution certificate
+        if: inputs.upload-to-app-store
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          p12-password: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+
+      - name: Prepare App Store Connect API key
+        if: inputs.upload-to-app-store
+        id: app_store_api_key
+        shell: bash
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ inputs.app-store-connect-api-key-id }}
+          APP_STORE_CONNECT_API_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          api_key_dir="$RUNNER_TEMP/app-store-connect-private-keys"
+          api_key_path="$api_key_dir/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          mkdir -p "$api_key_dir"
+          printf '%s' "$APP_STORE_CONNECT_API_PRIVATE_KEY" > "$api_key_path"
+          chmod 600 "$api_key_path"
+
+          if ! grep -q -- '-----BEGIN PRIVATE KEY-----' "$api_key_path"; then
+            echo "APP_STORE_CONNECT_API_PRIVATE_KEY 不是完整的 AuthKey_*.p8 内容。" >&2
+            exit 1
+          fi
+
+          echo "path=$api_key_path" >> "$GITHUB_OUTPUT"
+
+      - name: Build App Store signed IPA
+        if: inputs.upload-to-app-store
+        id: app_store_build
+        shell: bash
+        env:
+          APP_VERSION: ${{ steps.setup.outputs.version }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ inputs.app-store-connect-api-key-id }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ inputs.app-store-connect-issuer-id }}
+          APP_STORE_CONNECT_API_KEY_PATH: ${{ steps.app_store_api_key.outputs.path }}
+        run: |
+          set -euo pipefail
+
+          archive_path="$RUNNER_TEMP/NipaPlay.xcarchive"
+          export_path="$RUNNER_TEMP/NipaPlay-AppStore"
+          export_options="$RUNNER_TEMP/ExportOptions-AppStore.plist"
+          marketing_version="${APP_VERSION%%+*}"
+          build_number="${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+
+          rm -rf "$archive_path" "$export_path" "$export_options"
+          mkdir -p "$export_path"
+
+          /usr/libexec/PlistBuddy -c 'Add :method string app-store-connect' "$export_options"
+          /usr/libexec/PlistBuddy -c 'Add :destination string export' "$export_options"
+          /usr/libexec/PlistBuddy -c 'Add :signingStyle string automatic' "$export_options"
+          /usr/libexec/PlistBuddy -c "Add :teamID string $APPLE_TEAM_ID" "$export_options"
+          /usr/libexec/PlistBuddy -c 'Add :manageAppVersionAndBuildNumber bool false' "$export_options"
+          /usr/libexec/PlistBuddy -c 'Add :stripSwiftSymbols bool true' "$export_options"
+          /usr/libexec/PlistBuddy -c 'Add :uploadSymbols bool true' "$export_options"
+
+          echo "构建 App Store 归档：版本 $marketing_version，构建号 $build_number"
+          xcodebuild \
+            -workspace ios/Runner.xcworkspace \
+            -scheme Runner \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$archive_path" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$APP_STORE_CONNECT_API_KEY_PATH" \
+            -authenticationKeyID "$APP_STORE_CONNECT_API_KEY_ID" \
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
+            DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY='Apple Distribution' \
+            FLUTTER_BUILD_NAME="$marketing_version" \
+            FLUTTER_BUILD_NUMBER="$build_number" \
+            CURRENT_PROJECT_VERSION="$build_number" \
+            archive \
+            -quiet
+
+          xcodebuild \
+            -exportArchive \
+            -archivePath "$archive_path" \
+            -exportPath "$export_path" \
+            -exportOptionsPlist "$export_options" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$APP_STORE_CONNECT_API_KEY_PATH" \
+            -authenticationKeyID "$APP_STORE_CONNECT_API_KEY_ID" \
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
+            -quiet
+
+          signed_ipa="$(find "$export_path" -maxdepth 1 -type f -name '*.ipa' -print -quit)"
+          if [ -z "$signed_ipa" ]; then
+            echo "Xcode 导出完成，但未找到签名 IPA。" >&2
+            find "$export_path" -maxdepth 2 -print >&2 || true
+            exit 1
+          fi
+
+          codesign --verify --deep --strict "$archive_path/Products/Applications/Runner.app"
+          echo "ipa-path=$signed_ipa" >> "$GITHUB_OUTPUT"
+          echo "build-number=$build_number" >> "$GITHUB_OUTPUT"
+          echo "version=$marketing_version" >> "$GITHUB_OUTPUT"
+
+      - name: Upload signed IPA for post-release App Store publishing
+        if: inputs.upload-to-app-store
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-store-iOS
+          path: ${{ steps.app_store_build.outputs.ipa-path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+      - name: Clean App Store signing files
+        if: always() && inputs.upload-to-app-store
+        shell: bash
+        run: |
+          rm -rf \
+            "$RUNNER_TEMP/app-store-connect-private-keys" \
+            "$RUNNER_TEMP/NipaPlay.xcarchive" \
+            "$RUNNER_TEMP/NipaPlay-AppStore" \
+            "$RUNNER_TEMP/ExportOptions-AppStore.plist"
       
-      - name: Upload iOS Artifacts
+      - name: Upload unsigned iOS Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: release-iOS
-          path: build/**/*.ipa
+          path: ${{ steps.unsigned_build.outputs.ipa-path }}
 
       - name: Upload Dart debug symbols (for de-obfuscating crash stacks)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,11 @@ on:
         description: 'Release title, e.g. 2026.0430'
         required: true
         type: string
+      submit_ios_for_review:
+        description: 'Upload iOS build and automatically submit it for App Review'
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -56,6 +61,15 @@ jobs:
     needs: Gatekeeper
     if: needs.Gatekeeper.outputs.triggered == 'true'
     uses: ./.github/workflows/build-ios.yml
+    with:
+      upload-to-app-store: true
+      app-store-connect-api-key-id: ${{ vars.APP_STORE_CONNECT_API_KEY_ID }}
+      app-store-connect-issuer-id: ${{ vars.APP_STORE_CONNECT_ISSUER_ID }}
+    secrets:
+      IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+      IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APP_STORE_CONNECT_API_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
 
   Build-macOS:
     name: Build macOS
@@ -355,6 +369,14 @@ jobs:
             : > release_notes.md
           fi
 
+      - name: Upload generated release notes for downstream publishing
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: release_notes.md
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Upload to release
         uses: ncipollo/release-action@v1
         with:
@@ -366,6 +388,206 @@ jobs:
           artifactErrorsFailBuild: true
           replacesArtifacts: true
           token: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+
+  Publish-iOS-App-Store:
+    name: Publish iOS to App Store Connect
+    needs: [Publish, Build-iOS]
+    if: success()
+    runs-on: macos-26
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    env:
+      APP_BUNDLE_ID: com.aimessoft.nipaplay
+      APP_VERSION: ${{ needs.Build-iOS.outputs.app-store-version }}
+      APP_BUILD_NUMBER: ${{ needs.Build-iOS.outputs.app-store-build-number }}
+      APP_STORE_ZH_LOCALE: ${{ vars.APP_STORE_ZH_LOCALE || 'zh-Hans' }}
+      APP_STORE_EN_LOCALE: ${{ vars.APP_STORE_EN_LOCALE || 'en-US' }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ vars.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_ISSUER_ID: ${{ vars.APP_STORE_CONNECT_ISSUER_ID }}
+      AI_API_URL: ${{ vars.RELEASE_AI_API_URL }}
+      AI_MODEL: ${{ vars.RELEASE_AI_MODEL || 'gemini-3-flash-preview' }}
+      FASTLANE_SKIP_UPDATE_CHECK: "1"
+      FASTLANE_HIDE_CHANGELOG: "1"
+      FASTLANE_DISABLE_COLORS: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download signed App Store IPA
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.Build-iOS.outputs.app-store-artifact-name }}
+          path: ${{ runner.temp }}/app-store-ipa
+
+      - name: Download generated GitHub release notes
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes
+          path: ${{ runner.temp }}/release-notes
+
+      - name: Validate App Store publishing inputs
+        shell: bash
+        env:
+          APP_STORE_CONNECT_API_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
+          AI_API_TOKEN: ${{ secrets.RELEASE_AI_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for variable_name in \
+            APP_VERSION \
+            APP_BUILD_NUMBER \
+            APP_STORE_CONNECT_API_KEY_ID \
+            APP_STORE_CONNECT_ISSUER_ID \
+            APP_STORE_CONNECT_API_PRIVATE_KEY \
+            AI_API_URL \
+            AI_MODEL \
+            AI_API_TOKEN; do
+            if [ -z "${!variable_name:-}" ]; then
+              missing+=("$variable_name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "Missing App Store publishing configuration: ${missing[*]}" >&2
+            exit 1
+          fi
+
+          signed_ipa="$(find "$RUNNER_TEMP/app-store-ipa" -maxdepth 2 -type f -name '*.ipa' -print -quit)"
+          if [ -z "$signed_ipa" ]; then
+            echo "Signed App Store IPA was not found in the downloaded artifact." >&2
+            exit 1
+          fi
+
+          release_notes="$RUNNER_TEMP/release-notes/release_notes.md"
+          if [ ! -s "$release_notes" ]; then
+            echo "Generated GitHub release notes are empty; refusing to upload and submit without localized update notes." >&2
+            exit 1
+          fi
+
+          echo "SIGNED_IPA=$signed_ipa" >> "$GITHUB_ENV"
+          echo "GITHUB_RELEASE_NOTES=$release_notes" >> "$GITHUB_ENV"
+
+      - name: Generate Chinese and English App Store release notes
+        shell: bash
+        env:
+          AI_API_TOKEN: ${{ secrets.RELEASE_AI_TOKEN }}
+        run: |
+          python3 .github/workflows/scripts/generate-app-store-release-notes.py \
+            --source "$GITHUB_RELEASE_NOTES" \
+            --output-dir "$RUNNER_TEMP/app-store-metadata" \
+            --zh-locale "$APP_STORE_ZH_LOCALE" \
+            --en-locale "$APP_STORE_EN_LOCALE" \
+            --max-characters 4000 \
+            --max-attempts 5
+
+      - name: Upload App Store release notes artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-store-release-notes
+          path: ${{ runner.temp }}/app-store-metadata
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Setup Ruby for fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install fastlane
+        run: gem install fastlane --version 2.237.0 --no-document
+
+      - name: Prepare App Store Connect API key
+        shell: bash
+        env:
+          APP_STORE_CONNECT_API_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          api_key_path="$RUNNER_TEMP/app-store-connect-api-key.json"
+          jq -n \
+            --arg key_id "$APP_STORE_CONNECT_API_KEY_ID" \
+            --arg issuer_id "$APP_STORE_CONNECT_ISSUER_ID" \
+            --arg key "$APP_STORE_CONNECT_API_PRIVATE_KEY" \
+            '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
+            > "$api_key_path"
+          chmod 600 "$api_key_path"
+          echo "APP_STORE_CONNECT_API_KEY_PATH=$api_key_path" >> "$GITHUB_ENV"
+
+      - name: Check whether this App Store build is already uploaded
+        id: existing_build
+        shell: bash
+        run: |
+          set +e
+          ruby .github/workflows/scripts/check-app-store-build.rb \
+            "$APP_STORE_CONNECT_API_KEY_PATH" \
+            "$APP_BUNDLE_ID" \
+            "$APP_VERSION" \
+            "$APP_BUILD_NUMBER"
+          status=$?
+          set -e
+
+          case "$status" in
+            0)
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              ;;
+            10)
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unable to check the existing App Store build." >&2
+              exit "$status"
+              ;;
+          esac
+
+      - name: Upload metadata, upload build, and submit for review
+        if: steps.existing_build.outputs.exists != 'true'
+        shell: bash
+        env:
+          SUBMIT_FOR_REVIEW: ${{ inputs.submit_ios_for_review }}
+        run: |
+          fastlane deliver \
+            --api_key_path "$APP_STORE_CONNECT_API_KEY_PATH" \
+            --ipa "$SIGNED_IPA" \
+            --app_identifier "$APP_BUNDLE_ID" \
+            --app_version "$APP_VERSION" \
+            --platform ios \
+            --metadata_path "$RUNNER_TEMP/app-store-metadata" \
+            --skip_screenshots true \
+            --submit_for_review "$SUBMIT_FOR_REVIEW" \
+            --automatic_release true \
+            --submission_information '{"export_compliance_uses_encryption":false}' \
+            --run_precheck_before_submit false \
+            --version_check_wait_retry_limit 10 \
+            --force true
+
+      - name: Reuse existing build, update metadata, and submit for review
+        if: steps.existing_build.outputs.exists == 'true'
+        shell: bash
+        env:
+          SUBMIT_FOR_REVIEW: ${{ inputs.submit_ios_for_review }}
+        run: |
+          fastlane deliver \
+            --api_key_path "$APP_STORE_CONNECT_API_KEY_PATH" \
+            --skip_binary_upload true \
+            --build_number "$APP_BUILD_NUMBER" \
+            --app_identifier "$APP_BUNDLE_ID" \
+            --app_version "$APP_VERSION" \
+            --platform ios \
+            --metadata_path "$RUNNER_TEMP/app-store-metadata" \
+            --skip_screenshots true \
+            --submit_for_review "$SUBMIT_FOR_REVIEW" \
+            --automatic_release true \
+            --submission_information '{"export_compliance_uses_encryption":false}' \
+            --run_precheck_before_submit false \
+            --version_check_wait_retry_limit 10 \
+            --force true
+
+      - name: Clean App Store credentials
+        if: always()
+        shell: bash
+        run: rm -f "$RUNNER_TEMP/app-store-connect-api-key.json"
 
   UpdateVersion:
     needs: [Publish]

--- a/.github/workflows/scripts/check-app-store-build.rb
+++ b/.github/workflows/scripts/check-app-store-build.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+
+require "fastlane_core/build_watcher"
+require "spaceship"
+
+api_key_path, bundle_id, app_version, build_number = ARGV
+
+if [api_key_path, bundle_id, app_version, build_number].any? { |value| value.nil? || value.empty? }
+  warn "usage: check-app-store-build.rb API_KEY_JSON BUNDLE_ID APP_VERSION BUILD_NUMBER"
+  exit 2
+end
+
+Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.from(filepath: api_key_path)
+app = Spaceship::ConnectAPI::App.find(bundle_id)
+
+unless app
+  warn "App Store Connect app not found for bundle ID #{bundle_id}"
+  exit 2
+end
+
+platform = Spaceship::ConnectAPI::Platform::IOS
+builds = Spaceship::ConnectAPI::Build.all(
+  app_id: app.id,
+  version: app_version,
+  build_number: build_number,
+  platform: platform
+)
+
+if builds.empty?
+  puts "Build #{app_version} (#{build_number}) is not uploaded yet."
+  exit 10
+end
+
+puts "Build #{app_version} (#{build_number}) already exists; waiting for processing to finish."
+build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(
+  app_id: app.id,
+  platform: platform,
+  app_version: app_version,
+  build_version: build_number,
+  poll_interval: 15,
+  timeout_duration: 3600,
+  return_spaceship_testflight_build: false
+)
+
+unless build.processing_state == Spaceship::ConnectAPI::Build::ProcessingState::VALID
+  warn "Build processing finished with state #{build.processing_state}, not VALID."
+  exit 2
+end
+
+puts "Build #{app_version} (#{build_number}) is valid and can be reused."

--- a/.github/workflows/scripts/generate-app-store-release-notes.py
+++ b/.github/workflows/scripts/generate-app-store-release-notes.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Generate localized App Store release notes from the GitHub release notes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import sys
+import time
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+DEFAULT_MAX_CHARACTERS = 4000
+DEFAULT_MAX_ATTEMPTS = 5
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--zh-locale", default="zh-Hans")
+    parser.add_argument("--en-locale", default="en-US")
+    parser.add_argument("--max-characters", type=int, default=DEFAULT_MAX_CHARACTERS)
+    parser.add_argument("--max-attempts", type=int, default=DEFAULT_MAX_ATTEMPTS)
+    return parser.parse_args()
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def character_count(text: str) -> int:
+    """Use the larger of Unicode code points and UTF-16 code units."""
+    utf16_units = len(text.encode("utf-16-le")) // 2
+    return max(len(text), utf16_units)
+
+
+def normalize_response(content: str) -> str:
+    content = content.replace("\r\n", "\n").replace("\r", "\n").strip()
+    fenced = re.fullmatch(r"```(?:text|markdown)?\s*\n?(.*?)\n?```", content, re.DOTALL)
+    if fenced:
+        content = fenced.group(1).strip()
+    return content
+
+
+def extract_content(response: dict[str, Any]) -> str:
+    try:
+        content = response["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as error:
+        raise RuntimeError("AI response does not contain choices[0].message.content") from error
+
+    if isinstance(content, str):
+        return normalize_response(content)
+    if isinstance(content, list):
+        text_parts = [part.get("text", "") for part in content if isinstance(part, dict)]
+        return normalize_response("".join(text_parts))
+    raise RuntimeError("AI response content is not text")
+
+
+def call_ai(api_url: str, api_token: str, model: str, prompt: str) -> str:
+    payload = json.dumps(
+        {
+            "model": model,
+            "temperature": 0.3,
+            "stream": False,
+            "messages": [{"role": "user", "content": prompt}],
+        },
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+    request = Request(
+        api_url,
+        data=payload,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {api_token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+    )
+
+    last_error: Exception | None = None
+    for request_attempt in range(1, 4):
+        try:
+            with urlopen(request, timeout=180) as response:
+                body = response.read().decode("utf-8")
+            return extract_content(json.loads(body))
+        except HTTPError as error:
+            last_error = error
+            if error.code not in {408, 429, 500, 502, 503, 504}:
+                detail = error.read().decode("utf-8", errors="replace")[:1000]
+                raise RuntimeError(f"AI request failed with HTTP {error.code}: {detail}") from error
+        except (URLError, TimeoutError, json.JSONDecodeError) as error:
+            last_error = error
+
+        if request_attempt < 3:
+            delay = 5 * request_attempt
+            print(f"AI request failed; retrying in {delay} seconds...", file=sys.stderr)
+            time.sleep(delay)
+
+    raise RuntimeError(f"AI request failed after retries: {last_error}")
+
+
+def initial_prompt(language: str, source: str, max_characters: int) -> str:
+    if language == "zh":
+        language_rules = """
+请使用简体中文。把内容编辑成 App Store“此版本的新功能”文案。
+""".strip()
+    else:
+        language_rules = """
+Write in natural US English. Translate and edit the source into App Store “What's New” copy.
+""".strip()
+
+    return f"""
+You are the release-note editor for NipaPlay, a cross-platform video player.
+{language_rules}
+
+Requirements:
+- Return only the final release-note text.
+- The result must be no more than {max_characters} characters; aim for no more than 3600.
+- Use plain text only. Do not use Markdown headings, links, URLs, code fences, or emoji.
+- Short bullet lines using “•” are allowed.
+- Keep only user-visible new features, improvements, and fixes.
+- Remove contributors, pull request numbers, issue numbers, CI/build/release-process details, dependency maintenance, and internal refactors.
+- Do not invent features or fixes that are absent from the source.
+- Make the result concise and suitable for an App Store product page.
+
+Source GitHub release notes:
+---
+{source}
+---
+""".strip()
+
+
+def shorten_prompt(language: str, previous: str, current_count: int, max_characters: int) -> str:
+    language_instruction = "继续使用简体中文。" if language == "zh" else "Continue in natural US English."
+    return f"""
+The following App Store release notes are {current_count} characters long and exceed the {max_characters}-character limit.
+{language_instruction}
+Rewrite and shorten them to no more than {max_characters} characters; aim for no more than 3600.
+Preserve the most important user-visible features and fixes.
+Return only plain text, with no Markdown headings, links, URLs, code fences, emoji, contributor names, or internal maintenance details.
+
+Text to shorten:
+---
+{previous}
+---
+""".strip()
+
+
+def generate_language(
+    language: str,
+    source: str,
+    api_url: str,
+    api_token: str,
+    model: str,
+    max_characters: int,
+    max_attempts: int,
+) -> str:
+    prompt = initial_prompt(language, source, max_characters)
+    for attempt in range(1, max_attempts + 1):
+        result = call_ai(api_url, api_token, model, prompt)
+        count = character_count(result)
+        print(f"{language} App Store notes attempt {attempt}: {count} characters")
+
+        if result and count <= max_characters:
+            return result
+
+        if not result:
+            prompt = initial_prompt(language, source, max_characters)
+        else:
+            prompt = shorten_prompt(language, result, count, max_characters)
+
+    raise RuntimeError(
+        f"Unable to generate {language} App Store notes within {max_characters} characters "
+        f"after {max_attempts} attempts"
+    )
+
+
+def write_metadata(output_dir: Path, locale: str, content: str) -> Path:
+    locale_dir = output_dir / locale
+    locale_dir.mkdir(parents=True, exist_ok=True)
+    path = locale_dir / "release_notes.txt"
+    path.write_text(content.rstrip(), encoding="utf-8")
+    return path
+
+
+def main() -> int:
+    args = parse_args()
+    source = args.source.read_text(encoding="utf-8").strip()
+    if not source:
+        raise RuntimeError("GitHub release notes are empty; refusing to submit empty App Store notes")
+
+    api_url = required_env("AI_API_URL")
+    api_token = required_env("AI_API_TOKEN")
+    model = required_env("AI_MODEL")
+
+    zh_notes = generate_language(
+        "zh", source, api_url, api_token, model, args.max_characters, args.max_attempts
+    )
+    en_notes = generate_language(
+        "en", source, api_url, api_token, model, args.max_characters, args.max_attempts
+    )
+
+    zh_path = write_metadata(args.output_dir, args.zh_locale, zh_notes)
+    en_path = write_metadata(args.output_dir, args.en_locale, en_notes)
+
+    summary = {
+        args.zh_locale: {"path": str(zh_path), "characters": character_count(zh_notes)},
+        args.en_locale: {"path": str(en_path), "characters": character_count(en_notes)},
+    }
+    (args.output_dir / "release-notes-summary.json").write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(json.dumps(summary, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -123,6 +123,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>https</string>


### PR DESCRIPTION
## Summary

- Build a separately signed App Store IPA while keeping the public GitHub Release IPA unsigned.
- Publish the signed build only after the GitHub Release succeeds, in parallel with the Homebrew update.
- Generate Simplified Chinese and English App Store release notes from the AI-generated GitHub changelog.
- Automatically submit the iOS version for App Review and release it after approval.

## What Changed

- Added Apple Distribution signing and temporary signed-IPA artifact handling to the reusable iOS workflow.
- Added a post-release App Store publishing job using App Store Connect API credentials and fastlane.
- Added localized `zh-Hans` and `en-US` release-note generation with a 4000-character limit and up to five AI refinement attempts.
- Added existing-build detection so failed-job reruns can reuse an uploaded build instead of attempting a duplicate upload.
- Declared `ITSAppUsesNonExemptEncryption=false` and supplied the same export-compliance response during submission.
- Added a workflow input that can disable review submission while still allowing the release workflow to run.

## Required Repository Configuration

Variables:

- `APP_STORE_CONNECT_API_KEY_ID`
- `APP_STORE_CONNECT_ISSUER_ID`
- Optional: `APP_STORE_ZH_LOCALE` (defaults to `zh-Hans`)
- Optional: `APP_STORE_EN_LOCALE` (defaults to `en-US`)

Secrets:

- `IOS_DISTRIBUTION_CERTIFICATE_BASE64`
- `IOS_DISTRIBUTION_CERTIFICATE_PASSWORD`
- `APP_STORE_CONNECT_API_PRIVATE_KEY`
- Existing `APPLE_TEAM_ID`
- Existing release AI configuration

## Validation

- Parsed both modified workflows as YAML.
- Validated the new workflow paths with actionlint.
- Validated `Info.plist` with `plutil`.
- Compiled the Python helper and tested its 4000-character boundary and AI retry behavior.
- Checked the Ruby helper syntax.
- Installed fastlane 2.237.0 in an isolated environment and verified the used CLI options.

## Related Issue

- No linked issue.