### PR TITLE
修复中文媒体文件名导致播放失败

### DIFF
--- a/lib/services/playback_source_service.dart
+++ b/lib/services/playback_source_service.dart
@@ -17,6 +17,7 @@ import 'package:nipaplay/services/jellyfin_service.dart';
 import 'package:nipaplay/services/smb_proxy_service.dart';
 import 'package:nipaplay/services/smb_service.dart';
 import 'package:nipaplay/services/webdav_service.dart';
+import 'package:nipaplay/utils/media_path_name.dart';
 import 'package:nipaplay/utils/media_source_utils.dart';
 import 'package:nipaplay/utils/shared_remote_history_helper.dart';
 import 'package:nipaplay/utils/webdav_file_sorter.dart';
@@ -873,11 +874,7 @@ class PlaybackSourceService {
   }
 
   static String _pathName(String path) {
-    final uri = Uri.tryParse(path);
-    if (uri != null && uri.pathSegments.isNotEmpty) {
-      return Uri.decodeComponent(uri.pathSegments.last);
-    }
-    return p.basename(path);
+    return mediaPathName(path);
   }
 
   static String? _firstNonEmpty(List<String?> values) {

--- a/lib/utils/media_path_name.dart
+++ b/lib/utils/media_path_name.dart
@@ -1,0 +1,10 @@
+import 'package:path/path.dart' as p;
+
+/// Returns the decoded final path segment from a local path or media URI.
+String mediaPathName(String path) {
+  final uri = Uri.tryParse(path);
+  if (uri != null && uri.pathSegments.isNotEmpty) {
+    return uri.pathSegments.last;
+  }
+  return p.basename(path);
+}

--- a/test/media_path_name_test.dart
+++ b/test/media_path_name_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/utils/media_path_name.dart';
+
+void main() {
+  group('mediaPathName', () {
+    test('accepts an already-decoded Unicode filename', () {
+      const path = '/media/[云光字幕组] 新 攻壳机动队THE.GHOST.IN.THE.SHELL[01].mp4';
+
+      expect(
+        mediaPathName(path),
+        '[云光字幕组] 新 攻壳机动队THE.GHOST.IN.THE.SHELL[01].mp4',
+      );
+    });
+
+    test('preserves a literal percent sign in the filename', () {
+      expect(
+        mediaPathName('/media/Magical Star Kanon 100%.mkv'),
+        'Magical Star Kanon 100%.mkv',
+      );
+    });
+
+    test('decodes an encoded URI path segment exactly once', () {
+      expect(
+        mediaPathName('https://media.example/%E6%94%BB%E5%A3%B3%20100%25.mp4'),
+        '攻壳 100%.mp4',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 修改内容

- 移除播放来源文件名的二次 URI 解码
- 提取统一的媒体路径名称解析工具
- 覆盖中文文件名、字面百分号和编码 URL 的回归测试

## 根因与影响

`Uri.pathSegments` 已返回解码后的文件名，但播放来源解析又调用 `Uri.decodeComponent`。中文文件名或包含 `%` 的文件名因此抛出 `Illegal percent encoding in URI`，并在 fallback 中再次触发，导致播放器初始化前直接失败。

修复后路径片段只解码一次，《攻壳机动队》这类中文文件名可以正常进入播放器初始化。

## 验证

- `flutter analyze --no-pub lib/services/playback_source_service.dart lib/utils/media_path_name.dart test/media_path_name_test.dart`
- `flutter test --no-pub test/media_path_name_test.dart`（3 项通过）
- `git diff --check`

## 范围

现有的 `macos/Podfile.lock` 本地修改未包含在此 PR 中。