### PR TITLE
ci: derive Erika prebuilt tag from dependency

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -240,3 +240,32 @@ runs:
           exit 1
         fi
         flutter pub get # 暂时移除了--enforce-lockfile
+
+    - name: Configure Erika prebuilt release
+      if: env.ERIKA_PREBUILT == '1' && env.ERIKA_FORCE_SOURCE_BUILD != '1'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [ -n "${ERIKA_PREBUILT_TAG:-}" ]; then
+          echo "Using explicitly configured Erika prebuilt release ${ERIKA_PREBUILT_TAG}."
+          exit 0
+        fi
+
+        ERIKA_PACKAGE_VERSION="$(awk '
+          /^  erika_flutter:/ {in_erika=1; next}
+          in_erika && /^    version:/ {
+            gsub(/"/, "", $2)
+            print $2
+            exit
+          }
+          in_erika && /^  [^ ]/ {exit}
+        ' pubspec.lock)"
+        if [ -z "${ERIKA_PACKAGE_VERSION}" ]; then
+          echo "Unable to resolve the Erika package version from pubspec.lock." >&2
+          exit 1
+        fi
+
+        ERIKA_PREBUILT_TAG="v${ERIKA_PACKAGE_VERSION#v}"
+        echo "ERIKA_PREBUILT_TAG=${ERIKA_PREBUILT_TAG}" >> "$GITHUB_ENV"
+        echo "Erika ${ERIKA_REF} uses prebuilt release ${ERIKA_PREBUILT_TAG}."

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -63,9 +63,7 @@ jobs:
     env:
       FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
       FVP_DEPS_LATEST: 1
-      ERIKA_REF: v0.1.1
       ERIKA_PREBUILT: "1"
-      ERIKA_PREBUILT_TAG: v0.1.1
     steps:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -40,9 +40,7 @@ jobs:
     env:
       FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
       FVP_DEPS_LATEST: 1
-      ERIKA_REF: v0.1.1
       ERIKA_PREBUILT: "1"
-      ERIKA_PREBUILT_TAG: v0.1.1
     steps:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -25,9 +25,7 @@ jobs:
       # CI runners that fatally breaks extraction. The mdk-sdk is pre-downloaded
       # by the build-windows action, so fvp must trust it and skip downloads.
       FVP_DEPS_LATEST: 0
-      ERIKA_REF: v0.1.1
       ERIKA_PREBUILT: "1"
-      ERIKA_PREBUILT_TAG: v0.1.1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## What changed

- Removed hardcoded `ERIKA_REF` and `ERIKA_PREBUILT_TAG` values from the iOS, macOS, and Windows workflows.
- Kept the Erika source ref driven by `pubspec.yaml` through the existing dependency refresh step.
- Added a post-`flutter pub get` step that derives the GitHub prebuilt release tag from the resolved `erika_flutter` package version, for example `0.1.2` → `v0.1.2`.
- Preserved support for an explicit `ERIKA_PREBUILT_TAG` override when one is intentionally supplied.

## Why

The workflow-level version pins duplicated the dependency configuration and had drifted to `v0.1.1` while the resolved Erika package version was `0.1.2`. This could combine newer Flutter/plugin bindings with an older native prebuilt library. Making dependency resolution the source of truth removes the extra version bump step across platform workflows.

## Validation

- `git diff --check`
- Parsed all four modified YAML files successfully.
- Verified the derivation path for the current commit-pinned Erika dependency: `be8192d223f32a1bec512b935446999d3694ddff` resolves to package version `0.1.2`, producing prebuilt tag `v0.1.2`.
- A full local iOS IPA build using the `v0.1.2` prebuilt artifact completed successfully before this workflow refactor.
