### PR TITLE
保持播放器子菜单容器高度一致

### DIFF
--- a/lib/themes/nipaplay/widgets/video_settings_menu.dart
+++ b/lib/themes/nipaplay/widgets/video_settings_menu.dart
@@ -363,6 +363,7 @@ class VideoSettingsMenuState extends State<VideoSettingsMenu>
     PlayerMenuPaneId paneId, {
     required VoidCallback onPaneClose,
     required bool showBackButton,
+    required double height,
   }) {
     late final Widget child;
     switch (paneId) {
@@ -459,7 +460,7 @@ class VideoSettingsMenuState extends State<VideoSettingsMenu>
 
     return _wrapMenu(
       showBackItem: showBackButton,
-      height: _heightForPane(paneId),
+      height: height,
       forceShowHeader: !showBackButton,
       useBackButtonOverride: showBackButton,
       child: child,
@@ -494,6 +495,7 @@ class VideoSettingsMenuState extends State<VideoSettingsMenu>
             .build()
             .where((item) => item.paneId != PlayerMenuPaneId.playlist)
             .toList();
+        final double menuHeight = _heightForSettingsItemCount(menuItems.length);
         final bool hideBackForStandaloneInitialPane =
             widget.hideBackButtonForInitialPane &&
                 widget.initialPaneId != null &&
@@ -506,7 +508,7 @@ class VideoSettingsMenuState extends State<VideoSettingsMenu>
         final Widget menuContent = _activePaneId == null
             ? _wrapMenu(
                 showBackItem: false,
-                height: _heightForSettingsItemCount(menuItems.length),
+                height: menuHeight,
                 child: BaseSettingsMenu(
                   title: '设置',
                   width: _menuWidth,
@@ -524,6 +526,9 @@ class VideoSettingsMenuState extends State<VideoSettingsMenu>
                 _activePaneId!,
                 onPaneClose: paneCloseCallback,
                 showBackButton: !hideBackForStandaloneInitialPane,
+                height: hideBackForStandaloneInitialPane
+                    ? _heightForPane(_activePaneId!)
+                    : menuHeight,
               );
         final Widget animatedMenuContent = FadeTransition(
           opacity: _menuFadeAnimation,


### PR DESCRIPTION
## 修改内容

- 统一复用播放器主菜单按可见调节项数量计算出的容器高度
- 子菜单切换时不再按自身内容数量改变外层容器高度
- 保留独立播放列表菜单原有的内容高度计算逻辑

## 原因与影响

此前每个子菜单都会根据自身内容重新计算高度，导致从主菜单进入不同面板时容器明显跳变。现在常规子菜单继承主菜单高度，内容较多时继续使用原有滚动区域。

## 验证

- `flutter analyze lib/themes/nipaplay/widgets/video_settings_menu.dart`
- `flutter test test/player_menu_definition_builder_test.dart`
- `git diff --check`