### PR TITLE
build(erika): consume v0.1.3 prebuilt runtimes

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -27,6 +27,7 @@ runs:
       uses: android-actions/setup-android@v3
 
     - name: Setup Rust for Android
+      if: env.ERIKA_PREBUILT != '1' || env.ERIKA_FORCE_SOURCE_BUILD == '1'
       uses: dtolnay/rust-toolchain@stable
       with:
         targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
@@ -38,10 +39,16 @@ runs:
         yes | sdkmanager --licenses >/dev/null
         set -o pipefail
 
-    - name: Install Android native build dependencies
+    - name: Install Android packaging dependencies
       shell: bash
       run: |
         sudo apt-get update
+        sudo apt-get install -y --no-install-recommends p7zip-full
+
+    - name: Install Erika Android source-build dependencies
+      if: env.ERIKA_PREBUILT != '1' || env.ERIKA_FORCE_SOURCE_BUILD == '1'
+      shell: bash
+      run: |
         sudo apt-get install -y --no-install-recommends \
           build-essential \
           cmake \
@@ -50,11 +57,11 @@ runs:
           meson \
           nasm \
           ninja-build \
-          p7zip-full \
           pkg-config \
           python3-venv
 
     - name: Cache Erika Android native dependencies
+      if: env.ERIKA_PREBUILT != '1' || env.ERIKA_FORCE_SOURCE_BUILD == '1'
       uses: actions/cache@v4
       with:
         path: |
@@ -112,9 +119,11 @@ runs:
     - name: Configure Gradle
       shell: bash
       run: |
-        ERIKA_CARGO_TARGET_DIR="${RUNNER_TEMP}/erika-android-target"
-        mkdir -p "${ERIKA_CARGO_TARGET_DIR}"
-        echo "CARGO_TARGET_DIR=${ERIKA_CARGO_TARGET_DIR}" >> "$GITHUB_ENV"
+        if [ "${ERIKA_PREBUILT:-}" != "1" ] || [ "${ERIKA_FORCE_SOURCE_BUILD:-}" = "1" ]; then
+          ERIKA_CARGO_TARGET_DIR="${RUNNER_TEMP}/erika-android-target"
+          mkdir -p "${ERIKA_CARGO_TARGET_DIR}"
+          echo "CARGO_TARGET_DIR=${ERIKA_CARGO_TARGET_DIR}" >> "$GITHUB_ENV"
+        fi
         mkdir -p ~/.gradle
         cat > ~/.gradle/gradle.properties << EOF
         org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -33,6 +33,9 @@ jobs:
     env:
       FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
       FVP_DEPS_LATEST: 1
+      ERIKA_REF: v0.1.3
+      ERIKA_PREBUILT: "1"
+      ERIKA_PREBUILT_TAG: v0.1.3
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -63,9 +63,9 @@ jobs:
     env:
       FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
       FVP_DEPS_LATEST: 1
-      ERIKA_REF: v0.1.1
+      ERIKA_REF: v0.1.3
       ERIKA_PREBUILT: "1"
-      ERIKA_PREBUILT_TAG: v0.1.1
+      ERIKA_PREBUILT_TAG: v0.1.3
     steps:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -40,9 +40,9 @@ jobs:
     env:
       FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
       FVP_DEPS_LATEST: 1
-      ERIKA_REF: v0.1.1
+      ERIKA_REF: v0.1.3
       ERIKA_PREBUILT: "1"
-      ERIKA_PREBUILT_TAG: v0.1.1
+      ERIKA_PREBUILT_TAG: v0.1.3
     steps:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -25,9 +25,9 @@ jobs:
       # CI runners that fatally breaks extraction. The mdk-sdk is pre-downloaded
       # by the build-windows action, so fvp must trust it and skip downloads.
       FVP_DEPS_LATEST: 0
-      ERIKA_REF: v0.1.1
+      ERIKA_REF: v0.1.3
       ERIKA_PREBUILT: "1"
-      ERIKA_PREBUILT_TAG: v0.1.1
+      ERIKA_PREBUILT_TAG: v0.1.3
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -291,11 +291,11 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: be8192d223f32a1bec512b935446999d3694ddff
-      resolved-ref: be8192d223f32a1bec512b935446999d3694ddff
+      ref: v0.1.3
+      resolved-ref: "9ddd8a46eb69ce6d6405da91fac99aa3b19238f6"
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
-    version: "0.1.2"
+    version: "0.1.3"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,9 +84,8 @@ dependencies:
   erika_flutter:
     git:
       url: https://github.com/AimesSoft/Erika.git
-      # Keep Nipa reproducible while Erika Android support is under review.
-      # Move this back to main after AimesSoft/Erika#42 is merged.
-      ref: be8192d223f32a1bec512b935446999d3694ddff
+      # Consume the versioned source and matching native prebuilt artifacts.
+      ref: v0.1.3
       path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   mobile_scanner: ^7.2.0


### PR DESCRIPTION
## Summary

- pin the Flutter dependency to Erika `v0.1.3` and its exact merge SHA
- update macOS, iOS, and Windows build workflows to consume the matching release assets
- make Android release builds consume `erika-capi-android.zip` instead of compiling Erika from source
- retain NDK setup for Flutter/other plugins; source-build toolchain and caches remain available through `ERIKA_FORCE_SOURCE_BUILD=1`

## Commit split

1. `ci(erika): consume v0.1.3 prebuilt runtimes`
2. `build(erika): pin v0.1.3 release`

## Validation

- `flutter pub get --enforce-lockfile`
- actionlint for the changed workflows
- Erika Release dry-run verified the real Android bundle layout and Gradle staged the real x86_64 ELF runtime without source compilation

Depends on the tag-triggered Erika `v0.1.3` release workflow publishing its assets.