### PR TITLE
Fix liquid glass safe areas and Android fallback rendering

### DIFF
--- a/lib/themes/cupertino/pages/cupertino_main_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_main_page.dart
@@ -10,6 +10,7 @@ import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
 import 'package:nipaplay/services/external_player_console_service.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_adaptive_platform_ui.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
+import 'package:nipaplay/themes/cupertino/utils/cupertino_glass_navigation_insets.dart';
 import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_app_page_actions.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_page_actions_scope.dart';
@@ -254,7 +255,9 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
     );
     final bottomInset = MediaQuery.viewPaddingOf(context).bottom;
     final tabBarHeight = bottomInset > 0 ? 56.0 : 50.0;
-    final glassTabBarBottom = bottomInset > 14 ? bottomInset - 8 : 6.0;
+    final glassTabBarBottom = resolveGlassTabBarBottomOffset(
+      viewPaddingBottom: bottomInset,
+    );
     final glassTabBarSettings =
         CupertinoTheme.brightnessOf(context) == Brightness.light
             ? _lightPhoneNavigationGlassSettings

--- a/lib/themes/cupertino/utils/cupertino_glass_navigation_insets.dart
+++ b/lib/themes/cupertino/utils/cupertino_glass_navigation_insets.dart
@@ -1,0 +1,11 @@
+const double _glassTabBarEdgeGap = 6.0;
+
+/// Resolves the bottom offset for the floating liquid-glass tab bar.
+///
+/// Keeps the entire system navigation inset unobstructed and adds a small,
+/// consistent visual gap on every platform using the Flutter fallback.
+double resolveGlassTabBarBottomOffset({
+  required double viewPaddingBottom,
+}) {
+  return viewPaddingBottom + _glassTabBarEdgeGap;
+}

--- a/packages/liquid_glass_widgets/.gitignore
+++ b/packages/liquid_glass_widgets/.gitignore
@@ -1,0 +1,2 @@
+pubspec.lock
+example/pubspec.lock

--- a/packages/liquid_glass_widgets/CHANGELOG.md
+++ b/packages/liquid_glass_widgets/CHANGELOG.md
@@ -1,0 +1,4302 @@
+# 0.21.3
+
+## 🐛 Bug Fixes
+
+- **SVG and custom icons restored** — `SizedBox`-wrapped icons (e.g. `SvgPicture`) were silently stripped from the render tree since `0.20.0`. The `SizedBox.shrink()` sentinel detection now checks `width`, `height`, and `child` fields so a caller-supplied `SizedBox` wrapping a real icon is always rendered correctly.
+- **Searchable bar pill stays active while dragging** — the glass indicator on `GlassTabBar.searchable` collapsed back to its resting state when the finger passed over the currently selected tab mid-drag. The thickness spring now includes the `tabIsDragging` guard, matching the behaviour already present in `GlassTabBar.bottom`.
+- **`JellyClipper` Impeller radius guard** — the clip radius is now clamped to strictly less than half the indicator's shortest side, preventing a malformed `RRect` path that caused content to vanish under Impeller's Metal renderer in certain animation frames.
+
+## 🧹 Example
+
+- **Indicator Parity demo calibrated** — default refraction set to `1.15` (`GlassDefaults.refractiveIndex`) to match all Apple demos; both `GlassTabBar.inline` variants now wire live tuner sliders for expansion and pinch strength.
+
+---
+
+# 0.21.2
+
+
+## 🐛 Bug Fixes
+
+- **Extra button stretch disabled over platform views** — `GlassTabBarExtraButton` now correctly disables its stretch effect when `platformViewBackdrop: true`, matching the behavior of `GlassTabBar.bottom` and fixing the jittery spring animation.
+- **`GlassMenu` item scroll wiggle fixed** — menu items with wrapped text (e.g. `maxLines: 2`) could drift sub-pixel vertically during slide-to-select dragging because `ClampingScrollPhysics` allowed fractional scroll offsets even when no overflow was intended. Non-scrollable menus now use `NeverScrollableScrollPhysics`, locking the content completely in place during drag.
+- **`GlassPopover` first-frame height fixed** — the popover was briefly rendered at full-screen height before its content height was known, producing a visible flash and forcing users to wrap content in a `SingleChildScrollView` as a workaround. An invisible `Offstage` measurement pass now runs on Frame 1, letting Flutter's layout engine calculate the exact intrinsic content height before the morph animation starts. The animation launches on Frame 2 with perfect geometry — no mid-flight height correction, no flash, no heuristics.
+
+## ⚡ Performance
+
+- **Removed unnecessary compositing layer in `GlassBottomBar`** — the `RepaintBoundary` wrapping the icon layer in `_buildHighQualityMode` is now only mounted when `platformViewBackdrop: true`, where it is required for the Platform View capture path (bug #99). In the common case (`platformViewBackdrop: false`) the boundary was creating a GPU offscreen texture every frame with no caching benefit, since the `JellyClipper` changes on every animation frame.
+- **`GlassPopover` idle trigger optimised** — when the popover is fully closed, the trigger widget now skips unnecessary `Transform`, `Opacity`, and `IgnorePointer` compositing layers. This removes redundant GPU work in the common idle state.
+
+## 🧹 Code Quality
+
+- **Null-safe trigger child access** — replaced a `child!` force-unwrap in `GlassPopoverInternal` with a null-safe `child ?? const SizedBox.shrink()` fallback, preventing a hard crash if `child` is ever omitted in a future refactor.
+
+## 🧪 Example
+
+- **Refraction slider added to Indicator Parity demo tuner** — a "Refraction (n)" slider (range 1.0–2.0, default 1.59 matching `GlassTabBar.bottom`'s internal default) for tuning the `refractiveIndex` on the Premium (Impeller) glass indicator. Standard indicators do not perform background capture so the parameter has no visual effect there.
+
+---
+
+# 0.21.1
+
+## 🐛 Bug Fixes — Standard indicator parity
+
+- **Two-pills misalignment fixed** — at `GlassQuality.standard`, the background rim and glass lens now share the same shape geometry (`ShapeDecoration`) and ride the same jelly `Transform`, eliminating the visible separation mid-morph. Regression reported against `GlassTabBar.inline` / segmented controls.
+- **Indicator collapse on drag fixed** — the glass indicator no longer morphs back to the resting pill when dragging over the selected tab. The thickness gate now includes `tabIsDragging` so the indicator stays fully active for the entire gesture duration.
+- **Standard rim thickness normalised** — the indicator rim on `GlassQuality.standard` is now proportionally mapped from `indicatorSettings.thickness` (same value as Premium) rather than scaling from the raw glass-depth value, which produced a ~2.8 px border. The result is a fine hairline that gracefully matches the Premium look on Standard-quality devices.
+
+---
+
+# 0.21.0
+
+## ✨ New Features
+
+- **`GlassModalSheet` drag progress** — controller now exposes a `progress` getter and `progressListenable` reporting the live 0–1 drag position between half↔full snap points, so hosts can drive coordinated UI in real time. ([#148](https://github.com/sdegenaar/liquid_glass_widgets/pull/148), [@jfhair](https://github.com/jfhair))
+- **`GlassTabBar.inline` spring control** — the `.inline` factory now accepts `springDescription`, matching the other factory constructors. Previously inline tab bars were locked to the shared default spring. ([#149](https://github.com/sdegenaar/liquid_glass_widgets/pull/149), [@jfhair](https://github.com/jfhair))
+- **`LiquidGlassSettings.ambientRim`** — tunable full-perimeter rim on the moving indicator pill. Defaults match Apple Music's segmented control (brighter in light mode, off in dark). ([#150](https://github.com/sdegenaar/liquid_glass_widgets/pull/150), [@jfhair](https://github.com/jfhair))
+- **`AnimatedGlassIndicator` shadow** — `shadowElevation`/`shadow` in `indicatorSettings` now correctly paints a drop shadow on the glass jelly. Previously these values were silently ignored. ([#151](https://github.com/sdegenaar/liquid_glass_widgets/pull/151), [@jfhair](https://github.com/jfhair))
+
+## 🐛 Bug Fixes — PlatformView gesture stability
+
+- **Tab bar freeze fixed:** Intermittent freeze where the tab indicator stopped
+  responding after interacting over an iOS `PlatformView` (e.g. a map or WebView).
+  The iOS gesture arena can silently drop terminal callbacks, leaving the recognizer
+  wedged. Fixed with proactive cleanup on `PointerDown`, post-frame recovery, and
+  a gesture ID guard to prevent rapid-tap state corruption.
+- **Hybrid gesture mode on `platformViewBackdrop: true`:** When the tab bar
+  floats over a `PlatformView`, the visual indicator now animates to its new
+  position instantly on touch-down (matching native iOS responsiveness), while the
+  actual tab content swap is deferred safely to touch-up. This prevents the iOS
+  UIKit view system from dropping the touch stream mid-gesture due to a mid-frame
+  unmount of the `PlatformView`. No impact on any screen where
+  `platformViewBackdrop` is `false` — those continue to swap instantly on down.
+- **Stretch disabled on `platformViewBackdrop: true`:** Flutter's `BackdropFilter`
+  must re-acquire the native pixel buffer every time its bounding box changes.
+  Stretch animations resize the glass container, causing a one-frame flicker over
+  a `PlatformView`. Stretch is now skipped on all bar elements when
+  `platformViewBackdrop` is set; press-scale (`interactionScale`) is unaffected
+  because it is a GPU-level transform that leaves the backdrop bounds stable.
+  No impact on any other screen or platform.
+
+---
+
+# 0.20.1
+
+## 🐛 Bug Fix — `GlassButton.custom` layout expansion
+
+**Fixes:** `GlassButton.custom` unexpectedly expanding to fill bounded parent constraints (e.g., inside `AppBar` actions) ([#146](https://github.com/sdegenaar/liquid_glass_widgets/issues/146)).
+
+- `GlassButton.custom` `height` now correctly defaults to `null` (matching documented behavior).
+- The button now properly shrink-wraps to its content when explicit width/height are not provided.
+- **Migration:** No breaking changes. If you were relying on the undocumented `56px` default height, explicitly set `height: 56`.
+
+---
+
+# 0.20.0
+
+## 💥 Breaking — `GlassListTile` divider refactor
+
+`GlassListTile` no longer draws its own divider. The `isLast`, `showDivider`,
+and `dividerIndent` parameters have been removed.
+
+**Rationale:** A list tile should be a clean, position-agnostic item. Divider
+rendering is a layout concern that belongs to the parent container.
+
+### Migration
+
+**Inside `GlassGroupedSection` — no changes needed.**
+`GlassGroupedSection` now automatically injects `GlassDivider`s between tiles
+with smart leading-indent detection (56px if the preceding tile has a leading
+widget, 16px otherwise). The last tile never gets a trailing divider.
+
+**Standalone column layouts — compose `GlassDivider` explicitly:**
+
+```dart
+// Before:
+Column(children: [
+  GlassListTile(title: Text('A')),                    // showDivider: true (default)
+  GlassListTile(title: Text('B'), isLast: true),      // suppresses divider
+])
+
+// After (standard Flutter composition pattern):
+Column(children: [
+  GlassListTile(title: Text('A')),
+  GlassDivider(indent: 16),
+  GlassListTile(title: Text('B')),
+])
+```
+
+This aligns with Flutter's own `ListTile` + `Divider` composition model.
+
+---
+
+## ✨ New — `GlassTabBar.inline`
+
+A compact glass tab bar for pinned content-filter sections — sits fixed between
+a page header and its scrollable list, not inside the scroll view itself.
+
+> **Performance note:** `GlassQuality.premium` re-runs the full shader pipeline
+> whenever the backdrop changes. Placing the bar inside a scroll view invalidates
+> the backdrop on every scroll frame. Pin it outside the scrollable region or
+> drop to `GlassQuality.standard` if embedding inside a list.
+
+```dart
+GlassTabBar.inline(
+  tabs: const [
+    GlassTab(label: 'For You'),
+    GlassTab(label: 'Following'),
+    GlassTab(label: 'New'),
+  ],
+  selectedIndex: _selectedIndex,
+  onTabSelected: (i) => setState(() => _selectedIndex = i),
+)
+```
+
+**Key differences from `GlassTabBar.bottom`:**
+- Zero padding — sits flush in its parent container.
+- Compact height (40px) with a full stadium shape (`barBorderRadius: 100`, clamped to `height/2`).
+- Indicator pill automatically matches the track corner radius (`indicatorBorderRadius` defaults to `barBorderRadius`).
+- Indicator expansion `h:12, v:10` — same horizontal weight as `GlassSegmentedControl` and `GlassTabBar.bottom`, +2px vertical to compensate for the shorter bar height giving the glass pill proportional visual mass.
+- `indicatorPinchStrength: 0.4` — aligned with all other pill controls.
+- Magnification disabled (`1.0x`) — text labels never grow on selection.
+- Text-only tabs render with correct vertical centering (no icon slot consuming space).
+- `extraButton` not supported (structural navigation feature only).
+
+All standard physics parameters (`indicatorPinchStrength`, `indicatorExpansion`,
+`indicatorSettings`, `quality`) are still fully configurable.
+
+See the updated **Indicator Parity** demo (`indicator_parity_demo.dart`) where
+`GlassTabBar.inline` now appears alongside the other five pill widgets — including
+a text-only variant (40px) and an icon + text variant (52px) — with live tuning sliders.
+
+---
+
+# 0.19.7
+
+
+## 🐛 Bug Fixes
+
+- **`GlassTabBar.bottom` / `GlassBottomBar`** — fixes RTL support (#143, @naeemeltaief).
+  The pill and tap/drag hit-testing now correctly align with the visually reversed tab order
+  under RTL. The bottom layout normalises the tab data, selected index and callback for RTL,
+  and pins only the two inner tab `Row`s to LTR — leaving `indicatorExpansion`, `tabPadding`
+  and all text to resolve against the ambient direction as expected. Consumers no longer
+  need to force `Directionality.ltr` and reverse tabs by hand. +2 tests.
+
+- **`AnimatedGlassIndicator`** — restores the resting selection pill inside a `GlassContainer`
+  (#144, @jfhair). The background pill was permanently hidden whenever an ancestor set
+  `avoidsRefraction`, which is a steady-state layout flag on `GlassContainer` — not a
+  transient capture signal. The guard was incorrect and is removed. The pill now renders
+  correctly in all contexts. No API change. +1 test.
+
+
+# 0.19.6
+
+## ✨ New — `GlassLargeTitle` + `GlassLargeTitleController`
+
+First-class iOS 26 large-title + search-bar collapse. Replaces manual
+`ScrollController` + `setState` wiring with a single controller and two
+widgets.
+
+### Two-phase collapse
+
+- **Phase 1** — large title fades out (`Curves.easeIn`, rubber-band overscroll stretch).
+- **Phase 2** — optional inline search bar collapses under the nav bar immediately after.
+
+### New API
+
+- `GlassLargeTitle` — sliver widget. Drop it as the first sliver in any `CustomScrollView`.
+  - `searchBar: Widget?` — Phase 2 collapse (e.g. `GlassSearchBar`).
+  - `trailing`, `fontSize`, `fontWeight`, `letterSpacing`, `padding`, `searchBarPadding`, `color`.
+- `GlassLargeTitleController` — owns the `ScrollController`, exposes `collapseProgress` and `searchBarCollapseProgress`. Self-calibrates to Dynamic Type via `reportMeasuredHeight` / `reportSearchBarHeight`.
+- `GlassAppBar.largeTitleController` — new optional param. Bar title cross-fades in as the large title collapses. Non-breaking.
+
+```dart
+final _ctrl = GlassLargeTitleController(); // dispose in State.dispose()
+
+// Phase 1 only
+GlassLargeTitle(text: 'Chats', controller: _ctrl)
+
+// Phase 1 + 2
+GlassLargeTitle(
+  text: 'Messages',
+  controller: _ctrl,
+  searchBar: GlassSearchBar(placeholder: 'Search', onChanged: (_) {}),
+)
+```
+
+### Demo
+
+- Pattern 2 updated to new API. Pattern 7 (Large Title + Search Bar) added.
+- Apple Messages demo migrated from manual `AnimatedOpacity` to `GlassLargeTitle`.
+
++10 tests. **2,291 total, all passing.**
+
+## ⚡ Performance — `GlassBottomBar` Indicator (Impeller)
+
+- **`GlassBottomBar` indicator** — eliminates the live `BackdropFilterLayer` on Impeller
+  premium, replacing it with a deterministic `toImageSync` capture path. Fixes the
+  opaque-white indicator rendering on physical iOS (#99) and improves drag performance
+  by removing a redundant compositor pass.
+
+## 🔧 `GlassGroupedSection` — Header/Footer styling
+
+- Header and footer text is now styled automatically via `DefaultTextStyle`
+  (`CupertinoColors.secondaryLabel`, 13pt) — callers no longer need to style them manually.
+- Margin is now applied via `Padding` wrapping the full section rather than on the inner
+  `GlassCard`, fixing card-edge clipping when a header or footer is present.
+- Import changed to `cupertino.dart` for correct `CupertinoColors` resolution.
+
+## 📝 Dart doc improvements
+
+- `GlassContainer`, `GlassCard`, `GlassGroupedSection`, `GlassSegmentedControl` — added
+  **⚠️ Anti-Pattern** sections documenting the glass-in-glass restriction: placing interactive
+  glass controls inside a container degrades refraction and clips jelly animations.
+
+# 0.19.5
+
+- **`LiquidGlassSettings`** — adds `platformViewFallbackColor` (#138, @jfhair). Splits
+  `backerColor`'s dual role: `backerColor` remains the aesthetic backer pad; the new
+  field controls the `uBackgroundFallback` shader uniform (PlatformView fill).
+  Fully backwards-compatible — defaults to `null`, falling back to `backerColor`.
+
+- **`GlassModalSheet`** — removes the interior `BoxShadow` that bled through the glass
+  as a vignette (#137, @jfhair). Elevation now flows via `LiquidGlassSettings.shadowElevation`.
+  Pass `shadowElevation: 0` to disable entirely.
+
+# 0.19.4
+
+## ✨ Enhancements — `GlassButtonGroupItem.menu` & `GlassPullDownButton` improvements
+
+### `GlassButtonGroupItem.menu` — whole-pill liquid glass morph
+
+
+Adds a new `GlassButtonGroupItem.menu` named constructor that turns any item in a
+`GlassButtonGroup.icons` pill into a pull-down menu trigger.
+
+When tapped, the **entire pill morphs** into the menu — the full `GlassButton.custom`
+shell becomes the `GlassMenu` trigger, so the whole group shape liquefies and expands
+into the menu card. This matches the iOS 26 `GlassEffectContainer` morph pattern where
+the source shape, not just the tapped slot, participates in the transition.
+
+```dart
+GlassButtonGroup.icons(
+  items: [
+    GlassButtonGroupItem(icon: Icon(CupertinoIcons.chart_bar), onTap: () {}),
+    GlassButtonGroupItem(icon: Icon(CupertinoIcons.clock),     onTap: () {}),
+    GlassButtonGroupItem.menu(
+      icon: Icon(CupertinoIcons.ellipsis),
+      menuItems: [
+        GlassMenuItem(title: 'Add to Watchlist', icon: Icon(CupertinoIcons.star), onTap: () {}),
+        GlassMenuItem(title: 'Share',            icon: Icon(CupertinoIcons.share), onTap: () {}),
+        GlassMenuDivider(),
+        GlassMenuItem(title: 'Remove', icon: Icon(CupertinoIcons.trash), isDestructive: true, onTap: () {}),
+      ],
+      menuAlignment: GlassMenuAlignment.topRight, // optional
+      menuWidth: 200,                              // optional, default 200
+    ),
+  ],
+)
+```
+
+**Notes:**
+- Only the first `GlassButtonGroupItem.menu` in the list is used as the menu trigger; any subsequent menu items are treated as plain tap items.
+- Accepts both `GlassMenuItem` and `GlassMenuDivider`, matching `GlassMenu.items` directly.
+- Non-menu siblings in the group continue to fire their own `onTap` independently.
+- Works with both `Axis.horizontal` and `Axis.vertical` groups.
+
+**Alternatively — group + standalone `GlassPullDownButton`**
+
+For cases where the menu trigger is a separate, visually distinct action from the
+group (e.g. a trailing overflow button next to a row of chart controls), compose a
+`GlassButtonGroup` alongside a standalone `GlassPullDownButton`. The pull-down
+button morphs independently and fully, with no pill residue:
+
+```dart
+Row(
+  children: [
+    GlassButtonGroup.icons(
+      items: [
+        GlassButtonGroupItem(icon: Icon(CupertinoIcons.chart_bar), onTap: () {}),
+        GlassButtonGroupItem(icon: Icon(CupertinoIcons.clock),     onTap: () {}),
+      ],
+    ),
+    SizedBox(width: 8),
+    GlassPullDownButton(
+      icon: Icon(CupertinoIcons.ellipsis),
+      menuAlignment: GlassMenuAlignment.topRight,
+      items: [
+        GlassMenuItem(title: 'Add to Watchlist', icon: Icon(CupertinoIcons.star), onTap: () {}),
+        GlassMenuItem(title: 'Share',            icon: Icon(CupertinoIcons.share), onTap: () {}),
+        GlassMenuDivider(),
+        GlassMenuItem(title: 'Remove', icon: Icon(CupertinoIcons.trash), isDestructive: true, onTap: () {}),
+      ],
+    ),
+  ],
+)
+```
+
+| | `.menu` item (shared pill) | group + standalone |
+|---|---|---|
+| All actions in one pill | ✅ | ❌ |
+| Entire pill morphs | ✅ | — |
+| Menu button morphs independently | — | ✅ |
+| Best for | Overflow within a related set | Separate trailing action |
+
+### `GlassPullDownButton` improvements
+
+- **`items` widened to `List<Widget>`** — now accepts `GlassMenuDivider` alongside `GlassMenuItem`. Source-compatible: existing `List<GlassMenuItem>` code compiles and behaves identically. The `onSelected` callback is applied only to `GlassMenuItem` instances.
+- **`menuAlignment` exposed** — new `GlassMenuAlignment?` parameter forwarded to the underlying `GlassMenu`. Defaults to `null` (auto-detect from screen position) — fully backward-compatible.
+
+## 🐛 Bug Fixes — PlatformView Frost Halo & GlassButton Dispose-Race ([#134](https://github.com/sdegenaar/liquid_glass_widgets/pull/134), [#135](https://github.com/sdegenaar/liquid_glass_widgets/pull/135))
+
+Both fixes contributed by [@jfhair](https://github.com/jfhair).
+
+### `LiquidOval` rectangular blur halo over a PlatformView ([#134](https://github.com/sdegenaar/liquid_glass_widgets/pull/134))
+
+**Problem:** Any glass surface with a `LiquidOval` shape (the default for `GlassButton`,
+`GlassIconButton`, the collapsed search/dismiss pill, and `GlassBottomBarExtraButton`)
+rendered a rectangular blur halo when `platformViewBackdrop: true` routed it through the
+`_FrostedFallback` `BackdropFilter` path. The halo matched the widget's bounding box rather
+than its circular outline.
+
+**Root cause:** Flutter engine PR #177551 (3.41+) forwards `ClipRRect` clip data to the iOS
+PlatformView mutator stack, allowing a descendant `BackdropFilter` to be bounded correctly
+over a hybrid-composed view. The same forwarding does NOT apply to `ClipPath` — and
+`LiquidOval` (unlike `LiquidRoundedSuperellipse`) was routing through `ClipPath`, leaving
+the `BackdropFilter` unclipped.
+
+**Fix:** `_ShapeClip` now accepts a `platformViewBackdrop` flag. When set, any shape whose
+border radius can be expressed as a `BorderRadius` (including `LiquidOval` →
+`circular(9999)`, `LiquidRoundedRectangle`, and their vertical variants) is routed through
+`ClipRRect` instead of `ClipPath`. The clip is then forwarded to the PlatformView mutator
+stack and the frost is bounded cleanly to the shape. Off a PlatformView the original
+`ClipPath` is used (true ellipse). The flag is threaded through all `_ShapeClip` call sites
+in `_FrostedFallback` — the blur body, the content clip, and the specular rim — as well as
+the backer dimming pad in `AdaptiveGlass._wrapWithBacker`.
+
+Completes the partial fix shipped in 0.19.3 and fully resolves the rectangular-blur
+regression first reported in [#79](https://github.com/sdegenaar/liquid_glass_widgets/issues/79).
+
+### `GlassButton` crash when disposed mid-press ([#135](https://github.com/sdegenaar/liquid_glass_widgets/pull/135))
+
+**Problem:** Tapping a `GlassButton` that is removed by the very tap that activates it
+(e.g. a collapsed bar restore button that expands the bar and disposes itself) could throw:
+
+```
+AnimationController.reverse() called after AnimationController.dispose()
+(assert _ticker != null)
+```
+
+A queued `pointerUp` or `pointerCancel` was still dispatched to the now-disposed
+`RenderPointerListener`, and the press handler called `_saturationController.reverse()`
+after `dispose()`.
+
+**Fix:** All six tap/pointer press handlers in `_GlassButtonState` now guard on `!mounted`
+before touching `_saturationController`. A disposed `State` always has `mounted == false`,
+so the handler bails safely without touching the controller.
+
+Surfaces frequently in apps that morph or collapse a bar on the tap of a glass control
+over a PlatformView (the pattern introduced in #127/#79).
+
+# 0.19.3
+
+## 🐛 Bug Fixes — Search Pill Colors & PlatformView Compositing
+
+- Fixed an issue where the `SearchPill` icon colors (search, mic) would incorrectly render as black when using dark glass (`glassColor: Colors.black26`) over an iOS PlatformView. The root cause was that the color resolution used the OS system brightness (light) instead of the glass brightness (dark), causing `CupertinoDynamicColor.label` to always resolve to its light-mode black variant. The widget now resolves colors through `GlassTheme.brightnessOf()` — the package's single brightness authority — and explicitly passes the resolved color via `IconThemeData` to guarantee white glyphs on dark glass regardless of system brightness.
+- Mitigated a Flutter engine clipping bug over PlatformViews by ensuring `LiquidRoundedSuperellipse` and `LiquidOval` correctly clip their bounds using an outer `ClipRRect` when rendering over an iOS PlatformView, preventing blur bleed outside the circular button shape.
+- Updated the `google_maps_demo` to correctly demonstrate how to configure `selectedIconColor`, `unselectedIconColor`, and `searchIconColor` for dark glass bottom bars to ensure all tab elements remain visible over the map layer.
+
+# 0.19.2
+
+## 🐛 Bug Fixes — PlatformView Gesture & Rendering
+
+This release resolves a pair of related issues that caused the glass bottom bar
+to freeze and render incorrectly when floating over an iOS PlatformView (e.g. a
+Mapbox map). All three fixes were contributed by [@jfhair](https://github.com/jfhair)
+via detailed PRs that included root-cause analysis, regression tests, and working
+reproductions. Many thanks for the exceptional quality of this contribution.
+
+### Gesture freeze over an iOS PlatformView ([#127](https://github.com/sdegenaar/liquid_glass_widgets/pull/127))
+
+**Problem:** `GlassTabBar.searchable` (and `GlassBottomBar`) would freeze when
+the draggable indicator was dragged or tapped while the bar floated over an iOS
+PlatformView. The freeze was permanent until the widget was rebuilt or disposed.
+
+**Root cause:** iOS reconstructs the platform-view clip chain whenever a clip
+layer is added or removed mid-gesture. The engine responds by cancelling the
+active touch, which left the bar's `GestureDetector` recognizer wedged — it
+never received a terminal callback (`onDragEnd` / `onDragCancel`) and stopped
+responding to input. The most frequent trigger was the indicator's `innerBlur`
+frost layer unmounting at drag-start (a clip-add/remove cycle).
+
+**Fix — two-part:**
+- **Primary fix (PR #127):** The indicator's frost `ClipRRect + BackdropFilter`
+  layer now stays _mounted_ across the full drag lifecycle by tracking a
+  persistent `bool _frostMounted` flag in `AnimatedGlassIndicator`. This
+  eliminates the clip-add/remove cycle that was triggering the iOS clip-chain
+  reconstruction.
+- **Backstop fix (PR #127):** `TabBarDragGestureMixin` gains a
+  `gestureEpoch` counter, a `_gestureActive` liveness flag, and a raw
+  `Listener` on the `GestureDetector` subtree. If the raw pointer-up or
+  pointer-cancel arrives while `_gestureActive` is still `true` (i.e. the
+  terminal callback was silently dropped by the platform-view gesture arena),
+  `recoverIfGestureStuck` is called: it selects a fallback tab, bumps
+  `gestureEpoch` (forcing the `GestureDetector` to be torn down and
+  recreated via `ValueKey`), and clears the stuck state. Covers both the
+  tap-without-cancel and drag-start-without-end freeze signatures.
+
+### PlatformView backdrop routing ([#128](https://github.com/sdegenaar/liquid_glass_widgets/pull/128))
+
+**Problem:** Setting `platformViewBackdrop: true` on a bar had no visible effect
+for the glass indicator or bar body — the premium/standard Impeller shader paths
+read a captured backdrop that excludes hybrid-composed PlatformViews, so the
+glass rendered inert (opaque black or clear) over a map.
+
+**Fix:** `AdaptiveGlass` now routes any surface with `platformViewBackdrop: true`
+to the frosted fallback (`_FrostedFallback`) regardless of the requested quality
+tier. The frosted fallback uses a live `BackdropFilter`, which correctly blurs
+hybrid-composed PlatformViews. `_FrostedFallback` also overrides the
+`isInteractive` blur-omission that would otherwise skip the blur for interactive
+indicator surfaces — over a PlatformView the live blur must always run.
+
+### Premium glass goes black over a PlatformView — `backerColor` fallback ([#129](https://github.com/sdegenaar/liquid_glass_widgets/pull/129))
+
+**Problem:** At `GlassQuality.premium` over a PlatformView, the Impeller shader
+sampled a captured backdrop that contained only transparent black where the
+PlatformView sat. With no real background pixels to refract, the glass lens
+rendered black.
+
+**Fix:** A new `uBackgroundFallback` (vec4) uniform was added to
+`liquid_glass_final_render.frag`. The shader composites the fallback colour
+over the captured backdrop using a standard `over` blend weighted by the
+backdrop's own alpha — where the backdrop is real (alpha ≈ 1) it is left
+untouched; where it is transparent black (alpha ≈ 0, i.e. over a PlatformView)
+the fallback fills in. `backerColor` from `LiquidGlassSettings` is bound to
+this uniform at render time, giving the premium lens a solid colour to refract
+instead of transparent black.
+
+### Extra button `platformViewBackdrop` threading (follow-up, this release)
+
+`GlassTabBarExtraButton` previously ignored the bar's `platformViewBackdrop`
+flag — the internal `BottomBarExtraBtn` widget was not forwarding it to the
+underlying `GlassButton`, so the extra button continued to use the inert shader
+path even when the rest of the bar correctly used the frosted fallback.
+`platformViewBackdrop` is now threaded through `BottomBarExtraBtn` and both
+call sites (`TabBarBottomLayout`, `TabBarSearchableLayout`) to `GlassButton`.
+
+---
+
+# 0.19.1
+
+
+## 🛡️ Stability Improvements
+
+Addresses production crash and ANR reports seen with v0.19.0 on Flutter 3.44.2
+(tracked in flutter/flutter#187140). These are exposure-window mitigations — the
+root cause is a Flutter engine issue and requires an engine-level fix.
+
+### Changes
+
+**`GlassEffect` & `LightweightLiquidGlass` — lifecycle-aware Ticker suspension**
+Both state classes now implement `WidgetsBindingObserver` and halt background-capture
+Tickers during `AppLifecycleState.inactive`, `paused`, and `hidden`. Captures restart
+one frame after `resumed`. This reduces GPU texture activity during surface transitions
+(rotation, split-screen, keyboard resize) which is the window where engine-level
+crashes and ANRs are most likely to occur.
+
+**`GlassEffect` & `LightweightLiquidGlass` — `_isDisposed` guard**
+A `_isDisposed` flag prevents Ticker callbacks and async `.then()` continuations
+from accessing GPU resources after `dispose()` has completed, guarding against
+post-frame-callback / dispose races during rapid navigation.
+
+**`LiquidGlassWidgets.initialize()` — faster startup**
+The Impeller pipeline warm-up is no longer `await`ed inside `initialize()`. It now
+runs after the first frame via `addPostFrameCallback`, removing a `~16ms` delay from
+the startup critical path. Shader disk-loads are still awaited as before.
+
+**Debug log cleanup**
+Removed stale `debugPrint` success messages from `GlassEffect` and `LightweightLiquidGlass`
+shader pre-warm paths (`✓ Shader precached`, `✓ Created unique shader instance`). These
+fired on every debug startup for every app using the package. Failures still surface via
+the existing `[LightweightGlass] Pre-warm failed:` error log. The `[LiquidGlass]`
+startup bracket (`Initializing...` / `Initialization complete.`) and the
+`PerformanceMonitor started` log are retained as actionable developer information.
+
+
+# 0.19.0
+
+
+## 💥 Breaking: Pre-v1.0 Public API Cleanup
+
+A pre-release naming audit to establish consistent, idiomatic conventions before v1.0 locks the API.
+
+### Renames
+
+| Old | New | Reason |
+|---|---|---|
+| `GlassBottomBarExtraButton` | `GlassTabBarExtraButton` | Tracks parent rename `GlassBottomBar` → `GlassTabBar` |
+| `GlassGroupItem` | `GlassButtonGroupItem` | Mirrors Flutter's `DropdownMenuItem` pattern |
+| `SheetState` | `GlassSheetState` | Prevents collision with Material 3 sheet infrastructure |
+| `SheetMode` | `GlassSheetMode` | Same — too generic as a bare name |
+| `FillTransition` | `GlassFillTransition` | Too generic as a bare name |
+| `ExtraButtonPosition` | `GlassExtraButtonPosition` | Ambiguous without prefix |
+
+> **Migration:** A `@Deprecated` typedef for `GlassBottomBarExtraButton` is provided. All other old names will produce compile errors — migration is mechanical find-and-replace.
+
+### GlassSegment — new concrete class
+
+`GlassSegment` was previously a `typedef` alias for `GlassTab`. It is now a proper class with a focused API for `GlassSegmentedControl`:
+
+```dart
+// GlassSegment — for GlassSegmentedControl only
+GlassSegment({ Widget? icon, String? label, String? tooltip, String? semanticLabel, bool enabled = true })
+
+// GlassTab — for GlassTabBar.bottom() and GlassTabBar.searchable()
+GlassTab({ Widget? icon, Widget? activeIcon, String? label, Color? glowColor, double? thickness })
+```
+
+Fields like `activeIcon`, `glowColor`, and `thickness` are navigation-specific and only exist on `GlassTab`. `GlassSegment` adds `tooltip` and `enabled` (with built-in disabled rendering at 38% opacity).
+
+### Barrel hygiene
+
+Internal types (`SheetSnapshot`, `SheetGeometry`, `GesturePhase`, `GestureArena`, `FrozenState`) are no longer accessible from the package barrel. These were implementation details that leaked through `part` file exports.
+
+## ⚡ Performance
+
+- **Shader:** `interactive_indicator.frag` — replaced `pow()` calls with multiply chains; collapsed duplicate rim pass; zero transcendental functions in highlight path.
+- **Shader:** `liquid_glass_final_render.frag` — `⁶√x` computed via sqrt cascade (3 SFU vs 2 transcendentals); `sceneSDF` samples reduced from 5 → 4.
+- **Dart:** `resolveAdaptiveRadius` scoped to `MediaQuery.viewPaddingOf` + `MediaQuery.sizeOf` — glass widgets no longer rebuild on keyboard or unrelated `MediaQueryData` changes.
+- **Dart:** Searchable tab bar and `GlassSegmentedControl` spring animations now use `ListenableBuilder` scoped to the indicator subtree. Verified on-device: zero `State.build()` calls during 120Hz spring animation.
+
+## 🐛 Fix
+
+- **`LiquidGlassWidgets.initialize()`** now pre-warms all four shaders — `liquid_glass_geometry_blended.frag` and `liquid_glass_final_render.frag` were previously lazy-loaded, causing first-frame jank.
+- **`GlassSegment.enabled = false` now blocks tap/tapDown** — disabled segments rendered at 38% opacity but still fired `onSegmentSelected` in both fixed-width and scrollable modes. Tap and `onTapDown` handlers now early-return when the target segment is disabled.
+
+
+---
+
+# 0.18.6
+
+## 🐛 Fix: Glass widgets now honour app `ThemeMode`, not OS dark mode
+
+Resolves a class of UI inconsistency where glass widgets incorrectly read the **device/OS** brightness instead of the **app**'s brightness. The most visible symptom was `GlassBottomTabBar` shadows disappearing when the device was in Dark Mode but the app was pinned to Light Mode via `MaterialApp(themeMode: ThemeMode.light)`.
+
+### Root cause
+
+Every glass widget that needed to decide between light/dark colours or shadow visibility called either `CupertinoTheme.of(context).brightness` or `MediaQuery.platformBrightnessOf(context)` directly. Both of these APIs fall back to the OS/device setting and are blind to `MaterialApp.themeMode`.
+
+### Fix: Centralised brightness cascade
+
+A new `GlassTheme.brightnessOf(context)` authority now governs all brightness decisions in the library. It resolves via a four-level cascade:
+
+1. **`GlassThemeData.brightness`** — new field; an explicit developer override pinned in the `GlassTheme` widget tree (highest priority).
+2. **`CupertinoThemeData.brightness`** — explicit Cupertino pin (non-null only; intentional opt-in).
+3. **`Theme.maybeBrightnessOf(context)`** — Material `ThemeMode.light`/`.dark`/`.system`, honouring `MaterialApp.themeMode`.
+4. **`MediaQuery.platformBrightnessOf(context)`** — OS/device setting (safe fallback).
+
+### Changes
+
+- **New:** `lib/utils/glass_brightness.dart` — `resolveGlassBrightness(context)` utility (package-private).
+- **New field:** `GlassThemeData.brightness` — explicit brightness override for fine-grained glass-subtree control. Accepted by both the default and `GlassThemeData.simple()` constructors.
+- **New method:** `GlassTheme.brightnessOf(context)` — the single, mandatory brightness authority for the entire library.
+- **Fixed:** Shadow suppression in `GlassBottomTabBar`, `GlassSearchableBottomBar`, `AdaptiveLiquidGlassLayer`, and `AdaptiveGlass` (`_FrostedFallback`).
+- **Fixed:** Shader `backdropLuma` proxy in `GlassEffect` (controls glass strength in the GPU path).
+- **Fixed:** Light/dark colour selection in 20+ widget files across `interactive/`, `containers/`, `input/`, `overlays/`, and `surfaces/` layers.
+
+### Tests
+
+Three new test files cover every level of the cascade:
+
+- `test/utils/glass_brightness_test.dart` — unit tests for `resolveGlassBrightness`.
+- `test/theme/glass_theme_brightness_test.dart` — `GlassTheme.brightnessOf` integration tests including the canonical regression scenario.
+- `test/theme/glass_theme_data_brightness_test.dart` — `GlassThemeData.brightness` override field, `copyWith`, equality, and backward-compat tests.
+
+---
+
+# 0.18.5
+
+## 🔧 Corrected minimum SDK constraint — Flutter ≥ 3.41.0
+
+- **Fix:** Raised the minimum Flutter constraint to `3.41.0`. The `filterQuality` parameter on `FragmentShader.setImageSampler()` was actually introduced in Flutter 3.41.0 (commit `add442b29c`), not 3.24.0 as previously stated. This prevents users on 3.38.x from failing at compile time.
+- **Reverted:** Raised the internal `meta` constraint back to `^1.18.0` since Flutter 3.41.0 guarantees this version is available.
+
+---
+
+# 0.18.4
+
+- **Fix:** Loosened the `meta` dependency constraint to `^1.12.0` (instead of `^1.18.0`) to avoid pub resolution conflicts for users on older Flutter SDKs where `flutter_test` is bound to `meta 1.17.0`.
+
+---
+
+# 0.18.3
+
+
+## ✨ Per-state label text style on bottom bars — `selectedLabelStyle` / `unselectedLabelStyle`
+
+Adds `selectedLabelStyle` / `unselectedLabelStyle` (`TextStyle?`) to `GlassTabBar.bottom`, `GlassTabBar.searchable`, and the deprecated `GlassBottomBar` / `GlassSearchableBottomBar`.
+
+This complements the `selectedLabelColor` / `unselectedLabelColor` parameters by letting callers set the selected/unselected label's **font family, weight, and letter-spacing per state** — needed to match Apple's tab bar, where the selected label is heavier than a single shared `textStyle` can express.
+
+The per-state style is **merged over** the base label style, so it overrides only the fields it sets and keeps the resolved per-state label color unless the style provides its own. Both default to `null` → existing behavior unchanged.
+
+Also fixes a related precedence bug: an explicit `selectedLabelColor` / `unselectedLabelColor` was silently dropped whenever a `textStyle` was also supplied (the per-state color only fed the fallback style). It now overrides the base color — including a color baked into `textStyle` — while `textStyle`-only callers are unaffected.
+
+
+## ✨ `innerBlur` — Apple-style rest-blur behind the selected tab
+
+The `innerBlur` parameter on `GlassTabBar.bottom`/`.searchable` (and the deprecated `GlassBottomBar`/`GlassSearchableBottomBar` shims) now renders. It was declared and threaded bar→internal, but never forwarded to the indicator, and `AnimatedGlassIndicator` had no implementation. This wires it through the tab-bar internals and adds the rest-gated `BackdropFilter`.
+
+It paints a backdrop blur behind the **resting** selected pill — the iOS 26 "frost at rest" look — with the sigma scaled by the pill's resting opacity, so the frost is full when settled and fades out as it morphs into the liquid-glass lens during a drag/tap (motion stays crisp).
+
+- `0.0` (default) disables it — no behavior change for existing callers.
+- Only the background-painting indicator is affected (reads through a translucent `indicatorColor`).
+
+## ✨ `platformViewBackdrop` on the public glass widgets
+
+Follows up [#94](https://github.com/sdegenaar/liquid_glass_widgets/pull/94) by exposing the premium-over-PlatformView flag on the remaining public widgets — `GlassContainer`, `GlassButton`, `GlassIconButton`, `GlassButtonGroup`, `GlassMenu`, and `GlassModalSheet` — so apps can render premium glass cleanly over an iOS PlatformView (e.g. a Mapbox `MapWidget`) for any control, not just the bottom bar.
+
+Each gets an explicit `platformViewBackdrop` parameter defaulting to `false` (zero overhead / no behavior change for callers that don't need it), forwarded to the underlying `AdaptiveGlass`. For `GlassModalSheet` the flag threads through `GlassModalSheetScaffold` and the sheet state down to the `_SheetLayout`'s glass. Adds widget tests covering the simple-widget forwards.
+
+
+## 🧹 Removed — `GlassTintBlend` (a no-op since 0.17.0)
+
+`GlassTintBlend` (added in [#107](https://github.com/sdegenaar/liquid_glass_widgets/pull/107)) and the `LiquidGlassSettings.tintBlend` field have been removed.
+
+Since the 0.17.0 shader rewrite, `tintBlend` was never wired into the renderer — it was packed into no uniform, so setting it had no effect: every surface used the automatic chroma-gated blend regardless of the value. We only caught this during real-device tuning, after all the related PRs had already landed.
+
+The automatic behavior is unchanged. `applyGlassColor` still picks luminosity-preserving blending for chromatic tints and flat blending for achromatic tints. Recipes that previously passed `tintBlend: flat` for achromatic (white / grey / near-black) tints render identically, because the chroma gate already resolves those to the flat path.
+
+**Breaking, but inert:** code that passed `LiquidGlassSettings(tintBlend: …)` must drop the argument. No rendered output changes.
+
+## 🔧 SDK constraints bump *(corrected in 0.18.5)*
+
+Raised minimum Flutter to `>=3.24.0` — this was incorrect. The actual minimum is `3.41.0`, corrected in `0.18.5`.
+
+---
+
+# 0.18.2
+
+### Rendering Quality
+
+- **Fix:** Eliminated stair-step aliasing on `AnimatedGlassIndicator` / `GlassEffect` pill edges during press animations.
+  Root cause: `FragmentShader.setImageSampler()` defaults to `FilterQuality.none` (Nearest-Neighbor). The 4 % press-scale animation was block-replicating geometry texels into 2×2 stair-step patterns visible as jagged fringe on the pill rim.
+  **Resolution:** Pass `filterQuality: FilterQuality.medium` to every `setImageSampler()` call in `liquid_glass_render_object.dart`, `glass_effect.dart`, and `lightweight_liquid_glass.dart`. Zero GPU cost — hardware bilinear filtering happens in a single texel-unit clock cycle.
+
+- **Fix:** Eliminated 2×2 blocky normal artifacts on glass pill edges (all platforms, most visible on iOS/macOS Metal).
+  Root cause: Metal's `dFdx`/`dFdy` evaluate in 2×2 pixel quads, so all four neighbours share one gradient vector. At the high-contrast white rim of the pill this produces a coarse stair-step normal map that manifests as jaggy rainbow banding regardless of scale.
+  **Resolution:** Replaced hardware derivatives with per-pixel central finite differences in `liquid_glass_geometry_blended.frag` (`dx = sceneSDF(p + 0.5) − sceneSDF(p − 0.5)`). Costs 4 extra SDF evaluations per geometry pixel — negligible on a cached, one-shot geometry pass.
+
+- **Fix:** Restored full rim brightness after the anti-aliasing band was widened.
+  Root cause: The previous asymmetric `smoothstep(-smoothing, 0.0, sd)` placed the mathematical pill boundary (`sd = 0`) at the dark end of the alpha ramp (alpha = 0). The rim-lighting peak lives exactly at `sd = 0`, so it was multiplied by zero and rendered invisible.
+  **Resolution:** Centred the smoothstep around the boundary — `smoothstep(smoothing * 0.5, -smoothing * 0.5, sd)` — so `sd = 0` maps to alpha = 0.5. This is the canonical SDF anti-aliasing formulation and restores maximum rim brightness with no other visual side-effect.
+
+- **Fix:** Eliminated backdrop texture wrap-around artifacts during `LiquidStretch` scaling and jelly overshoot.
+  Root cause: Impeller's default texture sampler wrap mode is `Repeat`. A fragment slightly outside `uGeometrySize` (e.g. during a spring overshoot) produced a `geometryUV` marginally above 1.0; the sampler wrapped it to near-0.0, sampling the opposite edge of the SDF and producing inverted normals and extreme chromatic aliasing.
+  **Resolution:** Clamp `geometryUV` to `[0, 1]` before the texture fetch. Clamped-edge pixels have near-zero SDF alpha and are discarded by the existing `geometryData.a < 0.01` early-out — no separate bounds-check branch required.
+
+- **Fix:** Eliminated chromatic wrap artifacts during jelly overshoot in `interactive_indicator.frag`.
+  Root cause: When the indicator pill overshoots its `RepaintBoundary` bounds, out-of-bounds `textureBilinear` sample points could trigger the same Repeat-mode wrap in the background texture.
+  **Resolution:** Explicitly clamp all four bilinear sample points to `[0, physSize − 1]` before the `texture()` fetch.
+
+- **Fix:** Eliminated jagged/pixelated stair-step artifacts on `AnimatedGlassIndicator` pill edges when `indicatorPinchStrength > 0`.
+  Root cause: `BackdropFilterLayer` implicit samplers are bound to `FragmentShader` as Nearest-Neighbor with no Dart API to override it ([Flutter Issue #139887](https://github.com/flutter/flutter/issues/139887)). Continuous sub-pixel UV shifts from the lens pinch and chromatic aberration were snapping to integer texels, producing blocky rainbow fringes on high-contrast backgrounds.
+  **Resolution:** Added a `textureBilinear` helper to `liquid_glass_final_render.frag` that performs a standard 4-texel bilinear interpolation in GLSL, restoring perfectly smooth sub-pixel background sampling. The geometry texture (`uGeometryTexture`) is intentionally excluded — its pixel-aligned SDF data must not be softened.
+
+- **Fix:** Eliminated pixelation on the interactive indicator pill (`GlassSegmentedControl`, `GlassEffect`).
+  Two compounding causes: (1) the background texture was previously captured at `pixelRatio: 1.0`, so each texel covered a 3×3 block of physical pixels on a 3× Retina display; (2) Impeller's `setImageSampler()` binding defaults to Nearest-Neighbor, snapping continuous UV offsets from edge refraction to these large texels.
+  **Resolution:** Background capture now uses the device's full DPR. A `textureBilinear` GLSL helper replaces all raw `texture()` calls in `interactive_indicator.frag`. ~250 KB additional GPU texture memory; sub-0.1 ms additional GPU time per frame — negligible on any modern device.
+
+- **Fix:** Resolved intermittent Metal API Validation abort on iOS (`GlassQuality.premium`) — missing buffer bindings for `uWhiten`, `uWhitenGated`, and `uPinchStrength` ([#121](https://github.com/sdegenaar/liquid_glass_widgets/issues/121)).
+  All shader uniforms (slots 0–20) are now written atomically on every paint frame, preventing a stale or zero-initialised `FragmentShader` snapshot from reaching the Metal draw call. Affected: `GlassTabBar.bottom(quality: GlassQuality.premium)` with an animating indicator. No API changes.
+
+### Notes
+
+- **Note (Flutter engine limitation):** The `textureBilinear` workaround in `liquid_glass_final_render.frag` (4-tap bilinear in GLSL) remains necessary for backdrop sampling because Impeller binds the implicit `BackdropFilterLayer` sampler as Nearest-Neighbor with no Dart API to override `FilterQuality`. A Flutter engine feature request to expose sampler filter quality for backdrop layers has been filed at [Flutter Issue #188365](https://github.com/flutter/flutter/issues/188365). Once resolved, the GLSL workaround can be replaced with a single `texture()` call.
+
+### Chore
+
+- **Chore:** Removed unreachable early-out branch in `liquid_glass_final_render.frag` — the `if (any(lessThan(geometryUV, ...)))` check after `clamp(geometryUV, 0.0, 1.0)` could never fire. Replaced with a single consolidated comment explaining how the clamp and the downstream alpha check together handle both the Impeller Repeat-mode and clipExpansion cases.
+- **Chore:** Removed dead code from `render.glsl` (`computeY`, `getHeight`, `calculateLighting`, `calculateRefraction`, `renderLiquidGlass`, `debugNormals`) — functions superseded by the inline logic in `liquid_glass_final_render.frag`. Reduces compiled shader binary size.
+
+# 0.18.1
+
+- **Hotfix:** Resolved missing coverage in layout engines and segmented controls.
+- **Hotfix:** Fixed package analysis warnings due to unused local variables and unnecessary imports in test files.
+
+# 0.18.0
+
+## 🏗️ Unified Navigation API — iOS 26 Alignment
+
+This release consolidates the widget API to map 1:1 with Apple's iOS 26 control vocabulary. Two v1-era widgets are deprecated (see Migration below), and `GlassTabBar` becomes the single source of truth for all tab-navigation work.
+
+---
+
+### ⚠️ Breaking Change: Android Bottom Bar Padding
+
+`GlassScaffold` now automatically manages the Android system navigation bar padding for `bottomBar`. If you previously added manual `Padding` or `SafeArea` around your bottom bar to prevent it from slipping behind the Android navigation buttons, please remove it to avoid double-padding.
+
+---
+
+### New: `GlassTabBar.bottom()` — iOS 26 UITabBar equivalent
+
+Named constructor for bottom navigation bars. Full liquid glass layer, jelly physics pill indicator, `MaskingQuality` dual-layer icon rendering, and optional `dividerSettings`.
+
+```dart
+GlassTabBar.bottom(
+  tabs: [
+    GlassTab(icon: Icon(Icons.home), label: 'Home'),
+    GlassTab(icon: Icon(Icons.search), label: 'Search'),
+    GlassTab(icon: Icon(Icons.person), label: 'Profile'),
+  ],
+  selectedIndex: _selectedIndex,
+  onTabSelected: (i) => setState(() => _selectedIndex = i),
+)
+```
+
+---
+
+### New: `GlassTabBar.searchable()` — UITabBar + morphing search
+
+Named constructor combining bottom navigation with a morphing glass search pill. Identical API to `GlassTabBar.bottom()` with additional `searchBarConfig` and `controller` parameters.
+
+```dart
+GlassTabBar.searchable(
+  tabs: [...],
+  selectedIndex: _selectedIndex,
+  onTabSelected: (i) => setState(() => _selectedIndex = i),
+  searchBarConfig: GlassSearchBarConfig(hintText: 'Search...'),
+  controller: _tabBarController,
+)
+```
+
+---
+
+### New: `GlassSegmentedControl` — icon support + scrollable mode
+
+#### Icon + label support (fixed mode)
+
+`segments` now accepts `List<GlassTab>` instead of `List<String>`. Each segment can render:
+- **Label only** — `GlassTab(label: 'Weekly')`
+- **Icon only** — `GlassTab(icon: Icon(Icons.photo))`
+- **Icon + label** — `GlassTab(icon: Icon(Icons.photo), label: 'Photos')` (icon above label)
+
+This matches iOS 26 UISegmentedControl which has supported `UIImage` segments since early iOS.
+
+#### Scrollable mode — 100% parity with original `GlassTabBar(isScrollable: true)`
+
+---
+
+### 🚨 Removed: `GlassTabBar()` inline constructor
+
+The default `GlassTabBar()` constructor has been **removed**. `GlassTabBar` is now exclusively used for structural bottom navigation (`GlassTabBar.bottom()` and `GlassTabBar.searchable()`). 
+
+**Migration:**
+For all inline tab bars, pill menus, or scrollable tag lists, use `GlassSegmentedControl()` or `GlassSegmentedControl.scrollable()`. They provide 100% feature parity with the old inline `GlassTabBar`.
+
+```diff
+- GlassTabBar(
+-   tabs: const [
+-     GlassTab(label: 'A'),
+-     GlassTab(label: 'B'),
+-   ],
+-   selectedIndex: _selectedIndex,
+-   onTabSelected: (i) => setState(() => _selectedIndex = i),
+- )
++ GlassSegmentedControl(
++   segments: const [
++     GlassSegment(label: 'A'),
++     GlassSegment(label: 'B'),
++   ],
++   selectedIndex: _selectedIndex,
++   onSegmentSelected: (i) => setState(() => _selectedIndex = i),
++ )
+```
+
+
+New `GlassSegmentedControl.scrollable()` named constructor for category filter tabs (6+ items). Internally uses `ScrollableSegmentContent` — a dedicated widget that owns scrollable pill physics, gesture handling, and 3-layer rendering. Structurally identical to the old inline `GlassTabBar(isScrollable: true)`, now correctly located in the interactive widget family.
+
+```dart
+// Fixed (UISegmentedControl — equal width, 2–6 items)
+GlassSegmentedControl(
+  segments: const [
+    GlassSegment(label: 'All'),
+    GlassSegment(icon: Icon(Icons.photo), label: 'Photos'),
+    GlassSegment(label: 'Videos'),
+  ],
+  selectedIndex: _selectedIndex,
+  onSegmentSelected: (i) => setState(() => _selectedIndex = i),
+)
+
+// Scrollable (category filter tabs — natural width, 7+ items)
+GlassSegmentedControl.scrollable(
+  segments: List.generate(12, (i) => GlassSegment(label: 'Category ${i + 1}')),
+  selectedIndex: _selectedIndex,
+  onSegmentSelected: (i) => setState(() => _selectedIndex = i),
+)
+```
+
+---
+
+### Architecture: Dependency inversion
+
+All tab-bar layout logic now lives in dedicated layout files:
+
+| File | Owns |
+|---|---|
+| `interactive/shared/scrollable_segment_content.dart` | `ScrollableSegmentContent` — scrollable pill + gesture engine (used by `GlassSegmentedControl.scrollable`) |
+| `interactive/shared/segmented_control_internal.dart` | `SegmentedControlContent` — fixed-width pill + gesture engine (used by `GlassSegmentedControl`) |
+| `surfaces/shared/tab_bar_bottom_layout.dart` | `TabBarBottomLayout` — full glass bottom shell |
+| `surfaces/shared/tab_bar_searchable_layout.dart` | `TabBarSearchableLayout` — search morph shell |
+
+`GlassTabBar` dispatches to these shells. `GlassBottomBar` and `GlassSearchableBottomBar` are now zero-logic shims that delegate to the same shells.
+
+---
+
+### Deprecated — removal in v1.0
+
+#### `GlassBottomBar` → `GlassTabBar.bottom()`
+
+```dart
+// BEFORE
+GlassBottomBar(
+  tabs: [GlassBottomBarTab(icon: Icon(Icons.home), label: 'Home')],
+  selectedIndex: _selectedIndex,
+  onTabSelected: (i) => setState(() => _selectedIndex = i),
+)
+
+// AFTER
+GlassTabBar.bottom(
+  tabs: [GlassTab(icon: Icon(Icons.home), label: 'Home')],
+  selectedIndex: _selectedIndex,
+  onTabSelected: (i) => setState(() => _selectedIndex = i),
+)
+```
+
+#### `GlassSearchableBottomBar` → `GlassTabBar.searchable()`
+
+```dart
+// BEFORE
+GlassSearchableBottomBar(tabs: [...], ...)
+
+// AFTER
+GlassTabBar.searchable(tabs: [...], ...)
+```
+
+#### `GlassTabBar()` default constructor → `GlassSegmentedControl`
+
+```dart
+// BEFORE
+GlassTabBar(
+  tabs: [GlassTab(label: 'A'), GlassTab(label: 'B')],
+  selectedIndex: _selectedIndex,
+  onTabSelected: (i) => setState(() => _selectedIndex = i),
+)
+
+// AFTER
+GlassSegmentedControl(
+  segments: [GlassTab(label: 'A'), GlassTab(label: 'B')],
+  selectedIndex: _selectedIndex,
+  onSegmentSelected: (i) => setState(() => _selectedIndex = i),
+)
+```
+
+#### `GlassSegmentedControl.segments: List<String>` → `List<GlassTab>`
+
+```dart
+// BEFORE
+GlassSegmentedControl(segments: ['Daily', 'Weekly', 'Monthly'], ...)
+
+// AFTER
+GlassSegmentedControl(
+  segments: [
+    GlassTab(label: 'Daily'),
+    GlassTab(label: 'Weekly'),
+    GlassTab(label: 'Monthly'),
+  ],
+  ...
+)
+```
+
+---
+
+### iOS 26 control vocabulary — full mapping
+
+| Widget | iOS 26 equivalent | Glass tier |
+|---|---|---|
+| `GlassSegmentedControl(...)` | `UISegmentedControl` | Light tint + glass pill |
+| `GlassSegmentedControl.scrollable(...)` | Scrollable filter tabs | Light tint + glass pill |
+| `GlassTabBar.bottom(...)` | `UITabBar` | Full liquid glass |
+| `GlassTabBar.searchable(...)` | `UITabBar` + search | Full liquid glass |
+
+---
+
+### New: Configurable label colors and indicator border radius for bottom bars
+
+`GlassTabBar.bottom()`, `GlassTabBar.searchable()`, `GlassBottomBar`, and `GlassSearchableBottomBar` expose three additional styling parameters:
+
+- **`selectedLabelColor`** — tab label colour when selected, independent of `selectedIconColor`
+- **`unselectedLabelColor`** — tab label colour when unselected, independent of `unselectedIconColor`
+- **`indicatorBorderRadius`** — pill indicator corner radius, independent of `barBorderRadius` (e.g. `100` for a fully round pill on a subtly curved bar)
+
+All three are optional; omitting them preserves existing behaviour exactly.
+
+```dart
+GlassTabBar.bottom(
+  tabs: [...],
+  selectedIndex: _selectedIndex,
+  onTabSelected: (i) => setState(() => _selectedIndex = i),
+  selectedLabelColor: Colors.blue,
+  unselectedLabelColor: Colors.grey,
+  indicatorBorderRadius: 100,
+)
+```
+
+---
+
+# 0.17.1
+
+## 🐛 Fix — `platformViewBackdrop` toggle no longer snaps the selected-tab indicator ([#112](https://github.com/sdegenaar/liquid_glass_widgets/pull/112) by [@jfhair](https://github.com/jfhair))
+
+Toggling `platformViewBackdrop` at runtime (e.g. switching between a map tab and a Flutter-content tab) caused the selected-indicator pill to snap to the new tab instead of sliding. The spring animation controllers inside the indicator subtree were being re-seeded at their already-settled value because the toggle added or removed the `LiquidGlassBlendGroup` wrapper in `AdaptiveLiquidGlassLayer`, changing the child's depth in the element tree and forcing Flutter to discard and re-inflate the whole subtree via `initState`.
+
+**Fix:** `AdaptiveLiquidGlassLayer` is now a `StatefulWidget` that holds a stable `GlobalKey`. The child is always wrapped in a `KeyedSubtree` with that key, so the element identity is preserved across the wrapper toggle — the indicator's `AnimationController`s survive and the morph continues correctly.
+
+No API changes. No breaking changes.
+
+---
+
+# 0.17.0
+
+
+## 🔬 iOS 26 Concave Lens Pinch — All Four Pill Widgets
+
+The `indicatorPinchStrength` concave lens warp is now unified across all four interactive pill widgets. During a drag the pill edges curve inward (iOS 26 "through a lens" effect). Fully tunable — `0.0` disables it, `1.0` is maximum distortion.
+
+### New parameters
+
+- **`GlassTabBar.indicatorPinchStrength`** (default `0.4`)
+- **`GlassTabBar.indicatorExpansion`** (default `EdgeInsets.symmetric(horizontal: 12, vertical: 8)`)
+- **`GlassSegmentedControl.indicatorPinchStrength`** (default `0.4`)
+- **`GlassSegmentedControl.indicatorExpansion`** (default `EdgeInsets.symmetric(horizontal: 12, vertical: 8)`)
+- **`AnimatedGlassIndicator`** exported from the public API — enables `baseIndicatorSettings.copyWith(...)` from app code.
+
+### Changed defaults (`AnimatedGlassIndicator.baseIndicatorSettings`)
+
+- `glassColor`: `alpha: 0.15` → `alpha: 0.0` — glass pill no longer applies a white tint overlay by default.
+- `chromaticAberration`: `GlassDefaults.chromaticAberration` → `0.15` — the iridescent rim fringe is now explicitly set for iOS 26 parity.
+
+### Bug fixes
+
+- **`GlassSegmentedControl` refraction** — labels are now refracted through the glass pill at `GlassQuality.premium` (was rendered in wrong z-order).
+- **`GlassTabBar` indicator radius** — resting pill now inherits the tab bar's `borderRadius` (was hardcoded `16 px`).
+- **`AnimatedGlassIndicator` settings merge** — partial `indicatorSettings` overrides no longer silently reset `chromaticAberration`.
+- **Pinch lens jitter at rest** — icon and label content no longer shimmers through the lens when the pill settles. Root cause: the jelly spring's micro-oscillations (±10 % of `thickness`) were directly amplified into the UV warp. Fixed by applying a quadratic ease-out to the pinch multiplier (`1 − (1 − fade)²`), compressing the near-settled oscillation range ≈10×.
+
+### Try it — Indicator Parity demo
+
+The example app includes a live **Indicator Parity** demo (`Demos → Indicator Parity`) with all four pill widgets side-by-side and real-time sliders for `pinchStrength`, `indicatorExpansion`, and `chromaticAberration`. Use it to tune parameters before writing any code.
+
+## 🌑 Apple Dimming Layer — `LiquidGlassSettings.backerColor` ([#111](https://github.com/sdegenaar/liquid_glass_widgets/pull/111) by [@jfhair](https://github.com/jfhair))
+
+New optional `backerColor` on `LiquidGlassSettings` — a shape-matched color pad composited *behind* the glass, giving a control's content contrast over rich or colorful backdrops (video, maps, photography) where the glass tint alone can't. This is Apple's "dimming layer" guidance from the Human Interface Guidelines (Materials section) and the pattern behind SwiftUI's clear `Glass` variant.
+
+```dart
+LiquidGlassSettings(
+  glassColor: Color(0x20FFFFFF),
+  backerColor: Color(0x59000000), // ~35% black — Apple's starting point
+)
+```
+
+- **`backerColor`** (`Color?`, default `null`) — the color's alpha *is* the dimming opacity. `null` means no backer, so all existing recipes are untouched.
+- Rendered at the widget level (like `shadow`) and clipped to the glass shape via `ClipRRect`, so it composites correctly even over a `PlatformView` — maps, video — where a shader-side tint cannot reach.
+- Applies in both light and dark mode, and for flat-edge shapes (a bar over a map is a primary use case).
+- Skipped on the grouped path (like shadow) — inserting a `Stack` between grouped glass and its shared layer would break metaball morphing.
+- `lerp` fades `backerColor` smoothly from transparent when one side is `null`, rather than snapping at the midpoint.
+
+### Migration
+
+All four widgets share the same tuning API:
+
+```dart
+indicatorPinchStrength: 0.4,
+indicatorExpansion: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+indicatorSettings: AnimatedGlassIndicator.baseIndicatorSettings
+    .copyWith(chromaticAberration: 0.15),
+```
+
+---
+
+# 0.16.3
+
+## ✨ `GlassTintBlend` — selectable tint blending path ([#107](https://github.com/sdegenaar/liquid_glass_widgets/pull/107) by [@jfhair](https://github.com/jfhair))
+
+New `GlassTintBlend` enum on `LiquidGlassSettings` to explicitly control how `glassColor` blends with the refracted backdrop, instead of relying entirely on the chroma heuristic.
+
+- `GlassTintBlend.auto` — the default. Existing chroma gate, byte-for-byte unchanged behavior.
+- `GlassTintBlend.luminosity` — always preserve backdrop luminosity. For near-neutral tints that need to keep the glassy look rather than flattening to a film.
+- `GlassTintBlend.flat` — always impose the tint's brightness. For dimming layers, backing scrims, or deliberate frost-film surfaces.
+
+Fully threaded through `LiquidGlassSettings` (`copyWith`, `lerp`, `props`), both the Premium and Standard shader paths, and preserved through `AdaptiveGlass` elevation rebuilds. Frosted fallback renders flat by construction and ignores the setting.
+
+## ✨ `GlassScrollEdgeEffect.bottomFadeInset` ([#109](https://github.com/sdegenaar/liquid_glass_widgets/pull/109) by [@jfhair](https://github.com/jfhair))
+
+New optional `bottomFadeInset` parameter (default `0.0`) that lifts the bottom fade off the widget's true bottom edge by the specified logical pixels. Fixes cases where the scroll viewport extends below the visible area — such as a bottom sheet whose content box overflows past the screen bottom — causing the bottom fade to anchor off-screen and never appear.
+
+**No breaking changes.** All new parameters are optional with safe defaults.
+
+---
+
+# 0.16.2
+
+## 🐛 Bug Fix — `GlassMenu` / `GlassPopover` rebuild on keyboard open/close
+
+`GlassMenu` and `GlassPopover` were rebuilding on every keyboard open/close event,
+even when closed. Caused by `MediaQuery.of(context)` in `didChangeDependencies`
+subscribing to `viewInsets`. Fixed by switching to scoped accessors
+(`disableAnimationsOf`, `maybeSizeOf`, `textScalerOf`). Regression tests added.
+
+## ✨ Content-luminance scroll-edge scrim ([#106](https://github.com/sdegenaar/liquid_glass_widgets/pull/106) by [@jfhair](https://github.com/jfhair))
+
+The continuous companion to the `contentAwareBrightness` discrete lever. Scroll-edge
+fades now track content luminance and dissolve toward a dark color as dark content
+scrolls under the bars — matching the native App Store early-darkening behaviour.
+
+- `GlassContentAwareScope.register()` gains `onLuminanceChanged` (brightness callback is now optional). Per-rect mean luminance is delivered from the existing single capture; deliveries are gated on >0.005 movement.
+- `GlassScrollEdgeEffect.contentAwareFade` — each edge band registers with the scope and lerps toward `darkFadeColor` as content darkens (`luminanceDarkBelow` / `luminanceLightAbove` thresholds, 280 ms ease-out). Inert without a scope.
+- `GlassScaffold.contentAwareEdgeFade` — one flag to enable both bars, composing with `contentAwareBrightness`.
+- **Latent wrap-order fix (0.16.0):** `GlassScaffold` was wrapping the body in `GlassContentAwareContent` *after* the edge fade, so the fade overlays were inside the sampled region. With the adaptive scrim this is a feedback loop. Wrap order corrected + regression test added.
+
+## 🐛 `GlassModalSheet` handle-drag fixes ([#106](https://github.com/sdegenaar/liquid_glass_widgets/pull/106))
+
+- Handle drag no longer fights the inner scroll. `_handleDragActive` notifier is set on pointer-down (before the inner `Scrollable` can claim slop), disabling inner scroll for the gesture lifetime. Fixes a freeze when dragging the handle over a `PlatformView`.
+- `dragIndicatorColor` now actually reaches the drag indicator — it was silently wired into `_SheetLayout` but never forwarded to `_GlassDragIndicator`.
+
+## 🐛 `GlassEffect` — defer capture when boundary is mid-paint ([#106](https://github.com/sdegenaar/liquid_glass_widgets/pull/106))
+
+`toImageSync` called during a dirty repaint boundary spammed `[GlassEffect] toImageSync failed` in debug and dropped the frame's capture. Guarded with `debugNeedsPaint` check (release-safe, same pattern as `GlassScrollEdgeEffect`).
+
+**No breaking changes.** New parameters are all optional with safe defaults — existing code compiles and behaves identically without changes.
+
+---
+
+# 0.16.1
+
+
+## 🍎 iOS 26 Indicator Defaults — Parity Calibration
+
+Three indicator defaults have been updated across `GlassBottomBar` and
+`GlassSearchableBottomBar` to better match the iOS 26 bottom-bar pill
+out of the box. No API changes — all parameters remain fully configurable.
+
+### Changed defaults
+
+#### `indicatorPinchStrength` — `1.0` → `0.4`
+
+The previous default of `1.0` applied the maximum concave lens / pinch effect
+during drag. iOS 26's actual pinch is more restrained — `0.4` produces the
+characteristic "through a lens" look without over-distorting the edges.
+
+**To restore the previous behaviour:**
+```dart
+GlassBottomBar(
+  indicatorPinchStrength: 1.0,
+  ...
+)
+```
+
+#### `indicatorExpansion` — `EdgeInsets.all(8)` → `EdgeInsets.symmetric(horizontal: 12, vertical: 8)`
+
+The indicator pill in iOS 26 bottom bars is slightly wider than it is tall —
+a subtle "landing pad" shape that reads as a rounded rectangle rather than a
+near-circle. The new default matches this proportion.
+
+**To restore the previous behaviour:**
+```dart
+GlassBottomBar(
+  indicatorExpansion: const EdgeInsets.all(8.0),
+  ...
+)
+```
+
+#### `AnimatedGlassIndicator` chromatic aberration — `0.0` → `0.15`
+
+The indicator's internal `_baseGlassSettings` now sets
+`chromaticAberration: 0.15`. Real iOS 26 glass has a faint iridescent
+rainbow fringe at the rim. At `0.15` the effect is a whisper — visible
+up close, subliminal during normal use.
+
+**To disable the aberration** pass a full `indicatorSettings` override:
+```dart
+GlassBottomBar(
+  indicatorSettings: LiquidGlassSettings(
+    chromaticAberration: 0.0,
+    // include other fields you need
+  ),
+  ...
+)
+```
+
+### Affected widgets
+
+- `GlassBottomBar` — `indicatorPinchStrength` and `indicatorExpansion`
+- `GlassSearchableBottomBar` — `indicatorPinchStrength` and `indicatorExpansion`
+- All widgets using `AnimatedGlassIndicator` — `chromaticAberration` baseline
+
+`GlassTabBar` and `GlassSegmentedControl` retain their existing expansion
+defaults (`EdgeInsets.all(8.0)`) as their geometry is different from a
+bottom navigation bar.
+
+---
+
+# 0.16.0
+
+## 🎨 Content-Aware Light/Dark Adaptation
+
+Glass bars now automatically adapt their icon and label colors to match the
+content scrolling behind them — light glyphs over dark content, dark glyphs over
+light content — with a smooth cross-fade transition. This matches the iOS 26
+behaviour where navigation chrome remains legible regardless of what is visible
+underneath.
+
+*Core engine contributed by [@jfhair](https://github.com/jfhair) in [PR #103](https://github.com/sdegenaar/liquid_glass_widgets/pull/103).*
+
+### New widgets
+
+- **`GlassContentAwareScope`** — wraps a screen and owns the sampling engine.
+  Captures the content boundary at scroll rate (~5 fps), divides each registered
+  control's rectangle into voting cells, and delivers per-control brightness
+  verdicts via WCAG contrast ratios and dual-threshold hysteresis.
+- **`GlassContentAwareContent`** — marks the sampled content region. Installs a
+  `RepaintBoundary` that the scope captures. Controls must be **outside** this
+  region (e.g. in `Scaffold.bottomNavigationBar` with `extendBody: true`).
+- **`GlassContentAwareBrightness`** — per-control consumer that cross-fades
+  between the light and dark `GlassThemeVariant` via `GlassThemeVariant.lerp`.
+  Supports an external `brightnessOverride` (for PlatformView escape hatches),
+  configurable grid dimensions, and per-control flip duration/curve overrides.
+
+### New parameters on existing widgets
+
+- **`GlassBottomBar`** — `adaptiveBrightness`, `brightnessOverride`,
+  `onBrightnessChanged`. Set `adaptiveBrightness: true` to opt in.
+- **`GlassSearchableBottomBar`** — same three parameters. Both bars
+  automatically wrap in `GlassContentAwareBrightness` when enabled.
+- **`GlassScaffold`** — `contentAwareBrightness`. When `true`, the scaffold
+  automatically wraps the body in `GlassContentAwareContent` and the entire
+  layout in `GlassContentAwareScope`. One flag, no manual widget wiring.
+
+### New API surface
+
+- **`GlassThemeVariant.lerp(a, b, t)`** — interpolates settings, glow colors,
+  quality, and border radius between two theme variants. Used internally by the
+  cross-fade but available to consumers building custom transitions.
+- **`GlassThemeSettings.lerp(a, b, t)`** — interpolates all 9 glass setting
+  fields (thickness, blur, glassColor, lightAngle, lightIntensity, etc.).
+- **`resolveBarLabelColor(context, brightness)`** — shared utility for bars
+  to resolve label color from `CupertinoTheme` given an overridden brightness.
+
+### Usage
+
+The recommended path — one flag on `GlassScaffold`, one on the bar:
+
+```dart
+GlassScaffold(
+  contentAwareBrightness: true,
+  bottomBar: GlassBottomBar(
+    adaptiveBrightness: true,
+    onBrightnessChanged: (b) => /* flip your own icon colors */,
+    tabs: [...],
+    selectedIndex: _index,
+    onTabSelected: (i) => setState(() => _index = i),
+  ),
+  body: CustomScrollView(...),
+)
+```
+
+For custom layouts without `GlassScaffold`, use the standalone widgets directly:
+
+```dart
+GlassContentAwareScope(
+  child: Scaffold(
+    extendBody: true,
+    body: GlassContentAwareContent(
+      child: ListView(...),
+    ),
+    bottomNavigationBar: GlassBottomBar(
+      adaptiveBrightness: true,
+      ...
+    ),
+  ),
+)
+```
+
+### Bug fix
+
+- **`GlassThemeVariant.==` / `hashCode` missing `borderRadius`** — fixed a
+  pre-existing bug where two variants differing only in `borderRadius` compared
+  equal. This caused stale radius during content-aware cross-fades where
+  intermediate lerped variants would not trigger rebuilds.
+
+### Polish
+
+- **`_sample()` error reporting** — the bare `catch (_)` in the sampling
+  pipeline now reports to `FlutterError` inside an assert closure. Errors are
+  still suppressed in release builds but surface in debug mode so programming
+  mistakes are visible.
+- **Removed redundant `setState`** — `_GlassContentAwareBrightnessState._setBrightness`
+  no longer calls `setState` since `AnimatedBuilder` already listens to the
+  animation controller and rebuilds on every tick.
+
+### Example app
+
+- **Content-Aware Brightness demo** (new) — dedicated showcase with alternating
+  light and dark content bands that force visible bar flips during scrolling.
+  Available in the Examples tab.
+
+---
+
+# 0.15.7
+
+## 🌙 Adaptive Brightness Fix
+
+Fixed a bug in `LightweightLiquidGlass` where the shader's internal brightness estimation (`backdropLuma`) was incorrectly reading from the OS-level `MediaQuery.platformBrightnessOf(context)` rather than the inherited Flutter `Theme.of(context).brightness`. 
+
+This ensures that glass surfaces now correctly switch to Light Mode parameters (such as the legibility veil) when the app itself overrides the theme to Light Mode, even if the user's physical device remains in Dark Mode.
+
+---
+
+# 0.15.6
+
+## 🌫️ Scroll Edge Fade — Perceptual Gradient Curve
+
+Replaced the 2-stop linear alpha gradient in `GlassScrollEdgeEffect` with a
+multi-stop eased curve that matches the perceptual dissolve of iOS 26.
+
+- **5-stop gradient profiles** for both `soft` and `hard` styles — eliminates
+  the "denser in the centre" banding and the visible seam at the fade boundary.
+- **`hard` style reworked**: steeper hold → sharper drop curve instead of just
+  compressing the soft profile. Height multiplier relaxed from 0.33× to 0.5×.
+- **Example app**: Nav Patterns demo now fully brightness-aware (adaptive text
+  colours, `GlassStatusBarStyle.auto`, adaptive solid-bar colour).
+
+No API changes. No breaking changes.
+
+---
+
+# 0.15.5
+
+## ✨ Whiten Strength — Light-Mode Legibility Veil
+
+Opt-in whitening ("legibility veil") lifts glass toward white for legibility over
+busy light backgrounds — modelling iOS 26's light-mode glass.
+
+- **`LiquidGlassSettings.whitenStrength`** (0.0–1.0, default 0.0): lifts the
+  finished glass toward white as the last step of the render. A single
+  control-wide value with no spatial seams or halo artifacts.
+- **`LiquidGlassSettings.whitenGated`** (default `true`): when gated, the lift
+  scales by per-pixel luminance so bright content lifts to white while dark
+  content (text, icons) stays crisp. Ungated applies the lift uniformly — useful
+  for dark-mode frost effects.
+- **Consistent across all three quality tiers** from one knob: Premium
+  (fragment shader), Standard (tint lerp), and Minimal (frosted fallback) all
+  render the same whitenStrength value consistently.
+- **`GlassSearchableBottomBar` whiten-at-bottom**: when a `scrollController`
+  is provided, the bar animates its whitening toward full white as the page
+  nears the scroll bottom — the iOS light-mode behaviour where content crowding
+  under a bar gets the strongest legibility lift.
+
+- **Example app**: Buttons & Shadows demo now includes a real-time whiten
+  slider with side-by-side comparison cards and scroll-to-bottom boost preview.
+
+*Contributed by [@jfhair](https://github.com/jfhair) in [PR #100](https://github.com/sdegenaar/liquid_glass_widgets/pull/100).*
+
+## 🎬 Scale-with-Morph — Cohesive Overlay Content Reveal
+
+Menu items and popover content now scale in alongside the liquid morph animation
+instead of popping in at the tail. The glass container and its content feel like
+a single continuous motion.
+
+- **Items enter the tree at 30% morph progress** (down from 94%) and scale from
+  0.5× to 1.0× via an `easeOut` curve alongside opacity. Text and icons visually
+  grow with the expanding glass container.
+- **Applied to both `GlassMenu` and `GlassPopover`** for consistent overlay
+  behaviour across the widget family. Content scales in on open and scales
+  back out on close — the morph animation is symmetrical in both directions.
+- No new API surface. No breaking changes. Purely visual polish.
+
+*`GlassMenu` scale-with-morph contributed by [@F1orian](https://github.com/F1orian) in [PR #97](https://github.com/sdegenaar/liquid_glass_widgets/pull/97).*
+
+---
+
+# 0.15.4
+
+## ⚡ Render Pipeline Performance Pass — FPS & Battery
+
+Internal optimizations targeting the render object `paint()` hot path and background
+capture lifecycle. Zero API changes, zero visual changes. All 2,050 tests passing.
+
+## 🎯 Bottom Bar Lateral Sway
+
+- **Subtle lateral sway on fast pill drags** — `GlassBottomBar` and
+  `GlassSearchableBottomBar` now respond with a near-subliminal horizontal
+  shift when the interactive pill is flicked quickly, matching iOS 26 bottom
+  bar physics. Velocity-gated (slow drags produce no movement) and
+  spring-animated back to center on release.
+
+### GPU allocation pressure (FPS)
+
+- **Cached `ImageFilter` in `_RenderLightweightGlass`** — the composed
+  blur+saturation `ImageFilter` (and its 20-element `ColorFilter.matrix` list) was
+  previously reconstructed on every `paint()` frame for every visible glass widget.
+  With 5 glass cards at 60 fps, that's ~300 list allocations/second hitting the GC.
+  The filter is now cached on the render object and only rebuilt when `blur` or
+  `saturation` changes.
+- **Cached `ImageFilter` in `_RenderInteractiveIndicator`** — same optimization
+  for the interactive indicator shader path (`GlassEffect`). The brightness+blur
+  composed filter is now cached and invalidated only when `blurSigma` changes.
+- **Cached `ImageFilter.blur` in `RenderLiquidGlassLayer`** — the premium glass
+  layer's `BackdropFilterLayer` blur filter was previously recreated on every
+  `paintLiquidGlass()` call, even when the blur sigma hadn't changed. During
+  jelly/morph animations (60 fps), this creates an `ImageFilter.blur` object per
+  frame per premium glass layer. Now cached and reused.
+- **Cached `_shapesWithGeometry` list** — the premium glass `paint()` method
+  previously allocated a new list on every frame to collect active geometry
+  shapes. It now reuses a cleared instance list, eliminating another per-frame
+  allocation on the hot path.
+- **Cached light angle trigonometry** — both `_RenderLightweightGlass` and
+  `_RenderInteractiveIndicator` now cache `cos(lightAngle)` and `-sin(lightAngle)`
+  instead of recomputing them on every `_updateShaderUniforms()` call. Matches the
+  caching pattern already used by the premium `LiquidGlassRenderObject._cachedLightDir`.
+- **Conditional `alwaysNeedsCompositing`** — both `_RenderLightweightGlass` and
+  `_RenderInteractiveIndicator` previously returned `true` unconditionally, forcing
+  the framework to create a compositing layer even in the fallback path (null shader
+  or zero blur). Now returns `true` only when a `BackdropFilterLayer` will actually
+  be pushed. Reduces layer tree depth on low-end devices.
+
+### Battery life
+
+- **Background Ticker auto-suspend** — `LightweightLiquidGlass` runs a Ticker to
+  capture the background behind each glass widget via `toImageSync`. Previously,
+  this ticker ran at 60 fps permanently — even when the background hadn't changed
+  for minutes (e.g. a static bottom bar over a static page). After 3 consecutive
+  no-change frames (~50 ms), the ticker now self-suspends. It restarts automatically
+  when `didUpdateWidget` detects a configuration change. For a bottom bar with 5 tab
+  pills, this eliminates 300 unnecessary method calls/second while idle.
+
+### GC pressure on frame timing path
+
+- **Optimised `GlassQualityAdapter._percentile`** — the Phase 3 runtime percentile
+  computation previously called `_window.toList()` + `List.from(data)..sort()` every
+  120 frames, creating two heap-allocated lists on the frame timing callback path.
+  Now reuses a pre-allocated sort buffer (`List<int>.filled`) that is overwritten
+  in-place. Eliminates GC pressure from the very code path that monitors for
+  GC-induced frame drops.
+
+### Community contribution
+
+- **Collapsed search indicator stretch feedback** — the collapsed indicator in
+  `GlassSearchableBottomBar` now wraps in `LiquidStretch`, giving it the same
+  press-scale physics as the normal tab indicator.
+  *Contributed by [@g3mf0r](https://github.com/g3mf0r) in [PR #96](https://github.com/sdegenaar/liquid_glass_widgets/pull/96).*
+
+### Widget tree rebuild reduction
+
+- **Shared spring listener in `GlassSearchableBottomBar`** — the three morph-
+  animation `AnimationController`s (tab width, search left, search width) each
+  had their own anonymous `addListener(() => setState(() {}))` callback. During
+  a pill morph all three springs tick every frame, producing three independent
+  `setState` calls per frame. Now all three share a single named `_onSpringTick`
+  callback — Flutter coalesces the dirty mark so only one rebuild fires. Also
+  fixes a subtle listener leak: anonymous lambdas can't be matched by
+  `removeListener`, but named methods can.
+
+### Consistency fix
+
+- **`GlassEffect.preWarm()` dummy image** — changed from async `await picture.toImage(1, 1)`
+  to synchronous `picture.toImageSync(1, 1)`, matching the `LightweightLiquidGlass`
+  pattern. Eliminates a 1-frame async initialization delay for a 1×1 transparent
+  texture. Added `picture.dispose()` to prevent a minor leak.
+
+---
+
+# 0.15.3
+
+## `platformViewBackdrop` — Premium Glass Over iOS PlatformViews
+
+New opt-in flag that lets glass bars render correctly over native iOS views
+(Google Maps, Apple Maps, WebView, MapLibre, video players) while keeping the
+premium indicator animations alive. Previously, developers had to downgrade to
+`GlassQuality.standard` on iOS — now they can stay on `premium`.
+
+*Contributed by [@jfhair](https://github.com/jfhair) in [PR #94](https://github.com/sdegenaar/liquid_glass_widgets/pull/94).*
+
+### New parameter: `platformViewBackdrop`
+
+- **`GlassBottomBar`** — new `platformViewBackdrop` parameter. When `true`,
+  the bar background renders via live `BackdropFilter` (the premium shader's
+  `toImageSync` cannot capture a `UIKitView`), while the premium indicator
+  refracts the bar's own icon layer instead of the un-capturable backdrop.
+- **`GlassSearchableBottomBar`** — same parameter, applied to both the tab
+  indicator and the search pill. The collapsed search button automatically
+  falls back to `GlassQuality.standard` over a PlatformView.
+- **`AdaptiveGlass` / `AdaptiveGlass.grouped()`** — new `platformViewBackdrop`
+  parameter that forces the `BackdropFilter` rendering path even at
+  `GlassQuality.premium`.
+- **`AdaptiveLiquidGlassLayer`** — new `platformViewBackdrop` parameter that
+  skips the `LiquidGlassBlendGroup` wrapper when rendering over a PlatformView.
+
+### Usage
+
+```dart
+GlassBottomBar(
+  quality: GlassQuality.premium,
+  platformViewBackdrop: Platform.isIOS, // ← one line fix
+  tabs: myTabs,
+  selectedIndex: _index,
+  onTabSelected: (i) => setState(() => _index = i),
+)
+```
+
+### Example app
+
+- **Google Maps demo** — updated to use `platformViewBackdrop: Platform.isIOS`
+  instead of the old `Platform.isIOS ? GlassQuality.standard : GlassQuality.premium`
+  workaround. The bar now stays at `GlassQuality.premium` on all platforms.
+
+---
+
+# 0.15.2
+
+## GPU SDF Shadows — Light Mode Performance & Metaball Support
+
+Replaced the previous inverse-clip shadow system with GPU SDF shadows that render
+directly from the merged geometry matte. This is both a performance improvement
+and a visual correctness fix — shadows now correctly follow the liquid metaball
+shape during morph animations, which was impossible with the old per-element
+`ClipPath` approach.
+
+### Light mode shadows
+
+- **GPU SDF shadow pass** — `RenderLiquidGlassLayer.paintGlass` now includes a
+  Pass 0 that draws each `BoxShadow` using the geometry matte image. The matte
+  is drawn with `ImageFilter.blur` for the shadow spread, tinted via
+  `ColorFilter.mode`, and then the interior is punched out with `BlendMode.dstOut`
+  so the glass backdrop filter never samples its own shadow. This replaces the
+  widget-level `_InversePillClipper` / `_InverseOvalClipper` `ClipPath` approach.
+- **Shadows plumbed through the full stack** — `LiquidGlassSettings.effectiveShadow`
+  is now resolved at the `AdaptiveGlass` and `AdaptiveLiquidGlassLayer` level and
+  passed through `LiquidGlass.withOwnLayer` → `LiquidGlassLayer` → `_RawShapes` →
+  `RenderLiquidGlassLayer`. Dark mode and flat-edge shapes (`borderRadius: 0`)
+  correctly receive an empty shadow list.
+- **Removed old clip-based shadow system** — deleted `_InversePillClipper`,
+  `_InverseOvalClipper` from `GlassBottomBar`, and the equivalent clippers from
+  `GlassSearchableBottomBar`. Removed `_wrapWithLightModeShadow` from
+  `AdaptiveGlass`. This eliminates ~140 lines of widget-level shadow plumbing and
+  the associated `ClipPath` compositing cost.
+- **Geometry image exposed to subclasses** — `LiquidGlassRenderObject` now
+  exposes `geometryImage` and `geometryLocalBounds` as `@protected` getters so
+  `RenderLiquidGlassLayer` can access the matte for shadow rendering.
+
+### `GlassMenu` overlay rendering
+
+- **`AdaptiveLiquidGlassLayer` in menu overlay** — the morph overlay now uses
+  `AdaptiveLiquidGlassLayer` instead of raw `LiquidGlassLayer`, ensuring correct
+  quality resolution and backdrop blur when the menu is rendered in premium mode.
+
+### Example app
+
+- **Buttons & Shadows demo** — locked to Light Mode (`Brightness.light`) to serve
+  as the definitive showcase for GPU SDF shadows. Moved from the Demos tab to the
+  Examples tab with updated card gradient and subtitle.
+- **Apple Messages demo** — menu trigger buttons now use `useOwnLayer: true` to
+  correctly enter the GPU SDF shadow pipeline. Menu glass settings are
+  brightness-aware (`Colors.white12` dark / `Color(0x99FFFFFF)` light).
+- **Surfaces demo** — `_buildDemoBackground()` now accepts `BuildContext` and
+  returns a light frosted gradient in Light Mode instead of the hardcoded dark
+  navy gradient that caused unreadable text.
+
+### Bug fixes
+
+- Fixed unused import `snap_rect_to_pixels.dart` in `liquid_glass_layer.dart`.
+- Fixed unused `isDark` variable in `glass_menu_internal.dart`.
+- Removed unnecessary `package:flutter/material.dart` import from
+  `adaptive_liquid_glass_layer.dart` (already provided by `cupertino.dart`).
+- Fixed duplicate doc comment in `glass_bottom_bar.dart`.
+- Fixed release-mode crash in `GlassScrollEdgeEffect._captureBackground` — 
+  `RenderRepaintBoundary.toImage()` throws synchronously on `layer!` when called
+  before the first paint completes (layer not yet composited). The
+  `debugNeedsPaint` guard only runs inside `assert()` and is stripped in release
+  builds. Fixed by deferring the initial capture to a post-frame callback and
+  wrapping `toImage()` in `try`/`catch` as a safety net. Falls back to the
+  solid-colour gradient overlay on failure. _(reported by [@RuslanTsitser](https://github.com/RuslanTsitser) via [#93](https://github.com/sdegenaar/liquid_glass_widgets/pull/93))_
+- Updated `GlassBottomBar` golden test reference image.
+
+
+
+# 0.15.1
+
+## Full Light & Dark Mode — Complete Adaptive UI Kit
+
+`liquid_glass_widgets` is now a **fully adaptive** iOS 26 UI kit. Every widget
+— buttons, menus, search bars, sliders, switches, sheets, toasts, chips, form
+fields, and all surface bars — automatically resolves the correct glass color,
+rim lighting, shadow, text, and icon values for both **Light** and **Dark**
+mode. No manual configuration required.
+
+This release closes the last remaining light-mode rendering gaps and ships a
+reference implementation in the Apple Messages demo that matches the
+iOS 26 Messages app in both modes. Run the example app to toggle light and dark mode for all demo pages.
+
+### New features
+
+- **Configurable glass shadow** — `LiquidGlassSettings.shadowElevation` scales the light-mode drop shadow (`0.0` = off, `1.0` = default, `2.0` = double). `LiquidGlassSettings.shadow` accepts a custom `List<BoxShadow>` for full control. Both flow through `globalSettings` (theme-level) and per-widget `settings:`.
+- **`GlassShadow` constants** — centralised shadow values (`GlassShadow.elevation`, `.contact`, `.defaults`, `.scaled(double)`) exported for custom widget authors.
+- **`GlassButtonGroup.icons()`** — introduced a lightweight group constructor for iOS 26 style segmented icon toolbars. Uses a single `GlassButton` parent to drive cohesive group-level stretch/glow interaction, while children are rendered as zero-overhead stateless tap targets.
+- **`GlassMenuController`** — imperative controller for `GlassMenu` with `open()`, `close()`, and `isOpen`. Drives the menu programmatically instead of (or in addition to) tapping the trigger — useful for gesture-arena-driven menus. _(contributed by [@F1orian](https://github.com/F1orian))_
+- **`GlassMenu.showDismissBarrier`** — when `false`, suppresses the full-screen tap-to-dismiss barrier so an external gesture owner can keep receiving pointer events while the menu is open. Defaults to `true`. _(contributed by [@F1orian](https://github.com/F1orian))_
+- **`GlassMenu.morphFromZero`** — when `true`, the menu body lerps from a zero-size point at the trigger center instead of from the trigger's own dimensions, suppressing the spawn blob (Blob A). For invisible or zero-sized triggers. _(contributed by [@F1orian](https://github.com/F1orian))_
+- **`GlassMenuController.setFollowOffset(Offset)`** — nudges the open menu to track a moving anchor in real-time. The offset is added to the captured trigger position each frame and reset on the next `open()`. _(contributed by [@F1orian](https://github.com/F1orian))_
+
+### Light & dark mode improvements
+
+- **Complete adaptive rendering** — all widgets now resolve glass color, rim borders, shadows, text, and icon colors from `CupertinoTheme.brightnessOf(context)`. Switching between light and dark mode requires zero widget-level changes.
+- **Light-mode rim borders** — removed the heavy dark rim border on glass surfaces in light mode. Dark mode rim lighting remains fully intact and unchanged.
+- **Light-mode drop shadows** — added inverse-clipped drop shadows to glass surfaces in light mode (cards, standalone buttons, bottom bars). Shadows render outside the glass boundary so the backdrop filter doesn't blur them. Note: morphing elements like the search pill do not have shadows to prevent animation artifacts.
+- **Standard glass white frost** — standard quality glass in light mode now correctly renders as clean frosted white instead of muddy grey.
+- **Dynamic color resolution** — improved internal text and icon styling to accurately resolve `CupertinoColors` against the active theme brightness.
+- **`GlassSearchBar` and `GlassTextField` default colors now brightness-aware** — default text, icon, and glow colors now resolve dynamically against `CupertinoTheme.brightnessOf(context)` instead of being hardcoded to white. This ensures correct contrast in both light and dark mode.
+
+### Bug fixes
+
+- Fixed missing `} else {` in `lightweight_glass.frag` that caused PATH B (standard widgets) to run inside PATH A.
+- Fixed `GlassSheet` sharp corners on macOS by decoupling top and bottom border radius.
+- Fixed `GlassMenu` selection pill alignment and hit-test accuracy when system text scaler is active.
+- Fixed `GlassChip` resolving with invisible white text and icons in light mode.
+- Fixed Apple Podcasts demo incorrectly forcing dark-mode glass colors in light mode.
+- Fixed `GlassFormField` label (`Colors.white`) and helper text (`Color(0x99FFFFFF)`) being invisible in light mode — now resolves from `CupertinoColors.label` / `.secondaryLabel`
+- Fixed `GlassPicker` value text (`Colors.white`) and chevron icon (`Colors.white70`) being invisible in light mode — now resolves from `CupertinoColors.label` / `.secondaryLabel`.
+- Fixed `GlassPasswordField` lock and eye toggle icons (`Colors.white70`) being invisible in light mode — now resolves from `CupertinoColors.secondaryLabel`.
+- Fixed `GlassActionSheet` forcing dark card background (`Colors.black @ 0.65`), dividers, and pressed highlights regardless of brightness — now resolves to light frosted glass in light mode.
+- Fixed `GlassToast` forcing dark pill (`Colors.black @ 0.7`) and white text regardless of brightness — background and text now resolve from brightness for correct contrast in both modes.
+- Removed unnecessary `import 'package:flutter/material.dart'` from `GlassFormField`, `GlassPicker`, `GlassPasswordField`, and `GlassToast`.
+- Fixed `GlassMenu` morph size going negative during spring undershoot on small triggers — `currentWidth`/`currentHeight` now clamped to `>= 0` to prevent debug `BoxConstraints` assertion. _(contributed by [@F1orian](https://github.com/F1orian))_
+- Fixed `GlassMenu` sub-pixel Impeller crash — body container is replaced with `SizedBox.shrink()` when dimensions fall below 1.0 logical pixel, preventing 0-area matte rasterisation. _(contributed by [@F1orian](https://github.com/F1orian))_
+- Fixed `GlassIconButton` bypassing theme quality chain — `quality` now passes `null` through to `GlassButton.custom()` so `GlassThemeHelpers.resolveQuality` can resolve from ancestor layers, theme, then widget default. _(contributed by [@F1orian](https://github.com/F1orian))_
+
+### ⚠️ Breaking — Removed frosted well overlay from `GlassTextField`
+
+`GlassTextField` no longer applies a hidden internal darkening overlay ("frosted well") on top of the glass surface. Previously, a `DecoratedBox` with `Colors.black.withValues(alpha: 0.12)` plus a top-edge gradient was composited inside the glass shape to simulate an iOS 26 recessed input tray. This has been removed entirely.
+
+**Why:** The frosted well fought against user-specified `glassColor`, making text fields appear darker/muddier than buttons with identical settings. It also caused visible nested border artifacts when the overlay's `BorderRadius.circular()` didn't match the glass surface's `LiquidRoundedSuperellipse` shape — especially with `useOwnLayer: true` and `padding: EdgeInsets.zero`.
+
+**Design philosophy:** `GlassTextField` is a hero surface (search bars, compose bars, app bar inputs) — not a form field nested inside glass cards. `glassColor` is now the single source of truth for appearance, consistent with every other glass widget.
+
+**Migration:** If you relied on the frosted well for visual distinction inside a grouped layout, set a slightly darker `glassColor` on the text field explicitly. Most users will see cleaner, more predictable text fields with no action required.
+
+### Example app
+
+- **Input demos** — replaced `GlassCard` wrappers around form fields with flat `CupertinoColors.systemFill` containers. Glass text fields now render as standalone hero surfaces (`useOwnLayer: true`) inside flat-colored form sections, demonstrating the correct pattern. Glass-in-glass nesting is an anti-pattern.
+- **Apple Messages demo** — fully adaptive light and dark mode implementation. Light mode uses the iOS system grouped background (`#F2F2F7`), brightness-aware white glass tint, and dynamic layer separation to enable shadows. Dark mode retains liquid blending via the shared `AdaptiveLiquidGlassLayer`. Press interactions use `persistPressOnDrag: true` and an elevated `ambientBaseLight` in light mode so the pressed state remains visible while holding and dragging off the button edge.
+
+
+# 0.15.0
+
+## ⚠️ Breaking — API Cleanup & Standardisation
+
+Removes Material-leaning widgets and thin wrappers that don't map to real
+iOS 26 components. Standardises the public API for v1.0 readiness. This is a
+breaking release — users on `^0.14.0` will not auto-upgrade.
+
+### Deleted widgets
+
+| Widget | Migration |
+|---|---|
+| `GlassPanel` | Replace with `GlassCard(padding: EdgeInsets.all(24))` |
+| `GlassWizard` / `GlassWizardStep` | No direct replacement — use `GlassStepper` for sequential steps |
+| `GlassSideBar` / `GlassSideBarItem` | No direct replacement — a proper `UISplitViewController`-style sidebar is planned for post-1.0 |
+| `GlassSnackBar` | Replace with `GlassToast` (identical API — `GlassSnackBar` was documented as an alias) |
+
+### `glassSettings` → `settings` rename
+
+The `glassSettings` parameter on 8 widgets has been renamed to `settings` for
+consistency. The `Glass` prefix on the widget name already identifies the
+settings type — `glassSettings` was redundant.
+
+**Affected widgets:** `GlassBottomBar`, `GlassSearchableBottomBar`,
+`GlassSegmentedControl`, `GlassButtonGroup`, `GlassMenu`, `GlassPopover`,
+`GlassToolbar`, `GlassPicker`.
+
+**Migration:** Find-and-replace `glassSettings:` → `settings:` in your code.
+
+### `GlassSheet.show()` API Cleanup
+
+Removed dead Material parameters from `GlassSheet.show()` that have no effect in the liquid glass rendering pipeline:
+- `backgroundColor`
+- `elevation`
+- `shape`
+- `clipBehavior`
+- `constraints`
+
+**Migration:** Remove these parameters from your `GlassSheet.show()` calls. Use `settings` to configure the glass visual appearance, and `margin` / `padding` / `borderRadius` to control the layout and shape.
+
+## 🎨 Content Colour Audit — Adaptive Light/Dark Mode
+
+All hardcoded `Colors.white` / `Colors.black` in widget content layers replaced with `CupertinoColors` adaptive equivalents. Widgets now render correctly in both light and dark mode without requiring a `MaterialApp` ancestor.
+
+**Affected widgets:** `GlassDialog`, `GlassActionSheet`, all interactive and surface widgets.
+
+`GlassPage` is now fully safe to use inside a pure `CupertinoApp` — the `Theme.of` guard no longer throws when no Material ancestor is present.
+
+## 🐛 Bug Fixes
+
+### `GlassSheet` sharp corners (All Platforms)
+
+Fixed a bug where `GlassSheet` would render with completely sharp, square corners on all devices (including iOS and Android). The internal `SafeArea` wrapper was consuming the bottom safe area before the adaptive radius calculation could read it, causing it to incorrectly fallback to `0.0` everywhere. `GlassSheet` now decouples its top and bottom border radii, defaulting to `topBorderRadius: 32.0`, and smartly assigning `bottomBorderRadius` to `32.0` when floating (with margin) or `0.0` when docked.
+
+## ✨ New — `GlassButtonStyle.prominent`
+
+A new button style matching iOS 26's `.prominentGlass` / `.glassProminent`
+configuration — thicker, more opaque glass for primary call-to-action buttons.
+
+```dart
+GlassButton(
+  style: GlassButtonStyle.prominent,
+  icon: Icon(CupertinoIcons.plus),
+  onTap: () {},
+)
+```
+
+## ✨ New — `GlassGroupedSection`
+
+A convenience wrapper that groups `GlassListTile`s inside a `GlassCard`,
+automatically applying `isLast: true` to the final tile to suppress its
+bottom divider — the most common source of bugs.
+
+```dart
+GlassGroupedSection(
+  header: Text('Network'),
+  children: [
+    GlassListTile(title: Text('Wi-Fi')),
+    GlassListTile(title: Text('Bluetooth')),
+    GlassListTile(title: Text('VPN')), // isLast applied automatically
+  ],
+)
+```
+
+## ✨ New — `GlassPageControl`
+
+iOS `UIPageControl` equivalent — dot indicators for paged content (carousels,
+onboarding, gallery pages). Features animated capsule-shaped active dot with
+glass treatment and optional tap-to-navigate.
+
+```dart
+GlassPageControl(
+  count: 5,
+  currentPage: _currentPage,
+  onPageChanged: (page) => _pageController.animateToPage(page,
+    duration: Duration(milliseconds: 300),
+    curve: Curves.easeInOut,
+  ),
+)
+```
+
+## 📖 README — Glass vs Content design guide
+
+Added a design philosophy section explaining iOS 26's glass hierarchy:
+glass for navigation chrome and controls, opaque for content areas.
+Repositioned `GlassContainer` as an advanced primitive in the widget catalogue.
+
+### What stays
+
+- **`GlassBackdropScope`** — deprecated no-op stays until 1.0.0 as previously
+  committed in the 0.14.0 changelog. Zero cost to keep.
+- All other widgets — no changes.
+
+## 🐛 Fix — `GlassMenu` auto-scrolling with large system text
+
+When the user increased system text size, `GlassMenu` would become scrollable
+even without `menuHeight` being set. The height calculation now accounts for
+`textScaler` so the menu sizes correctly at any accessibility text scale.
+
+## 🐛 Fix — `GlassMenu` selection pill misalignment at large text scale
+
+The sliding selection highlight and hit-test math used the nominal `44px` item
+height for positioning, while the actual `GlassMenuItem` widgets grew taller
+via `ConstrainedBox` when system text was scaled up. This caused the pill to
+drift out of alignment and sometimes produce a "double highlight" effect. All
+layout math (`_getItemOffset`, `_calculateIndexFromPosition`, `_isScrollable`)
+now uses the `TextScaler`-aware height calculation.
+
+## 🐛 Fix — `GlassMenuItem` / `GlassMenuDivider` / `GlassMenuLabel` Light Mode
+
+These widgets previously hardcoded `Colors.white` for text, icons, and divider
+colours, making them invisible on light backgrounds. They now inherit from
+`CupertinoTheme.of(context)`:
+
+| Widget | Colour Source |
+|---|---|
+| `GlassMenuItem` | `theme.textTheme.textStyle.color` → `CupertinoColors.label` |
+| `GlassMenuDivider` | `theme.textTheme.tabLabelTextStyle.color` at 15 % opacity |
+| `GlassMenuLabel` | `theme.textTheme.tabLabelTextStyle.color` at 45 % opacity |
+
+Custom `iconColor`, `titleStyle`, and `color` parameters still take priority
+over the theme default — zero breaking changes.
+
+## 🧹 Core — `CupertinoApp` compatibility
+
+Removed all `Theme.of(context)` dependencies from the core library, replacing them with `CupertinoTheme` and `defaultTargetPlatform`. This ensures glass widgets adapt correctly to dark mode and background colours in pure `CupertinoApp` structures without falling back to Material defaults.
+
+## 🧹 Example app — `CupertinoApp` migration
+
+All 16 standalone demos and the main showcase app have been migrated from
+`MaterialApp` to `CupertinoApp`. This is the correct root widget for an iOS 26
+glass library — it provides `CupertinoTheme` to the entire widget tree, which
+glass widgets depend on for colour resolution.
+
+A `Theme(data: ThemeData.dark(...))` builder is injected below `CupertinoApp`
+so that any `Scaffold` widgets in demo pages continue to receive proper Material
+theming (background colour, text defaults).
+
+## 🧹 Example app — `GlassMenu` demo controls
+
+Added text-scale slider (1.0×–3.0×) and light/dark theme toggle to the menu
+demo. Also added `GlassMenuLabel`, `GlassMenuDivider`, and a destructive
+`GlassMenuItem` to the menu items so their theme colour inheritance can be
+visually verified.
+
+---
+
+# 0.14.2
+
+## 🧹 Material Artifact Purge
+
+Replaced internal Material primitives with Cupertino-native equivalents for
+better iOS 26 fidelity. No public API changes.
+
+- **Tap feedback:** `InkWell` → `GestureDetector` + iOS-style opacity highlight
+  in `GlassListTile` and `GlassActionSheet`.
+- **Icons:** `Icons.chevron_right`, `Icons.add`, `Icons.remove`, `Icons.info_outline`
+  → `CupertinoIcons` equivalents in `GlassListTile` and `GlassStepper`.
+- **Colours:** Hardcoded `Colors.green` / `Colors.red` → `CupertinoColors.systemGreen`
+  / `CupertinoColors.destructiveRed` across `GlassSwitch`, `GlassBadge`,
+  `GlassWizard`, `GlassDialog`, `GlassMenuItem`, and `GlassFormField`.
+
+---
+
+# 0.14.1
+
+## 🐛 Fixed — `GlassScaffold` black background
+
+`GlassScaffold` with no `background:` widget was forcing the inner `Scaffold` to
+`Colors.transparent`, rendering black instead of `Theme.scaffoldBackgroundColor`.
+Added a `backgroundColor: Color?` parameter; the scaffold now defaults to the
+theme colour when no explicit background is provided.
+
+## ✨ Improved — Cancel icon size & customisation
+
+The dismiss `×` button in `GlassSearchableBottomBar` was hardcoded to `size: 16`,
+which felt undersized compared to iOS 26. Default bumped to `24`. Both
+`GlassSearchBar` and `GlassSearchBarConfig` now expose `cancelIconSize` and
+`cancelIcon` so the icon size and glyph are fully overridable.
+
+## ✨ New — `GlassPopover`
+
+A new overlay widget that presents **custom content** in a glass container with
+the same liquid morph animation as `GlassMenu`. Use it for tooltips, mini forms,
+preview cards, colour pickers, or any content that should appear in a glass
+popover — without being limited to a list of menu items.
+
+`GlassPopover` shares `GlassMenu`'s liquid teardrop expansion, spring physics,
+auto-positioning, and screen-edge clamping. The `contentBuilder` receives a
+`close` callback so popover content can dismiss itself.
+
+```dart
+GlassPopover(
+  trigger: GlassIconButton(
+    icon: Icon(CupertinoIcons.info_circle),
+    onPressed: null, // handled by GlassPopover
+  ),
+  contentBuilder: (context, close) => Padding(
+    padding: EdgeInsets.all(16),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('Profile Details',
+          style: TextStyle(color: Colors.white, fontSize: 16)),
+        SizedBox(height: 12),
+        GlassButton(onTap: close, child: Text('Done')),
+      ],
+    ),
+  ),
+)
+```
+
+**Key parameters:**
+- `contentBuilder` — builder for custom popover content, receives a `close` callback
+- `trigger` / `triggerBuilder` — the widget that opens the popover on tap
+- `popoverWidth` / `popoverHeight` — size control (height defaults to intrinsic)
+- `alignment` — manual `GlassMenuAlignment`, or `null` for auto-detect
+- `autoAdjustToScreen` — screen-edge clamping (on by default, with 12px padding)
+- `barrierDismissible` — whether tapping outside closes the popover (default: true)
+- `onOpen` / `onClose` — lifecycle callbacks
+- Full `LiquidStretch` and `GlassGlow` support
+
+# 0.14.0
+
+## ⚠️ Breaking — `GlassAppBar` redesigned as pure layout widget
+
+`GlassAppBar` has been fundamentally redesigned from a `StatefulWidget` with its own glass rendering to a lightweight `StatelessWidget` that serves purely as a layout container. This matches iOS 26's actual navigation bar pattern where the bar itself is transparent and glass effects belong on individual interactive elements.
+
+**Removed parameters:**
+- `settings` — glass surface settings (the bar no longer renders glass)
+- `quality` — glass quality selector
+- `useOwnLayer` — layer isolation control
+- `scrollController` — scroll-driven glass transition
+- `scrollEdgeThreshold` — scroll fade threshold
+
+**New parameter:**
+- `buttonSettings: LiquidGlassSettings?` — provides default glass settings to all descendant `GlassButton` widgets via `DefaultButtonSettings` (a new `InheritedWidget`). Individual buttons can still override with their own `settings`.
+
+**Migration:**
+
+```dart
+// Before (0.13.x) — scroll-driven glass bar:
+GlassAppBar(
+  title: Text('Title'),
+  scrollController: _ctrl,
+  scrollEdgeThreshold: 50.0,
+  settings: LiquidGlassSettings(blur: 15),
+  quality: GlassQuality.premium,
+)
+
+// After (0.14.0) — transparent layout bar:
+GlassAppBar(
+  title: Text('Title'),
+  buttonSettings: LiquidGlassSettings(
+    glassColor: Color(0x33FFFFFF),
+    thickness: 20,
+  ),
+)
+// Use GlassScaffold.header + headerScrollController for fading headers.
+```
+
+Apps that relied on `GlassAppBar.scrollController` for scroll-driven glass should migrate to `GlassScaffold` with its `header` / `headerScrollController` parameters (see below).
+
+## ✨ New — `GlassScaffold` — one-widget page layout
+
+A brand new scaffold that replaces the manual assembly of `GlassPage` + `Scaffold` + `GlassScrollEdgeEffect` + `Stack` with a single widget. Handles z-ordering (bars always above body), edge fading, safe-area padding, and glass layer setup automatically.
+
+### `header` + `headerScrollController` + `headerFadeDistance`
+
+A fixed header widget positioned below the status bar that fades out as the user scrolls — matching the iOS 26 large-title pattern used by Apple Music ("Listen Now"), Apple Podcasts, and similar apps.
+
+```dart
+GlassScaffold(
+  header: Text('Listen Now', style: largeTitle),
+  headerScrollController: _scrollController,
+  headerFadeDistance: 60.0,
+  body: CustomScrollView(
+    controller: _scrollController,
+    slivers: [...],
+  ),
+)
+```
+
+The header is wrapped in `IgnorePointer` only when fully faded (opacity == 0), so tappable elements remain interactive at full visibility.
+
+### `bodyOverlays`
+
+Optional list of widgets rendered between the body and the navigation bars in z-order. Designed for floating elements like Apple Music's play-bar pill that need to render above scrollable content but below the bottom bar.
+
+```dart
+GlassScaffold(
+  bodyOverlays: [
+    AnimatedPositioned(
+      bottom: isMiniMode ? miniBottom : aboveBarBottom,
+      left: 20, right: 20,
+      child: PlayBarPill(),
+    ),
+  ],
+  body: scrollContent,
+)
+```
+
+### `AnnotatedRegion` status bar fix
+
+`GlassScaffold` now wraps the internal `Scaffold` in an `AnnotatedRegion<SystemUiOverlayStyle>` so that the `statusBarStyle` setting correctly overrides `CupertinoPageRoute`'s own region. Previously, pages without a `GlassAppBar` could lose their status bar icon styling when pushed via `CupertinoPageRoute`.
+
+### Improved isolation strategy
+
+`GlassScaffold` now wraps app bar and bottom bar in `GlassIsolationScope(isolated: false, defaultQuality: GlassQuality.premium)` instead of the previous `GlassIsolationScope(isolated: true)`. This means bar buttons join the page-level glass blend group (shared backdrop capture) rather than creating their own layers — saving GPU cost. Stack paint order already guarantees bars render on top of body content.
+
+### Stable `ValueKey`s on stack children
+
+All conditional children (header, app bar, bottom bar) now have explicit `ValueKey`s so Flutter tracks them by identity rather than position. This prevents unmount/remount cycles (and loss of animation state) when toggling the header on and off.
+
+> See `example/lib/demos/nav_bar_patterns_demo.dart` for complete `GlassScaffold` usage patterns.
+
+## ✨ New — `GlassIsolationScope.defaultQuality`
+
+`GlassIsolationScope` gains a `defaultQuality: GlassQuality?` parameter that provides a quality hint for descendants without requiring explicit `quality:` on each widget. This is separate from `isolated` — a scope can be de-isolated (for grouping) while still providing a premium quality default.
+
+`GlassThemeHelpers.resolveQuality` now checks `scopeDefault` and skips inherited page-level quality when a scope provides a `defaultQuality`. This fixes a regression where bar buttons inside `GlassScaffold` would inherit the page's `standard` quality instead of getting the bar's intended `premium`.
+
+## ✨ New — `DefaultButtonSettings` InheritedWidget
+
+A new `InheritedWidget` in `glass_app_bar.dart` that provides default `LiquidGlassSettings` to descendant `GlassButton` widgets. `GlassButton` now checks `DefaultButtonSettings.of(context)` as a fallback between explicit `settings` and inherited layer settings.
+
+## ✨ New — `AdaptiveGlass` interactive auto-promotion
+
+`AdaptiveGlass` now automatically promotes interactive elements (`isInteractive: true`) to their own compositing layer in premium mode. This gives buttons the prominent independent refraction that matches iOS 26's button design, rather than softly blending them into the page blend group. The own-layer wrapper de-isolates children via `GlassIsolationScope(isolated: false)` so nested glass (e.g. tab items inside a bottom bar) groups correctly with the button's layer.
+
+## 🐛 Fix — `GlassBottomBar` extra button z-order
+
+Fixed a compositing z-order issue where the jelly tab indicator would incorrectly render behind the extra trailing button. The internal layout has been restructured from a `Row` to a `Stack` with explicit paint ordering — the extra button is painted first (bottom of z-order), and the tab indicator is painted last (top). This matches the existing pattern in `GlassSearchableBottomBar`.
+
+## 🐛 Fix — `GlassSearchableBottomBar` pill z-order
+
+Fixed the paint order of the search pill and tab pill in `GlassSearchableBottomBar`. The search pill is now painted first (bottom of stack) and the tab pill last (top), so the glass indicator correctly renders on top when it overlaps the search pill during tab transitions.
+
+## 🐛 Fix — `mounted` guards in gesture handlers
+
+Added `if (mounted)` guards before every `setState()` call in `TabDragGestureMixin`, `TabIndicator`, and `SearchableTabIndicator`. Pointer events (`onPointerDown`, `onPointerUp`, `onPointerCancel`) and drag gesture callbacks can fire after the widget has been unmounted during rapid tab switching or page transitions, causing `setState() called on disposed widget` exceptions in debug mode. These guards are zero-cost safety nets.
+
+## 🔄 Changed — Nav bar patterns demo
+
+Removed three `GlassAppBar` demo patterns that used the now-deleted scroll-driven glass API:
+- ~~Scroll-Driven Glass~~ (transparent → glass on scroll)
+- ~~Static Glass~~ (always-on glass surface)
+- ~~Large Title Glass on Scroll~~ (combined collapsing + glass materialisation)
+
+Added a new "Fade Header (No App Bar)" pattern demonstrating the `GlassScaffold.header` fade approach (Apple Music / Podcasts style).
+
+## 🔄 Changed — Example app restructured
+
+### Showcase app uses `GlassScaffold`
+The main showcase app (`main.dart`) now uses `GlassScaffold` instead of manually composing `GlassPage` + `Scaffold` + `bottomNavigationBar`. Added a fourth tab ("Examples") and redesigned the Widgets tab with a 2-column card grid.
+
+### Apple demos migrated to `GlassScaffold`
+All four Apple demo apps have been migrated from manual `Scaffold` + `Stack` + `GlassScrollEdgeEffect` composition to `GlassScaffold`:
+
+- **Apple Messages** — `GlassScaffold` handles positioning, z-ordering, and edge fading automatically. 8 lines changed.
+- **Apple Music** — uses `GlassScaffold.header` for the "Listen Now" fade header, `bodyOverlays` for the floating play pill. Major simplification (294 lines changed).
+- **Apple News** — migrated to `GlassScaffold`. Removed unnecessary nested `Stack`. 57 lines changed.
+- **Apple Podcasts** — uses `GlassScaffold.bodyOverlays` for the mini-player pill. 372 lines changed.
+
+### Category pages re-indented
+All 6 showcase category pages (containers, feedback, input, interactive, overlays, surfaces) have been re-indented for consistency. No functional changes.
+
+
+## 🐛 Fix — Impeller backdrop visual corruption
+
+Fixed a critical rendering issue where `GlassAppBar` buttons would lose their glass background (rendering as invisible) when multiple `LiquidGlassLayer`s shared a single root `BackdropGroup` (via `GlassBackdropScope`). On Impeller, sharing a `BackdropKey` across multiple `RepaintBoundary` layers caused the engine to bind stale or incorrect backdrop textures.
+
+**Root cause:** The shared `BackdropGroup` architecture assumed that all glass surfaces could safely share a single GPU backdrop capture. On Impeller's tile-based renderer, this created a race between layers trying to use the same `BackdropKey`, causing visual corruption (backgrounds vanishing, ghost artifacts during route transitions).
+
+**Fix:** Each `LiquidGlassLayer` now creates its own isolated `BackdropGroup` → `RepaintBoundary` subtree. This ensures every glass surface captures only its own clipped bounding box — a ~30× reduction in GPU bandwidth compared to the previous full-screen capture, and eliminates cross-layer texture conflicts entirely.
+
+## ⚠️ Deprecated — `GlassBackdropScope`
+
+`GlassBackdropScope` is now a no-op and can be safely removed from your widget tree. Each glass layer manages its own backdrop isolation automatically. `GlassPage` continues to work exactly as before — no migration needed for apps using `GlassPage`.
+
+Apps using `GlassBackdropScope` directly will see a deprecation warning but will compile and run without issues. Remove the widget at your convenience; it will be deleted in 1.0.0.
+
+## 🔄 Changed — `GlassInteractionSettings` is now the canonical interaction API
+
+`GlassInteractionSettings` (introduced in 0.13.0) is now the recommended way to configure all interaction physics app-wide. Pass it via `GlassThemeData.interaction` inside `LiquidGlassWidgets.wrap()`:
+
+```dart
+runApp(LiquidGlassWidgets.wrap(
+  child: const MyApp(),
+  theme: GlassThemeData(
+    interaction: GlassInteractionSettings(
+      stretch: 0.2,              // subtler drag-following globally
+      interactionScale: 1.03,    // less scale-up on press
+      resistance: 0.01,          // drag damping factor
+      anchorStretch: true,       // iOS 26 rubber-band from anchor
+      anchorStretchSettings: AnchorStretchSettings(
+        intensity: 0.8,
+        squashFactor: 0.15,
+      ),
+    ),
+  ),
+));
+```
+
+Set `stretch: 0.0` to disable drag-following app-wide while keeping press-scale. Individual widgets can still override any value via their own `stretch:` / `interactionScale:` parameters.
+
+---
+
+# 0.13.0
+
+## ✨ New — Anchor Stretch, Ambient Light, and Interaction Physics
+
+### `AnchorStretchSettings` — fine-tuned stretch feel
+
+A new configuration class for `LiquidStretch` that controls how widgets deform when pressed and dragged. Widgets now stretch *from their anchor point* toward the drag direction — matching iOS 26 button physics where the surface rubber-bands from its resting position rather than free-following the finger.
+
+```dart
+GlassButton(
+  anchorStretchSettings: AnchorStretchSettings(
+    intensity: 0.8,       // more stretchy
+    squashFactor: 0.3,    // perpendicular compression
+    translationDamping: 0.15, // center-shift toward finger
+    bounciness: 0.2,      // elastic snap-back overshoot
+  ),
+)
+```
+
+All parameters have sensible defaults matching iOS 26 behaviour. Most developers won't need to change them.
+
+### `GlassButton.ambientBaseLight` — surface luminosity
+
+A subtle white overlay (default `0.08`) applied during press/drag interactions. Simulates iOS 26 surface luminosity — when the directional glow tracks off-edge, the button still maintains a faint lit appearance rather than going completely dark.
+
+### `GlassButton.persistPressOnDrag`
+
+Controls whether the pressed visual state persists when the user's finger drags outside the button bounds. Defaults to `true`, matching iOS 26 behaviour where buttons stay visually pressed during drag-off and only release on pointer-up. Set to `false` for the traditional behaviour where leaving the hit-test area cancels the press.
+
+### `GlassPage.settings` — page-level glass configuration
+
+`GlassPage` now accepts an optional `settings: LiquidGlassSettings` parameter and internally wraps its child in an `AdaptiveLiquidGlassLayer`. This means all glass widgets inside the page (`GlassAppBar`, `GlassCard`, `GlassButton`, etc.) automatically inherit the page's glass settings — no need to set `useOwnLayer: true` or pass `settings:` to each widget individually.
+
+```dart
+GlassPage(
+  settings: LiquidGlassSettings(
+    glassColor: Color.fromRGBO(28, 28, 30, 0.8),
+    thickness: 30,
+    blur: 4,
+  ),
+  child: Scaffold(...),
+)
+```
+
+When `settings` is null, the layer inherits from `GlassTheme` or uses defaults.
+
+### `GlassScaffold` — comprehensive structural layer
+
+A new structural widget that coordinates interactions between `GlassAppBar`, `GlassBottomBar`, and the page body. It automatically handles edge-to-edge layout, scroll bleeding, and isolates glass rendering layers for maximum performance. This replaces the need to manually compose `AdaptiveLiquidGlassLayer` and `GlassIsolationScope` at the page root.
+
+### `GlassInteractionSettings` Theme
+
+Added a dedicated theme extension to globally configure interaction physics across all glass widgets — stretch, press scale, drag resistance, anchor stretch, and anchor stretch fine-tuning. No more passing interaction parameters to every widget manually.
+
+```dart
+GlassThemeData(
+  interaction: GlassInteractionSettings(
+    stretch: 0.2,              // subtler drag-following globally
+    interactionScale: 1.03,    // less scale-up on press
+    resistance: 0.01,          // drag damping factor
+    anchorStretch: true,       // iOS 26 rubber-band from anchor
+    anchorStretchSettings: AnchorStretchSettings(
+      intensity: 0.8,
+      squashFactor: 0.15,
+    ),
+  ),
+)
+```
+
+Set `stretch: 0.0` to disable drag-following app-wide while keeping press-scale. Individual widgets can still override any value.
+
+## 🐛 Fixes & Improvements
+
+### Wide Button Stretch Distortion
+Fixed a rendering artifact where very wide `GlassButton`s would exhibit severe shape distortion at the extreme edges during horizontal stretch physics.ts.
+
+### `GlassSearchBarConfig.cursorColor` — cursor follows Flutter theme by default
+
+Thanks to [@jfhair](https://github.com/jfhair) for [PR #71](https://github.com/sdegenaar/liquid_glass_widgets/pull/71). 🙏
+
+`GlassSearchableBottomBar`'s expanded search field now exposes a `cursorColor` knob via `GlassSearchBarConfig`, and the default behaviour aligns with Flutter convention — the cursor follows the standard theme-resolution chain (`Theme.of(context).textSelectionTheme.cursorColor` → `CupertinoTheme.primaryColor` on iOS → `Theme.of(context).colorScheme.primary`) rather than being hard-coupled to `textColor`.
+
+Apps that want the previous behaviour — cursor matching `textColor` — can opt in explicitly:
+
+```dart
+GlassSearchBarConfig(
+  textColor: Colors.white,
+  cursorColor: Colors.white,  // ← previously implicit
+)
+```
+
+> **⚠ Breaking change.** Apps that set a `textColor` and rely on the cursor implicitly matching it will see their cursor colour change to whatever their `Theme.of(context).colorScheme.primary` is (typically `Colors.blue` if untouched). Two-line migration above.
+
+## 🐛 Fix — Premium stretch edge clipping
+
+Premium-quality `GlassButton` could exhibit jagged rasterization edges during stretch deformation. The Impeller `LiquidGlassLayer` rasterizes at its native resolution, which doesn't perfectly align with the deformed shape boundary during stretch.
+
+Fixed by wrapping the premium glass surface in a vector `ClipPath` at the shape boundary. This renders at screen resolution every frame while preserving full refraction, chromatic aberration, and 3D specular — no quality downgrade needed.
+
+## 🐛 Fix — Mali GPU crash guard
+
+`render_liquid_glass_geometry.dart` now guards against zero and negative dimensions in both `render()` and `renderAsync()`. During jelly animations or rapid layout transitions (modal expansion, tab switching), `matteBounds` can momentarily collapse to zero dimensions — producing an invalid GPU texture request that crashes Mali drivers.
+
+The fix returns a minimal 1×1 fallback cache for zero-dimension frames. Additionally, `matte.toImageSync()` is wrapped in a `try/catch` to handle Mali driver failures gracefully — returning a safe fallback instead of crashing the app. The next paint frame rebuilds the geometry with valid dimensions automatically.
+
+## 🐛 Fix — Searchable bottom bar collapsed shape
+
+The collapsed search button and tab indicator in `GlassSearchableBottomBar` used `LiquidRoundedSuperellipse` even when collapsed to a square. A superellipse with `borderRadius: 32` on a 50×50 square has subtle flat segments between the arcs — invisible at rest but clearly distorted during stretch deformation.
+
+Fixed by switching to `LiquidOval` when constraints are square (within 2px tolerance), which renders a mathematically perfect circle that stretches uniformly. During the collapse animation (when the width is still wider than the height), the superellipse is used to avoid a squashed oval appearance.
+
+## 🎨 Visual — iOS 26 thin glass defaults
+
+The three default theme variants have been standardised to match the thin, refractive glass aesthetic of iOS 26:
+
+| Property | Dark | Light | Minimal |
+|----------|------|-------|---------|
+| thickness | 40 → **10** | 20 → **12** | 30 → **10** |
+| blur | 5 → **4** | 6 → **5** | 12 → **8** |
+| lightIntensity | 1.5 → **0.7** | 1.2 → **0.85** | unchanged |
+| lightAngle | unset → **135°** | unset → **135°** | unchanged |
+| chromaticAberration | unset → **0.01** | 0.3 → **0.02** | unchanged |
+
+> **⚠ Visual change.** Apps using `GlassThemeVariant.dark`, `.light`, or `.minimal` without explicit `LiquidGlassSettings` overrides will see thinner, subtler glass. This is intentional — the previous defaults were heavier than the native iOS 26 aesthetic. If you prefer the heavier look, set explicit `thickness` and `blur` values in your `GlassThemeData`.
+
+## ⚠️ Semi-Breaking — `GlassAppBar` transparent by default
+
+`GlassAppBar` now renders a **transparent** navigation bar by default — no glass surface, no specular rim. This matches iOS 26's actual navigation bar pattern where the glass effect is on individual buttons, not the bar itself.
+
+Previously, `GlassAppBar` always wrapped its content in an `AdaptiveGlass` surface with `LiquidGlassSettings(blur: 15)`. This created a visible glass rectangle behind the title and actions — a Material-style app bar with glass paint, not an iOS 26 navigation bar. A better version of this to come next
+
+To opt in to a glass background (e.g. for scroll-edge transitions), pass explicit `settings`:
+
+```dart
+// Before (0.12.x) — glass was always on:
+GlassAppBar(title: Text('Title'))
+
+// After (0.13.0) — transparent by default:
+GlassAppBar(title: Text('Title'))  // transparent, iOS 26 style
+
+// Opt-in glass background:
+GlassAppBar(
+  title: Text('Title'),
+  settings: LiquidGlassSettings(blur: 15, thickness: 10),
+)
+```
+
+Additionally, `quality` now defaults to `null` (inherits from ambient scope) instead of `GlassQuality.premium`.
+
+## 🎨 Visual — Specular rim refinement
+
+Standard/minimal quality glass surfaces now render a more refined specular inner-border rim:
+
+- **True inner border** — the specular stroke is now clipped to its inner half via `_ShapeClip`, creating an optically correct glass-edge reflection instead of a center-straddling stroke that bleeds outside the shape boundary.
+- **Organic overlay blending** — `BlendMode.overlay` replaces `BlendMode.srcOver`, so the rim reacts to the background colour underneath rather than appearing as a flat white line. Darker backgrounds produce subtler rims; lighter backgrounds produce brighter ones.
+- **Flat-edge suppression** — shapes with `borderRadius: 0` (used by `GlassAppBar`, `GlassSideBar`, `GlassToolbar`) no longer render the specular rim. On full-width flat surfaces, the rim looked like a Material divider line rather than an internal glass reflection.
+
+Only affects standard and minimal quality. Premium quality uses Impeller's native `LiquidGlassLayer` which has its own refraction-based edge rendering.
+
+## ⚡ Performance — Quality adapter tuning
+
+- **Faster degradation** — Phase 3 runtime monitoring now triggers a quality step-down after 2 consecutive over-budget windows (previously 3), reducing reaction time from ~6 seconds to ~4 seconds. This means devices that genuinely can't sustain their assigned quality level are protected sooner.
+- **Documentation updated** — removed provisional calibration warnings from warmup threshold docs. The 20ms premium / 28ms standard thresholds are now considered validated.
+
+## ⚠️ Semi-Breaking — `LiquidStretch.resistance` default
+
+The default `resistance` value for `LiquidStretch` has changed from `0.08` to `0.01`. This makes all stretch interactions feel more responsive and fluid — closer to the iOS 26 native feel. The previous value was overly dampened.
+
+All widgets using `LiquidStretch` without explicitly setting `resistance` (including `GlassButton`, `GlassCard`, `GlassContainer`, `GlassMenu`) will feel stretchier. To restore the previous behaviour:
+
+```dart
+LiquidStretch(
+  resistance: 0.08, // previous default
+  child: ...,
+)
+```
+
+## 🧪 Tests — 1898 passing (+124 new)
+
+- New `GlassButton` tests: `persistPressOnDrag` true/false behaviour, default values, cancel paths.
+- New `GlassSearchBarConfig.cursorColor` tests: default null, explicit value, independence from `textColor`.
+- Updated `glass_quality_adapter` tests for `degradeWindowCount: 2`.
+- Updated stretch tests for new `resistance` default.
+- Updated `GlassAppBar` defaults test for transparent-by-default change.
+- Updated golden tests for specular rim flat-edge suppression.
+
+## 📦 Example app
+
+- **Keypad lock screen demo** — new full-screen demo showcasing `GlassButton` in a PIN-entry layout.
+- **Restructured showcase pages** — all category pages (containers, feedback, input, interactive, overlays, surfaces) reorganised for cleaner presentation. More work to come...
+
+---
+
+# 0.12.8
+
+## 🐛 Fix — `GlassTextField` reverted to v0.12.4 + icon drift fix
+
+- **Reverted to v0.12.4** — restored exact line-count and layout logic. The v0.12.6–0.12.7 changes introduced regressions (line breaks at wrong character boundary, icons pinned to container bottom).
+- **Fixed icon drift under system text scaling** — in fixed-height mode, icons are now always centred relative to the container rather than relative to the text row. This prevents icons from shifting position when users change system text scaling. In dynamic-height mode (no `height` parameter), `iconAlignment` is respected as before.
+
+Thanks [@g3mf0r](https://github.com/g3mf0r) for the detailed testing.
+
+---
+
+# 0.12.7
+
+## 🐛 Fix — `GlassTextField` icon alignment (retained) + line-count regression fix
+
+- **`iconAlignment: .end` no longer drifts under system Large Text.** The `Center` widget wraps only the `TextField`, not the entire icon `Row`, so `CrossAxisAlignment.end/.start` works correctly against the full container height. *(retained from 0.12.6)*
+- **Reverted line-count measurement** back to `renderBox.size.width` (the v0.12.4 approach). The v0.12.6 `RenderEditable` width change caused line breaks to fire a couple of characters early. Thanks [@g3mf0r](https://github.com/g3mf0r) for catching this.
+
+---
+
+# 0.12.6
+
+## 🐛 Fix — `GlassTextField` icon alignment and line-count accuracy
+
+- **`iconAlignment: .end` no longer drifts under system Large Text.** The `Center` widget now wraps only the `TextField`, not the entire icon `Row`, so `CrossAxisAlignment.end/.start` works correctly against the full container height.
+- **Line-count measurement is now pixel-perfect.** `_measureLineCount` walks the render tree to find the actual `RenderEditable` and uses its layout width (which accounts for the internal `_caretMargin` ≈ 3 px). Falls back gracefully if the render walk fails.
+
+---
+
+# 0.12.5
+
+## ✨ New — `GlassMenu.onClose` callback
+
+Added `onClose: VoidCallback?` to `GlassMenu`. Fires when a close is triggered
+(barrier tap, trigger re-tap, or item selection), before the animation completes.
+Useful for synchronising external state such as a `GlassMorphController`.
+
+Thanks to [@g3mf0r](https://github.com/g3mf0r) for the contribution ([#67](https://github.com/sdegenaar/liquid_glass_widgets/pull/67)).
+
+---
+
+# 0.12.4
+
+## 🐛 Fix — `GlassTextField` layout and reactivity
+
+### `onLineCountChanged` fires correctly under fixed-height constraints
+
+The `onLineCountChanged` callback silently stopped firing after the first
+measurement when the field was inside a fixed-height container (e.g.
+`SizedBox(height: 46)` or `height: 46` on the field itself). The internal
+guard used `size == _lastTextFieldSize` — but a fixed outer height keeps the
+`RenderBox` size constant, so the guard always exited early after the first
+call. The fix replaces the size-equality guard with a `(text, constrainedWidth)`
+guard: the callback fires whenever the text content or available wrapping width
+changes, regardless of what the outer height is doing.
+
+This also resolves the stale-state reactivity bug where `_lines` stored in
+`State` stopped updating `borderRadius` after re-opening the keyboard.
+
+### Placeholder and text stay vertically centred under system Large Text
+
+When `height` is specified (fixed-height mode), the outer `padding`'s vertical
+component was applied inside the `SizedBox`, pushing placeholder text and icons
+downward when the user enabled a large system font. The field now strips
+vertical padding in fixed-height mode and centres the text row via `Align`,
+matching the behaviour of `GlassSearchBar`. The `padding` parameter's
+horizontal values are unchanged.
+
+## ✨ New — `bottom` panel for `GlassTextField` and `GlassTextArea`
+
+Both widgets now accept an optional `bottom` widget that renders below the text
+area inside the same glass card. Use it to build the "rich composer" pattern — a
+text input on top with an action bar, attachment strip, or formatting toolbar
+below, all sharing one glass surface:
+
+```dart
+GlassTextField(
+  maxLines: 5,
+  minHeight: 44,
+  maxHeight: 160,
+  bottom: Padding(
+    padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+    child: Row(
+      children: [
+        IconButton(icon: Icon(Icons.attach_file), onPressed: _attach),
+        const Spacer(),
+        IconButton(icon: Icon(Icons.send), onPressed: _send),
+      ],
+    ),
+  ),
+)
+```
+
+The panel renders inside the glass surface alongside the text area.
+Callers can add a `Divider` between the text area and the panel if a visual
+separator is desired. Not available on `GlassTextField.search` (that
+constructor is single-line only; `bottom` is always `null` there).
+
+---
+
+# 0.12.3
+
+## 🎨 Visual — Slider & Switch thumb refraction tuning
+
+- **`GlassSlider` thumb** — increased `refractiveIndex` (1.15 → 1.3) and `thickness` (10 → 13) for a more pronounced glass lens feel. Reduced `glassColor` alpha (0.1 → 0.08), `lightIntensity` (2.0 → 1.8 premium), `baseAlphaMultiplier` (0.2 → 0.08 premium), and `edgeAlphaMultiplier` (0.4 → 0 premium) for a cleaner, more transparent thumb.
+- **`GlassSwitch` thumb** — reduced `refractiveIndex` (1.15 → 1.12) and `glassColor` alpha (0.1 → 0.08) for subtler refraction.
+- **Material fade via `Opacity` widget** — slider thumb now uses widget-level `Opacity` (matching `GlassSwitch` pattern) instead of color alpha for the press-down fade. Critical for Impeller: properly removes the child from the compositing tree so native refraction shows through.
+
+## ⚡ Jelly physics — spring-based velocity
+
+- **`GlassSlider` jelly** — replaced raw `_velocity` tracking with a `SingleSpringController` feeding `buildJellyTransform`. Produces smooth squash/stretch with natural deceleration and elastic bounce-back, matching the tab bar / bottom bar pill feel. `maxDistortion` raised (0.25 → 0.6), `velocityScale` lowered (30 → 2) to account for the spring's normalised 0→1 position range.
+
+---
+
+# 0.12.2
+
+## ✨ New — `GlassTextField` enhancements
+
+Three community-requested features for `GlassTextField` (and `GlassTextArea`):
+
+### Explicit size properties
+
+`height`, `minHeight`, and `maxHeight` give direct control over the field's dimensions — no wrapping `SizedBox` needed:
+
+```dart
+// Fixed height — matches GlassSearchBar's 44pt:
+GlassTextField(height: 44, placeholder: 'Search')
+
+// Constrained range — grows with content:
+GlassTextField(minHeight: 44, maxHeight: 200, maxLines: 10)
+```
+
+`height` is mutually exclusive with `minHeight`/`maxHeight` (assertion enforced).
+
+### `onLineCountChanged` callback
+
+Fires whenever the number of **rendered** lines changes (accounting for text wrapping, not `\n` characters). Also fires on initial build. Uses the `TextField`'s own `RenderBox` height — no external `TextPainter` math, so it works correctly with text scaling and system accessibility settings.
+
+```dart
+GlassTextField(
+  maxLines: 6,
+  onLineCountChanged: (lines) {
+    setState(() => _borderRadius = lines > 1 ? 8.0 : 20.0);
+  },
+)
+```
+
+### `iconAlignment` parameter
+
+Controls where prefix/suffix icons sit when the field spans multiple lines:
+
+```dart
+// Pin send button to bottom — chat composer pattern:
+GlassTextField(
+  maxLines: 6,
+  iconAlignment: CrossAxisAlignment.end,
+  suffixIcon: Icon(Icons.send),
+)
+```
+
+Accepts `CrossAxisAlignment.start` (top), `.center` (default), or `.end` (bottom). No visible effect on single-line fields.
+
+All three features are forwarded through `GlassTextArea`.
+
+### `GlassTextField.search` named constructor
+
+A new convenience constructor that pre-configures `GlassTextField` with compact search-bar defaults: `height: 44`, `iconSpacing: 8`, `padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8)`, `borderRadius: 22`, and `textInputAction: TextInputAction.search`. Eliminates the boilerplate previously required to match `GlassSearchBar` visuals:
+
+```dart
+GlassTextField.search(
+  placeholder: 'Search messages…',
+  prefixIcon: Icon(CupertinoIcons.search, size: 20),
+  useOwnLayer: true,
+)
+```
+
+`GlassSearchBar` now uses this constructor internally, reducing duplicated decoration code.
+
+## 🐛 Fix
+
+- **`onLineCountChanged` now fires on programmatic controller changes** — Previously the callback only responded to physical keyboard input (`TextField.onChanged`). Setting `controller.text = '...'` or calling `controller.clear()` (e.g. in a chat "Send" handler) did not re-measure the line count. The widget now actively listens to the `TextEditingController` and re-measures on any text mutation.
+
+- **Suffix icon spacing now respects `iconSpacing`** — The gap before the suffix icon was hard-coded to 12px while the prefix icon correctly used `widget.iconSpacing`. Both sides now use the same parameter.
+
+# 0.12.1
+
+## 🐛 Fix — eliminate rectangular blur halo over PlatformViews (iOS Impeller)
+
+`LightweightLiquidGlass` and `_FrostedFallback` previously wrapped their glass surface in `ClipPath(ShapeBorderClipper(...))`. When the parent was an iOS PlatformView (e.g. `mapbox_maps_flutter` `MapWidget`, `video_player` on iOS), the descendant `BackdropFilter`'s rectangular blur output leaked past the rounded clip — visible as a faint square halo around the rounded glass shape, most obvious when light backdrop content scrolled underneath.
+
+Flutter framework [PR #177551](https://github.com/flutter/flutter/pull/177551) (merged Dec 2025, shipped in 3.41.0-0.0.pre+) fixed this at the engine level by forwarding `ClipRRect` clip data to the iOS PlatformView mutator stack — but **only `ClipRRect`, not `ClipPath`**, even when the path inside is mathematically a rounded rect.
+
+This release routes shapes that resolve to a `RoundedRectangleBorder` (i.e. `LiquidRoundedSuperellipse`, `LiquidVerticalRoundedSuperellipse`) through `ClipRRect` instead of `ClipPath`. The engine fix now triggers and the halo disappears for those shapes.
+
+`LiquidOval` is intentionally NOT routed through `ClipRRect` — empirically the engine fix doesn't forward `ClipRRect` with `circular(double.infinity)` nor a `LayoutBuilder`-computed finite radius on the `LiquidOval` path. Callers that need a halo-free circular glass surface over a PlatformView should use `LiquidRoundedSuperellipse(borderRadius: size / 2)` instead, which renders identically on a square widget and triggers the engine fix.
+
+Closes upstream Flutter [#175048](https://github.com/flutter/flutter/issues/175048) and [#115926](https://github.com/flutter/flutter/issues/115926) for `liquid_glass_widgets` users.
+
+*Based on [PR #61](https://github.com/sdegenaar/liquid_glass_widgets/pull/61) by [@jfhair](https://github.com/jfhair).*
+
+# 0.12.0
+
+## ✨ New
+
+### `LiquidGlassWidgets.wrap()` — `theme` parameter
+
+`wrap()` now accepts an optional `GlassThemeData? theme` parameter. When provided, it wraps the child in a `GlassTheme` — eliminating the need for a separate `GlassTheme` widget in your tree.
+
+### `LiquidGlassSettings.standardOpacityMultiplier`
+
+A new multiplier applied to the glass colour alpha when rendering in Standard mode. This allows tuning Standard 2D compositing opacity to achieve more parity with Premium 3D volumetric refraction without needing separate colour values for each mode.
+
+```dart
+LiquidGlassSettings(
+  glassColor: Colors.white.withValues(alpha: 0.3),
+  standardOpacityMultiplier: 0.4, // Standard renders at 0.3 × 0.4 = 0.12 alpha
+)
+```
+
+Defaults to `1.0` (no change). Fully interpolated via `LiquidGlassSettings.lerp()` and wired through `copyWith()`.
+
+### `GlassPage` — full-screen glass scaffold
+
+A new full-screen scaffold widget for glass-based layouts. Handles background imagery, status bar styling, and background sampling in a single widget.
+
+`enableBackgroundSampling` defaults to `true` when a `background` widget is provided, and `false` otherwise — so the common case just works without extra configuration.
+
+```dart
+GlassPage(
+  background: Image.asset('assets/wallpaper.jpg'),
+  child: Scaffold(...),
+)
+```
+
+### Export hygiene
+
+- `glass_page.dart` now uses a `show` clause: only `GlassPage` and `GlassStatusBarStyle` are exported (internal state classes are no longer public).
+- `liquid_glass_scope.dart` now uses a `show` clause: only `LiquidGlassScope`, `GlassBackgroundSource`, and `GlassRefractionSource` are exported.
+
+## 🎨 Visual — Standard/Premium parity improvements
+
+### Shader composite improvements (`lightweight_glass.frag`)
+
+The Standard-tier lightweight shader composite logic has been improved for closer visual parity with the Premium Impeller path. Shader rim constants are **unchanged** from 0.11.0 — AdaptiveGlass normalization now handles Premium → Standard scaling in Dart space instead:
+
+- **PATH A** (background texture): now uses `applyGlassColorLW()` — a luminosity-preserving glass tint that matches Premium's colour handling for both chromatic (mint, bronze) and achromatic (white, grey) glass colours.
+- **PATH A** ambient darkening: `ambientStrength × 0.25 + 0.08` creates the glass shadow effect that visually separates glass from non-glass, matching what Premium achieves through blur compositing.
+- **PATH A** adaptive rim colour: `mix(bgRgb, white, 0.7)` brightens the background at the edge, matching Premium's `getHighlightColor`.
+- **PATH A** edge-zone refraction: indicator-style background warping at rounded corners using `smoothstep` edge zone with quadratic falloff — the same proven approach as `interactive_indicator.frag` but scaled for containers. Zero transcendentals (polynomial `smoothstep` + multiplies only). Flat interior pixels naturally produce zero offset. Currently active on surface widgets (`GlassBottomBar`, `GlassTabBar`, `GlassSideBar`, `GlassToolbar`) when a `backgroundKey` is provided; `GlassCard` and `GlassButton` use PATH B and will benefit once `AdaptiveGlass` gains scope-aware background key passthrough.
+- **PATH A** unified interactive glow: `uGlowIntensity` press-feedback now applies in PATH A, closing an architectural gap where switch/slider thumbs inside background-sampled containers had no glow.
+- **Volumetric depth gradient**: subtle top-to-bottom ambient shading (`+vertCoord × 0.04`) in both PATH A and PATH B creates a natural 3D anchored depth feel, simulating light entering from above. Cost: one multiply + one add per fragment.
+- **PATH B** frost floor: 8% minimum material alpha ensures glass surfaces are always visible when `glassColor.a = 0` (Premium default), preventing invisible glass in SrcOver compositing.
+- **PATH B** contrast-adaptive rim: shifts rim colour toward mid-grey on bright backgrounds so white-on-white borders remain distinguishable.
+- **Directional rim bonus**: a small `0.15 × directionalInfluence × lightIntensity` term adds subtle lit-side variation on top of the constant rim base — matching how Premium's 3D bevel naturally brightens toward the light source.
+
+### Interactive widget transparency tuning
+
+- `GlassSwitch` standard thumb: `baseAlphaMultiplier: 0.0`, `edgeAlphaMultiplier: 0.15` — fully transparent body with subtle edge presence for a cleaner glass look.
+- `GlassSlider` standard thumb: `baseAlphaMultiplier: 0.08`, `edgeAlphaMultiplier: 0.1` — minimal body opacity with soft edge glow.
+
+### Elevated widget predictability
+
+Removed the arbitrary `+0.2` alpha boost on elevated widgets inside `AdaptiveGlass`. Elevation is now expressed purely through the shader's `densityFactor` physics, making the opacity response predictable and proportional to user settings.
+
+### Interactive widget normalisation (`GlassEffect`)
+
+Standard-tier interactive indicators (slider thumbs, switch thumbs, segmented control pills) now apply the same normalisation as `AdaptiveGlass` — `thickness × 0.4`, `lightIntensity × 0.6` — preventing the 2D shader from rendering these elements heavier than their Premium counterparts.
+
+## 📦 Example app
+
+- Quality comparison demo background image bundled as a local asset (`example/assets/mountain_landscape.jpg`) — eliminates network dependency and first-frame loading flash.
+
+---
+
+# 0.11.0
+
+## ✨ New — Liquid Morph Engine (new architectural system)
+
+This release introduces the **Liquid Morph Engine** — a standalone, reusable physics and animation system for iOS 26-style liquid glass morphing. It lives in `lib/engine/` and is fully decoupled from any specific widget.
+
+`GlassMenu` is the **first consumer** of the engine. Future widgets (sheets, cards, buttons) will use the same engine to achieve consistent, physics-correct liquid glass transitions throughout the library.
+
+> **Documentation:** [`docs/LIQUID_MORPH_ENGINE.md`](docs/LIQUID_MORPH_ENGINE.md) — full guide covering `GlassMorphController`, `LiquidMorphState`, `LiquidMorphPhysics`, and how to integrate the engine into your own custom widgets.
+
+### Core engine types
+
+| Type | Role |
+|---|---|
+| `GlassMorphController` | Lifecycle owner — manages the spring, exposes `open()` / `close()` |
+| `LiquidMorphState` | Immutable value object — one per frame, contains all render values |
+| `MorphPhase` | Semantic lifecycle enum — tells you where in the animation you are |
+| `MorphSpeed` | Enum — controls spring stiffness without exposing raw physics constants |
+| `LiquidMorphPhysics` | Internal stateless math engine |
+
+### How it works
+
+Two conceptual "blobs" drive every morphing animation:
+
+- **Blob A** (anchor) — the ghost trigger that shrinks away over the first 40 % of the animation, cleanly breaking the liquid bridge.
+- **Blob B** (body) — travels from the trigger centre to the widget centre along a J-curve overshoot trajectory, expanding from trigger size to target size.
+
+The SDF metaball shader creates the teardrop neck between the blobs automatically — there is no explicit neck geometry. `LiquidMorphPhysics.compute()` determines each blob's position, scale, and blend factor on every frame.
+
+### `GlassMenu` — first engine consumer
+
+- **Teardrop open animation** · The menu grows from the trigger point along the dual-curve SDF path, producing the iOS 26 "bubble emerging from button" effect.
+- **Rubber-band close physics** · On dismiss the teardrop recoils with a critically-damped spring + overshoot tail, matching the tactile snap of native iOS context menus.
+- **Velocity-bump alignment** · Spring initial velocity is seeded from touch velocity at release — fast flicks close snappily, slow releases settle deliberately.
+- **Handoff latching** · Re-opening during a close animation inherits the in-flight velocity and reverses smoothly — no pop or cut.
+- **Blob scaling** · Blob sizes scale relative to trigger size and computed menu height, so short and tall menus receive proportionally correct teardrop curvature.
+
+> **See it live:** The [Apple Messages demo](example/lib/apple_messages/apple_messages_demo.dart) (`cd example && flutter run -t lib/apple_messages/apple_messages_demo.dart`) showcases the morphing engine in a real-world context — tap the menu or **Edit** button at the top of the screen to trigger the `GlassMenu` with full teardrop open/close physics.
+
+### Spring physics refinements
+
+- Critical damping (`ζ = 1.0`) on all spring controllers prevents oscillation on rapid successive opens.
+- `interactionScale`, `stretch`, and `stretchResistance` integrate into the morphing path via the same spring solver used by `LiquidStretch`.
+
+## 🐛 Fixes
+
+- **`GlassMenu` — safe area / notch clipping on iOS and Android** · Menu position and maximum height were computed from `MediaQuery.padding`, which is consumed by ancestor `SafeArea` widgets and reports `0` inside a fully-safe tree. Switched to `View.of(context).padding` (raw hardware insets) so the menu is always clamped correctly regardless of `SafeArea` nesting depth. Fixes the menu appearing under the Dynamic Island on iPhone 14 Pro and similar devices.
+
+- **`GlassMenu` (scrollable) — scrolling now works on large menus** · Menus with more items than fit on screen can now be scrolled reliably.
+
+## 🗂 Example restructure — `demos/` suite
+
+The `example/` package has been reorganised for a cleaner public-facing demo experience:
+
+- New `example/lib/demos/` folder containing seven self-contained, copy-pasteable demos:
+  - **`glass_menu_demo.dart`** — all 9 `GlassMenuAlignment` positions, scrollable item list
+  - **`glass_tab_bar_scrollable_demo.dart`** — scrollable `GlassTabBar` with dynamic tab add
+  - **`glass_modal_sheet_demo.dart`** — all sheet states (peek / half / full), Apple Maps peek style
+  - **`glass_bottom_bar_demo.dart`** — magic-lens masking with `GlassBottomBar`
+  - **`bottom_bar_tab_width_demo.dart`** — `tabWidth` on both bar variants side-by-side
+  - **`searchable_bar_demo.dart`** — `GlassSearchableBottomBar` edge cases
+  - **`shape_debug_demo.dart`** — `GlassButton` shape visualiser
+
+- **Apple Messages demo** (`example/lib/apple_messages/`) — showcases the Liquid Morph Engine in a full real-world context; tap the menu or **Edit** button at the top to trigger `GlassMenu`.
+- `example/lib/modal_sheet_showcase/` removed (file moved to `demos/glass_modal_sheet_demo.dart`).
+- Experimental scratchpad scripts moved to git-ignored `example/lib/playground/`.
+
+---
+
+# 0.10.10
+
+
+Thanks to [@g3mf0r](https://github.com/g3mf0r) for [PR #55](https://github.com/sdegenaar/liquid_glass_widgets/pull/55). 🙏
+
+## ✨ New
+
+- **`GlassMenu` — `menuAlignment` enum** · A new `GlassMenuAlignment` enum (10 values: `none`, `topLeft`, `topCenter`, `topRight`, `centerLeft`, `center`, `centerRight`, `bottomLeft`, `bottomCenter`, `bottomRight`) lets you pin the menu to a specific edge or corner of its trigger instead of relying solely on auto-detection. The enum is now part of the public API surface exported from `glass_menu.dart`.
+
+- **`GlassMenu` — `autoAdjustToScreen` with `menuPadding`** · When `autoAdjustToScreen: true`, the new `menuPadding: EdgeInsets?` parameter applies additional inset constraints so the menu body never clips against device edges.
+
+- **`GlassMenu` — `itemBorderRadius`** · Controls the corner radius of individual menu item cells, independent of the outer `menuBorderRadius`.
+
+## 🐛 Fixes
+
+- **`GlassTabBar` — multi-tab drag jump** · Dragging the indicator across multiple tab widths in a single gesture now snaps to the correct distant tab. The previous implementation only incremented/decremented by ±1 regardless of drag distance, causing the indicator to teleport unexpectedly when the finger crossed more than one tab boundary.
+
+- **`GlassTabBar` — glass refraction during indicator drag** · Refraction and shadow effects are correctly suppressed during the drag animation and restored on settlement, eliminating a visual glitch where the glass distortion would persist after releasing the indicator.
+
+## 🧪 Tests
+
+- Added 4 new `GlassMenu` tests covering `GlassMenuAlignment` enum values, `menuAlignment` parameter, `autoAdjustToScreen` + `menuPadding`, and `itemBorderRadius`.
+- Added 2 new `GlassTabBar` tests covering multi-tab drag jump (left and right) to prevent regression of the PR #55 fix.
+
+---
+
+# 0.10.9
+
+Thanks to [@g3mf0r](https://github.com/g3mf0r) for [PR #54](https://github.com/sdegenaar/liquid_glass_widgets/pull/54). 🙏
+
+## ✨ New
+
+- **`GlassTabBar` (scrollable) — jelly physics on indicator drag** · The scrollable indicator pill now feeds real-time drag velocity into the liquid glass shader, producing the same organic stretch-and-settle effect that fixed-mode tabs already had.
+
+## 🐛 Fixes
+
+- **`LiquidGlassWidgets.wrap` — `adaptiveQuality: true` without `adaptiveConfig` permanently locks to `standard`** · The default fallback config was created with `initialQuality: GlassQuality.standard`, which the adapter treats as a skip-Phase-2 signal — immediately jumping to Phase 3 at `standard` without ever running the warmup benchmark. On capable devices (including the iPhone simulator on Apple Silicon) this prevented the adapter from ever discovering that the device can sustain `premium`. Fixed by removing the erroneous `initialQuality` from the fallback; Phase 2 now always runs when no explicit quality is provided.
+
+- **`GlassTabBar` (scrollable) — indicator overflows bar on low tab counts** · The right drag boundary was computed as `viewMax` instead of `viewMax - indicatorWidth`, allowing the pill to slide outside the bar when there were only 2–3 wide tabs. Corrected to `viewMax - targetWidth`.
+
+- **`GlassTabBar` (fixed) — tiny accidental drags switch tabs** · Tab switching on drag-end now requires either a displacement greater than 20 % of the tab width **or** a flick velocity above 400 px/s, preventing unintended switches from small incidental movements.
+
+- **`GlassTabBar` (scrollable) — flick gesture ignored in scrollable mode** · A horizontal flick with sufficient velocity now overrides the nearest-tab distance calculation and advances the indicator in the flick direction, matching the fixed-mode behaviour.
+
+---
+
+# 0.10.8
+
+
+Thanks to [@g3mf0r](https://github.com/g3mf0r) for [PR #52](https://github.com/sdegenaar/liquid_glass_widgets/pull/52). 🙏
+
+## 🐛 Fixes
+
+- **`GlassTabBar` — indicator drag drift on desktop/web** · The indicator position was accumulated via `delta.dx` additions each frame, causing the pill to visually lag behind the pointer on desktop platforms where pointer events arrive at a higher frequency than the frame budget. Fixed by computing position from the absolute global pointer coordinate on every update event, eliminating accumulated drift.
+
+- **`GlassTabBar` (scrollable) — tab labels hidden behind indicator pill** · The `SingleChildScrollView` (tab labels) and the background pill were inserted in the wrong stack order — labels were painted first, then the pill on top, obscuring them. Fixed by inserting the pill before the labels so labels always paint above the pill (correct z-order).
+
+- **`GlassTabBar` (scrollable) — indicator fly-off past bar edges** · The indicator pill had no boundary clamping in scrollable mode, allowing it to animate outside the visible bar area. Drag offset is now clamped to `[scrollOffset - 35 %, scrollOffset + screen + 35 %]`.
+
+## ✨ New
+
+- **`DividerSettings`** — new optional `dividerSettings` parameter on `GlassTabBar`. Renders animated vertical dividers between tabs with configurable `thickness`, `indent`, `endIndent`, custom `decoration`, animation `duration`/`curve`, and an `isHideAutomatically` flag that fades out dividers adjacent to the active tab. Includes a `copyWith` helper for convenient inline customisation.
+
+- **Grab-to-drag in scrollable mode** — the indicator pill in scrollable mode can now be directly grabbed and dragged to a new tab. Uses a `GestureArenaTeam` (`HorizontalDragGestureRecognizer` as captain + `TapGestureRecognizer`) to correctly win the arena against the `SingleChildScrollView` when the initial touch is within the active indicator's bounds. The scroll view retains natural scrolling behaviour when touching outside the pill.
+
+- **`indicatorShadow`** — new optional `indicatorShadow: List<BoxShadow>?` parameter on `GlassTabBar`. Applies a drop shadow to the resting (solid-colour) indicator pill, improving contrast in light-mode themes where the pill and track share similar colours. The shadow is automatically suppressed during the liquid glass drag animation so it does not interact with the backdrop blur, and restored when the pill returns to its idle state.
+
+---
+
+# 0.10.7
+
+
+Thanks to [@yukinoaruu](https://github.com/yukinoaruu) for [PR #51](https://github.com/sdegenaar/liquid_glass_widgets/pull/51). 🙏
+
+## 🐛 Fixes
+
+- **`GlassMenu` — trigger button dead zone after closing** · After closing the menu, the trigger button would ignore taps for the duration of the closing spring animation (~95% of travel), forcing the user to wait several seconds before being able to reopen it. Fixed by separating the visual-hide threshold (`0.05`) from the input-block threshold (`0.80`) into two independent booleans: `isButtonVisible` and `isMenuBlocking`. The button now becomes tappable again as soon as the animation drops below 80%, and the morphing glass overlay wraps in `IgnorePointer(ignoring: value < 0.8)` to prevent the contracting container from consuming the tap instead.
+
+---
+
+# 0.10.6
+
+## 🐛 Fixes
+
+- **`GlassBottomBar` — `extraButton` causes bar to float in the middle of the screen** · Wrapped the inner `Row` in a `SizedBox(height: barHeight)` so the `Scaffold.bottomNavigationBar` slot always receives an explicit tight height constraint. Without this, the `Expanded` child introduced by `extraButton` propagated an unbounded height through `LiquidGlassLayer`, causing Flutter to render the bar centred on screen instead of pinned to the bottom edge.
+
+---
+
+
+# 0.10.5
+
+## ✨ New
+
+- **`SearchableBottomBarController`** — added `openSearch()`, `closeSearch()`, and `isSearchOpen` getter for programmatic search control. Previously the only way to open search was by driving `isSearchActive` from parent state.
+- **`GlassTabBar`** — added `maskingQuality` parameter (`MaskingQuality.high` / `MaskingQuality.off`), matching the existing `GlassBottomBar` API. Set to `off` to disable the 8 px jelly-bloom expansion on lower-end devices.
+- **`GlassSlider`** — added `interactionBehavior`, `glowColor`, and `glowRadius` for consistent drag-glow customisation across all interactive widgets.
+- **`GlassSegmentedControl`** — same `interactionBehavior`, `glowColor`, `glowRadius` params added for API parity with `GlassSlider` and `GlassTextField`.
+- **`LiquidGlassWidgets.respectsAccessibility`** — deprecated alias added pointing to `respectSystemAccessibility`. Will be removed in v1.0.
+
+## 🐛 Fixes
+
+- **`GlassTextField`** — fixed a use-after-dispose crash when `focusNode` cycled `null → external → null`. The widget now tracks ownership with an explicit `_ownsNode` flag and correctly creates a fresh internal node on each transition.
+- **`GlassTabBar`** — resolved scrollable-mode visual glitches. The indicator now stays perfectly glued to the active tab during scrolling without drifting, uses native "snappy" spring physics for consistent feel, and implements a three-layer rendering architecture so the solid indicator pill cleanly clips at the rounded viewport corners while the 8px jelly bloom expands freely over the tab bar boundaries.
+
+# 0.10.4
+
+A huge, heartfelt thank-you to [@yukinoaruu](https://github.com/yukinoaruu) for [PR #49](https://github.com/sdegenaar/liquid_glass_widgets/pull/49). 🙏
+
+We made a mess of the original 0.10.3 merge of his work — introducing regressions that broke the very things he had so carefully built. He came straight back, fixed every issue, and did it with incredible patience and generosity. This release is entirely his. If you are enjoying `GlassMenu`, it is because of him.
+
+## 🐛 Fixes (regressions from 0.10.3 merge)
+
+- **GlassMenu — full-list rebuilds on every pointer event** · Restored the `_cachedWrappedItems` mechanism that was accidentally dropped. The previous merge caused the entire wrapped-item list to be recreated on each pointer move, resetting pressed/hover states mid-gesture and tanking performance on menus with many items.
+- **GlassMenu — selection and hover state precision** · Migrated to a `ValueNotifier` system (`_hoveredIndexNotifier`, `_isDraggingNotifier`). Individual menu items now rebuild in isolation instead of triggering a full `setState` on the entire menu tree, keeping animations at a steady 60 fps.
+- **GlassMenu — ghosting on selection pill** · Fixed a double-background artifact where the selected `GlassMenuItem` painted its own hover fill on top of the sliding pill, producing a faint ghost ring. Selected items now transition to `Colors.transparent` instantly.
+- **GlassMenu — disabled items could be tapped** · Tapping a disabled item no longer calls `onTap` or closes the menu. The pill highlight correctly skips disabled items during pointer tracking.
+- **GlassMenu — double `onTap` firing** · Removed a redundant `onTap` callback in the internal wrapped-item builder that was causing every selection to fire twice.
+- **GlassMenu — `RangeError` when item list shrinks while open** · `didUpdateWidget` now clears `_hoveredIndex` when `items.length` decreases, preventing an out-of-bounds crash when the pill tried to measure a deleted item.
+- **GlassMenuItem — disabled opacity** · Disabled items now render at `Opacity(0.4)` to match the design spec and test expectations.
+- **GlassMenuLabel — hybrid `title`/`child` API** · `GlassMenuLabel` now accepts either a `title` String (rendered as stylised uppercase) or an arbitrary `child` Widget, enabling diverse non-interactive content beyond simple section headers.
+- **GlassMenuLabel — `height` default** · Default `height` set to `30.0` so the selection pill cannot drift when items with non-standard font sizes are mixed in.
+- **GlassMenu — `glowIntensity` parameter** · Added `glowIntensity` and wired it through to `GlassContainer`, completing the full interaction-glow parameter surface.
+- **GlassMenu — `glowOnTapOnly` default corrected** · Default changed to `true` to prevent a permanently stuck glow artefact during scroll and drag gestures.
+- **GlassMenu — stretch parameter rename** · Renamed `allowPositiveXStretch` / `allowNegativeXStretch` / `allowPositiveYStretch` / `allowNegativeYStretch` to `allowPositiveX` / `allowNegativeX` / `allowPositiveY` / `allowNegativeY` to align with the `LiquidStretch` API surface.
+- **GlassMenu — compositing architecture** · Removed redundant `RepaintBoundary` nodes that were leaving descendant glass layers DETACHED from the compositor scene, and moved `GlassGlow` inside `GlassContainer`'s clip subtree to prevent glow bleed onto the background.
+
+## ⚠️ Breaking — `GlassMenu` stretch parameter renames
+
+The four optional stretch-axis override parameters introduced in 0.10.3 have been renamed:
+
+| 0.10.3 name | 0.10.4 name |
+|---|---|
+| `allowPositiveXStretch` | `allowPositiveX` |
+| `allowNegativeXStretch` | `allowNegativeX` |
+| `allowPositiveYStretch` | `allowPositiveY` |
+| `allowNegativeYStretch` | `allowNegativeY` |
+
+All four remain optional with `null` defaults (auto-inferred from menu position). Only code explicitly passing the old names needs updating.
+
+
+# 0.10.3
+
+Big thanks to [@yukinoaruu](https://github.com/yukinoaruu) for [PR #47](https://github.com/sdegenaar/liquid_glass_widgets/pull/47) — a comprehensive interaction engine upgrade for `GlassMenu` that brings it more in line with iOS 26 context menu behaviour. 🙏
+
+## ✨ Features
+
+### Heterogeneous menu items — `GlassMenuDivider` and `GlassMenuLabel`
+
+Menus now accept any `Widget`, enabling iOS 26-style section grouping:
+
+```dart
+GlassMenu(items: [
+  const GlassMenuLabel(title: 'Actions'),    // renders as 'ACTIONS'
+  GlassMenuItem(title: 'Save', onTap: () {}),
+  const GlassMenuDivider(),
+  GlassMenuItem(title: 'Delete', isDestructive: true, onTap: () {}),
+])
+```
+
+`GlassMenuLabel` exposes a `height` parameter (default `30.0`) so custom font sizes don't drift the selection-pill position.
+
+### `GlassMenuItem` — rich content
+
+Six new parameters: `subtitle`, `enabled`, `titleStyle`, `subtitleStyle`, `iconColor`, `iconSize`.
+
+### Scroll-aware selection pill
+
+A sliding highlight follows the pointer and disappears automatically when the user starts scrolling (10 px drag-slop guard + `ScrollNotification` listener).
+
+### Elastic stretch and scroll-safe glow
+
+`GlassMenu` now wraps in `LiquidStretch` for spring physics on drag. `glowOnTapOnly: true` (the new default) suppresses the glass glare after a drag, preventing a stuck-glow artefact during list scrolling. Full parameter surface: `interactionScale`, `stretch`, `stretchResistance`, `stretchAxis`, `allowPositiveX/NegativeX/Y`.
+
+### New primitives on `GlassGlow` and `GlassContainer`
+
+`GlassGlow.enabled`, `GlassGlow.glowOnTapOnly`, and `GlassContainer.glowIntensity` are now available for custom integrations.
+
+## 🐛 Fixes
+
+- **GlassMenu — double `BackdropFilter`** · Removed an extra blur layer above `GlassContainer` that doubled the blur sigma and created an over-frosted ring.
+- **GlassMenu — DETACHED compositing layers** · Removed the outer `RepaintBoundary` wrapping `_buildMorphingContainer`. When `GlassContainer(useOwnLayer: true)` installs a `BackdropFilter` layer it forces compositing on the entire subtree; a `RepaintBoundary` above it fought the compositor for `OffsetLayer` ownership, leaving descendant `RepaintBoundary` nodes (i.e. each `GlassMenuItem`'s glass layer) DETACHED from the scene. `GlassGlow` and `GlassContainer` already own their compositing layers — no extra boundary is needed. Separately, `Opacity` widgets at `>= 1.0` are now skipped entirely so no gratuitous `OpacityLayer` is inserted when compositing is already being forced by a `BackdropFilter` descendant.
+- **GlassMenu — layout overflow during open animation** · `GlassContainer(height: currentHeight)` propagated tight height constraints through its entire subtree during the morph. When menu items became visible (previously at `value > 0.65`), the container was only ~114 px tall while 3 items needed 132 px, causing the `Column` inside `Positioned.fill` to overflow by 18 px. Fixed by deferring content rendering until `value ≥ 0.85`, exactly when `currentHeight` becomes `null` and the container sizes naturally — no tight-constraint cascade possible.
+- **GlassMenu — interaction glow bleeds onto background** · `GlassGlow` previously wrapped `GlassContainer` from the outside. `_RenderGlassGlowLayer.paint()` called `canvas.drawCircle()` over the full overlay canvas with no shape boundary, causing the radial gradient to paint beyond the menu's glass shape onto the background. Fixed by moving `GlassGlow` inside `GlassContainer`'s `clipBehavior: Clip.antiAlias` subtree — matching the architecture used by `GlassButton`.
+- **GlassMenuItem — `AnimatedScale` layout overflow on press** · `AnimatedScale` (backed by `RenderTransform`) retains the pre-scale layout size during a 0.98-scale press animation, causing a spurious overflow against the menu's bounded `Positioned.fill`. Fixed by wrapping `AnimatedScale` in `SizedBox(height: effectiveHeight)` to isolate the transform's layout footprint.
+- **GlassMenu — selection pill layout exception** · `AnimatedPositioned` is now inside a bounded `SizedBox(height: totalH) → Stack`, preventing a debug-mode layout exception and an out-of-bounds pill position when scrolled.
+- **GlassMenu — `RangeError` on item removal** · `didUpdateWidget` clears `_hoveredIndex` when `items.length` shrinks while the menu is open.
+- **GlassMenu — `GlassMenuItem` state flicker** · Wrapped items cached; only rebuilt when `widget.items` changes, preventing pressed/hover resets during the 60 fps spring ticker.
+- **GlassGlow — permanently muted glow** · `didUpdateWidget` resets `_glowSuppressed` when `glowOnTapOnly` is toggled off.
+- **GlassMenuItem — desktop hover state leak** · `dispose()` clears `_isHovered`.
+- **Impeller — extreme-stretch glyph-bounds crash** · Scale determinant clamped before reaching the shader.
+- **Android — negative safe-area assertion** · `sysBottom > 25` guard added.
+
+## ⚠️ Semi-Breaking
+
+`GlassMenu.items` changed from `List<GlassMenuItem>` to `List<Widget>`. Existing code compiles unchanged — only typed `List<GlassMenuItem>` variable declarations need widening.
+
+## 🧪 Tests — 1,648 passing
+
+---
+
+# 0.10.2
+
+
+## Fixes
+
+- **GlassTabBar (scrollable) — indicator clipping** · Migrated the selected-tab indicator to an overlay architecture outside `SingleChildScrollView`, eliminating clip artifacts during scrolling and preserving the full iOS 26 glass bloom expansion.
+- **GlassTabBar (scrollable) — tap fires on scroll** · `onTabSelected` no longer fires when the user scrolls the tab bar; selection is now only triggered on confirmed taps.
+- **GlassTabBar (scrollable) — bloom activates on scroll** · The pressed indicator bloom no longer activates when scrolling the tab bar content.
+- **GlassTabBar (scrollable) — indicator pulsates on transition** · Fixed a threshold bug that caused the bloom to flicker during tab-switch animations.
+- **GlassTabBar (scrollable) — scroll into view** · Tapping or programmatically selecting a partially-visible tab now smoothly scrolls it fully into view.
+- **GlassAdaptiveScope — Android false-negative quality downgrade** · Mid-range Android devices with Impeller/Vulkan can report inflated warmup P75 values (17–18 ms) due to GPU clock-scaling and JIT shader cache warm-up — not actual slowness. The previous `premium` threshold of `< 16 ms` (the raw 60-fps frame budget) was too strict and incorrectly demoted capable hardware to `standard` or `minimal`. Thanks @hank205 for the detailed diagnostic log. 🙏
+- **GlassModalSheet / `.show()` / `GlassModalSheetScaffold` — `dragIndicatorWidth`** · The drag handle pill width was previously hardcoded at 36 (iOS native). A new `dragIndicatorWidth` parameter lets you customise it — e.g. `64` for sheets where a more prominent handle better suits the layout. Defaults to `36`, no breaking change. Thanks @jfhair (#46). 🙏
+
+## Changes
+
+- **`GlassQualityAdapter` / `GlassAdaptiveScopeConfig` / `GlassAdaptiveScope` — configurable warmup thresholds** · Two new parameters let you tune (and help us calibrate) the Phase 2 warmup classification thresholds:
+  - `warmupPremiumThresholdMs` — P75 below this → `premium`. Default raised from `16.0` to **`20.0`** to account for Android GPU warm-up inflation. *(Calibration status: 1 device report — please share yours!)*
+  - `warmupStandardThresholdMs` — P75 at or below this (and above premium) → `standard`. Default **`28.0`**. *(Calibration status: provisional — no real-device data for this band yet.)*
+  - `skipInitialFrames` raised from **60 → 90** (≈1.5 s at 60 Hz) to give Android more time for GPU clocks and shader caches to settle before the benchmark begins.
+
+> **Phase 3 hysteresis remains the safety net.** If a device cannot sustain its warmup-assigned quality, it steps down automatically within ~6 seconds — the new thresholds only affect the initial classification, not runtime correction.
+
+> ⚠ **Community calibration needed** — especially for `warmupStandardThresholdMs`. If your device produces a warmup P75 in the 20–28 ms range, please enable `debugLogDiagnostics: true` and post your P75 + device model to the [Threshold Calibration Discussion](https://github.com/sdegenaar/liquid_glass_widgets/discussions).
+
+# 0.10.1
+
+Big thanks to @yukinoaruu (#43) and @jfhair (#44, #45) for three excellent contributions this release. 🙏
+
+## Fixes
+
+- **GlassModalSheet — child State preservation** · Removed `GlobalObjectKey` from the internal `Focus` bridge. The key was changing every rebuild, quietly tearing down child `State` (scroll positions, controllers, etc.) on each expand/collapse. (#44)
+- **GlassModalSheet — `onStateChanged` skipped on slow drag** · Introduced `_settledState` to track the last published state separately from the in-flight animation target. Side-effects (haptics, callbacks, scroll-to-top) now fire reliably after a drag that crosses a snap threshold mid-gesture. (#45)
+- **GlassModalSheet — ghosting and jitter** · Fixed visual artefacts during sheet transitions. (#43)
+- **GlassModalSheet — element subtree stability** · `LiquidStretch` now always returns a consistent widget type regardless of `interactionScale`/`stretch` values, preventing a full subtree teardown on the frame the sheet reaches full expansion.
+- **LightweightLiquidGlass — null-shader passthrough** · The widget tree shape is now stable while the fragment shader loads asynchronously; a tinted passthrough is painted instead of switching widget types.
+
+# 0.10.0
+
+## ⚠️ Breaking — Pre-v1 API Cleanup
+
+### `LiquidGlassWidgets.wrap()` — `child` is now a required named parameter
+
+Before:
+```dart
+LiquidGlassWidgets.wrap(const MyApp(), adaptiveQuality: true)
+```
+After:
+```dart
+LiquidGlassWidgets.wrap(child: const MyApp(), adaptiveQuality: true)
+```
+This aligns with Flutter widget conventions where `child` is always named.
+
+### `GlassModalSheetScaffold` — parameter renames
+
+| Old | New | Reason |
+|-----|-----|--------|
+| `background:` | `body:` | Matches Flutter `Scaffold.body` — it's the primary content, not a visual property |
+| `sheetChild:` | `sheet:` | Cleaner, matches Flutter naming patterns |
+
+Before:
+```dart
+GlassModalSheetScaffold(
+  background: MyMapWidget(),
+  sheetChild: MySheetContent(),
+)
+```
+After:
+```dart
+GlassModalSheetScaffold(
+  body: MyMapWidget(),
+  sheet: MySheetContent(),
+)
+```
+
+### `GlassQualityAdapter.skipStaticProbeForTesting` — `@visibleForTesting` annotated
+
+The static field is now annotated `@visibleForTesting`. Production code referencing it
+will receive an analyzer hint. Usage in test files is unchanged.
+
+## 🐛 Fix — Android glass fallback on capable devices
+
+`GlassQualityAdapter` was applying the static probe result (`GlassQuality.minimal`) without
+respecting `minQuality`. On some Android devices `ImageFilter.isShaderFilterSupported`
+returns a false negative, causing the glass shader to be skipped even though the hardware
+supports it — the only workaround being `adaptiveQuality: false`.
+
+`minQuality` is now honoured as a true floor even when the static probe fires:
+
+```dart
+// Prevents fallback on Android devices with a false-negative static probe
+LiquidGlassWidgets.wrap(
+  child: const MyApp(),
+  adaptiveQuality: true,
+  adaptiveConfig: const GlassAdaptiveScopeConfig(
+    minQuality: GlassQuality.standard,
+  ),
+)
+```
+
+## ✨ New — Community contributions
+
+### `GlassSearchBarConfig.searchIcon` — custom search icon (PR #41)
+
+Thanks to [@jfhair](https://github.com/jfhair) for [PR #41](https://github.com/sdegenaar/liquid_glass_widgets/pull/41).
+
+The search pill now accepts a fully custom `Widget` in place of the default `CupertinoIcons.search` glyph:
+
+```dart
+GlassSearchBarConfig(
+  onSearchToggle: (active) { … },
+  searchIcon: const Icon(CupertinoIcons.sparkles, color: Colors.white),
+)
+```
+
+When `searchIcon` is `null` (default) the behaviour is unchanged.
+
+### `indicatorExpansion` — tunable jelly-stretch on bottom bars (PR #40)
+
+Thanks to [@jfhair](https://github.com/jfhair) for [PR #40](https://github.com/sdegenaar/liquid_glass_widgets/pull/40).
+
+Both `GlassBottomBar` and `GlassSearchableBottomBar` now expose `indicatorExpansion`
+to control how far the active-tab pill stretches during a drag gesture:
+
+```dart
+GlassBottomBar(
+  tabs: myTabs,
+  selectedIndex: _index,
+  onTabSelected: _onTab,
+  indicatorExpansion: 8,   // default 14; lower = tighter morph
+)
+```
+
+### `GlassModalSheet` — two-phase organic interpolation (PR #39)
+
+Thanks to [@yukinoaruu](https://github.com/yukinoaruu) for [PR #39](https://github.com/sdegenaar/liquid_glass_widgets/pull/39).
+
+The sheet's corner-radius animation now uses a two-phase curve that separates the
+rapid initial expansion from the final settle, eliminating the snapping artifacts
+that were visible at the `half → full` transition on some devices.
+
+The fix also corrects `resolveAdaptiveRadius` to use **logical screen height**
+(`MediaQuery.size.height`) instead of `viewPadding.top` as the primary Pro Max
+detector, preventing false-positive 54 dp radii on some non-Pro-Max iPhones with
+unusually high status-bar padding.
+
+### Asymmetric top/bottom corner radii in premium pipeline (PR #42)
+
+Thanks to [@jfhair](https://github.com/jfhair) for [PR #42](https://github.com/sdegenaar/liquid_glass_widgets/pull/42).
+
+`LiquidVerticalRoundedSuperellipse` now feeds independent top/bottom corner radii
+into the premium SDF shader via a 7-float-per-shape stride, enabling sheets that
+hug the device chassis curve at the bottom while keeping a tighter radius at the
+top — matching the Apple Music / Apple Maps card style:
+
+```dart
+LiquidGlass(
+  shape: const LiquidVerticalRoundedSuperellipse(
+    topRadius: 20,
+    bottomRadius: 54, // tracks iPhone 15 Pro Max chassis
+  ),
+  child: myContent,
+)
+```
+
+> **Shader note**: all shaders continue to pass `glslangValidator` SPIR-V
+> validation. The new stride-7 path is gated on `type == 3` in `sdf.glsl`
+> and leaves the existing stride-6 path untouched.
+
+---
+
+# 0.9.6
+
+## 🐛 Fix — `GlassModalSheet` interaction glow in full state
+
+Thanks to [@yukinoaruu](https://github.com/yukinoaruu) for [PR #38](https://github.com/sdegenaar/liquid_glass_widgets/pull/38).
+
+- **Haptic & glow suppression in full state:** `HapticFeedback.selectionClick()` and
+  `_saturationController.forward()` were firing on every touch when the sheet was in
+  `SheetState.full` — where the glass surface is fully opaque and neither effect is visible.
+  Both are now gated on `!isFull`, eliminating spurious haptic feedback and redundant
+  animation ticks.
+- **Background glass hides when content glass is active:** Added an `Opacity(0.0)` on the
+  background `AdaptiveGlass` layer when `expandProgress > 0.98` and `maintainContentGlass`
+  is enabled. Prevents "glass on glass" shader conflicts in Premium mode at full expansion.
+- **Interaction glow threshold tightened:** `GlassGlow` pulse guard lowered from
+  `expandProgress < 0.98` to `< 0.9` to match the existing saturation gate — consistent
+  behaviour across all glow signals.
+- **`GlassModalSheet` geometry defaults refined:** `topBorderRadius` defaults to `56`
+  (was `null`), `horizontalMargin` to `5.0` (was `8.0`), `bottomMargin` to `6.0`
+  (was `8.0`) for tighter, more native-feeling geometry.
+- **`InteractionNotification` exported:** `InteractionNotification` is now part of the
+  public API surface, enabling consumers to dispatch Smart Silence events from their own
+  widgets.
+- **Corner radius tuning:** `GlassThemeHelpers.resolveAdaptiveRadius` values updated to
+  54 / 46 / 46 (Pro Max / Pro / Notch) for a more conservative, closer-to-system look.
+
+## 🧪 Tests — Coverage improvements (1,573 tests)
+
+Extended branch coverage across five previously under-tested subsystems.
+Full test count grew from 1,491 → 1,573 (+82 tests).
+
+---
+
+# 0.9.5
+
+## ✨ Feature — Asymmetric corner radii & floating peek geometry for `GlassModalSheet`
+
+Thanks to [@yukinoaruu](https://github.com/yukinoaruu) for [PR #37](https://github.com/sdegenaar/liquid_glass_widgets/pull/37).
+
+- **Shader fix:** `lightweight_glass.frag` now supports per-quadrant corner radii via a new `uData6` uniform (slots 24–27). A sentinel of `uCornerRadius = -1.0` enables asymmetric mode; all existing symmetric shapes fall through unchanged.
+- **Clip gap fix:** `ClipPath` geometry on the Skia/Web path is now aligned to `RoundedRectangleBorder` (circular arc) to match the shader SDF — eliminates the sub-pixel transparent notch at sheet corners.
+- **Peek geometry:** Five new optional params on `GlassModalSheet` / `GlassModalSheetScaffold` — `peekWidth`, `peekHorizontalMargin`, `peekBottomMargin`, `peekTopBorderRadius`, `peekBottomRadius` — for Apple Maps-style floating pill peek states.
+- **Cleanup:** `forceSpecularRim` removed from `AdaptiveGlass`, `GlassSheet`, `GlassModalSheet`, and `GlassModalSheetScaffold`. The shader renders the specular rim natively; no migration needed.
+
+## 🐛 Fix — `GlassSearchableBottomBar` dismiss pill focus & keyboard restoration
+
+The dismiss (×) pill was calling `FocusScope.of(context).unfocus()` which left the `FocusNode` in a "previously focused" state. This caused Flutter to restore the keyboard on back-navigation, and made the first post-dismiss tap get swallowed by focus routing.
+
+**Fixed by:**
+- Replacing `FocusScope.unfocus()` with `FocusManager.instance.primaryFocus?.unfocus()` in the DismissPill, fully clearing focus state.
+- The × button now **only dismisses the keyboard** — it does not collapse the search state. This matches the real Apple Music / Apple News behaviour where the search bar remains visible (unfocused/ready) after tapping ×. The caller explicitly collapses search by tapping the home pill or switching tabs.
+- `onCancelTap` fires first (before the unfocus) so callers can react (clear results, analytics, etc.) before focus is released.
+
+A new `onCancelTap: VoidCallback?` on `GlassSearchBarConfig` gives callers a hook into the × tap.
+
+## ✨ Demo — Apple Music mini-player refinements
+
+High-fidelity improvements to the Apple Music demo to match the real Apple Music app:
+
+- **Play pill visibility:** The floating play pill now stays visible when the search bar is in the "search ready" state (keyboard dismissed). It only hides when the keyboard is actively up (`_searchFieldFocused`), matching real Apple Music behaviour.
+- **Dynamic icon colour:** `collapsedLogoBuilder` now shows the selected (red) icon in scroll-collapse mini mode and the unselected (white) icon when search is active, via a static `_kTabs` field so tab definitions aren't duplicated.
+- **Play pill positioning:** `aboveBarBottom` is now responsive to the bar's current height — switching to `collapsedNavBarH` when search is active so the pill doesn't drop excessively when the bar shrinks.
+- **Play pill animates on search from mini mode:** When search is activated from the scroll-collapsed mini state, the play pill animates from the mini gap position back to its full-width position above the expanded search bar, matching real Apple Music.
+- **Home pill restores full bar from any state:** Tapping the home pill now always calls `_dismissMiniMode()` when in mini mode — whether arriving from scroll-collapse or from search — scrolling to top and restoring the full 3-tab bar.
+- **Library default preserved:** `collapsedLogoBuilder` in the library remains `unselectedIconColor` — the Apple Music colour logic is isolated to the demo's `GlassSearchBarConfig`.
+- **Multi-tab scroll fix:** `_dismissMiniMode` now uses `_activeScrollController` (per active tab) instead of hardcoding the home tab's controller, fixing a bug where tapping Radio/Library in mini mode would leave the bar stuck.
+
+---
+
+# 0.9.4
+
+
+## ✨ Feature — `GlassSearchableBottomBar` programmatic interaction callbacks
+
+Addresses two community-requested quality-of-life gaps for `GlassSearchableBottomBar`.
+
+### 1. `onBarTap` — tap-to-restore after scroll-to-hide
+
+A new `onBarTap: VoidCallback?` parameter on `GlassSearchableBottomBar` fires whenever the user taps anywhere on the bar. The callback is wired through a **translucent** `GestureDetector` wrapper, so all internal handlers (tab selection, search toggle, indicator drag) continue to work normally — there is zero interference.
+
+Primary use-case is restoring the bar after a scroll-to-hide animation that is managed in the caller's code:
+
+```dart
+GlassSearchableBottomBar(
+  onBarTap: () => setState(() => _barVisible = true),
+  ...
+)
+```
+
+When `onBarTap` is `null` (the default) no extra widget is inserted into the tree — zero overhead.
+
+### 2. `onSearchFieldTap` — detect taps on the active search field
+
+A new `onSearchFieldTap: VoidCallback?` parameter on `GlassSearchBarConfig`, passed directly to `TextField.onTap`. Fires on every tap of the expanded search field body, including re-focus taps after the keyboard was dismissed.
+
+Useful for navigating to a dedicated search screen, showing a suggestion overlay, or logging an analytics event without needing to own the `FocusNode`:
+
+```dart
+GlassSearchBarConfig(
+  onSearchToggle: ...,
+  onSearchFieldTap: () {
+    showSuggestions();
+    analytics.log('search_field_tapped');
+  },
+)
+```
+
+Zero breaking changes. Both parameters are optional with `null` defaults.
+
+---
+
+# 0.9.3
+
+## ✨ Feature — `GlassModalSheet` system & rendering performance refinement
+
+Big thanks to [@yukinoaruu](https://github.com/yukinoaruu) for [PR #33](https://github.com/sdegenaar/liquid_glass_widgets/pull/33) — a comprehensive and beautifully engineered contribution that brings a whole new class of interactive modal sheet to the library.
+
+### 1. `GlassModalSheet` system
+
+A new, comprehensive modal sheet implementation supporting three interactive states: `peek`, `half`, and `full`.
+
+- **Physics-Driven Transitions:** Spring physics for fluid, organic state changes.
+- **Asymmetric Geometry:** Morphs from a rounded floating pill to a sharp-bottomed full-screen container using the new `LiquidVerticalRoundedSuperellipse`.
+- **Isolated Mechanics:** Logic separated into a robust state machine (`glass_modal_sheet_state.dart`) and physics handler (`glass_modal_sheet_mechanics.dart`) — a clean architectural blueprint for future complex components.
+
+### 2. Device-Aware Adaptive Radius
+
+An intelligent radius resolution algorithm that infers the ideal corner curvature from the device's physical safe area — Dynamic Island vs. Notch vs. Android Home Bar — automatically matching glass curvature to device hardware without manual updates.
+
+### 3. Advanced Visual Feedback — Pulse System
+
+A global pulse synchronisation system in the rendering layer allows `GlassModalSheet` to trigger coordinated saturation and lighting pulses during high-velocity interactions, giving the glass surface a "living", organic feel.
+
+### 4. Smart Silence — `suppressInteractionOnChildren`
+
+`InteractionNotification` support prevents the "double-reacting" artifact where both a button **and** the sheet scale simultaneously on a single tap. Child buttons/switches can seamlessly suppress the parent sheet's scaling and glow effects when tapped.
+
+### 5. New shapes & `LiquidStretch` constraints
+
+- **`LiquidVerticalRoundedSuperellipse`**: Enables asymmetric corner radii (top-rounded, bottom-flat) essential for the modal sheet's full-screen morphing animation.
+- **Axis constraints**: `allowPositive` / `allowNegative` pivot support prevents the sheet from "collapsing" downward when dragged — it only stretches upward as a tactile response.
+
+### Documentation & Testing
+
+- `docs/assets/GLASS_MODAL_SHEETS_GUIDE.md` — comprehensive developer guide covering the full parameter surface and state behaviours.
+- `test/widgets/overlays/glass_modal_sheet_test.dart` — 679 lines of rigorous unit and widget tests covering state transitions, gesture arena logic, and physics edge cases.
+
+Zero breaking changes. `GlassModalSheet` is additive — all existing `GlassSheet` usages are unaffected.
+
+---
+
+## 🐛 Fix — Selected icon colour washed out by glass indicator
+
+A huge shoutout and thanks to [@jfhair](https://github.com/jfhair) for spotting this issue and putting together [PR #29](https://github.com/sdegenaar/liquid_glass_widgets/pull/29) — it was a fantastic catch, and you had exactly the right instinct on the fix!
+
+The active-tab icon was visually muted ("dull") at rest because the `AnimatedGlassIndicator` glass lens was painting *over* the icon layer. Simply moving the indicator behind the icons restores vibrancy but kills the refraction effect — the glass shader needs icons beneath it to warp them as the pill moves.
+
+The fix uses a split-pass sandwich: the pill's solid background renders *below* the icons (full vibrancy at rest), while the glass shader renders *above* them (refraction preserved during animation). Both `GlassBottomBar` and `GlassSearchableBottomBar` are updated. Zero breaking changes.
+
+---
+
+## 🐛 Fix — `GlassSheet` specular rim artifact & washed-out inner elements
+
+Inspired by [@yukinoaruu](https://github.com/yukinoaruu)'s work in PR #33, who introduced the `forceSpecularRim` flag and first surfaced this class of visual fidelity issue with the lightweight glass renderer.
+
+### The problem & fix
+
+On the Skia/Web (lightweight) rendering path, a `refractiveIndex` of `0.7` on a large `GlassSheet` produced a hard, visible border around the sheet — a bright "line" that looked like an artifact rather than a premium glass surface. 
+
+Lowering it globally to fix the sheets caused components **inside** the sheet to lose their specular highlights and become washed out.
+
+We've introduced semantic preset separation via two distinct `RecommendedGlassSettings` presets to solve this:
+- **`RecommendedGlassSettings.overlay`** (`refractiveIndex: 0.7`): For cards, buttons, and small interactive widgets.
+- **`RecommendedGlassSettings.sheet`** (`refractiveIndex: 0.15`): For large bottom sheets and modal overlays.
+
+All `GlassSheet.show()` calls in the demo app now use the `sheet` preset, while every `GlassButton.custom` and `GlassCard` **inside** a sheet explicitly passes `settings: RecommendedGlassSettings.overlay`. The package-level default for `GlassSheet` (`glass_sheet_defaults.dart`) has also been updated to use `refractiveIndex: 0.15` for a better out-of-the-box experience.
+
+Zero breaking changes.
+
+---
+
+# 0.9.2
+
+
+## 🐛 Fix — `GlassSwitch` initial-state bloom anchor & polish
+
+- **First-click bloom anchored correctly.** A switch initialised with `value: true`
+  now anchors the bloom to the right edge on the very first tap, matching all
+  subsequent interactions. Previously `_isMovingForward` was hardcoded to `true`
+  at construction regardless of `widget.value`.
+
+- **`_justEndedDrag` race condition eliminated.** The flag is now consumed
+  atomically inside `didUpdateWidget` rather than being reset one frame later via
+  `addPostFrameCallback`, preventing a rare double-bloom after a drag toggle.
+
+- **Floating-point guard hardened.** Animation controller resets now use `>= 0.99`
+  instead of `== 1.0`, making the bloom sequence robust against sub-epsilon drift
+  during rapid consecutive toggles.
+
+- **Dead code removed** (`glassOverlay` no-op widget).
+
+- **Haptic feedback added.** `GlassSwitch` now emits `HapticFeedback.lightImpact()`
+  on tap-toggle, when the thumb crosses the 50 % midpoint during a drag, and on
+  drag-release snap (when the midpoint was never crossed, e.g. a fast flick).
+  Opt out with `enableHaptics: false`.
+
+- **3 new regression tests** added; `GlassSwitch` test count now 24.
+
+Zero breaking changes.
+
+---
+
+# 0.9.1
+
+## 🐛 Fix — Adaptive quality system calibration
+
+Three coordinated improvements to `GlassAdaptiveScope` / `GlassQualityAdapter` that
+prevent modern flagship devices from being incorrectly demoted to `standard` quality
+during app startup.
+
+### 1. Startup-skip window (`skipInitialFrames = 60`)
+
+Phase 2 now discards the **first 60 frames** (≈ 1 second at 60 Hz) before collecting
+warmup data. Those frames capture shader compilation, the first route transition, and
+provider/localisation initialisation — all artificially inflated and unrepresentative of
+steady-state glass rendering. Discarding them means the warmup benchmark reflects actual
+glass workload, not cold-start overhead.
+
+The constant is tunable for testing: `GlassQualityAdapter.skipInitialFrames = 0`.
+
+### 2. Raised premium threshold: 12 ms → 16 ms
+
+The old threshold of 12 ms (75 % of a 60 fps frame budget) was too tight.
+The new threshold is **16 ms — one full 60 fps frame budget** — which has a cleaner
+semantic meaning: "can the device render a premium glass frame within the 60 fps
+budget at P75? Yes → premium."
+
+| P75 raster time | Before | After |
+|---|---|---|
+| < 12 ms | premium | — |
+| **< 16 ms** | standard | **premium** |
+| 16–20 ms | standard | standard |
+| > 20 ms | minimal | minimal |
+
+### 3. `allowStepUp` defaults to `true`
+
+Previously `allowStepUp` defaulted to `false`, meaning a Phase 2 decision could never
+be corrected at runtime. If Phase 2 still makes a conservative call (e.g. on a device
+under thermal load at startup), Phase 3 can now self-correct after 10 consecutive
+under-budget windows (≈ 20 seconds) + an 8-second cooldown.
+
+The step-up is deliberately slow and invisible to users. Set `allowStepUp: false`
+explicitly if you need to lock quality for the session.
+
+### Zero breaking changes (adaptive fix)
+
+All three changes are additive or alter defaults in a user-beneficial direction.
+Explicit constructor overrides (`allowStepUp: false`, `skipInitialFrames`, custom
+threshold via `targetFrameMs`) continue to take precedence.
+
+---
+
+## 🐛 Fix — `GlassSwitch` drag interaction
+
+`GlassSwitch` now supports tap and horizontal drag simultaneously without either
+interaction interfering with the other.
+
+**What was fixed:**
+
+- **Tap animation restored** — registering both `onTap` and `onHorizontalDrag*`
+  on the same `GestureDetector` caused Flutter's gesture arena to drop one
+  interaction after the first touch. Taps now use `onTapDown` / `onTapUp` so
+  they share the gesture stream cleanly with drags.
+- **Slow drag no longer cancels** — Flutter fires `onTapCancel` before
+  confirming a horizontal drag, which was deflating the "liquid bloom" pill
+  prematurely. `_onDragStart` now stops any in-progress deflation and restores
+  the plump state immediately.
+- **Animation resets between interactions** — the thickness animation controller
+  was left at `1.0` after its first cycle and silently skipped the bloom on
+  subsequent taps. It now resets to `0.0` before each new forward pass.
+
+**Gesture behaviour unchanged from the user's perspective:** tap = full liquid
+jump animation; drag = thumb tracks finger with symmetric pill stretch; flick =
+velocity-based snap.
+
+### Zero breaking changes
+
+No API changes. All existing `GlassSwitch` usages continue to work without
+modification.
+
+---
+
+## 🐛 Fix — `interactionGlowColor` now reads from `GlassThemeData`
+
+`GlassBottomBar` and `GlassSearchableBottomBar` (including its `collapsedLogoBuilder`
+state and `SearchPill`) previously used a hardcoded white glow (`0x33FFFFFF`) when
+no explicit `interactionGlowColor` was set, silently ignoring any `GlassThemeData`
+override on the ancestor tree.
+
+**Resolution order is now:**
+
+```
+interactionGlowColor param → GlassThemeData.glowColorsFor(context).primary → internal fallback
+```
+
+This means setting the primary glow color in `GlassThemeData` now takes effect
+on the press-interaction highlight across both bar variants, including the collapsed
+logo pill, without requiring any code changes at the call site.
+
+### Affected widgets
+
+| Widget | Location |
+|---|---|
+| `GlassBottomBar` | `TabIndicator` interaction glow |
+| `GlassSearchableBottomBar` | `SearchableTabIndicator` (normal + collapsed/logo state) |
+| `GlassSearchableBottomBar` | `SearchPill` expanded glow |
+
+### Zero breaking changes
+
+Explicit `interactionGlowColor` parameters continue to win with highest priority.
+This only changes what happens when the parameter is left `null`.
+
+---
+
+## ✨ Feature — `glowBlurRadius`, `glowSpreadRadius`, `glowOpacity` on `GlassGlowColors`
+
+Three new appearance fields on `GlassGlowColors` give fine-grained control over the
+shape of the directional press-glow across all glass widgets:
+
+| Field | Type | Default | Effect |
+|---|---|---|---|
+| `glowBlurRadius` | `double` | `4.0` | Gaussian blur sigma via `MaskFilter.blur` — softens the glow edge into a natural liquid-glass halo |
+| `glowSpreadRadius` | `double` | `0` | Extra circle radius as a fraction of the layer's shortest side |
+| `glowOpacity` | `double` | `1` | Master opacity multiplier (0–1) applied on top of the glow color's own alpha |
+
+### Usage
+
+Set them globally via `GlassThemeData` to affect all glass widgets at once:
+
+```dart
+GlassTheme(
+  data: GlassThemeData(
+    light: GlassThemeVariant(
+      glowColors: GlassGlowColors(
+        primary: Color(0x55FFFFFF),
+        glowBlurRadius: 8,       // soft, diffuse halo
+        glowSpreadRadius: 0.15,  // bleeds 15 % beyond touch radius
+        glowOpacity: 0.75,       // 75 % of the color's own alpha
+      ),
+    ),
+  ),
+  child: ...,
+)
+```
+
+Or override per-widget via `GlassButton.glowBlurRadius` / `glowSpreadRadius` /
+`glowOpacity` — widget-level values take precedence over the theme.
+
+### Defaults preserve existing visual behaviour
+
+`glowSpreadRadius` and `glowOpacity` default to `0` and `1` respectively,
+preserving previous rendering. `glowBlurRadius` defaults to **`4.0`** —
+a soft, natural halo that better fits the liquid-glass aesthetic.
+`MaskFilter.blur` is guarded at zero so there is no GPU cost when the value
+is left at `0`. Set `glowBlurRadius: 0` explicitly for a hard-edge disc.
+
+### Affected widgets
+
+All widgets that render `GlassGlow` consume these fields, including:
+`GlassButton`, `GlassBottomBar`, `GlassSearchableBottomBar`
+(both the tab pill and the search pill), `GlassSlider`, `GlassSwitch`.
+
+### Zero breaking changes
+
+Existing code that does not set these fields continues to render identically.
+`copyWith`, `==`, and `hashCode` all include the three new fields.
+
+---
+
+
+
+# 0.9.0
+
+## ✨ New — `tabWidth` on `GlassBottomBar`
+
+**`tabWidth` is now available on both `GlassBottomBar` and `GlassSearchableBottomBar`.**
+Both bar variants share identical compact-sizing semantics and the same default.
+
+### API
+
+```dart
+GlassBottomBar(
+  // Default (no tabWidth): expand — pill fills available space.
+  // tabWidth: 88.0 → iOS 26 compact sizing
+  tabWidth: 88.0,
+  ...
+)
+```
+
+| `tabWidth` | Behaviour | 2 tabs | 3 tabs | 4 tabs |
+|---|---|---|---|---|
+| `null` *(default)* | Expand — fills available space | fills bar | fills bar | fills bar |
+| `88.0` | Compact — iOS 26 style | 176 px | 264 px | 352 px |
+
+The pill is automatically **clamped** so it never overflows its container,
+regardless of how many tabs are present or how narrow the screen is.
+
+### Zero breaking changes
+
+`tabWidth` defaults to `null` (expand) on both `GlassBottomBar` and
+`GlassSearchableBottomBar`. Existing code that does not pass `tabWidth`
+continues to behave exactly as before — the tab pill fills the bar.
+Pass `tabWidth: 88.0` to opt-in to iOS 26 compact sizing.
+
+### Shared infrastructure (internal)
+
+- **`bar_layout_utils.dart`** — new pure-Dart file containing
+  `resolveTabPillWidth`. Both `GlassBottomBar` and
+  `SearchableBottomBarController` delegate to this single function, eliminating
+  two separate inline implementations of the same arithmetic.
+- **`kBottomBarGlassDefaults`** — the 9-field `LiquidGlassSettings` constant
+  that was previously copy-pasted into both bar state classes is now defined
+  once in `bottom_bar_internal.dart` and referenced from both locations.
+
+### Production hardening
+
+- **Extra button pinned to trailing edge in `GlassBottomBar`.**
+  Previously the extra button sat immediately adjacent to the tab pill when
+  using compact `tabWidth` sizing, leaving empty space to its right. It is now
+  always pinned to the far-right edge (using `Expanded` + `Align(centerRight)`)
+  to match the searchable bar's layout. The `maxTabW` arithmetic is unchanged;
+  only the Row structure changed. Works correctly in both compact and expand modes.
+- `resolveTabPillWidth` guards against negative `maxAvailable` values
+  (`math.max(0.0, maxAvailable)` before the `clamp`) to prevent a `RangeError`
+  in unusual layout constraint environments.
+- Both constructors now assert `tabWidth == null || tabWidth > 0` — passing a
+  negative value previously produced a zero-width pill silently.
+- Golden regression sentinel added for `tabWidth: null` (expand mode), so a
+  layout regression in legacy behaviour is caught by the pixel-test suite.
+
+
+### Example
+
+`example/lib/tab_width_demo.dart` — covers both `GlassBottomBar`
+and `GlassSearchableBottomBar` via a **Bar variant** chip, with live metrics
+showing the computed pill width in real time.
+
+---
+
+# 0.8.4
+
+
+## CI & Tooling
+
+- **CI: Multi-platform test matrix.** The CI pipeline now runs the full test suite
+  on `ubuntu-latest`, `macos-latest`, and `windows-latest` across both `stable`
+  and `beta` Flutter channels. Previously only `macos-latest / stable` was tested,
+  which silently allowed the three Windows shader regressions shipped in 0.7.9–0.7.12.
+  Fail-fast is disabled so all platform failures are visible in a single run.
+
+- **CI: Windows shader validation gate.** `glslangValidator` (the same SPIR-V
+  compiler core Flutter uses on Windows) now runs in CI on every push and PR via
+  the `shader-validation` job. Any shader that would produce a
+  _"index expression must be constant"_ or _"loop bounds must be compile-time
+  constants"_ error is caught before it reaches `main`. Previously this check only
+  ran locally via `bash scripts/validate_shaders.sh` on macOS.
+
+- **CI: pub.dev publish dry-run gate.** A dedicated `pub-check` job runs
+  `dart pub publish --dry-run` on every push and PR. Catches missing dartdoc
+  comments, `pubspec.yaml` issues, platform declaration gaps, and score regressions
+  before they land in a release.
+
+- **CI: Coverage threshold guard (≥ 90 % effective).** The pipeline now fails if
+  effective line coverage drops below 90 % on the stable channel. _Effective_
+  coverage is computed after stripping `lib/src/renderer/*` — 16 GPU
+  `CustomPainter` / `RenderObject` files that cannot execute in a headless VM (no
+  GPU rasterizer; documented as untestable in `ARCHITECTURE.md`). Current effective
+  coverage is **91.8 %** (4 146 / 4 514 lines). A `.codecov.yml` config now mirrors
+  this exclusion so the pub.dev / GitHub badge agrees with the CI gate rather than
+  showing the raw ~81 % figure that included the untestable renderer paths.
+
+- **CI: Run concurrency cancel.** Added `concurrency` group so redundant
+  in-progress runs on the same branch are cancelled automatically, saving CI
+  minutes on rapid-push workflows.
+
+- **Tooling: `scripts/validate_shaders.sh` cross-platform update.** The shader
+  validation script now resolves `glslangValidator` / `glslangValidator.exe`
+  automatically, works on Windows (Git for Windows bash), and prints correct
+  install instructions for macOS (`brew`), Ubuntu (`apt-get`), and Windows
+  (`choco` / `winget`). Path resolution is now robust regardless of which
+  directory the script is called from.
+
+## GlassAdaptiveScope Diagnostics *(experimental)*
+
+- **`GlassAdaptiveDiagnostic` — rich quality change event.** A new immutable
+  data class is emitted whenever `GlassAdaptiveScope` changes quality tier.
+  It carries the full context of *why* the change happened: `from`/`to` quality,
+  `reason` (`warmupComplete`, `thermalDegradation`, `thermalRecovery`,
+  `restoredFromCache`, `staticProbe`), `phase`, and the P75/P95 raster timing
+  that triggered the decision.
+
+- **`GlassAdaptiveScope.onDiagnostic`** — a new optional callback that receives
+  a `GlassAdaptiveDiagnostic` alongside the existing `onQualityChanged`. The old
+  callback is unchanged — this is purely additive.
+
+- **`GlassAdaptiveScope.debugLogDiagnostics: true`** — zero-wiring diagnostic
+  mode. Add this flag to print a structured console block on every quality change
+  in debug builds (no-op in profile/release). Designed to lower the barrier for
+  community threshold calibration reports:
+
+  ```
+  ┌─ 📊 GlassAdaptiveScope ─────────────────────────────────────────
+  │  Change  : premium → standard
+  │  Reason  : warmupComplete
+  │  Phase   : runtime
+  │  P75     : 14.2 ms
+  │  Frames  : 10
+  │
+  │  📬 Post to: github.com/sdegenaar/liquid_glass_widgets/discussions
+  └──────────────────────────────────────────────────────────
+  ```
+
+- **`GlassQualityChangeReason` enum** — exported publicly so analytics pipelines
+  can filter on specific event types (e.g. only log `warmupComplete` and skip
+  `restoredFromCache` noise).
+
+- **Adapter diagnostic tracking** — `GlassQualityAdapter` now records
+  `lastP75Ms`, `lastP95Ms`, `lastFramesMeasured`, and `lastChangeReason` before
+  every quality decision so the scope can snapshot them synchronously before the
+  async `addPostFrameCallback` gap.
+
+## Bug Fixes
+
+- **FIX: Refraction inverted on Android (Pixel 7, Mali GPU, OpenGL ES emulator).** On all
+  devices where Impeller uses the OpenGL ES backend, the liquid glass refraction effect
+  appeared to bend inward rather than outward — content beneath the glass lens distorted
+  toward the centre instead of away from it. The glass bottom bar, segmented control
+  indicator, and all premium-quality glass surfaces were affected.
+
+  **Root cause:** OpenGL ES stores render-to-texture outputs with a bottom-left Y origin
+  (Y increases upward), whereas Flutter's widget coordinate system uses Y-down. The shaders
+  already flip `screenUV.y` and `geometryUV.y` with `1.0 − y` to compensate when _sampling_
+  textures. However, the `displacement` vector (in `liquid_glass_final_render.frag`) and
+  `edgeOffsetLogical` (in `interactive_indicator.frag`) were computed in Flutter's Y-down
+  space and added directly to the Y-up UV without correcting the Y component. A positive Y
+  displacement (outward at the bottom edge) therefore moved the sample _toward_ the centre
+  in UV space — the exact opposite of the intended direction.
+
+  **Fix:** Under `#ifdef IMPELLER_TARGET_OPENGLES`, negate the Y component of the
+  displacement/offset vector before applying it to the sampled UV. This re-aligns the
+  Y-down displacement with the Y-up UV coordinate space.
+
+  The Metal (iOS/macOS) and Vulkan (Samsung S22 / Adreno / AMD Xclipse) code paths are
+  unchanged — the fix is gated entirely by `IMPELLER_TARGET_OPENGLES` and verified against
+  both a Pixel 7 API 35 emulator and a physical Samsung Galaxy S22.
+
+---
+
+
+
+
+# 0.8.3
+
+## Performance & Bug Fixes
+
+
+- **`GlassBottomBar` / `GlassSearchableBottomBar` — glass lens now correctly refracts active tab icons.** Previously the selected icon layer was rendered *above* the `AnimatedGlassIndicator` in a separate compositor layer, making it invisible to the `BackdropFilter`. The glass pill swept over a blank canvas, producing a flat, unrefracted active icon. Both the selected and unselected icon layers are now combined into a single `RepaintBoundary` placed *behind* the glass lens, so all icon colours are physically sampled and warped by the chromatic aberration as the pill moves — matching iOS 26 behaviour.
+
+- **Performance improvement.** The fix eliminates 5–9 redundant GPU compositor layers per bar render frame: the per-tab `RepaintBoundary` nodes on both the selected and unselected icon rows have been removed in favour of a single shared compositor texture for the entire icon canvas. Fewer texture uploads, one `BackdropFilter` sample — net improvement at 120 Hz.
+
+---
+
+# 0.8.2
+
+
+## Bug Fixes
+
+- **`GlassQuality.premium` no longer crashes outside a `LiquidGlassLayer`.** Previously caused an opaque `Null check operator` crash. Now throws a descriptive `AssertionError` in debug builds and falls back gracefully (renders child without glass) in release. Fix: add `useOwnLayer: true` to any standalone `GlassButton` using `premium` quality.
+
+- **`GlassBottomBar` / `GlassSearchableBottomBar` — repeat-tap on active tab now fires `onTabSelected` ([#22](https://github.com/sdegenaar/liquid_glass_widgets/issues/22)).** Previously the `index != widget.tabIndex` guard silently suppressed callbacks when the user tapped the already-selected tab, making it impossible to implement scroll-to-top or refresh-on-retap patterns. The guard has been removed; `onTabSelected` is now always called once per gesture lifecycle regardless of whether the tab index changes.
+
+- **`GlassBottomBar` / `GlassSearchableBottomBar` — drag-end snaps to correct tab ([#23](https://github.com/sdegenaar/liquid_glass_widgets/pull/23)).** A coordinate-space mismatch in `_onDragEnd` caused the indicator to snap to the wrong tab: dragging to the centre of a 5-tab bar landed on tab 3 instead of tab 2. The fix corrects the inversion formula to `i = round(relX × (n − 1))`, which is the exact inverse of the alignment space `computeAlignment(i, n) = −1 + 2i/(n−1)`.
+
+- **`GlassBottomBar` / `GlassSearchableBottomBar` — `onTabSelected` no longer fires twice per tap.** `BottomBarTabItem` had its own `onTap: () => onTabSelected(i)` callback that fired independently of the outer `TabIndicator`'s `onTapDown` handler, causing every tap to call `onTabSelected` twice. The item-level callback is now `null`; the outer indicator is the single source of truth for all selection events.
+
+  > **Credit:** These interaction fixes were identified and originally patched by [@qinshah](https://github.com/qinshah) in [PR #23](https://github.com/sdegenaar/liquid_glass_widgets/pull/23). The implementation was refactored to preserve the existing jelly physics, desktop tap support, and fling-based navigation that the PR removed, and extended to cover `GlassSearchableBottomBar` with shared logic via the new internal `TabDragGestureMixin`.
+
+## API
+
+- **`GlassSearchBarConfig.expandWhenActive`** *(new)*. Controls whether the search pill expands when `isSearchActive` is `true`. Default `true` — no change needed for standard usage. Set to `false` for advanced layouts (e.g. Apple Music Play Pill pattern) where the search pill should remain compact while `isSearchActive` drives a non-search transition independently.
+
+## Examples
+
+- **`apple_music_demo`** — added as a reference for the Play Pill pattern: a floating `GlassButton` (`useOwnLayer: true`, `GlassQuality.premium`) that animates between a full-screen player and a mini-mode docked pill using `AnimatedPositioned` + `AnimatedOpacity`, synchronized with `GlassSearchableBottomBar`'s spring morph via `expandWhenActive`.
+
+---
+
+
+# 0.8.1
+
+## New Features
+
+### `GlassInteractionBehavior` — precise, orthogonal control of press interactions
+
+A new first-class enum that independently controls the two dimensions of press
+feedback on `GlassBottomBar`, `GlassSearchableBottomBar`, and `GlassTextField`
+(as well as its derivative inputs):
+
+| Value | Glow | Scale |
+|---|---|---|
+| `none` | ✗ | ✗ |
+| `glowOnly` | ✓ | ✗ |
+| `scaleOnly` | ✗ | ✓ |
+| `full` *(default)* | ✓ | ✓ |
+
+The *glow* is the iOS 26-style directional light spotlight that follows the
+touch position across the glass surface. The *scale* is the spring-physics
+size pulse on press.
+
+```dart
+// Glow only — light follows your finger, no bounce:
+GlassBottomBar(
+  interactionBehavior: GlassInteractionBehavior.glowOnly,
+  ...
+)
+
+// Scale only — spring bounce, no glow:
+GlassSearchableBottomBar(
+  interactionBehavior: GlassInteractionBehavior.scaleOnly,
+  pressScale: 1.06,
+  ...
+)
+
+// Disable both for a completely static bar:
+GlassBottomBar(
+  interactionBehavior: GlassInteractionBehavior.none,
+  ...
+)
+```
+
+**Zero overhead when disabled.** When `interactionBehavior` suppresses glow (`none`
+or `scaleOnly`), the `GlassGlow` sensor widget is removed from the tree entirely —
+saving 3 widget allocations and 3 `RenderBox` nodes per tab indicator per frame.
+Scale is resolved at build time to a scalar `1.0` with no animation controller
+overhang.
+
+### New parameters on `GlassBottomBar`, `GlassSearchableBottomBar`, and `GlassTextField`
+
+`GlassTextField` now shares the same `interactionBehavior` API as the bar-family
+widgets. The *scale* dimension maps onto the subtle press-bounce animation
+(field squishes slightly when pressed down); the *glow* dimension is the directional
+spotlight that tracks touch position across the glass surface.
+
+`GlassPasswordField` and `GlassTextArea` delegate to `GlassTextField` and inherit
+the new parameter automatically.
+
+| Parameter | Widget(s) | Type | Default |
+|---|---|---|---|
+| `interactionBehavior` | All three | `GlassInteractionBehavior` | `.full` |
+| `pressScale` | Bar widgets / Inputs | `double` | `1.04` (bars) / `1.03` (inputs) |
+| `interactionGlowColor` | Bar widgets | `Color?` | `null` (theme default) |
+| `glowColor` | `GlassTextField` | `Color?` | `null` (~12% white) |
+| `interactionGlowRadius` | Bar widgets | `double` | `1.5` |
+| `glowRadius` | `GlassTextField` | `double` | `1.5` |
+
+All defaults preserve existing `0.8.0` visual behaviour — **no migration required**.
+
+#### Migration from `enableGlow` / `enableFocusAnimation`
+
+`GlassTextField.enableGlow` and `GlassTextField.enableFocusAnimation` have been
+replaced by `interactionBehavior`. The mapping is direct:
+
+```dart
+// Before (0.8.0):
+GlassTextField(enableGlow: false, enableFocusAnimation: false)
+
+// After (0.8.1):
+GlassTextField(interactionBehavior: GlassInteractionBehavior.none)
+
+// Before: glow only
+GlassTextField(enableGlow: true, enableFocusAnimation: false)
+// After:
+GlassTextField(interactionBehavior: GlassInteractionBehavior.glowOnly)
+```
+
+
+## Bug Fixes
+
+- **FIX**: `SearchPill` was silently ignoring `interactionBehavior`. The `interactionGlowColor`
+  parameter was never passed to the `SearchPill` constructor, so the search pill always rendered
+  with a visible glow regardless of the bar's `interactionBehavior` setting. The glow was
+  hardcoded to `Color(0x1FFFFFFF)` even when `behavior = none`.
+
+- **FIX**: `SearchPillState` had no glow short-circuit on the expanded pill path. Added
+  `_wrapWithGlow` helper (matching the pattern already in `TabIndicatorState` and
+  `SearchableTabIndicatorState`) to skip `GlassGlow` allocation when glow is suppressed.
+
+---
+
+# 0.8.0
+
+## New Features
+
+### `GlassAdaptiveScope` *(experimental)* — automatic runtime quality adaptation
+
+A new scope widget that automatically adjusts `GlassQuality` for its subtree
+based on real raster performance observed from `SchedulerBinding` frame timings.
+Handles the three device scenarios that are impossible to test on a developer
+device:
+
+- **Broken / slow shader drivers** (e.g. Pixel 4a, Galaxy A22 class): detected
+  synchronously at startup via `ImageFilter.isShaderFilterSupported` and capped
+  immediately to `minimal`.
+- **Warm-up jank** ("wrong quality at startup"): resolved by a ~180-frame
+  benchmark that measures real P75 raster durations and sets the initial quality
+  tier before the user notices.
+- **Thermal throttling** ("fine at launch, janky after 10 minutes"): detected
+  and corrected by a continuous runtime hysteresis engine.
+
+**Three-phase adaptation:**
+
+| Phase | Trigger | Action |
+|---|---|---|
+| Phase 1 — Static probe | Mount | Forces `minimal` on unsupported hardware; caps at `standard` on web |
+| Phase 2 — Warm-up | First ~180 frames (~3 s at 60 fps) | Sets initial quality from real P75 raster durations |
+| Phase 3 — Runtime hysteresis | Ongoing | Degrades after 3 bad windows; recovers after 10 good windows (8 s cooldown) |
+
+The scope acts as a **quality ceiling** — widgets with an explicit `quality:`
+parameter are unaffected. The ceiling is enforced by
+`GlassThemeHelpers.resolveQuality`, which reads `GlassAdaptiveScopeData` from
+the nearest ancestor scope.
+
+```dart
+// Per-screen control:
+GlassAdaptiveScope(
+  child: Scaffold(...),
+)
+
+// Advanced — conservative start for fragmented Android market:
+GlassAdaptiveScope(
+  initialQuality: GlassQuality.standard, // earn your way up to premium
+  allowStepUp: true,
+  onQualityChanged: (from, to) => analytics.log('glass_quality_changed'),
+  child: child,
+)
+```
+
+> **Experimental in 0.8.0.** `GlassAdaptiveScope` and `GlassAdaptiveScopeConfig` are
+> annotated `@experimental`. The three-phase adaptation logic is architecturally sound
+> and fully tested, but the Phase 2 timing thresholds (P75 < 12 ms → premium,
+> 12–20 ms → standard, > 20 ms → minimal) have been validated by reasoning, not yet
+> by broad real-device data across the Android fragmentation landscape.
+>
+> **How to enable it:** `LiquidGlassWidgets.wrap(myApp, adaptiveQuality: true)`
+> (opt-in, default `false`).
+>
+> **If you observe unexpected behaviour** — quality too low on a mid-range device,
+> or stuck at `standard` on a flagship — please file an issue with your device model
+> and raster timings from Flutter DevTools. Your data will be used to tune the
+> thresholds for a future release.
+
+### `GlassAdaptiveScopeConfig` *(experimental)* — portable configuration value object
+
+Bundles all `GlassAdaptiveScope` parameters into a single `const`-constructible,
+equality-comparable value object. Used by `LiquidGlassWidgets.wrap()` and useful
+for passing scope configuration through APIs that cannot accept widget parameters
+directly.
+
+```dart
+const config = GlassAdaptiveScopeConfig(
+  initialQuality: GlassQuality.standard,
+  allowStepUp: true,
+  targetFrameMs: 8, // 120 Hz ProMotion
+);
+```
+
+## API Refactor — `initialize()` and `wrap()` separation
+
+The responsibilities of `initialize()` and `wrap()` have been clarified and
+made consistent with the broader Flutter ecosystem (cf. `easy_localization`,
+`MaterialApp`):
+
+| Method | Responsibility |
+|---|---|
+| `initialize()` | Async platform / engine setup only (shader prewarming, Impeller pipeline, debug monitor) |
+| `wrap()` | Widget-tree composition and all behavioral configuration |
+
+### `wrap()` — new parameters
+
+```dart
+runApp(LiquidGlassWidgets.wrap(
+  const MyApp(),
+  respectSystemAccessibility: false, // moved from initialize()
+  adaptiveQuality: true,             // new — inserts GlassAdaptiveScope
+  adaptiveConfig: GlassAdaptiveScopeConfig(
+    initialQuality: GlassQuality.standard,
+    allowStepUp: true,
+  ),
+));
+```
+
+### Scope nesting order inserted by `wrap()`
+
+`GlassAdaptiveScope` → `GlassBackdropScope` → `child`
+
+## Breaking Changes
+
+### `initialize(respectSystemAccessibility:)` removed
+
+`respectSystemAccessibility` has moved from `initialize()` to `wrap()`.
+
+**Migration** (one-line change):
+
+```dart
+// Before (0.7.x):
+await LiquidGlassWidgets.initialize(respectSystemAccessibility: false);
+runApp(LiquidGlassWidgets.wrap(const MyApp()));
+
+// After (0.8.0):
+await LiquidGlassWidgets.initialize();
+runApp(LiquidGlassWidgets.wrap(const MyApp(), respectSystemAccessibility: false));
+```
+
+The `LiquidGlassWidgets.respectSystemAccessibility` getter and setter remain
+available as an escape hatch for tests and advanced runtime overrides. In
+production code, set it through `wrap()`.
+
+## Bug Fixes
+
+### Glass invisible on white / light backgrounds (transparency regression)
+
+- **FIX**: Standalone glass widgets (`GlassButton`, `GlassContainer`, `GlassTextField`,
+  `GlassCard`, and all widgets that delegate to them) rendered with zero opacity on
+  light backgrounds when no explicit `settings:` were provided. Root cause: these
+  widgets fell through to `InheritedLiquidGlass.ofOrDefault()`, which returns
+  `LiquidGlassSettings()` — a default with `glassColor: Color(0x00FFFFFF)` (alpha = 0).
+  The lightweight shader computes `body tint = glassColor.alpha × 0.15`, so
+  `0 × 0.15 = 0` — the glass body was literally transparent regardless of `thickness`
+  or `blur`.
+
+  **Fix**: Replaced all `InheritedLiquidGlass.ofOrDefault()` call sites with the new
+  `GlassThemeHelpers.resolveSettings()`, which traverses the full 5-level priority chain:
+
+  1. Widget-level `settings:` parameter (explicit wins)
+  2. `InheritedLiquidGlass` — nearest parent `AdaptiveLiquidGlassLayer`
+  3. `LiquidGlassWidgets.globalSettings` — app-level override
+  4. `GlassThemeData` — brightness-aware theme variant (light / dark)
+  5. `LiquidGlassSettings()` — absolute last resort
+
+  Standalone widgets now correctly resolve to the theme's `glassColor` and are
+  always visible out of the box.
+
+### Light theme defaults rebalanced
+
+- **TWEAK**: `GlassThemeVariant.light` updated for an icy-frosted aesthetic that
+  reads clearly on white backgrounds:
+
+  | Property | Before | After |
+  |---|---|---|
+  | `blur` | 10.0 | 6.0 |
+  | `glassColor` | `0x73FFFFFF` (45% neutral white) | `0x4AD2DCF0` (~29% cool blue-white) |
+  | `chromaticAberration` | 0.1 | 0.3 |
+  | `thickness` | 16.0 | 20.0 |
+  | `lightIntensity` | 1.0 | 1.2 |
+
+  The cool blue-white tint (`D2DCF0`) matches the icy tone of iOS 26 frosted glass.
+  Blur 6 gives visible background diffusion without obscuring content.
+
+## API
+
+### `GlassBackdropScope` now exported from the main barrel
+
+- **FIX**: `GlassBackdropScope` was missing from `liquid_glass_widgets.dart`. Consumers
+  had to use the internal path
+  `package:liquid_glass_widgets/widgets/shared/glass_backdrop_scope.dart`, which is
+  fragile and undocumented. It is now a first-class public export.
+
+  **Migration** — update any direct internal imports:
+  ```dart
+  // Before (workaround, fragile):
+  import 'package:liquid_glass_widgets/widgets/shared/glass_backdrop_scope.dart';
+
+  // After (correct):
+  import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+  ```
+
+- **CHORE**: add CI and Codecov badges.
+
+# 0.7.16
+
+### Bug Fixes
+
+- **FIX**: `GlassSearchableBottomBar` — memory leak when `controller` was swapped at runtime. The old controller's listener was never removed before attaching to the new controller. Now correctly removed in `didUpdateWidget`.
+- **FIX**: `DraggableIndicatorPhysics` — velocity NaN/Infinity guard. A zero-size render box (e.g. during widget tree warm-up) could produce `Infinity` or `NaN` for `velocityX`, which propagated into the spring physics and caused erratic snapping. Now clamped to 0 when the box has no size.
+
+### Refactor (zero breaking changes)
+
+- **REFACTOR**: Extracted `GlassSearchBarConfig` from `glass_searchable_bottom_bar.dart` into a dedicated file `lib/widgets/surfaces/shared/glass_search_bar_config.dart`. Resolves a circular import between the public widget and its internal sub-widgets. `GlassSearchBarConfig` is re-exported from the barrel file — no consumer-facing API change.
+- **REFACTOR**: Extracted `_TabIndicator` / `_TabIndicatorState` from `glass_bottom_bar.dart` into `shared/bottom_bar_internal.dart` as `TabIndicator` / `TabIndicatorState` (package-internal, not exported). Follows the same pattern used for `GlassSearchableBottomBar`. `glass_bottom_bar.dart` reduced from **1,406 → ~895 lines**.
+- **REFACTOR**: Extracted `_TabBarContent`, `_TabBarContentState`, and `_TabItem` from `glass_tab_bar.dart` into `shared/tab_bar_internal.dart`. `glass_tab_bar.dart` reduced from **728 → ~310 lines**. Architecture is now consistent across all bar-family widgets.
+
+### Test Coverage
+
+- **TEST**: Reached **91.85% effective coverage** (up from 89.6% in 0.7.15 — excluding GPU/shader renderer paths that are physically untestable in a headless VM). Total: **1,031 tests**, all passing, 0 analyzer warnings.
+- **TEST**: New `test/widgets/surfaces/glass_bottom_bar_drag_test.dart` — 7 regression tests covering `_onDragEnd` physics snapping, `_onDragCancel` (mid-drag and no-drag), slow drags, fast flings, and full-bar sweeps. These paths are the highest-risk regressions in navigation UX.
+
+# 0.7.15
+
+
+### Bug Fixes
+
+- **FIX**: `lib/theme/glass_theme_settings.dart` was accidentally omitted from version control in 0.7.14. All consumers of `GlassThemeSettings` received a compile error (`type 'GlassThemeSettings' is not a subtype`). This release commits the missing file. No API change — `GlassThemeSettings` was already exported from `liquid_glass_widgets.dart`.
+- **FIX**: `GlassPerformanceMonitor._emitWarning` — division-by-zero crash when `rasterBudget` was sub-millisecond (< 1 ms). Protected with a `max(1, ...)` guard.
+
+### Refactor (zero breaking changes)
+
+- **REFACTOR**: Consolidated 18 quality-resolution chains (`widgetQuality ?? inherited?.quality ?? themeData.qualityFor(context) ?? GlassQuality.standard`) into a single canonical helper: `GlassThemeHelpers.resolveQuality(context, widgetQuality: ..., fallback: ...)`. Surface widgets (`GlassAppBar`, `GlassToolbar`, `GlassBottomBar`, `GlassSearchableBottomBar`, `GlassSideBar`) pass `fallback: GlassQuality.premium` to preserve their documented defaults. All other widgets default to `GlassQuality.standard`.
+- **REFACTOR**: Extracted `_buildIconShadows` from `BottomBarTabItem` to a `@visibleForTesting` top-level function `buildIconShadows(...)` in `bottom_bar_internal.dart`. No behaviour change — enables isolated unit testing of the shadow-outline geometry.
+
+### Test Coverage
+
+- **TEST**: Reached **90%+ effective test coverage** (90.15% — excluding `src/renderer` GPU/shader layer where headless simulation is impossible). Total: **949 tests**, all passing.
+- **TEST**: New `test/theme/glass_theme_helpers_test.dart` — 5 widget tests covering all 4 priority levels of `GlassThemeHelpers.resolveQuality()`.
+- **TEST**: New `test/widgets/surfaces/build_icon_shadows_test.dart` — 6 unit tests covering `buildIconShadows()`: null thickness, active-icon suppression, shadow count, 45° offset math, and color propagation.
+- **TEST**: Added `test/theme/`, `test/renderer/`, `test/types/`, `test/constants/`, `test/utils/`, and `test/widgets/` test suites (committed for the first time — these were written during the 0.7.13–0.7.14 coverage push but never staged).
+
+# 0.7.14
+
+### Bug Fixes
+
+
+- **FIX**: `GlassSearchableBottomBar` — `extraButton` now fades out smoothly when search activates instead of being visually clipped/shrunk between the collapsing tab pill and the expanding search pill. Layout space is still reserved during the morph (no pills jump), only the visual opacity transitions. Taps on the extra button are also correctly blocked while hidden. Fades in when search closes.
+- **FIX**: `GlassSearchableBottomBar` — spring morph animations no longer produce a visible jump when reversing direction. Previously the three spring controllers (`tabW`, `searchLeft`, `searchW`) were each started in separate `addPostFrameCallback` calls, introducing a 1-frame desync at reversal. All three are now started in a single batched callback, so the morph is perfectly synchronized in both directions.
+- **FIX**: Indicator fade animation in `GlassBottomBar` / `GlassSearchableBottomBar` — replaced `Opacity` wrapper with `LiquidGlassSettings.visibility` fading. Wrapping a `BackdropFilter` in `Opacity` composites into an offscreen buffer, breaking backdrop sampling and causing the indicator to snap in/out instead of fading. The `visibility` path is a single GPU pass — no offscreen buffer — improving drag animation performance and working uniformly for all `blur` values.
+- **FIX**: `GlassBottomBar`, `GlassSearchableBottomBar`, `GlassAppBar`, `GlassToolbar`, and `GlassSideBar` resolved to `GlassQuality.standard` instead of their documented `GlassQuality.premium` default. Fixed by setting `quality: null` in the built-in light/dark variants so each widget's documented default is respected.
+- **FIX**: Setting any property in `GlassThemeVariant.settings` silently zeroed out all unset properties (e.g. setting only `thickness: 50` also reset `glassColor` to fully transparent). Fixed by introducing `GlassThemeSettings`: a parallel class with all-nullable fields that merges onto each widget's own defaults. Only the fields you explicitly set are applied; everything else inherits from the widget. `GlassThemeVariant.settings` now accepts `GlassThemeSettings?`.
+- **FIX**: `GlassSearchableBottomBar` — multiple layout-math regressions in the morph animation corrected:
+  - Reserved layout width now correctly scales to `min(size, searchBarHeight)` during search, eliminating the bloated gap when `searchBarHeight < barHeight`.
+  - Extra button rendered width now matches the layout reserve (`extraTargetW`), preventing a 14 px overflow into the search pill when `searchBarHeight < barHeight`.
+  - Restored `+ widget.spacing` in `targetSearchLeft`; an erroneous `tabToNextGap` variable had suppressed the gap between the tab pill and search pill when no extra button was present.
+  - `collapseOnSearchFocus` now exclusively controls visibility/opacity — it no longer affects layout geometry. Toggling it mid-animation no longer triggers the spring or causes the button to jump inside the collapsed tab circle.
+- **FIX**: `BottomBarTabItem` — removed a fixed `vertical: 4` padding wrapping the tab column. The padding consumed constraint space before `FittedBox` could scale, causing a 2 px `RenderFlex` overflow when the bar morphed to `searchBarHeight`.
+
+### New
+
+- **NEW**: `GlassThemeSettings` — a partial settings type for use in `GlassThemeVariant`. Accepts the same parameters as `LiquidGlassSettings` but all are nullable. Only non-null fields override the target widget's defaults, enabling precise single-property theme overrides without disturbing others.
+- **NEW**: `GlassTabPillAnchor` enum + `GlassSearchableBottomBar.tabPillAnchor` — controls how the tab pill is anchored during the morph animation. `GlassTabPillAnchor.start` (default) preserves existing left-anchor behaviour. `GlassTabPillAnchor.center` makes both edges collapse symmetrically from the pill's centre for a more balanced look. The search pill position adjusts automatically in center mode.
+- **NEW**: `GlassSearchBarConfig.showsCancelButton` now defaults to `true`. Tapping the dismiss pill unfocuses the keyboard and collapses search, matching the system-level behaviour seen across iOS apps (Weather, App Store, Apple News). Pass `showsCancelButton: false` to opt out.
+- **NEW**: `GlassSearchBarConfig.collapsedTabWidth` is now nullable. When omitted, the collapsed tab pill automatically matches `GlassSearchableBottomBar.searchBarHeight`, ensuring it morphs into a geometric circle with no leftover horizontal margin. Pass an explicit value to override.
+- **NEW**: `GlassBottomBarExtraButton.collapseOnSearchFocus` (default `true`) — controls whether the extra button collapses when the search field is focused. When `true`, the button fades out and its layout space spring-animates to zero, giving the search input the full available width (matching native iOS behaviour). When `false`, the button remains fully visible and tappable alongside the search input — useful for contextually relevant actions like a Filter button that applies to search results.
+- **EXAMPLE**: `searchable_bar_repro.dart` added to the example app — exercises `GlassSearchableBottomBar` edge cases (extra-button fade, spring desync, bar-height scale, dismiss pill) in isolation. Run standalone: `flutter run -t example/lib/searchable_bar_repro.dart`.
+
+# 0.7.13
+
+### New — `GlassQuality.minimal`
+
+- **FEAT**: `GlassQuality.minimal` — third quality tier: a crisp frosted glass surface with
+  zero custom fragment shader execution on any platform. Uses `BackdropFilter` blur
+  + Rec. 709 saturation matrix + a light-angle specular rim stroke. No refraction
+  warping or chromatic aberration — a deliberately flat, clean aesthetic that looks
+  excellent on any background and never adds GPU shader cost.
+
+  Two distinct use cases:
+
+  **Device fallback** — for hardware where even [standard] is too heavy:
+  very old Android devices with limited shader driver support, or any device where
+  `ImageFilter.isShaderFilterSupported` returns `false`.
+
+  **GPU budget management** — for shader-dense screens: use [minimal] for background
+  panels, list cards, and decorative containers while keeping [standard] or [premium]
+  on the focal element. A screen with 15 glass list cards running [minimal] fires
+  zero shader invocations during scroll — only `BackdropFilter` compositing.
+
+  ```dart
+  AdaptiveGlass(
+    quality: GlassQuality.minimal,
+    child: child,
+  )
+  ```
+
+- **FEAT**: `GlassThemeVariant.minimal` — static preset that applies `.minimal` quality globally via
+  `GlassThemeData`:
+
+  ```dart
+  GlassTheme(
+    data: GlassThemeData(
+      light: GlassThemeVariant.minimal,
+      dark:  GlassThemeVariant.minimal,
+    ),
+    child: child,
+  )
+  ```
+
+### New — `GlassPerformanceMonitor`
+
+- **FEAT**: Debug/profile-only performance monitor that watches raster frame durations while
+  `GlassQuality.premium` surfaces are active. When frames exceed the GPU budget
+  for 60 consecutive frames, a single `FlutterError` is emitted with actionable guidance
+  (specific widget parameters, device compatibility notes, and alternative quality tiers).
+
+  **Zero production overhead** — the monitor never registers a callback in release builds.
+  Enabled by default in debug/profile builds via `LiquidGlassWidgets.initialize()`:
+
+  ```dart
+  // Default: auto-enabled in debug/profile, zero-cost in release
+  await LiquidGlassWidgets.initialize();
+
+  // Opt out:
+  await LiquidGlassWidgets.initialize(enablePerformanceMonitor: false);
+
+  // Custom thresholds (advanced):
+  GlassPerformanceMonitor.rasterBudget = const Duration(microseconds: 8333); // 120 fps
+  GlassPerformanceMonitor.sustainedFrameThreshold = 120; // 2 seconds at 60 fps
+  ```
+
+  The monitor correctly attributes slowdowns to premium glass by counting active
+  `GlassQuality.premium` surfaces. It stays silent when no premium widgets are mounted,
+  avoiding false positives from other parts of the app.
+
+---
+
+# 0.7.12
+
+### Bug Fixes
+
+- **FIX**: Interactive blend-group stretch asymmetry — `LiquidStretch` now expands geometry symmetrically from the widget centre, fixing the left-leans-in / right-resists imbalance during touch-drag on button groups.
+
+- **FIX**: Erroneous highlight bias — removed a legacy shader hack that skewed surface normals horizontally. Normals are now derived accurately from the SDF gradient, eliminating optical hotspots that made straight groups look crooked.
+
+- **PERF**: Zero-jitter animation bounds — geometry texture mapping is now strictly bound to the physical size it was rasterised for, stopping frame-lag wobble when buttons change scale during interactive drags.
+
+- **FIX**: Theme quality cascade — audited 15+ widgets (`GlassBottomBar`, `GlassSwitch`, `GlassTextField`, and others) that were silently overriding the global `GlassThemeVariant` quality setting with `GlassQuality.premium`. All widgets now correctly inherit and respect the global quality profile, protecting frame rate and thermal limits on older devices (e.g. iPhone 12 and below).
+
+- **FIX**: Zero-thickness blur — setting `thickness: 0` no longer makes the glass fully transparent. Backdrop blur now renders correctly on glass surfaces regardless of geometric thickness, restoring backward-compatible behaviour.
+
+- **FEAT**: `GlassSearchBarConfig.focusNode` — optional `FocusNode` for `GlassSearchBarConfig`. When provided, the caller has full programmatic focus control (`requestFocus()`, `unfocus()`, `addListener()`) independent of `autoFocusOnExpand`. The widget adopts the caller-provided node without disposing it (caller owns lifecycle), matching Flutter's own `TextField.focusNode` contract.
+
+- **FEAT**: `GlassSearchBar.focusNode` — same `FocusNode` support added to the standalone `GlassSearchBar` for consistency. `GlassTextField` already had this.
+
+- **FIX**: `ExtraButtonPosition` — new enum on `GlassBottomBarExtraButton`. Set `.position = ExtraButtonPosition.afterSearch` to pin the extra button to the **right** of the search pill. Spring geometry calculations reserve space correctly to prevent `RenderFlex` overflows during expand/collapse. Default is `ExtraButtonPosition.beforeSearch` — fully backwards-compatible.
+
+- **FIX**: Windows / SkSL shader compilation — eliminated all dynamic array index expressions from `sdf.glsl`. The previous `getShapeSDFFromArray(int index)` computed offsets at runtime, which SkSL/glslang on Windows rejects with *"index expression must be constant"*. Replaced with literal-indexed `sdf0()`…`sdf15()` helpers and a fully-unrolled `sceneSDF` for 1–16 shapes. `MAX_SHAPES` stays 16; no API or visual change.
+
+- **TOOLING**: `scripts/validate_shaders.sh` — macOS script that validates all shaders against Windows/SkSL compiler rules using `glslangValidator`. Run `bash scripts/validate_shaders.sh` before releasing. Requires `brew install glslang` (one-time).
+
+---
+
+# 0.7.11
+
+### Bug Fixes
+
+- **FIX**: Windows/Android build failure — three shader compilation errors on the SPIR-V/glslang path: loop bounds must be compile-time constants; `dFdx`/`dFdy` on a scalar `float` is rejected by glslang (geometry shader now uses `#ifdef IMPELLER_TARGET_METAL` to keep hardware derivatives on iOS/macOS and fall back to ±0.5 px finite differences on Vulkan/OpenGL ES); global non-constant initialisers at file scope in `liquid_glass_final_render.frag` moved into `main()`.
+
+- **FIX**: Blend-group asymmetry — the liquid-glass merge neck between grouped buttons leaned toward the left button. Fixed with a bidirectional smooth-union pass (L→R + R→L, averaged 50/50) that cancels the directional bias exactly.
+
+---
+
+# 0.7.10
+
+### Bug Fixes
+
+- **FIX**: Windows build (`flutter build windows`) — two shader issues fatal on SkSL/glslang but silently accepted on Metal: `no match for min(int, int)` (replaced with a ternary) and global non-constant initialisers (moved into `main()`). No visual change on any platform.
+
+---
+
+# 0.7.9
+
+### Bug Fixes
+
+- **FIX**: Windows build failure — `uShapeData[MAX_SHAPES * 6]` was passed as a by-value function parameter, which glslang rejects. Fixed by accessing it as a global uniform. No visual change.
+
+### Tweaks
+
+- **TWEAK**: `GlassSearchableBottomBar` iOS 26 Apple News parity — animated inline `×` clear button replaces microphone when text is present; simplified hit-testing layout replaces `Overlay` layers; guaranteed GPU liquid-glass merging between the search and dismiss pills in a single shader pass.
+
+---
+
+# 0.7.8
+
+### Tweaks
+
+- **TWEAK**: `GlassThemeVariant.light` now defaults to a cool-tinted `glassColor` (`Color(0x32D2DCF0)`), stronger `refractiveIndex`, and boosted `ambientStrength` to ensure premium specular rendering and visible refraction on flat white backgrounds.
+
+### Examples
+
+- **Apple News demo** — replaced `Image.network` calls with pre-sized bundled assets (`example/assets/news_images/`) to fix Impeller GPU command-buffer overflow on iOS 26 physical devices.
+- **Apple News demo** — `collapsedLogoBuilder` now mirrors the active tab icon instead of a static badge.
+
+---
+
+# 0.7.7
+
+### Refactor
+
+- **Internal**: Removed `GlassIndicatorTapMixin` and migrated `GlassTabBar` and `GlassSegmentedControl` fully to raw `Listener` pointer events, matching `GlassBottomBar`'s robust drag-cancel and press-and-hold handling. No API change.
+
+---
+
+# 0.7.6
+
+### Bug Fixes
+
+- **FIX**: `LiquidGlassBlendGroup` asymmetry — left buttons attracted their neighbours more strongly than right buttons in groups of 3+. Fixed with a bidirectional smooth-union pass (L→R + R→L, averaged 50/50). Two-shape groups are mathematically identical to before.
+
+- **FIX**: `GlassButtonGroup` — glass effect could bleed as a dark rectangle on Impeller with `GlassQuality.premium` and `useOwnLayer: true`. A `ClipRRect(antiAlias)` now hard-clips the bleed at the superellipse boundary without forcing a quality downgrade.
+
+---
+
+# 0.7.5
+
+### Bug Fixes
+
+- **FIX**: `GlassBottomBar` / `GlassSearchableBottomBar` — added `HitTestBehavior.opaque` to the root `GestureDetector` so the full bar height reliably consumes pointer events on simulator and desktop.
+
+- **FIX**: `GlassSearchableBottomBar` — keyboard no longer flickers on physical devices; focus is requested after the expansion animation completes.
+
+- **FIX**: `GlassSearchableBottomBar` — dead zone at expanded search pill edges resolved; the full glass surface now claims taps and routes them to the search field.
+
+### New — `GlassSearchBarConfig` parameters
+
+Seven new parameters (all backwards-compatible):
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `autoFocusOnExpand` | `bool` | `false` | Keyboard opens automatically on expand. |
+| `trailingBuilder` | `WidgetBuilder?` | `null` | Replaces the mic icon with any custom widget. |
+| `textInputAction` | `TextInputAction?` | `null` | Keyboard action key (`search`, `done`, `go`, …). |
+| `keyboardType` | `TextInputType?` | `null` | Keyboard layout (`url`, `emailAddress`, …). |
+| `autocorrect` | `bool` | `true` | Disable for codes, usernames, etc. |
+| `enableSuggestions` | `bool` | `true` | Controls QuickType bar on iOS. |
+| `onTapOutside` | `TapRegionCallback?` | `null` | Called when user taps outside the field. |
+
+---
+
+# 0.7.4
+
+### New Components
+
+- **`GlassSearchableBottomBar`** — `GlassBottomBar` with a morphing search pill that shares the same `AdaptiveLiquidGlassLayer` as the tab pill, producing iOS 26 liquid-merge blending. When `isSearchActive` is `true` the tab pill collapses and the search pill expands via spring animation. Configured via `GlassSearchBarConfig`.
+
+### Examples
+
+- **Apple News demo** (`example/lib/apple_news/apple_news_demo.dart`) — iOS 26 Apple News replica showcasing `GlassSearchableBottomBar`.
+
+### Visual Fixes
+
+- **FIX**: Default glow color on press changed from iOS system blue to a brightness-adaptive neutral white (~35% light / ~22% dark), matching iOS 26 glass press behaviour.
+
+---
+
+# 0.7.3
+
+### Performance
+
+- **PERF**: Deleted unused `rotate2d()` from `render.glsl` — it was compiled into every shader binary but never called.
+- **PERF**: Eliminated a redundant `normalize()` in `interactive_indicator.frag` by reusing an already-computed length.
+- **PERF**: Removed a no-op `canvas.save()`/`canvas.restore()` pair in `GlassGlow` paint.
+
+### Bug Fixes
+
+- **FIX**: `GlassGlow` tracking — glow gradient is now correctly recreated each frame when `glowOffset` changes, fixing the spotlight freezing at its initial position.
+- **FIX**: Glow on Skia/Web — `LightweightLiquidGlass` now wraps in `GlassGlowLayer`, giving the Skia path the same light-follows-touch behaviour as Impeller.
+- **FIX**: Glow on first touch — spotlight now appears immediately at the tap position instead of sliding in from the widget's top-left corner.
+- **FIX**: Glow tracking inside button groups — converted from widget-local to global coordinates so the spotlight correctly follows touches regardless of nesting depth.
+- **FIX**: Glow radius on wide buttons — switched from `shortestSide` to `√(width × height)` so the spotlight scales proportionally to the button area.
+
+---
+
+# 0.7.2
+
+### Performance & Polish
+
+- **PERF**: Lightweight shader (`lightweight_glass.frag`) — reduced ALU instruction count ~10–15 ops per fragment; restored the `normalZ` Fresnel ramp to `sqrt(1 − dot(n,n))`.
+- **PERF**: Impeller final render shader — eliminated `length()`/`normalize()` from anisotropic specular; made `getHeight()` fully branchless; collapsed four `step()` multiplications into one.
+- **PERF**: Dart side — cached light direction trig in `LiquidGlassRenderObject` (only recomputed when `lightAngle` changes); changed `GlassGroupLink.shapeEntries` from `List` to `Iterable` to eliminate per-frame heap allocation.
+- **FIX**: Adjusted `GlassBottomBar`, `GlassTabBar`, and `GlassSegmentedControl` spring from 500ms `bouncySpring` to 350ms `snappySpring`, matching iOS 26 segment-indicator physics.
+
+---
+
+# 0.7.1
+
+### Bug Fixes
+
+- **FIX**: `GlassBottomBar`, `GlassTabBar`, `GlassSegmentedControl` — rapid taps no longer prematurely snap the indicator, killing spring physics. Removed pixel-snapping from `onHorizontalDragDown` so taps correctly use spatial distance for the iOS 26 jump animation.
+
+---
+
+# 0.7.0
+
+### New Components
+
+- **`GlassDivider`** — iOS 26-style hairline separator, horizontal and vertical. Theme-adaptive opacity (dark: 20% white / light: 10% black).
+- **`GlassListTile`** — iOS 26 Settings-style row with leading icon, title, subtitle, trailing widget, and automatic grouped dividers. Use inside a zero-padding `GlassCard`. Convenience constants: `GlassListTile.chevron`, `GlassListTile.infoButton`.
+- **`GlassStepper`** — iOS 26 `UIStepper` equivalent. Compact `−`/`+` glass pill with auto-repeat on hold, `min`/`max` clamping, `wraps` cycling, fractional `step`, and haptic feedback.
+- **`GlassWizard` + `GlassWizardStep`** — multi-step flow with numbered indicators, checkmarks, and expandable step content.
+
+### Accessibility
+
+- **`GlassAccessibilityScope`** — reads platform Reduce Motion and Reduce Transparency preferences and propagates them to all glass widgets in its subtree:
+  - **Reduce Motion**: spring animations snap instantly.
+  - **Reduce Transparency**: replaces the full glass shader pipeline with a plain `BackdropFilter(blur)` + frosted container.
+- Semantics updated across all remaining widgets to match iOS `UIAccessibility` conventions.
+
+### Performance
+
+- **PERF**: `GlassSpecularSharpness` enum — replaces `pow(lightCatch, exponent)` (two transcendentals per fragment) with a pure squaring chain in `lightweight_glass.frag`. Zero transcendentals. Default: `.medium`.
+- **PERF**: `pow(x, 1.5)` → `x·√x` in Impeller edge lighting — `sqrt()` is a single hardware SFU instruction.
+- **PERF**: Anisotropic specular and Fresnel rim brightening ported from the Impeller path to `lightweight_glass.frag`, closing the largest visual gap between rendering paths.
+- **PERF**: Content-adaptive glass strength — intensity auto-adjusts based on backdrop luminance on Impeller, or `MediaQuery.platformBrightness` on Skia/Web.
+
+### Developer Experience
+
+- **`GlassRefractionSource`** — renamed from `LiquidGlassBackground` to better reflect its role. `LiquidGlassBackground` remains as a deprecated `typedef` (removed in 1.0.0).
+- **Synchronous background capture** — rebuilt using `boundary.toImageSync()` on native (zero CPU↔GPU readback) and async `toImage()` on web.
+
+---
+
+# 0.6.1
+
+### Visual Quality
+
+- **FIX**: True surface normal storage in geometry texture — the geometry pass now stores the SDF-gradient-derived surface normal instead of the refraction displacement vector. The render shader decodes and recomputes displacement via `refract()`. Specular highlights on blended glass shapes (e.g. two overlapping pills) now correctly follow true surface curvature rather than the refraction direction. Single-shape surfaces are visually identical to 0.6.0.
+- **FIX**: Anisotropic specular highlights (Impeller) — specular lobe stretched 20% along the surface tangent, producing the horizontal oval highlight that matches iOS 26.
+- **FIX**: Fresnel edge luminosity ramp (Impeller) — gentle brightness ramp at grazing angles matching iOS 26's centre-to-edge luminosity gradient.
+- **FIX**: Luminosity-preserving glass tint in lightweight shader — replaced additive tint with the same `applyGlassColor()` model as the Impeller path: achromatic glass lifts toward white, chromatic glass shifts hue while preserving luminance.
+
+### Performance
+
+- **PERF**: Branchless `smoothUnion` — eliminated a conditional branch that caused warp divergence when glass shapes transition between merged and separate.
+- **PERF**: `if/else if` dispatch in shape SDF — GPU now short-circuits after the first type match; default changed to `0.0` for a clearly visible failure mode.
+- **PERF**: Single texture fetch when chromatic aberration is disabled — `interactive_indicator.frag` previously sampled the background three times unconditionally; 66% fewer texture reads in the common case.
+- **PERF**: Flat-interior early-exit in final render shader — pixels where `normalXY ≈ 0` skip `refract()` and all texture samples, replaced with a single background sample. Lossless.
+
+---
+
+# 0.6.0
+
+### Breaking Changes
+
+- **`LiquidGlassLayer.useBackdropGroup` removed.** Glass layers now automatically detect a `BackdropGroup` ancestor. Remove `useBackdropGroup: true` from any `LiquidGlassLayer(...)` calls.
+
+### New Features
+
+- **`LiquidGlassWidgets.wrap()`** — wraps your app in a `GlassBackdropScope` in one line:
+  ```dart
+  runApp(LiquidGlassWidgets.wrap(const MyApp()));
+  ```
+- **`GlassMotionScope`** — drives glass specular angle from any `Stream<double>` (e.g. device gyroscope). No new dependencies required.
+
+### Performance
+
+- **PERF**: `GlassBackdropScope` auto-activation — glass layers automatically share a single GPU backdrop capture when a scope ancestor is present.
+- **PERF**: Local-space geometry rasterization — geometry texture cached until pill size or shape changes, eliminating per-frame rebuilds during animation.
+- **PERF**: Shader UV bounds check — discards fragments where geometry UV falls outside `[0, 1]`, preventing the thin "protruding line" artifact during jelly-physics expansion.
+
+### Visual
+
+- **FIX**: Refraction UV — uses `uSize` uniform (always valid on first frame) instead of `textureSize()` which returns `(0,0)` on the first frame in Impeller.
+- **FIX**: `precision highp float` in final render shader (was `mediump`, risking colour banding on mobile).
+- **FIX**: iOS 26 glass tint model — preserves backdrop luminance while shifting chroma. Replaces Photoshop Overlay mode.
+- **FIX**: Leading-dot rim artifact — `x / (1 + x)` soft-clamping on highlight intensity prevents bright corner artifact during drag.
+- **FIX**: Impeller indicator clipping — jelly physics animations no longer clip at the static bounding box (`clipExpansion` parameter added).
+- **FIX**: Web & WASM — removed `dart:io` imports from shader resolution logic.
+
+### Dependencies
+
+- **Removed `motor` dependency** — replaced with self-contained `glass_spring.dart`. Zero third-party runtime dependencies beyond the Flutter SDK.
+
+---
+
+# 0.5.0
+
+### Breaking Changes
+
+**`LiquidGlass` removed from the public API.**
+It was inadvertently exposed and silently renders nothing on Skia/Web. Use `AdaptiveGlass` instead:
+
+```dart
+// Before
+LiquidGlass(settings: LiquidGlassSettings(...), child: ...)
+
+// After
+AdaptiveGlass(settings: LiquidGlassSettings(...), child: ...)
+```
+
+`LiquidGlassLayer`, `LiquidGlassBlendGroup`, `LiquidGlassSettings`, `LiquidShape`, `GlassGlow`, and `debugPaintLiquidGlassGeometry` remain public.
+
+### New Features
+
+- **`GlassBackdropScope`** — halves GPU blur capture cost when multiple glass surfaces are on screen simultaneously. Wrap your `MaterialApp` or `Scaffold` to activate:
+
+```dart
+GlassBackdropScope(
+  child: MaterialApp(
+    home: Scaffold(
+      appBar: GlassAppBar(...),
+      bottomNavigationBar: GlassBottomBar(...),
+    ),
+  ),
+)
+```
+
+### Renderer
+
+The renderer from `liquid_glass_renderer` (whynotmake.it, MIT) is now vendored directly, giving full control over the rendering pipeline with no user-facing API changes.
+
+---
+
+# 0.4.1
+
+### Bug Fixes
+
+- **FIX**: `GlassBottomBar` and other surfaces now correctly respond to dynamic `glassSettings` changes on `GlassQuality.standard` — `AdaptiveGlass` in grouped mode now inherits settings from `InheritedLiquidGlass` instead of using empty defaults.
+- **FIX**: Luminance-aware ambient floor for white glass on `GlassQuality.standard` — high-opacity white glass no longer renders as dark grey.
+
+### New
+
+- **FEAT**: `GlassBottomBar.iconLabelSpacing` — configurable vertical gap between tab icon and label (default: `4.0`). Thanks @baneizalfe (#11).
+
+### Breaking Changes
+
+**Library-wide `IconData` → `Widget` API migration.** All icon parameters now accept any `Widget`:
+
+```dart
+// Before
+GlassButton(icon: CupertinoIcons.heart, onTap: () {})
+
+// After
+GlassButton(icon: Icon(CupertinoIcons.heart), onTap: () {})
+// Or any custom widget:
+GlassButton(icon: SvgPicture.asset('assets/heart.svg'), onTap: () {})
+```
+
+`GlassBottomBarTab.selectedIcon` renamed to `activeIcon` to match Flutter's `BottomNavigationBarItem` convention.
+
+---
+
+# 0.4.0
+
+### New Components
+
+- **`GlassMenu` / `GlassMenuItem` / `GlassPullDownButton`** — iOS 26 morphing context menu with spring physics and position-aware expansion.
+- **`GlassButtonGroup`** — joined-style container for related actions (e.g. Bold/Italic/Underline toolbar).
+- **`GlassFormField`** / **`GlassPasswordField`** / **`GlassTextArea`** / **`GlassPicker`** — full iOS 26 input suite.
+- **`GlassSideBar`** — vertical navigation surface with header, footer, and scrollable items.
+- **`GlassToolbar`** — standard iOS-style action toolbar.
+- **`GlassTabBar`** — horizontal tab navigation bar with animated indicator and scrollable mode for 5+ tabs.
+- **`GlassProgressIndicator`** — circular and linear variants (indeterminate and determinate), iOS 26 specs.
+- **`GlassToast` / `GlassSnackBar`** — 5 notification types, 3 positions, auto-dismiss, swipe-to-dismiss.
+- **`GlassBadge`** — count and dot status badges, 4 positions.
+- **`GlassActionSheet`** — iOS-style bottom-anchored action list.
+
+### Performance
+
+- **Universal Platform Support** — `AdaptiveGlass` and `AdaptiveLiquidGlassLayer` introduced. All 26 widgets deliver consistent glass quality on Web, Skia, and Impeller.
+- **Batch-blur optimisation** — glass containers share a single `BackdropFilter` (was: one per widget). ~5× faster in common multi-widget layouts.
+- **Impeller pipeline warm-up** — shaders pre-compile at startup to eliminate first-frame jank.
+
+### Theme System
+
+- **`GlassTheme` / `GlassThemeData` / `GlassThemeVariant`** — global styling and quality inheritance across all widgets. Set once, inherited everywhere.
+
+---
+
+# 0.3.0 — 0.1.0
+
+Early access and preview releases establishing the core widget library, initial glass rendering pipeline (`LiquidGlass`, `LiquidGlassLayer`, `LiquidGlassBlendGroup`), and foundational components (`GlassBottomBar`, `GlassButton`, `GlassSwitch`, `GlassCard`, `GlassSearchBar`, `GlassSlider`, `GlassChip`, `GlassSegmentedControl`, `GlassSheet`, `GlassDialog`, `GlassIconButton`).

--- a/packages/liquid_glass_widgets/LICENSE
+++ b/packages/liquid_glass_widgets/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sebastian Degenaar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/liquid_glass_widgets/README.md
+++ b/packages/liquid_glass_widgets/README.md
@@ -1,0 +1,857 @@
+# Liquid Glass Widgets
+
+Bring Apple's iOS 26 Liquid Glass to your Flutter app — a comprehensive glass widget library with real shader-based blur, physics-driven jelly animations, and dynamic lighting. Works on every platform out of the box.
+
+[![pub package](https://img.shields.io/pub/v/liquid_glass_widgets.svg?label=pub.dev&labelColor=333940&logo=dart)](https://pub.dev/packages/liquid_glass_widgets)
+[![pub points](https://img.shields.io/pub/points/liquid_glass_widgets?label=pub%20points&labelColor=333940)](https://pub.dev/packages/liquid_glass_widgets/score)
+[![likes](https://img.shields.io/pub/likes/liquid_glass_widgets?label=likes&labelColor=333940)](https://pub.dev/packages/liquid_glass_widgets/score)
+[![CI](https://github.com/sdegenaar/liquid_glass_widgets/actions/workflows/ci.yml/badge.svg)](https://github.com/sdegenaar/liquid_glass_widgets/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/sdegenaar/liquid_glass_widgets/graph/badge.svg)](https://codecov.io/gh/sdegenaar/liquid_glass_widgets)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
+
+https://github.com/user-attachments/assets/2fe28f46-96ad-459d-b816-e6d6001d90de
+
+*[Wanderlust](example/showcase/) — a luxury travel showcase built entirely with `liquid_glass_widgets`*
+
+
+## Features
+
+- **Comprehensive glass widget library** — containers, interactive controls, inputs, feedback, overlays, and navigation surfaces (see [Widget Categories](#widget-categories))
+- **Liquid Morph Engine** — a standalone physics system powering iOS 26-style liquid morphing. `GlassMenu` is the first consumer; future widgets will use the same engine for consistent liquid transitions. See [`docs/LIQUID_MORPH_ENGINE.md`](docs/LIQUID_MORPH_ENGINE.md)
+- **Real frosted glass** — native two-pass Gaussian blur + shader refraction on Impeller; lightweight shader on Skia/Web
+- **Just works everywhere** — iOS, Android, macOS, Web, Windows, Linux; rendering path chosen automatically
+- **Adaptive quality** *(experimental)* — `GlassAdaptiveScope` benchmarks the device at startup and adjusts quality in real time: `minimal` on slow hardware, `standard` on mid-range, `premium` on fast devices. Degrades on thermal throttle, recovers when cool
+- **Minimal dependencies** — only `equatable`, `flutter_shaders`, and `logging` beyond the Flutter SDK
+- **One-line setup** — `LiquidGlassWidgets.wrap(child: myApp)` handles accessibility bridging, adaptive quality, and global theming; use `GlassScaffold` per screen for automatic backdrop isolation, z-ordering, edge fading, and status bar styling
+- **Content-aware brightness** — glass bars automatically flip between light and dark icons/labels based on the content scrolling behind them. One flag on `GlassScaffold`, matches iOS 26 behaviour
+- **Gyroscope lighting** — `GlassMotionScope` drives specular highlights from any `Stream<double>`
+- **WCAG-compliant by default** — Reduce Motion and Reduce Transparency are respected automatically; no setup required
+
+
+## Examples
+
+### [Wanderlust](example/showcase/) — Luxury Travel Showcase
+
+A premium app demonstrating `liquid_glass_widgets` in a real-world production context — full-bleed imagery, parallax scroll, hero transitions, and a concierge chat interface. **This is the app shown in the video above.**
+
+```bash
+cd example/showcase && flutter pub get && flutter run
+```
+
+
+### [Apple Music Demo](example/lib/apple_music/) — iOS 26 Replica
+
+A recreation of the Apple Music app demonstrating `GlassTabBar.searchable()`, a floating playback pill, and the full iOS 26 navigation model with smooth morphing transitions.
+
+```bash
+cd example && flutter pub get && flutter run -t lib/apple_music/apple_music_demo.dart
+```
+
+
+### [Apple Messages Demo](example/lib/apple_messages/) — iOS 26 Replica
+
+A replica showcasing the **Liquid Morph Engine** via `GlassMenu`. Tap the menu or **Edit** button at the top to see the teardrop open/close physics live.
+
+```bash
+cd example && flutter pub get && flutter run -t lib/apple_messages/apple_messages_demo.dart
+```
+
+
+### [Apple News Demo](example/lib/apple_news/) — iOS 26 Replica
+
+A recreation of the Apple News app demonstrating `GlassTabBar.searchable()` with its morphing search pill, category chips, hero cards, and rounded article tiles.
+
+```bash
+cd example && flutter pub get && flutter run -t lib/apple_news/apple_news_demo.dart
+```
+
+<img width="390" height="844" alt="Apple News Demo" src="https://raw.githubusercontent.com/sdegenaar/liquid_glass_widgets/main/docs/assets/apple_news_demo.jpg" />
+
+### [Widget Showcase](example/) — Full Component Library
+
+A complete catalogue of every glass widget organised by category. Use it to explore components, try live settings, and copy patterns directly into your app.
+
+```bash
+cd example && flutter pub get && flutter run
+```
+
+<img width="390" height="847" alt="Widget Showcase" src="https://raw.githubusercontent.com/sdegenaar/liquid_glass_widgets/main/docs/assets/showcase.jpg" />
+
+
+### [Component Demos](example/lib/demos/) — Copy-Pasteable Examples
+
+Eight focused, self-contained demos — one widget, one file, runnable standalone:
+
+| Demo | Run command (from `example/`) |
+|---|---|
+| `glass_menu_demo.dart` — all 9 menu alignments | `cd example && flutter run -t lib/demos/glass_menu_demo.dart` |
+| `glass_tab_bar_scrollable_demo.dart` — scrollable tab bar | `cd example && flutter run -t lib/demos/glass_tab_bar_scrollable_demo.dart` |
+| `glass_modal_sheet_demo.dart` — peek / half / full states | `cd example && flutter run -t lib/demos/glass_modal_sheet_demo.dart` |
+| `glass_bottom_bar_demo.dart` — magic-lens masking | `cd example && flutter run -t lib/demos/glass_bottom_bar_demo.dart` |
+| `bottom_bar_tab_width_demo.dart` — tabWidth showcase | `cd example && flutter run -t lib/demos/bottom_bar_tab_width_demo.dart` |
+| `searchable_bar_demo.dart` — searchable bar edge cases | `cd example && flutter run -t lib/demos/searchable_bar_demo.dart` |
+| `shape_debug_demo.dart` — GlassButton shapes | `cd example && flutter run -t lib/demos/shape_debug_demo.dart` |
+| `quality_comparison_demo.dart` — premium & standard quality comparison playground | `cd example && flutter run -t lib/demos/quality_comparison_demo.dart` |
+| `nav_bar_patterns_demo.dart` — GlassScaffold layout patterns | `cd example && flutter run -t lib/demos/nav_bar_patterns_demo.dart` |
+| `content_aware_brightness_demo.dart` — light/dark bar adaptation on scroll | `cd example && flutter run -t lib/demos/content_aware_brightness_demo.dart` |
+| `indicator_parity_demo.dart` — all four pill widgets side-by-side with live pinch/expansion/tint sliders | `cd example && flutter run -t lib/demos/indicator_parity_demo.dart` |
+
+
+## Glass vs Content — Design Philosophy
+
+In iOS 26, **glass is reserved for the navigation and control layer** — the
+floating UI that sits above your app's content. Content areas (lists, cards,
+article tiles) stay opaque.
+
+| ✅ Use glass for | ❌ Keep opaque |
+|---|---|
+| Navigation bars, tab bars, toolbars | List cells, table rows |
+| Floating action buttons | Full-screen backgrounds |
+| Sheets, popovers, menus | Scrollable content cards |
+| Toggles, sliders, segmented controls | Article tiles, media players |
+
+**Typical screen composition:**
+
+```
+┌──────────────────────────┐
+│   GlassAppBar (glass)    │  ← Navigation chrome
+├──────────────────────────┤
+│                          │
+│   Opaque content area    │  ← Standard Flutter widgets
+│   (ListView, Cards, etc) │
+│                          │
+├──────────────────────────┤
+│  GlassBottomBar (glass)  │  ← Navigation chrome
+└──────────────────────────┘
+```
+
+Building a Settings screen? Use `GlassScaffold` + `GlassAppBar` for navigation
+chrome, and `CupertinoListTile` or standard Flutter containers for the rows.
+Use `GlassGroupedSection` when you want glass-styled grouped rows.
+
+### Glass Composition Rule: Glass is a Platter, Not a Wrapper
+
+`GlassCard`, `GlassContainer`, and `GlassGroupedSection` are **base surfaces** — they sit
+beneath your content. They are not generic styling wrappers for other glass controls.
+
+| ✅ Place inside GlassCard / GlassContainer | ❌ Do not place inside GlassCard / GlassContainer |
+|---|---|
+| `Text`, `Icon`, `ListTile`, `CupertinoListTile` | `GlassSegmentedControl`, `GlassSlider`, `GlassSwitch` |
+| `GlassListTile`, `GlassDivider` | `GlassButton`, `GlassChip`, `GlassIconButton` |
+| Standard Flutter form widgets | Any other refractive glass widget |
+
+**Why?** `GlassContainer` sets `avoidsRefraction: true` on its children so nested glass
+cannot refract through the outer layer — the inner effect degrades by design. On Impeller
+with `useOwnLayer: true`, the container's own-layer clip also cuts jelly-physics overshots
+from interactive indicators (segmented control pill, slider thumb) during animations.
+
+Interactive glass controls already provide their own surface appearance via `backgroundColor`
+and `indicatorColor` — no outer container is needed for the track or background.
+
+
+## Widget Categories
+
+### Containers
+`GlassCard` · `GlassContainer`\* · `GlassDivider` · `GlassGroupedSection` · `GlassListTile` · `GlassStepper`
+
+\* `GlassContainer` is a low-level building block for custom glass surfaces.
+Most apps should use `GlassCard` or `GlassGroupedSection` instead.
+
+### Interactive
+`GlassButton` · `GlassIconButton` · `GlassChip` · `GlassSwitch` · `GlassSlider` · `GlassSegmentedControl` · `GlassPullDownButton` · `GlassButtonGroup` · `GlassBadge` · `GlassPageControl`
+
+### Input
+`GlassTextField` · `GlassTextArea` · `GlassPasswordField` · `GlassSearchBar` · `GlassPicker` · `GlassFormField`
+
+### Feedback
+`GlassProgressIndicator` · `GlassToast`
+
+### Overlays
+`GlassDialog` · `GlassSheet` · `GlassModalSheet` · `showGlassActionSheet` · `GlassMenu` · `GlassMenuItem` · `GlassMenuDivider` · `GlassMenuLabel` · `GlassPopover`
+
+### Surfaces
+`GlassScaffold` · `GlassAppBar` · `GlassTabBar` (`.bottom` / `.inline` / `.searchable`) · `GlassToolbar` · `GlassContentAwareScope` · `GlassContentAwareContent` · `GlassContentAwareBrightness`
+
+
+## Installation
+
+```yaml
+dependencies:
+  liquid_glass_widgets: ^0.21.3
+```
+
+```bash
+flutter pub get
+```
+
+> **Flutter version requirement:** Requires Flutter ≥ 3.41.0 (Dart ≥ 3.5.0).
+> **Recommended: Flutter 3.41+** for the best Impeller rendering quality.
+> This package uses cutting-edge shader APIs that improve significantly with each Flutter release.
+
+
+## Quick Start
+
+Two steps — that's the entire setup:
+
+**Step 1.** Call `initialize()` in `main()` to pre-warm shaders.
+
+**Step 2.** Wrap your app with `LiquidGlassWidgets.wrap()`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await LiquidGlassWidgets.initialize();
+
+  runApp(LiquidGlassWidgets.wrap(child: const MyApp()));
+}
+```
+
+That's it. Then use `GlassScaffold` on each screen — it handles background, status bar, z-ordering, and edge fading automatically:
+
+```dart
+GlassScaffold(
+  background: Image.asset('assets/wallpaper.jpg', fit: BoxFit.cover),
+  statusBarStyle: GlassStatusBarStyle.auto,
+  appBar: GlassAppBar(title: const Text('My App')),
+  body: Center(child: GlassCard(child: Text('Hello, Glass!'))),
+)
+```
+
+> **Why `GlassScaffold`?** Glass effects refract and blur against whatever is behind them. Without a controlled background, glass surfaces can appear flat, incorrectly tinted, or invisible. `GlassScaffold` wires up the background source, glass rendering layer, and bar isolation automatically — one widget instead of five.
+
+> **Accessibility is on by default.** The library automatically reads the
+> device's Reduce Motion and Reduce Transparency settings — no extra setup
+> required. See [Accessibility](#accessibility) for details.
+
+### Choose the right widget
+
+The package is centred around **navigation chrome** — `GlassScaffold` with `GlassAppBar` and `GlassTabBar` is the primary pattern and where the iOS 26 liquid glass effect is most impactful.
+
+| Scenario | Widget to use |
+|---|---|
+| Screen with app bar and/or tab bar | **`GlassScaffold`** — the primary pattern |
+| Custom layout without standard scaffold structure | **`GlassPage`** — lower-level building block |
+| Standalone glass card or panel in an existing layout | **`GlassCard` / `GlassContainer`** — opt-in, not the core pattern |
+| Localised group of glass elements in an existing layout | **`AdaptiveLiquidGlassLayer`** — scope a layer to a region; grouped cards share its settings |
+
+> `GlassContainer` / `GlassCard` are fully supported for localised glass UI (floating panels, settings cards, etc.) but most screens should start with `GlassScaffold`.
+
+### Optional: quality & theming
+
+For production apps, pass `adaptiveQuality` and/or `theme` to `wrap()` at the same call site:
+
+```dart
+runApp(LiquidGlassWidgets.wrap(
+  child: const MyApp(),
+  adaptiveQuality: true,          // auto-benchmarks device, degrades gracefully
+  theme: GlassThemeData.simple(   // optional app-wide glass defaults
+    blur: 10,
+    thickness: 30,
+    quality: GlassQuality.standard,
+  ),
+));
+```
+
+Both parameters are optional — omit them and the library uses sensible defaults.
+
+
+## Theming
+
+Pass a `theme:` to `LiquidGlassWidgets.wrap()` to set your app-wide defaults — every glass widget inherits them automatically, no per-widget configuration needed:
+
+```dart
+runApp(LiquidGlassWidgets.wrap(
+  child: const MyApp(),
+  theme: GlassThemeData(
+    light: GlassThemeVariant(
+      settings: GlassThemeSettings(thickness: 30, blur: 6),
+      quality: GlassQuality.standard,
+    ),
+    dark: GlassThemeVariant(
+      settings: GlassThemeSettings(thickness: 40, blur: 8),
+      quality: GlassQuality.standard,
+    ),
+  ),
+));
+```
+
+For a quick single-quality theme, use the `GlassThemeData.simple` shorthand:
+
+```dart
+runApp(LiquidGlassWidgets.wrap(
+  child: const MyApp(),
+  theme: GlassThemeData.simple(
+    blur: 10,
+    thickness: 30,
+    quality: GlassQuality.standard,
+  ),
+));
+```
+
+> **`GlassThemeSettings` vs `LiquidGlassSettings`:** Use `GlassThemeSettings` inside `GlassThemeVariant`. It accepts the same parameters but all are nullable — only fields you explicitly set are applied; everything else inherits from each widget's own defaults. `LiquidGlassSettings` is the full settings type used on individual widgets.
+
+Three-level override hierarchy (highest wins):
+
+1. **Widget `settings` parameter** — explicit, widget-level override
+2. **`GlassPage(themeOverride: ...)`** — per-screen override for special pages (onboarding, paywalls)
+3. **`GlassTheme` / `wrap(theme:...)`** — app-wide defaults
+
+Access the current theme programmatically:
+
+```dart
+final variant = GlassThemeData.of(context).variantFor(context);
+```
+
+#### Per-subtree theming
+
+For advanced use cases where you need different glass styles within a single screen, place a `GlassTheme` widget anywhere in your tree:
+
+```dart
+GlassTheme(
+  data: GlassThemeData.simple(blur: 4, quality: GlassQuality.minimal),
+  child: MyListSection(), // list cards get minimal quality
+)
+```
+
+### Glow Colors
+
+`GlassGlowColors` controls the interaction glow emitted by surfaces like `GlassBottomBar` and `GlassSearchableBottomBar`:
+
+```dart
+GlassThemeVariant(
+  glowColors: GlassGlowColors(
+    primary: Colors.blue,
+    glowBlurRadius: 12,
+    glowSpreadRadius: 0.2,
+    glowOpacity: 0.8,
+  ),
+)
+```
+
+
+## Platform Support
+
+| Platform | Renderer | Notes |
+|---|---|---|
+| iOS | Impeller (Metal) | Full shader pipeline, chromatic aberration |
+| Android | Impeller (Vulkan) | Full shader pipeline, chromatic aberration |
+| macOS | Impeller (Metal) | Full shader pipeline, chromatic aberration |
+| Web | CanvasKit | Lightweight fragment shader |
+| Windows | Skia | Lightweight fragment shader |
+| Linux | Skia | Lightweight fragment shader |
+
+Platform detection is automatic — no configuration required.
+
+
+## Glass Quality Modes
+
+### Standard — Default, Recommended
+
+The right choice for 95% of use cases. Works on every platform with iOS 26-accurate glass effects.
+
+```dart
+GlassContainer(
+  quality: GlassQuality.standard, // this is the default
+  child: const Text('Great for scrollable content'),
+)
+```
+
+### Premium — Impeller Only
+
+Enables the full Impeller shader pipeline with texture capture and chromatic aberration. On Skia/Web, automatically falls back to Standard.
+
+```dart
+GlassCard(
+  quality: GlassQuality.premium,
+  child: const Text('Static hero section'),
+)
+```
+
+> **Use Premium only for static, non-scrolling surfaces** (hero sections, feature cards). It may not render correctly inside `ListView` or `CustomScrollView` on Impeller. `GlassScaffold` automatically promotes app bars and bottom bars to premium quality via `GlassIsolationScope`.
+
+### Minimal — Shader-Free
+
+Zero custom fragment shader cost on any device. Uses `BackdropFilter` blur + a Rec. 709 saturation matrix + a specular rim stroke. Visually equivalent to a high-quality frosted panel.
+
+```dart
+GlassCard(
+  quality: GlassQuality.minimal,
+  child: const Text('No shader overhead'),
+)
+```
+
+Two ideal use cases:
+- **Device fallback** — very old Android devices or any device where `ImageFilter.isShaderFilterSupported` is `false`
+- **GPU budget management** — use `minimal` for background panels and list cards while keeping `standard` or `premium` on the focal element. A screen with 15 glass list cards running `minimal` fires zero shader invocations during scroll
+
+> **Theme shorthand**: `GlassThemeVariant.minimal` applies `minimal` quality globally via `GlassThemeData`.
+
+
+## GlassScaffold
+
+`GlassScaffold` is the recommended way to build any screen that uses glass surfaces. It replaces the manual assembly of `GlassPage` + `Scaffold` + `GlassScrollEdgeEffect` + `Stack` with a single widget:
+
+```dart
+GlassScaffold(
+  background: Image.asset('assets/wallpaper.jpg', fit: BoxFit.cover),
+  statusBarStyle: GlassStatusBarStyle.light,
+  appBar: GlassAppBar(
+    title: const Text('Messages'),
+    trailing: GlassButton(
+      icon: const Icon(CupertinoIcons.compose),
+      onTap: () {},
+    ),
+  ),
+  bottomBar: GlassTabBar.bottom(
+    selectedIndex: 0,
+    onTabSelected: (_) {},
+    tabs: const [
+      GlassTab(icon: Icon(Icons.home), label: 'Home'),
+      GlassTab(icon: Icon(Icons.search), label: 'Search'),
+    ],
+  ),
+  body: CustomScrollView(
+    slivers: [...],
+  ),
+)
+```
+
+| What it handles | Without `GlassScaffold` |
+|---|---|
+| Background + glass layer | Must wrap in `GlassPage` + set `scaffoldBackgroundColor: transparent` |
+| Z-ordering (bars above body) | Must build a manual `Stack` with correct paint order |
+| Edge fading | Must add `GlassScrollEdgeEffect` and calculate fade heights |
+| Safe-area padding | Must calculate top/bottom padding for app bar and bottom bar |
+| Bar isolation | Must wrap bars in `GlassIsolationScope` manually |
+| Status bar icons | Must call `SystemChrome.setSystemUIOverlayStyle` and restore it |
+
+> See `example/lib/demos/nav_bar_patterns_demo.dart` for complete `GlassScaffold` usage patterns.
+
+### Content-Aware Brightness
+
+Glass bars automatically adapt their icon and label colors to match the content
+scrolling behind them — light icons over dark content, dark icons over light
+content — with a smooth cross-fade transition. One flag on `GlassScaffold`,
+one on the bar:
+
+```dart
+GlassScaffold(
+  contentAwareBrightness: true,
+  bottomBar: GlassTabBar.bottom(
+    adaptiveBrightness: true,
+    onBrightnessChanged: (b) => debugPrint('Bar is now: $b'),
+    tabs: [...],
+    selectedIndex: _index,
+    onTabSelected: (i) => setState(() => _index = i),
+  ),
+  body: CustomScrollView(
+    slivers: [...], // content scrolls underneath the bar
+  ),
+)
+```
+
+`GlassScaffold.contentAwareBrightness` handles all the wiring — it wraps the
+body in `GlassContentAwareContent` and the layout in `GlassContentAwareScope`
+automatically. The bar uses WCAG contrast ratios with dual-threshold hysteresis
+to prevent flickering on borderline content.
+
+For custom layouts without `GlassScaffold`, use the standalone widgets directly:
+
+```dart
+GlassContentAwareScope(
+  child: Scaffold(
+    extendBody: true,
+    body: GlassContentAwareContent(
+      child: ListView(...),
+    ),
+    bottomNavigationBar: GlassTabBar.bottom(
+      adaptiveBrightness: true,
+      ...
+    ),
+  ),
+)
+```
+
+> See `example/lib/demos/content_aware_brightness_demo.dart` for a focused showcase.
+
+---
+
+## GlassPage
+
+`GlassPage` is the lower-level building block that `GlassScaffold` uses internally. Use it directly when you need full manual control over your layout — custom `Stack` ordering, non-standard bar placements, or screens without a traditional scaffold structure.
+
+> **For most apps, `GlassScaffold` is simpler** — it handles background, bars, edge fading, and isolation automatically. Use `GlassPage` only when you need to build a custom layout that `GlassScaffold` doesn't support.
+
+`GlassPage` eliminates several common setup mistakes in one widget:
+
+```dart
+// Minimum — just wrap your Scaffold, GlassPage handles everything else:
+GlassPage(
+  child: Scaffold(
+    appBar: GlassAppBar(title: const Text('Home')),
+    body: MyContent(),
+  ),
+)
+
+// With a wallpaper:
+GlassPage(
+  background: Image.asset('assets/wallpaper.jpg', fit: BoxFit.cover),
+  edgeToEdge: true,
+  statusBarStyle: GlassStatusBarStyle.auto,
+  child: Scaffold(
+    appBar: GlassAppBar(title: const Text('Home')),
+    body: MyContent(),
+  ),
+)
+```
+
+| What it handles | Without `GlassPage` |
+|---|---|
+| Transparent `Scaffold` | Must set `scaffoldBackgroundColor: transparent` manually |
+| Navigation ghosting | Handled automatically — each glass layer isolates its own backdrop |
+| Background scope setup | Must wrap in `LiquidGlassScope` manually |
+| Status bar icons | Must call `SystemChrome.setSystemUIOverlayStyle` and restore it |
+| Edge-to-edge mode | Must call `SystemChrome.setEnabledSystemUIMode` and restore it |
+| Per-screen theme | Must wrap subtree in a local `GlassTheme` manually |
+
+### Parameters
+
+| Parameter | Default | Purpose |
+|---|---|---|
+| `background` | `null` | Optional wallpaper/background widget. When omitted, `Scaffold` background is left unchanged |
+| `child` | required | Screen content, typically a `Scaffold` |
+| `enableBackgroundSampling` | `true` when `background` is set, `false` otherwise | GPU texture capture for real colour absorption. Set `false` explicitly to opt out |
+| `statusBarStyle` | `GlassStatusBarStyle.none` | Status bar icon brightness; `auto` is recommended for wallpaper screens |
+| `edgeToEdge` | `false` | Draw content behind system bars (full immersive) |
+| `themeOverride` | `null` | Per-screen `GlassThemeData` override for special screens |
+> 
+> **Tip for `edgeToEdge` on Android:** When `true`, content draws underneath the Android navigation bar. Remember to wrap your `Scaffold` body in a `SafeArea` (or use `extendBody: true` and pad the bottom) so your content isn't hidden behind the system buttons.
+
+### Specular Sharpness
+
+Control the tightness of the specular highlight on any glass surface via `LiquidGlassSettings.specularSharpness`:
+
+```dart
+GlassCard(
+  settings: LiquidGlassSettings(
+    specularSharpness: GlassSpecularSharpness.sharp, // tight, mirror-like
+  ),
+  child: ...,
+)
+```
+
+| Value | Look |
+|---|---|
+| `GlassSpecularSharpness.soft` | Wide, diffuse — frosted / matte glass |
+| `GlassSpecularSharpness.medium` | **Default** — matches iOS 26 |
+| `GlassSpecularSharpness.sharp` | Tight, polished — mirror-like surface |
+
+Each value maps to a fixed power-of-2 exponent. The GPU uses a zero-transcendental multiply chain for each — no `pow()` overhead.
+
+
+## Performance Tips
+
+1. **`LiquidGlassWidgets.initialize()`** at startup — pre-caches shaders, eliminates the white flash on first render
+2. **`LiquidGlassWidgets.wrap()`** in `main.dart` — installs accessibility bridging and global theming; pass `adaptiveQuality: true` for automatic per-device quality tuning
+3. **Standard quality for scrollable content** — lists, forms, interactive widgets
+4. **Premium quality for fixed surfaces** — app bars, bottom bars, and hero sections
+5. **Minimal quality for shader-dense screens** — use `GlassQuality.minimal` for background panels and list cards to fire zero custom shader invocations during scroll, then keep `standard` or `premium` only on the focal element
+6. **Accessibility fallbacks are zero-cost** — when Reduce Transparency is active, the glass shader is bypassed entirely; `BackdropFilter` blur runs in Flutter's own paint layer with no custom shader overhead
+
+### Automatic Quality Adaptation *(experimental)*
+
+> 📊 **`GlassAdaptiveScope` is `@experimental`** — its timing thresholds need more real-device data to be finalised. If you use `adaptiveQuality: true`, please share your device model, Flutter version, and observed P75 ms in our [Threshold Calibration Discussion](https://github.com/sdegenaar/liquid_glass_widgets/discussions). See [`docs/ADAPTIVE_QUALITY.md`](docs/ADAPTIVE_QUALITY.md) for current threshold values and the reporting snippet.
+
+`GlassAdaptiveScope` (enabled via `wrap(adaptiveQuality: true)`) automatically
+benchmarks the device at startup and adjusts quality in real time:
+
+```dart
+// Minimal — let the library decide the best quality for the device:
+runApp(LiquidGlassWidgets.wrap(child: const MyApp(), adaptiveQuality: true));
+
+// Per-screen — fine-grained control on specific routes:
+GlassAdaptiveScope(
+  initialQuality: GlassQuality.standard, // conservative start
+  allowStepUp: true,
+  // Android calibration — raise if your device is incorrectly demoted to standard.
+  // Post your P75 + device model to the Threshold Calibration Discussion!
+  // warmupPremiumThresholdMs: 24.0,  // default 20.0
+  // warmupStandardThresholdMs: 32.0, // default 28.0
+  child: Scaffold(...),
+)
+```
+
+#### Eliminating repeat warmup jank (recommended for production)
+
+On the first launch, `GlassAdaptiveScope` runs a ~3-second warm-up benchmark
+to measure real raster performance. On a Pixel 4a, this benchmark observes slow
+frames and steps down to `minimal`. Without persistence, this happens on every
+cold start — the user sees 3 seconds of degraded quality every time they open
+the app.
+
+**Within a single app process**, the library caches the settled quality
+automatically. If the scope is disposed and remounted (e.g. navigating away and
+back to the root), Phase 2 is not re-run — no extra code required.
+
+**Across cold starts**, use `onQualityChanged` + `initialQuality` with your
+preferred storage mechanism:
+
+```dart
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Load previously settled quality — avoids warmup jank on repeat launches.
+  final prefs = await SharedPreferences.getInstance();
+  final saved = prefs.getString('glass_quality');
+  final initial = saved != null
+      ? GlassQuality.values.byName(saved) // Dart 2.15+ built-in
+      : null; // null = run Phase 2 on first launch, then persist
+
+  await LiquidGlassWidgets.initialize();
+
+  runApp(LiquidGlassWidgets.wrap(
+    child: const MyApp(),
+    adaptiveQuality: true,
+    adaptiveConfig: GlassAdaptiveScopeConfig(
+      initialQuality: initial,       // restore immediately — no warmup window
+      allowStepUp: true,             // allow recovery after thermal throttle
+      onQualityChanged: (_, to) =>   // persist whenever quality settles
+          prefs.setString('glass_quality', to.name),
+    ),
+  ));
+}
+```
+
+On first launch: `initial` is null → Phase 2 runs → quality settles → persisted.  
+On every subsequent launch: `initial` is non-null → Phase 2 skipped → no jank.
+
+### GPU Budget Monitoring
+
+`GlassPerformanceMonitor` watches raster frame durations while `GlassQuality.premium` surfaces are active. When frames exceed the GPU budget for 60 consecutive frames it emits a single `FlutterError` with actionable guidance — which widget to change, which quality tier to try, and why.
+
+**Zero production overhead** — automatically disabled in release builds. Enabled by default in debug/profile via `LiquidGlassWidgets.initialize()`:
+
+```dart
+// Default — auto-enabled in debug/profile, zero-cost in release
+await LiquidGlassWidgets.initialize();
+
+// Opt out entirely
+await LiquidGlassWidgets.initialize(enablePerformanceMonitor: false);
+
+// Custom thresholds
+GlassPerformanceMonitor.rasterBudget = const Duration(microseconds: 8333); // 120 fps
+GlassPerformanceMonitor.sustainedFrameThreshold = 120;
+```
+
+## Custom Refraction for Interactive Indicators
+
+On Skia and Web, interactive widgets like `GlassSegmentedControl` can display
+true liquid glass refraction from a background image.
+
+**Recommended: use `GlassPage(background:...)`** — it wires up the refraction source
+automatically and is the cleanest integration path:
+
+```dart
+// GlassPage handles LiquidGlassScope + GlassBackgroundSource for you:
+GlassPage(
+  background: Image.asset('assets/wallpaper.jpg', fit: BoxFit.cover),
+  child: Scaffold(
+    body: Center(
+      child: GlassSegmentedControl(
+        segments: const ['Option A', 'Option B', 'Option C'],
+        selectedIndex: 0,
+        onSegmentSelected: (i) {},
+        quality: GlassQuality.standard,
+      ),
+    ),
+  ),
+)
+```
+
+**Manual alternative — `LiquidGlassScope`:**
+
+For advanced scenarios (e.g. isolated sections within a screen, non-`GlassPage` setups),
+use `LiquidGlassScope` directly:
+
+```dart
+// Shorthand — wallpaper behind your Scaffold:
+LiquidGlassScope.stack(
+  background: Image.asset('assets/wallpaper.jpg', fit: BoxFit.cover),
+  content: Scaffold(
+    body: Center(child: GlassSegmentedControl(...)),
+  ),
+)
+
+// Manual — granular control over which surface is sampled:
+LiquidGlassScope(
+  child: Stack(
+    children: [
+      Positioned.fill(
+        child: GlassBackgroundSource(
+          child: Image.asset('assets/wallpaper.jpg'),
+        ),
+      ),
+      Center(child: GlassSegmentedControl(...)),
+    ],
+  ),
+)
+```
+
+On Impeller, `GlassQuality.premium` uses the native scene graph — no
+`LiquidGlassScope` needed.
+
+
+| When | Recommendation |
+|---|---|
+| Skia / Web (recommended) | `GlassPage(background:...)` — automatic wiring |
+| Skia / Web (manual) | `LiquidGlassScope.stack` with `GlassQuality.standard` |
+| iOS / macOS (Impeller) | `GlassQuality.premium` — native scene graph |
+| Multiple isolated sections | Separate `LiquidGlassScope` per section |
+
+
+## Gyroscope Lighting
+
+`GlassMotionScope` drives the specular highlight angle from any `Stream<double>`, including a device gyroscope via [`sensors_plus`](https://pub.dev/packages/sensors_plus):
+
+```dart
+GlassMotionScope(
+  stream: gyroscopeEvents.map((e) => e.y * 0.5),
+  child: Scaffold(
+    appBar: GlassAppBar(title: const Text('My App')),
+    body: ...,
+  ),
+)
+```
+
+No new dependencies required — connect any stream source (scroll position, mouse, gyroscope).
+
+
+## Accessibility
+
+Every glass widget in this package respects the user's system accessibility preferences **automatically** — no setup required.
+
+| System Setting | Effect on glass widgets |
+|---|---|
+| **Reduce Motion** (iOS/macOS/Android) | All spring/jelly animations snap instantly to their target |
+| **Reduce Transparency / High Contrast** | Glass shader replaced with a plain frosted `BackdropFilter` panel — zero GPU shader cost |
+
+### No setup needed
+
+Just ship your app. If the user has Reduce Motion on, your widgets snap. If they have Reduce Transparency on, they get a solid frosted fallback. Nothing to configure.
+
+### Optional: `GlassAccessibilityScope`
+
+Place `GlassAccessibilityScope` in your tree to **override** system defaults — useful for testing, showcases, or per-subtree customisation:
+
+```dart
+// In your app (optional — place inside MaterialApp.builder for full coverage)
+MaterialApp(
+  builder: (context, child) => GlassAccessibilityScope(
+    child: child!, // reads system flags automatically
+  ),
+)
+
+// Force a specific state (e.g. demo frosted fallback in a settings screen)
+GlassAccessibilityScope(
+  reduceTransparency: true,
+  child: GlassSettingsPreview(),
+)
+```
+
+`GlassAccessibilityScope` always wins over the system flag — it's the highest-priority override.
+
+### Opting out globally
+
+For experiences where full glass fidelity is intentional (games, creative tools):
+
+```dart
+// 0.10.0+: child is a required named parameter
+runApp(LiquidGlassWidgets.wrap(
+  child: const MyApp(),
+  respectSystemAccessibility: false,
+));
+```
+
+This disables only the automatic system-flag bridge. An explicit `GlassAccessibilityScope` in the widget tree still works regardless.
+
+### Priority order (highest wins)
+
+1. `GlassAccessibilityScope` in the widget tree — explicit developer override
+2. System `MediaQuery` flags — automatic, respects user's OS setting
+3. `wrap(respectSystemAccessibility: false)` — disables (2) globally
+
+
+## Architecture
+
+### Rendering pipeline
+
+On Impeller, every `GlassQuality.premium` surface uses a two-pass pipeline:
+
+1. **Blur pass** — `BackdropFilterLayer(ImageFilter.blur)`, clipped to the exact widget shape. Each `LiquidGlassLayer` manages its own isolated `BackdropGroup` for GPU capture.
+2. **Shader pass** — `BackdropFilterLayer(ImageFilter.shader)` — refraction, edge lighting, glass tint, and chromatic aberration.
+
+On Skia/Web, `lightweight_glass.frag` runs as a single pass with no backdrop capture.
+
+### Liquid Morph Engine
+
+A standalone physics and animation system powering iOS 26-style teardrop morphing. It lives in `lib/engine/` and is fully decoupled from any specific widget — `GlassMenu` is its first consumer.
+
+Key types: `GlassMorphController` · `LiquidMorphState` · `LiquidMorphPhysics` · `MorphPhase` · `MorphSpeed`
+
+See [`docs/LIQUID_MORPH_ENGINE.md`](docs/LIQUID_MORPH_ENGINE.md) for a full integration guide.
+
+### Content-Adaptive Glass Strength (0.7.0)
+
+Both render paths automatically adapt glass strength to background brightness:
+
+- **Dark backgrounds** → richer, more opaque glass (1.2× strength, brighter Fresnel rim)
+- **Light backgrounds** → subtler, more translucent glass (0.8× strength)
+
+On Impeller, backdrop luminance is sampled directly from the refracted texture (zero extra reads).
+On Skia/Web, `MediaQuery.platformBrightnessOf` provides a lightweight proxy.
+
+
+## Testing
+
+```bash
+# All tests
+flutter test
+
+# Exclude golden tests
+flutter test --exclude-tags golden
+
+# macOS golden tests (require Impeller)
+flutter test --tags golden
+```
+
+
+## Dependencies
+
+Minimal runtime dependencies beyond the Flutter SDK: `equatable`, `flutter_shaders`, and `logging`.
+
+The glass rendering pipeline builds on the open-source work of [whynotmake-it](https://github.com/whynotmake-it). Their [`liquid_glass_renderer`](https://github.com/whynotmake-it/flutter_liquid_glass/tree/main/packages/liquid_glass_renderer) (MIT) has been vendored and extended with bug fixes, performance improvements, and shader optimisations.
+
+
+## Contributing
+
+Contributions are welcome. For major changes, open an issue first to discuss your proposal.
+
+
+## License
+
+MIT — see the [LICENSE](LICENSE) file for details.
+
+
+## Credits
+
+**Special thanks** to the [whynotmake-it](https://github.com/whynotmake-it) team for their [`liquid_glass_renderer`](https://github.com/whynotmake-it/flutter_liquid_glass/tree/main/packages/liquid_glass_renderer) (MIT), whose shader pipeline, texture capture, and chromatic aberration work forms the foundation of the rendering engine in this library.
+
+## Links
+
+- [pub.dev](https://pub.dev/packages/liquid_glass_widgets)
+- [Repository](https://github.com/sdegenaar/liquid_glass_widgets)
+- [Issue Tracker](https://github.com/sdegenaar/liquid_glass_widgets/issues)

--- a/packages/liquid_glass_widgets/analysis_options.yaml
+++ b/packages/liquid_glass_widgets/analysis_options.yaml
@@ -1,0 +1,35 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+analyzer:
+  errors:
+    unintended_html_in_doc_comment: ignore
+    # invalid_internal_annotation fires on vendored renderer code where @internal
+    # is used correctly (public classes in lib/src/) but our analyzer version
+    # is stricter than the upstream package's.
+    invalid_internal_annotation: ignore
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  # The lint rules applied to this project can be customized in the
+  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
+  # included above or to enable additional rules. A list of all available lints
+  # and their documentation is published at https://dart.dev/lints.
+  #
+  # Instead of disabling a lint rule for the entire project in the
+  # section below, it can also be suppressed for a single line of code
+  # or a specific dart file by using the `// ignore: name_of_lint` and
+  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
+  # producing the lint.
+  rules:
+    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/packages/liquid_glass_widgets/example/analysis_options.yaml
+++ b/packages/liquid_glass_widgets/example/analysis_options.yaml
@@ -1,0 +1,28 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  # The lint rules applied to this project can be customized in the
+  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
+  # included above or to enable additional rules. A list of all available lints
+  # and their documentation is published at https://dart.dev/lints.
+  #
+  # Instead of disabling a lint rule for the entire project in the
+  # section below, it can also be suppressed for a single line of code
+  # or a specific dart file by using the `// ignore: name_of_lint` and
+  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
+  # producing the lint.
+  rules:
+    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/packages/liquid_glass_widgets/example/example.dart
+++ b/packages/liquid_glass_widgets/example/example.dart
@@ -1,0 +1,207 @@
+/// Liquid Glass Widgets — pub.dev example.
+///
+/// Minimal recommended usage with [GlassScaffold]:
+/// [LiquidGlassWidgets.initialize], [LiquidGlassWidgets.wrap],
+/// [GlassScaffold], [GlassAppBar], [GlassTabBar], [GlassCard], [GlassButton].
+///
+///   cd example && flutter run -t example.dart
+
+library;
+
+import 'package:flutter/cupertino.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await LiquidGlassWidgets.initialize();
+  runApp(LiquidGlassWidgets.wrap(child: const _App()));
+}
+
+class _App extends StatefulWidget {
+  const _App();
+
+  @override
+  State<_App> createState() => _AppState();
+}
+
+class _AppState extends State<_App> {
+  Brightness _brightness = Brightness.dark;
+
+  void _toggle() => setState(() {
+        _brightness =
+            _brightness == Brightness.dark ? Brightness.light : Brightness.dark;
+      });
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      title: 'Liquid Glass Widgets',
+      debugShowCheckedModeBanner: false,
+      theme: CupertinoThemeData(brightness: _brightness),
+      home: _HomePage(brightness: _brightness, onToggle: _toggle),
+    );
+  }
+}
+
+class _HomePage extends StatefulWidget {
+  const _HomePage({required this.brightness, required this.onToggle});
+  final Brightness brightness;
+  final VoidCallback onToggle;
+
+  @override
+  State<_HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<_HomePage> {
+  int _tab = 0;
+
+  static const _tabs = [
+    GlassTab(icon: Icon(CupertinoIcons.house_fill), label: 'Home'),
+    GlassTab(icon: Icon(CupertinoIcons.compass_fill), label: 'Explore'),
+    GlassTab(icon: Icon(CupertinoIcons.music_note_2), label: 'Library'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = widget.brightness == Brightness.dark;
+
+    return GlassScaffold(
+      background: AnimatedContainer(
+        duration: const Duration(milliseconds: 400),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: isDark
+                ? const [
+                    Color(0xFF0A0A2E),
+                    Color(0xFF1A0A3E),
+                    Color(0xFF0D1B2A)
+                  ]
+                : const [
+                    Color(0xFFE8F0FE),
+                    Color(0xFFF3E8FF),
+                    Color(0xFFE8F4FD)
+                  ],
+          ),
+        ),
+      ),
+      appBar: GlassAppBar(
+        title: const Text('Liquid Glass'),
+        actions: [
+          GlassIconButton(
+            onPressed: widget.onToggle,
+            icon: Icon(
+              isDark ? CupertinoIcons.sun_max_fill : CupertinoIcons.moon_fill,
+            ),
+          ),
+        ],
+      ),
+      bottomBar: GlassTabBar.searchable(
+        tabs: _tabs,
+        selectedIndex: _tab,
+        onTabSelected: (i) => setState(() => _tab = i),
+        searchConfig: GlassSearchBarConfig(
+          hintText: 'Search widgets…',
+          onSearchToggle: (_) {},
+          onSearchFocusChanged: (_) {},
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            GlassCard(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'iOS 26 Liquid Glass',
+                    style: TextStyle(fontSize: 26, fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  const Text(
+                    'Shader-based refraction · jelly physics · dynamic lighting. '
+                    'Tap ☀/☾ to toggle the app brightness independently of the OS.',
+                    style: TextStyle(height: 1.5),
+                  ),
+                  const SizedBox(height: 20),
+                  Row(
+                    children: [
+                      GlassButton(
+                        icon: const Icon(CupertinoIcons.play_fill),
+                        onTap: () {},
+                        label: 'Get Started',
+                      ),
+                      const SizedBox(width: 12),
+                      GlassButton(
+                        icon: const Icon(CupertinoIcons.star_fill),
+                        onTap: () {},
+                        label: 'Star on GitHub',
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 20),
+            for (final item in [
+              (
+                CupertinoIcons.square_grid_2x2_fill,
+                'Containers',
+                'GlassCard · GlassContainer · GlassListTile'
+              ),
+              (
+                CupertinoIcons.hand_point_left,
+                'Interactive',
+                'GlassButton · GlassSwitch · GlassSlider · GlassChip'
+              ),
+              (
+                CupertinoIcons.layers_fill,
+                'Surfaces',
+                'GlassTabBar · GlassAppBar · GlassToolbar'
+              ),
+              (
+                CupertinoIcons.rectangle_stack_fill,
+                'Overlays',
+                'GlassSheet · GlassMenu · GlassDialog · GlassToast'
+              ),
+              (
+                CupertinoIcons.textformat,
+                'Input',
+                'GlassTextField · GlassSearchBar · GlassPicker'
+              ),
+            ])
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: GlassCard(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      Icon(item.$1, size: 26),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(item.$2,
+                                style: const TextStyle(
+                                    fontWeight: FontWeight.w600)),
+                            const SizedBox(height: 2),
+                            Text(item.$3, style: const TextStyle(fontSize: 12)),
+                          ],
+                        ),
+                      ),
+                      const Icon(CupertinoIcons.chevron_right, size: 16),
+                    ],
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/example/pubspec.yaml
+++ b/packages/liquid_glass_widgets/example/pubspec.yaml
@@ -1,0 +1,43 @@
+name: liquid_glass_widgets_example
+description: Example app showcasing Apple Liquid Glass widgets
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  # Local package
+  liquid_glass_widgets:
+    path: ../
+
+  # Required dependencies
+  cupertino_icons: ^1.0.8
+  flutter_svg: ^2.0.10+1
+  video_player: ^2.11.0
+  webview_flutter: ^4.13.1
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^5.0.0
+
+flutter:
+  uses-material-design: true
+  fonts:
+    - family: SFSymbols
+      fonts:
+        - asset: assets/fonts/SFSymbols.ttf
+  assets:
+    - assets/wallpaper.jpg
+    - assets/wallpaper_dark.jpg
+    - assets/mountain_landscape.jpg
+    - assets/bulldog.jpeg
+    - assets/news_logo.svg
+    - assets/audio.svg
+    - assets/following.svg
+    - assets/news_images/
+    - assets/modal_sheet_showcase/
+    - assets/podcast_images/

--- a/packages/liquid_glass_widgets/lib/constants/glass_defaults.dart
+++ b/packages/liquid_glass_widgets/lib/constants/glass_defaults.dart
@@ -1,0 +1,94 @@
+/// Common constants used throughout the liquid_glass_widgets package.
+///
+/// These constants define default values for glass effects, dimensions,
+/// and other commonly used values to ensure consistency across widgets.
+library;
+
+import 'package:flutter/widgets.dart';
+
+/// Default values for glass visual properties.
+class GlassDefaults {
+  // Prevent instantiation
+  GlassDefaults._();
+
+  // ============================================================================
+  // Glass Effect Properties
+  // ============================================================================
+
+  /// Default glass thickness for most widgets (30.0)
+  static const double thickness = 30.0;
+
+  /// Default blur amount for glass effects (3.0)
+  static const double blur = 3.0;
+
+  /// Default light intensity for specular highlights (2.0)
+  static const double lightIntensity = 2.0;
+
+  /// Default chromatic aberration amount (0.5)
+  static const double chromaticAberration = 0.5;
+
+  /// Default refractive index for glass (1.15)
+  static const double refractiveIndex = 1.15;
+
+  /// Default light angle in radians (135° = 0.75 * π — Apple iOS 26 standard, upper-left light)
+  static const double lightAngle = 0.75 * 3.14159265358979; // 0.75 * pi
+
+  // ============================================================================
+  // Border Radius
+  // ============================================================================
+
+  /// Standard border radius for most glass widgets (16.0)
+  static const double borderRadius = 16.0;
+
+  /// Small border radius for compact elements (8.0)
+  static const double borderRadiusSmall = 8.0;
+
+  /// Large border radius for prominent elements (20.0)
+  static const double borderRadiusLarge = 20.0;
+
+  // ============================================================================
+  // Padding
+  // ============================================================================
+
+  /// Standard padding for card-like widgets
+  static const EdgeInsets paddingCard = EdgeInsets.all(16.0);
+
+  /// Standard padding for panel-like widgets
+  static const EdgeInsets paddingPanel = EdgeInsets.all(24.0);
+
+  /// Standard padding for input fields
+  static const EdgeInsets paddingInput =
+      EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0);
+
+  /// Compact padding for small elements
+  static const EdgeInsets paddingCompact = EdgeInsets.all(8.0);
+
+  /// Minimal padding for tight layouts
+  static const EdgeInsets paddingMinimal = EdgeInsets.all(4.0);
+
+  // ============================================================================
+  // Dimensions
+  // ============================================================================
+
+  /// Standard height for interactive controls (32.0)
+  static const double heightControl = 32.0;
+
+  /// Standard height for buttons (48.0)
+  static const double heightButton = 48.0;
+
+  /// Standard height for input fields (48.0)
+  static const double heightInput = 48.0;
+
+  // ============================================================================
+  // Animation Durations
+  // ============================================================================
+
+  /// Standard animation duration for glass effects (200ms)
+  static const Duration animationDuration = Duration(milliseconds: 200);
+
+  /// Fast animation duration for quick transitions (100ms)
+  static const Duration animationDurationFast = Duration(milliseconds: 100);
+
+  /// Slow animation duration for deliberate effects (300ms)
+  static const Duration animationDurationSlow = Duration(milliseconds: 300);
+}

--- a/packages/liquid_glass_widgets/lib/constants/glass_shadow.dart
+++ b/packages/liquid_glass_widgets/lib/constants/glass_shadow.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/widgets.dart';
+
+/// Default light-mode glass shadow values, matching iOS 26 elevation.
+///
+/// Used by [AdaptiveGlass], [TabIndicator], [SearchableTabIndicator],
+/// and [SearchPill]. Centralised here to prevent drift between the
+/// four independent shadow wrappers.
+///
+/// These shadows are inverse-clipped so they only appear *outside* the
+/// glass boundary, preventing the glass from blurring its own shadow.
+///
+/// ## Usage
+///
+/// ```dart
+/// // Use the defaults
+/// GlassShadow.defaults
+///
+/// // Scale the defaults
+/// GlassShadow.scaled(1.5) // 50% stronger
+///
+/// // Disable shadows
+/// GlassShadow.scaled(0.0) // empty list
+/// ```
+abstract final class GlassShadow {
+  /// The default elevation shadow (≈6% black, 8px blur, 2px y-offset).
+  static const BoxShadow elevation = BoxShadow(
+    color: Color(0x0F000000),
+    blurRadius: 8,
+    spreadRadius: 0,
+    offset: Offset(0, 2),
+  );
+
+  /// The default contact shadow (≈2% black, 2px blur, 1px y-offset).
+  static const BoxShadow contact = BoxShadow(
+    color: Color(0x05000000),
+    blurRadius: 2,
+    spreadRadius: 0,
+    offset: Offset(0, 1),
+  );
+
+  /// The unscaled default shadow list: [elevation] + [contact].
+  static const List<BoxShadow> defaults = [elevation, contact];
+
+  /// Returns the default shadows scaled by [elevation].
+  ///
+  /// - `0.0` → empty list (no shadow)
+  /// - `1.0` → [defaults] (unchanged)
+  /// - `2.0` → double opacity and blur
+  ///
+  /// Opacity is clamped to [0.0, 1.0]; blur and offset scale linearly.
+  static List<BoxShadow> scaled(double elevation) {
+    if (elevation <= 0) return const [];
+    if (elevation == 1.0) return defaults;
+    return [
+      BoxShadow(
+        color: Color.fromRGBO(0, 0, 0, (0.06 * elevation).clamp(0.0, 1.0)),
+        blurRadius: 8 * elevation,
+        spreadRadius: 0,
+        offset: Offset(0, 2 * elevation),
+      ),
+      BoxShadow(
+        color: Color.fromRGBO(0, 0, 0, (0.02 * elevation).clamp(0.0, 1.0)),
+        blurRadius: 2 * elevation,
+        spreadRadius: 0,
+        offset: Offset(0, 1 * elevation),
+      ),
+    ];
+  }
+}

--- a/packages/liquid_glass_widgets/lib/liquid_glass_setup.dart
+++ b/packages/liquid_glass_widgets/lib/liquid_glass_setup.dart
@@ -1,0 +1,313 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'theme/glass_theme.dart';
+import 'theme/glass_theme_data.dart';
+import 'types/glass_quality.dart';
+import 'utils/accessibility_config.dart' as glass_config;
+import 'utils/glass_performance_monitor.dart';
+import 'src/renderer/liquid_glass_renderer.dart';
+import 'src/renderer/shaders.dart';
+import 'src/renderer/internal/multi_shader_builder.dart';
+import 'widgets/shared/glass_adaptive_scope.dart';
+import 'widgets/shared/glass_effect.dart';
+import 'widgets/shared/glass_accessibility_scope.dart';
+import 'widgets/shared/lightweight_liquid_glass.dart';
+
+/// Entry point and configuration for the Liquid Glass Widgets library.
+///
+/// ## Setup
+///
+/// ```dart
+/// void main() async {
+///   WidgetsFlutterBinding.ensureInitialized();
+///   await LiquidGlassWidgets.initialize(); // pre-warms shaders
+///
+///   runApp(LiquidGlassWidgets.wrap(
+///     child: const MyApp(),
+///     adaptiveQuality: true,
+///     theme: GlassThemeData(
+///       light: GlassThemeVariant(settings: GlassThemeSettings(blur: 10)),
+///       dark:  GlassThemeVariant(settings: GlassThemeSettings(blur: 14)),
+///     ),
+///   ));
+/// }
+/// ```
+class LiquidGlassWidgets {
+  LiquidGlassWidgets._();
+
+  // ── Global accessors ───────────────────────────────────────────────────────
+
+  /// Whether glass widgets automatically respect system accessibility settings
+  /// (Reduce Motion, Reduce Transparency / High Contrast).
+  ///
+  /// Set via [wrap]. Defaults to `true`. Read by glass widgets at build time
+  /// via [GlassAccessibilityScope] or a direct [MediaQuery] fallback.
+  ///
+  /// The setter is provided as an escape hatch for tests and advanced runtime
+  /// overrides. In production code, prefer setting this through [wrap].
+  static bool get respectSystemAccessibility =>
+      glass_config.respectSystemAccessibility;
+  static set respectSystemAccessibility(bool value) =>
+      glass_config.respectSystemAccessibility = value;
+
+  /// Deprecated — use [respectSystemAccessibility] instead.
+  ///
+  /// Retained for discoverability (the two-word form reads naturally as a
+  /// boolean predicate). Will be removed in v1.0.
+  @Deprecated('Use respectSystemAccessibility instead.')
+  static bool get respectsAccessibility => respectSystemAccessibility;
+  @Deprecated('Use respectSystemAccessibility instead.')
+  static set respectsAccessibility(bool value) =>
+      respectSystemAccessibility = value;
+
+  /// Global [LiquidGlassSettings] override for the entire application.
+  ///
+  /// When set, these settings are used as the base for all glass widgets
+  /// unless overridden at the widget or layer level.
+  static LiquidGlassSettings? globalSettings;
+
+  // ── initialize() ───────────────────────────────────────────────────────────
+
+  /// Initializes platform-level resources for the Liquid Glass library.
+  ///
+  /// **Responsibility**: async platform / engine setup only. Call once in
+  /// `main()` before [runApp]. All behavioral configuration belongs in [wrap].
+  ///
+  /// ```dart
+  /// void main() async {
+  ///   WidgetsFlutterBinding.ensureInitialized();
+  ///   await LiquidGlassWidgets.initialize();
+  ///   runApp(LiquidGlassWidgets.wrap(const MyApp()));
+  /// }
+  /// ```
+  ///
+  /// ### Parameters
+  ///
+  /// **`enablePerformanceMonitor`** (default `true`)\
+  /// In debug and profile builds, the library registers a
+  /// `SchedulerBinding.addTimingsCallback` that watches raster durations while
+  /// [GlassQuality.premium] surfaces are mounted. When frames consistently
+  /// exceed the GPU budget, a single [FlutterError] is emitted with actionable
+  /// guidance. The monitor is **automatically disabled in release builds** —
+  /// zero overhead in shipped apps. Set to `false` to suppress it during
+  /// profiling sessions where the warning would be a false positive.
+  ///
+  /// ### Tasks performed
+  ///
+  /// 1. Pre-warms / precaches the lightweight fragment shader.
+  /// 2. Pre-warms the interactive indicator shader (custom refraction).
+  /// 3. Pre-warms the Impeller rendering pipeline (iOS / Android / macOS).
+  /// 4. Optionally registers the debug performance monitor.
+  ///
+  /// ### Shaders pre-warmed
+  ///
+  /// | Shader | Role |
+  /// |---|---|
+  /// | `lightweight_glass.frag` | Minimal glass layer |
+  /// | `interactive_indicator.frag` | Custom refraction effect |
+  /// | `liquid_glass_geometry_blended.frag` | Geometry / SDF pass |
+  /// | `liquid_glass_final_render.frag` | Final composite pass |
+  static Future<void> initialize({
+    bool enablePerformanceMonitor = true,
+  }) async {
+    debugPrint('[LiquidGlass] Initializing library...');
+
+    // 1. Pre-warm shader programs in parallel — prevents first-frame jank /
+    //    "white flash" when glass widgets first appear.
+    //
+    //    Only shader disk-loads are awaited here (the only work that MUST
+    //    complete before runApp, since a missing program causes a white flash).
+    //
+    //    The Impeller pipeline warm-up is scheduled post-first-frame instead —
+    //    the splash screen or first non-glass frame provides enough GPU idle
+    //    time for pipeline compilation without blocking runApp.
+    await Future.wait([
+      LightweightLiquidGlass.preWarm(),
+      GlassEffect.preWarm(),
+      MultiShaderBuilder.precacheShaders([
+        ShaderKeys.blendedGeometry,
+        ShaderKeys.liquidGlassRender,
+      ]),
+    ]);
+
+    // 2. Schedule Impeller pipeline warm-up after the first frame — zero
+    //    startup cost. The first non-glass frame (e.g. splash screen) provides
+    //    ample idle GPU time for the driver to compile the Vulkan pipeline.
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => _warmUpImpellerPipeline());
+
+    // 3. Register the debug performance monitor (no-op in release builds).
+    if (enablePerformanceMonitor && !kReleaseMode) {
+      GlassPerformanceMonitor.start();
+    }
+
+    debugPrint('[LiquidGlass] Initialization complete.');
+  }
+
+  // ── wrap() ─────────────────────────────────────────────────────────────────
+
+  /// Wraps [child] in the Liquid Glass infrastructure scopes and applies all
+  /// behavioral configuration.
+  ///
+  /// **Responsibility**: widget-tree composition and runtime behavior. All
+  /// configuration that affects how glass widgets behave lives here — explicit,
+  /// visible, and co-located with the widget tree entry point.
+  ///
+  /// **Optional** — provides app-wide theming and adaptive quality.
+  /// `GlassBackdropScope` is no longer needed (each glass layer manages its own
+  /// backdrop); `wrap()` is only required if you use `theme:` or
+  /// `adaptiveQuality:`.
+  ///
+  /// ```dart
+  /// // Zero-config (most apps):
+  /// runApp(LiquidGlassWidgets.wrap(const MyApp()));
+  ///
+  /// // Recommended for Android / broad device support:
+  /// runApp(LiquidGlassWidgets.wrap(
+  ///   child: const MyApp(),
+  ///   adaptiveQuality: true,
+  ///   theme: GlassThemeData(...),
+  /// ));
+  ///
+  /// // Game / experience — bypass accessibility, conservative quality start:
+  /// runApp(LiquidGlassWidgets.wrap(
+  ///   child: const MyApp(),
+  ///   respectSystemAccessibility: false,
+  ///   adaptiveQuality: true,
+  ///   adaptiveConfig: GlassAdaptiveScopeConfig(
+  ///     initialQuality: GlassQuality.standard,
+  ///     allowStepUp: true,
+  ///   ),
+  /// ));
+  /// ```
+  ///
+  /// ### Parameters
+  ///
+  /// **`respectSystemAccessibility`** (default `true`)\
+  /// When `true`, system Reduce Motion and Reduce Transparency flags are
+  /// respected automatically — no extra setup required. All glass widgets read
+  /// `MediaQuery` directly and degrade gracefully. Set to `false` to ignore
+  /// system accessibility flags globally (e.g. for a game where full glass
+  /// fidelity is intentional regardless of OS settings). A
+  /// [GlassAccessibilityScope] placed anywhere in the widget tree always takes
+  /// precedence over this flag, allowing per-subtree overrides.
+  ///
+  /// **`adaptiveQuality`** (default `false`, **experimental**)\
+  /// When `true`, inserts a root [GlassAdaptiveScope] that automatically
+  /// benchmarks the device and adjusts the global glass quality ceiling in real
+  /// time. Three phases:
+  ///
+  /// - **Phase 1** (synchronous): forces `minimal` where shaders are
+  ///   unsupported; caps at `standard` on web.
+  /// - **Phase 2** (~180 frames ≈ 3 s at 60 fps): measures real P75 raster
+  ///   durations and sets the initial quality tier.
+  /// - **Phase 3** (ongoing, near-zero overhead): degrades when P95 exceeds
+  ///   1.5× the frame budget for 3 consecutive windows; recovers when P95
+  ///   drops below 0.6× budget for 10 consecutive windows.
+  ///
+  /// **Experimental in 0.8.0** — Phase 2 thresholds (12 ms / 20 ms P75) are
+  /// based on reasoning, not yet validated across the full Android device
+  /// landscape. Enable this feature and report unexpected quality degradation
+  /// or promotion to help us tune the thresholds.
+  ///
+  /// Acts as an app-wide *quality ceiling* — individual widgets with an
+  /// explicit `quality:` parameter are still capped by it. When no
+  /// [adaptiveConfig] is provided, the scope starts at [GlassQuality.standard]
+  /// to prevent jank during the warm-up window on mid-range devices.
+  ///
+  /// For per-screen control, use [GlassAdaptiveScope] directly in the tree.
+
+  ///
+  /// **`adaptiveConfig`** (optional)\
+  /// Custom [GlassAdaptiveScopeConfig] for the root [GlassAdaptiveScope].
+  /// Ignored when [adaptiveQuality] is `false`. Defaults to
+  /// `GlassAdaptiveScopeConfig(initialQuality: GlassQuality.standard)`.
+  ///
+  /// ### Scope nesting order (outermost → innermost → child)
+  ///
+  /// `GlassAdaptiveScope` (when enabled) → `GlassTheme` (when provided) → `child`
+  static Widget wrap({
+    required Widget child,
+    GlassThemeData? theme,
+    bool respectSystemAccessibility = true,
+    bool adaptiveQuality = false,
+    GlassAdaptiveScopeConfig? adaptiveConfig,
+  }) {
+    // Apply global accessibility preference.
+    glass_config.respectSystemAccessibility = respectSystemAccessibility;
+
+    Widget result = child;
+
+    if (theme != null) {
+      result = GlassTheme(data: theme, child: result);
+    }
+
+    if (adaptiveQuality) {
+      // When no adaptiveConfig is given: GlassAdaptiveScope.initState() seeds
+      // the first frame at GlassQuality.standard while Phase 2 benchmarks the
+      // device (~3 s). Phase 2 then promotes to `premium` if the device passes
+      // the warmup threshold — no caller config needed.
+      //
+      // When the caller provides adaptiveConfig: use their settings as-is.
+      // If initialQuality is null, Phase 2 still runs fresh and promotes/demotes
+      // from the conservative standard starting point.
+      final config = adaptiveConfig ?? const GlassAdaptiveScopeConfig();
+
+      result = GlassAdaptiveScope(
+        minQuality: config.minQuality,
+        maxQuality: config.maxQuality,
+        initialQuality: config.initialQuality,
+        targetFrameMs: config.targetFrameMs,
+        allowStepUp: config.allowStepUp,
+        onQualityChanged: config.onQualityChanged,
+        onDiagnostic: config.onDiagnostic,
+        debugLogDiagnostics: config.debugLogDiagnostics,
+        child: result,
+      );
+    }
+
+    return result;
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  /// Warms up the Impeller rendering pipeline for glass effects.
+  ///
+  /// Instantiates a minimal [LiquidGlassLayer] to trigger Impeller pipeline
+  /// compilation — eliminating first-frame jank when glass effects appear.
+  /// Skipped on Skia / Web where Impeller is not active.
+  ///
+  /// Called via [addPostFrameCallback] from [initialize], so it runs after
+  /// the first frame rather than blocking [runApp]. The first non-glass frame
+  /// (splash screen, loading state) provides natural GPU idle time for driver
+  /// pipeline compilation without any artificial delay.
+  static void _warmUpImpellerPipeline() {
+    if (!ui.ImageFilter.isShaderFilterSupported) {
+      debugPrint('[LiquidGlass] Skipping Impeller warm-up (Skia/Web detected)');
+      return;
+    }
+
+    try {
+      const warmUpSettings = LiquidGlassSettings(
+        blur: 3,
+        thickness: 30,
+        refractiveIndex: 1.5,
+      );
+
+      // Instantiating the layer registers the shader programs with the
+      // Impeller engine and kicks off async driver pipeline compilation.
+      // No artificial delay needed — the post-frame scheduling ensures the
+      // engine is in a stable state to accept the compilation work.
+      final _ = LiquidGlassLayer(
+        settings: warmUpSettings,
+        child: const SizedBox.shrink(),
+      );
+
+      debugPrint('[LiquidGlass] ✓ Impeller pipeline warm-up scheduled');
+    } catch (e) {
+      debugPrint('[LiquidGlass] Impeller warm-up failed (non-critical): $e');
+    }
+  }
+}

--- a/packages/liquid_glass_widgets/lib/liquid_glass_widgets.dart
+++ b/packages/liquid_glass_widgets/lib/liquid_glass_widgets.dart
@@ -1,0 +1,125 @@
+/// Liquid Glass Implementation according to Apple's Guidelines
+library;
+
+// Renderer — explicit public surface only.
+// LiquidGlass is intentionally excluded: use AdaptiveGlass or Glass* widgets
+// instead. LiquidGlass is Impeller-only and silently renders nothing on Skia/web.
+// LiquidStretch/RawLiquidStretch and GlassGlowLayer are internal utilities.
+export 'src/renderer/liquid_glass_renderer.dart'
+    show
+        AnchorStretchSettings,
+        LiquidGlassSettings,
+        LiquidGlassLayer,
+        LiquidGlassBlendGroup,
+        GlassGlow,
+        debugPaintLiquidGlassGeometry;
+export 'src/renderer/liquid_shape.dart'; // all shapes are public
+export 'src/renderer/internal/interaction_notification.dart'; // public for Smart Silence support
+export 'types/glass_specular_sharpness.dart'; // GlassSpecularSharpness enum
+
+// Setup and Configuration
+export 'liquid_glass_setup.dart';
+
+// Constants
+export 'constants/glass_defaults.dart';
+export 'constants/glass_shadow.dart';
+
+// Theme
+export 'theme/glass_theme.dart';
+export 'theme/glass_interaction_settings.dart';
+export 'theme/glass_theme_data.dart';
+export 'theme/glass_theme_settings.dart';
+
+// Types
+export 'types/glass_quality.dart';
+export 'types/glass_quality_change_reason.dart'; // GlassQualityChangeReason enum
+export 'src/types/glass_interaction_behavior.dart'; // GlassInteractionBehavior enum
+
+// Shared widgets
+export 'widgets/shared/adaptive_glass.dart';
+export 'widgets/shared/adaptive_liquid_glass_layer.dart';
+export 'widgets/shared/animated_glass_indicator.dart'
+    show AnimatedGlassIndicator; // baseIndicatorSettings for partial overrides
+export 'widgets/shared/glass_accessibility_scope.dart'; // GlassAccessibilityScope + GlassAccessibilityData
+export 'widgets/shared/glass_adaptive_scope.dart'; // GlassAdaptiveScope + GlassAdaptiveScopeData + GlassAdaptiveDiagnostic
+export 'widgets/shared/glass_backdrop_scope.dart'; // GlassBackdropScope — per-screen backdrop isolation
+export 'widgets/shared/glass_content_aware_scope.dart'; // GlassContentAwareScope + GlassContentAwareContent + GlassContentAwareBrightness
+export 'widgets/shared/glass_page.dart' show GlassPage, GlassStatusBarStyle;
+export 'widgets/shared/glass_motion_scope.dart';
+export 'widgets/shared/glass_scroll_edge_effect.dart';
+export 'widgets/shared/inherited_liquid_glass.dart';
+export 'widgets/shared/lightweight_liquid_glass.dart';
+
+// Utils — for advanced / custom widget authors
+export 'utils/glass_morph_controller.dart'
+    show
+        GlassMorphController,
+        MorphSpeed,
+        MorphStyle,
+        LiquidMorphState,
+        MorphPhase;
+export 'utils/glass_spring.dart';
+export 'utils/glass_performance_monitor.dart'
+    show GlassPerformanceMonitor; // PremiumGlassTracker is internal
+
+// Widgets - Containers
+export 'widgets/containers/glass_card.dart';
+export 'widgets/containers/glass_container.dart';
+export 'widgets/containers/glass_divider.dart';
+export 'widgets/containers/glass_grouped_section.dart';
+export 'widgets/containers/glass_list_tile.dart';
+export 'widgets/containers/glass_stepper.dart';
+// Widgets - Input
+export 'widgets/input/glass_form_field.dart';
+export 'widgets/input/glass_password_field.dart';
+export 'widgets/input/glass_picker.dart';
+export 'widgets/input/glass_search_bar.dart';
+export 'widgets/input/glass_text_area.dart';
+export 'widgets/input/glass_text_field.dart';
+// Widgets - Interactive
+export 'widgets/interactive/glass_badge.dart';
+export 'widgets/interactive/glass_button.dart';
+export 'widgets/interactive/glass_chip.dart';
+export 'widgets/interactive/glass_icon_button.dart';
+export 'widgets/interactive/glass_page_control.dart';
+export 'widgets/interactive/glass_segmented_control.dart';
+export 'widgets/interactive/liquid_glass_scope.dart'
+    show LiquidGlassScope, GlassBackgroundSource, GlassRefractionSource;
+export 'widgets/interactive/glass_slider.dart';
+export 'widgets/interactive/glass_switch.dart';
+export 'widgets/interactive/glass_pull_down_button.dart';
+export 'widgets/interactive/glass_button_group.dart';
+export 'types/glass_button_style.dart';
+// Widgets - Feedback
+export 'widgets/feedback/glass_progress_indicator.dart';
+// Widgets - Overlays
+export 'widgets/overlays/glass_action_sheet.dart';
+export 'widgets/overlays/glass_dialog.dart';
+export 'widgets/overlays/glass_menu.dart';
+export 'widgets/overlays/glass_menu_item.dart';
+export 'widgets/overlays/glass_sheet.dart';
+export 'widgets/overlays/glass_modal_sheet.dart'
+    show
+        GlassModalSheet,
+        GlassSheetState,
+        GlassSheetMode,
+        GlassFillTransition,
+        GlassModalSheetController,
+        GlassModalSheetScaffold, // used directly for maps-style hit-through layouts
+        GlassModalSheetStateProvider, // read sheet state from descendants
+        SheetStateInfo, // value type from GlassModalSheetStateProvider.of()
+        ScrollControllerProvider; // access scroll controller from sheet content
+export 'widgets/overlays/glass_toast.dart';
+export 'widgets/overlays/glass_popover.dart';
+// Widgets - Surfaces
+export 'widgets/surfaces/glass_app_bar.dart';
+export 'widgets/surfaces/glass_large_title.dart';
+export 'widgets/shared/glass_isolation_scope.dart';
+export 'widgets/surfaces/glass_scaffold.dart';
+export 'widgets/surfaces/glass_bottom_bar.dart';
+export 'widgets/surfaces/glass_searchable_bottom_bar.dart';
+export 'widgets/surfaces/shared/glass_search_bar_config.dart';
+export 'widgets/surfaces/shared/tab_bar_searchable_controller.dart';
+
+export 'widgets/surfaces/glass_tab_bar.dart';
+export 'widgets/surfaces/glass_toolbar.dart';

--- a/packages/liquid_glass_widgets/lib/src/renderer/RENDERER_ATTRIBUTION.md
+++ b/packages/liquid_glass_widgets/lib/src/renderer/RENDERER_ATTRIBUTION.md
@@ -1,0 +1,127 @@
+# Vendored: liquid_glass_renderer
+
+This directory contains source code vendored from
+[`liquid_glass_renderer`](https://github.com/whynotmake-it/flutter_liquid_glass/tree/main/packages/liquid_glass_renderer)
+by **whynotmake.it**, licensed under the **MIT License**.
+
+Vendored version: **0.2.0-dev.4** (vendored 2026-03-28)
+
+---
+
+## Why vendored
+
+Vendoring the renderer source gives `liquid_glass_widgets` full control over the
+rendering pipeline — bug fixes, improvements, and shader changes can be shipped
+in lock-step with the widget layer without waiting on a separate package release
+cycle. The original work by whynotmake.it remains the foundation; this is a
+continuation of that effort within a single package.
+
+---
+
+## Public API surface
+
+The renderer barrel (`liquid_glass_renderer.dart`) exports more types than
+users of `liquid_glass_widgets` should interact with directly. The main package
+barrel (`lib/liquid_glass_widgets.dart`) uses an explicit `show` clause to
+control exactly what is public:
+
+| Type | Public? | Reason |
+|------|---------|--------|
+| `LiquidGlassSettings` | ✅ | Core customisation — used everywhere |
+| `LiquidShape` + subtypes | ✅ | Shape argument for all glass widgets |
+| `LiquidGlassLayer` | ✅ | Advanced: building custom glass widgets |
+| `LiquidGlassBlendGroup` | ✅ | Advanced: custom blend groups |
+| `GlassGlow` | ✅ | Impeller glow effect |
+| `LiquidGlass` | ❌ | **Replaced by `AdaptiveGlass`** — Impeller-only, silently renders nothing on Skia/web |
+| `LiquidStretch`, `RawLiquidStretch` | ❌ | Internal utility |
+| `GlassGlowLayer` | ❌ | Internal |
+
+**Rule of thumb:** If a user needs a glass shape, they should use `AdaptiveGlass`
+or one of the `Glass*` widgets — never `LiquidGlass` directly.
+
+### Future: two-library architecture (post-v1)
+
+For v1+, consider splitting into:
+- `liquid_glass_widgets.dart` — the opinionated widget kit (current)
+- `liquid_glass_widgets/renderer.dart` — raw primitives for power users
+
+This is the pattern used by `go_router`, `riverpod`, and `dio`. It keeps
+autocomplete clean for 95% of users while giving escape hatches to the 5%
+building custom glass widgets.
+
+---
+
+## Syncing upstream changes
+
+Use the sync script for new upstream releases:
+
+```bash
+./tools/sync_renderer.sh <version>
+# e.g. ./tools/sync_renderer.sh 0.2.0-dev.5
+```
+
+The script automatically:
+- Copies and import-fixes the 11 "clean" Dart files
+- Syncs the 6 shaders we use
+- Stages the 5 structurally-modified files for manual diff
+- Updates this file's version/date
+- Runs `flutter analyze`
+
+After the script: manually reconcile the 5 staged structural files
+(`liquid_glass.dart`, `liquid_glass_render_scope.dart`,
+`liquid_glass_blend_group.dart`, `rendering/liquid_glass_layer.dart`,
+`shaders.dart`), then delete `.upstream_<version>/` and run `flutter test`.
+
+Mark any local deviations with `// [LOCAL PATCH]: <reason>` so they are
+obvious during the next sync.
+
+---
+
+## Local patches applied
+
+### B1 — `LiquidGlassBlendGroup` Skia/web crash
+**File:** `liquid_glass_blend_group.dart`
+Added `ImageFilter.isShaderFilterSupported` guard so `ShaderBuilder` is never
+built on non-Impeller backends. Without this, Skia/web threw an "Invalid SkSL"
+exception at runtime.
+
+### B2 — `shared.glsl` dead code
+**File:** `shaders/shared.glsl` (deleted)
+Was an orphaned copy of shared utilities. `liquid_glass_final_render.frag` was
+already using `render.glsl` (our optimised version); nothing included `shared.glsl`.
+
+### B3 — Geometry shader banding on mobile
+**File:** `shaders/liquid_glass_geometry_blended.frag`
+Changed `precision mediump float` → `precision highp float`. Mediump's 10-bit
+mantissa caused ~1.5px displacement quantisation banding at typical thickness values.
+
+### B5 — `calculateDispersiveIndex` dead function
+**File:** `shaders/render.glsl`
+Deleted full Cauchy wavelength dispersion formula that was defined but never
+called by `calculateRefraction`.
+
+### B6 — `blurRadius` dead parameter
+**File:** `shaders/render.glsl`
+Removed unused `blurRadius` parameter from `calculateRefraction` signature and
+its call site in `renderLiquidGlass`.
+
+### A1 — `markRebuilt` inverted naming
+**File:** `rendering/liquid_glass_render_object.dart`,
+`internal/render_liquid_glass_geometry.dart`
+Renamed `GeometryRenderLink.markRebuilt` → `notifyGeometryChanged`. The old
+name implied the object was clean; the method actually sets `_dirty = true`.
+
+### V4 — Duplicate highlight colour implementations
+**File:** `shaders/liquid_glass_final_render.frag`
+Replaced 8-line inline highlight colour block with a call to `getHighlightColor()`
+from `render.glsl`, which is already `#include`d by the same shader.
+
+### PP2 — `GlassSpecularSharpness` import in `liquid_glass_settings.dart`
+**File:** `liquid_glass_settings.dart`
+`GlassSpecularSharpness` is our own enum (not vendored). It lives in
+`lib/types/glass_specular_sharpness.dart`. The import in `liquid_glass_settings.dart`
+was updated from the local `'glass_specular_sharpness.dart'` to
+`'../../types/glass_specular_sharpness.dart'` and marked `// [LOCAL PATCH]`.
+
+**Sync note:** If upstream ever adds a `GlassSpecularSharpness`-equivalent, prefer
+ours and keep the `lib/types/` location. Do **not** restore the old import.

--- a/packages/liquid_glass_widgets/lib/src/renderer/_env_io.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/_env_io.dart
@@ -1,0 +1,3 @@
+import 'dart:io';
+
+final bool isTestEnvironment = Platform.environment.containsKey('FLUTTER_TEST');

--- a/packages/liquid_glass_widgets/lib/src/renderer/_env_web.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/_env_web.dart
@@ -1,0 +1,1 @@
+const bool isTestEnvironment = false;

--- a/packages/liquid_glass_widgets/lib/src/renderer/glass_glow.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/glass_glow.dart
@@ -1,0 +1,542 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:meta/meta.dart';
+import '../../utils/glass_spring.dart';
+
+/// {@template glass_glow}
+/// If placed as a descendant of a [GlassGlowLayer], this widget will
+/// send touch updates to that layer to create a glow effect.
+/// {@endtemplate}
+class GlassGlow extends StatefulWidget {
+  /// {@macro glass_glow}
+  const GlassGlow({
+    required this.child,
+    this.glowColor = Colors.white24,
+    this.glowRadius = 1,
+    this.glowBlurRadius = 0,
+    this.glowSpreadRadius = 0,
+    this.glowOpacity = 1,
+    this.pulse = 0,
+    this.clipper,
+    this.hitTestBehavior = HitTestBehavior.opaque,
+    this.enabled = true,
+    this.glowOnTapOnly = false,
+    super.key,
+  });
+
+  /// The radius of the glow effect relative to the layer's shortest side.
+  ///
+  /// A value of 0.8 means the glow radius will be 80% of the shortest
+  /// dimension (width or height) of the [GlassGlowLayer].
+  ///
+  /// Defaults to 1.
+  final double glowRadius;
+
+  /// The color of the glow effect.
+  ///
+  /// The glow will have this colors opacity at the center, and will fade out
+  /// to fully transparent at the edge of the glow.
+  final Color glowColor;
+
+  /// Additional blur sigma applied to the glow circle via a [MaskFilter].
+  ///
+  /// A value of 0 (the default) produces a sharp-edged radial gradient with no
+  /// additional blur. Higher values soften the glow, creating a wider diffuse
+  /// halo. The blur is applied *on top of* the radial gradient fade-out, so
+  /// even moderate values (4–12) are clearly visible.
+  ///
+  /// Corresponds to [GlassGlowColors.glowBlurRadius].
+  final double glowBlurRadius;
+
+  /// Extra radius added to the drawn circle beyond the physics radius.
+  ///
+  /// A value of 0 (the default) draws the circle at the physics radius. A
+  /// positive value (e.g. 0.2) expands it by that fraction of the layer's
+  /// shortest side — useful for making the glow bleed slightly further from
+  /// the touch point without inflating the radius spring.
+  ///
+  /// Corresponds to [GlassGlowColors.glowSpreadRadius].
+  final double glowSpreadRadius;
+
+  /// Master opacity multiplier applied on top of [glowColor]'s own alpha.
+  ///
+  /// Range 0–1. Defaults to 1 (no change). A value of 0.5 halves the effective
+  /// glow opacity without changing the color itself, making it easy to dial
+  /// the intensity down from the theme without adjusting the raw color.
+  ///
+  /// Corresponds to [GlassGlowColors.glowOpacity].
+  final double glowOpacity;
+
+  /// Global pulse intensity (0.0 to 1.0) for a full-window saturation/brightness
+  /// highlight. Used by [GlassModalSheet] to synchronise a whole-surface pulse
+  /// during high-velocity drag interactions.
+  ///
+  /// Defaults to 0 (no pulse).
+  final double pulse;
+
+  /// The hit test behavior of this gesture listener.
+  ///
+  /// Defaults to [HitTestBehavior.opaque].
+  final HitTestBehavior hitTestBehavior;
+
+  /// The child that will be painted above the glow effect.
+  final Widget child;
+
+  /// The shape to clip the glow to.
+  /// Only clips the additive glow effect, not the child widget.
+  final CustomClipper<Path>? clipper;
+
+  /// Whether the glow is active at all.
+  ///
+  /// When false, the widget renders as a plain passthrough to [child] with
+  /// zero overhead. Useful for disabling glow in specific states without
+  /// restructuring the widget tree.
+  ///
+  /// Defaults to true.
+  final bool enabled;
+
+  /// When true, the glow fires on touch-down but is suppressed after the
+  /// finger travels more than 10 logical pixels (i.e. a drag or scroll).
+  ///
+  /// This prevents the "stuck glow" artefact during scrollable menus or
+  /// lists where a drag gesture should not leave a persistent glare behind.
+  /// The glow is re-enabled automatically on the next touch-down.
+  ///
+  /// Defaults to false (glow always follows the pointer).
+  final bool glowOnTapOnly;
+
+  @override
+  State<GlassGlow> createState() => _GlassGlowState();
+}
+
+class _GlassGlowState extends State<GlassGlow> {
+  Offset? _initialPointerDown;
+  bool _glowSuppressed = false;
+
+  // BUG 3 FIX: Reset suppression flag when glowOnTapOnly is toggled off at
+  // runtime (e.g. animation-driven state changes). Without this, the glow
+  // remains permanently muted until the next pointer-down.
+  @override
+  void didUpdateWidget(GlassGlow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.glowOnTapOnly && !widget.glowOnTapOnly) {
+      _glowSuppressed = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Fast-path: no overhead if glow is disabled entirely.
+    if (!widget.enabled) return widget.child;
+
+    return GlassGlowLayer(
+      clipper: widget.clipper,
+      pulse: widget.pulse,
+      child: Builder(
+        builder: (innerContext) => Listener(
+          behavior: widget.hitTestBehavior,
+          onPointerDown: (event) {
+            _initialPointerDown = event.localPosition;
+            _glowSuppressed = false;
+            _handlePointer(innerContext, event);
+          },
+          onPointerMove: (event) {
+            if (widget.glowOnTapOnly && !_glowSuppressed) {
+              final delta =
+                  event.localPosition - (_initialPointerDown ?? Offset.zero);
+              if (delta.distance > 10.0) {
+                _glowSuppressed = true;
+                _removeTouch(innerContext);
+                return;
+              }
+            }
+            if (!_glowSuppressed) _handlePointer(innerContext, event);
+          },
+          onPointerUp: (event) => _removeTouch(innerContext),
+          onPointerCancel: (event) => _removeTouch(innerContext),
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+
+  void _handlePointer(BuildContext context, PointerEvent event) {
+    final layerState = GlassGlowLayer.maybeOf(context);
+    if (layerState == null) return;
+
+    // GlassGlowLayer may be at a different level than GlassGlow — e.g. a
+    // toolbar GlassGlowLayer wrapping three buttons, each with their own
+    // GlassGlow. event.localPosition is relative to this GlassGlow widget,
+    // not relative to the GlassGlowLayer. We must convert via global space.
+    final myBox = context.findRenderObject() as RenderBox?;
+    final layerBox = layerState.context.findRenderObject() as RenderBox?;
+
+    final Offset pos;
+    if (myBox != null &&
+        layerBox != null &&
+        myBox.attached &&
+        layerBox.attached) {
+      // local-in-GlassGlow → global screen → local-in-GlassGlowLayer
+      pos = layerBox.globalToLocal(myBox.localToGlobal(event.localPosition));
+    } else {
+      // Fallback for tests or during layout (same-level case is also correct).
+      pos = event.localPosition;
+    }
+
+    layerState.updateTouch(
+      pos,
+      radius: widget.glowRadius,
+      color: widget.glowColor,
+      blurRadius: widget.glowBlurRadius,
+      spreadRadius: widget.glowSpreadRadius,
+      opacity: widget.glowOpacity,
+    );
+  }
+
+  void _removeTouch(BuildContext context) {
+    GlassGlowLayer.maybeOf(context)?.removeTouch();
+  }
+}
+
+/// {@template glass_glow}
+/// Represents a layer that can paint a glowing effect below its child.
+///
+/// Any child [GlassGlow] will send touch updates to this layer to
+/// update the glow effect.
+///
+/// This is similar to how an `InkWell` works with a `Material` widget.
+/// {@endtemplate}
+class GlassGlowLayer extends StatefulWidget {
+  /// {@macro glass_glow}
+  const GlassGlowLayer({
+    required this.child,
+    this.clipper,
+    this.pulse = 0,
+    super.key,
+  });
+
+  /// The child that will be painted above the glow effect.
+  final Widget child;
+
+  /// The shape to clip the glow to.
+  final CustomClipper<Path>? clipper;
+
+  /// Global pulse intensity (0.0 to 1.0) for a full-window glow effect.
+  final double pulse;
+
+  @override
+  State<GlassGlowLayer> createState() => GlassGlowLayerState();
+
+  @internal
+  // ignore: public_member_api_docs
+  static GlassGlowLayerState? maybeOf(BuildContext context) {
+    if (!context.mounted) return null;
+    return context.findAncestorStateOfType<GlassGlowLayerState>();
+  }
+}
+
+@internal
+class GlassGlowLayerState extends State<GlassGlowLayer>
+    with TickerProviderStateMixin {
+  late final _offsetController = OffsetSpringController(
+    vsync: this,
+    spring: GlassSpring.smooth(duration: const Duration(seconds: 1)),
+    initialValue: Offset.zero,
+  );
+
+  late final _alphaController = SingleSpringController(
+    vsync: this,
+    spring: GlassSpring.smooth(),
+    initialValue: 0,
+    lowerBound: 0,
+    upperBound: 1,
+  );
+
+  late final _radiusController = SingleSpringController(
+    vsync: this,
+    spring: GlassSpring.smooth(),
+    initialValue: 1.2,
+  );
+
+  bool _dragging = false;
+
+  /// Whether a touch is currently active.
+  ///
+  /// Exposed for testing to verify the spring-switching behaviour introduced
+  /// in the glow-follow-speed fix.
+  @visibleForTesting
+  bool get dragging => _dragging;
+
+  double _baseRadius = 0;
+  Color _baseColor = const Color.fromARGB(0, 0, 0, 0);
+  double _baseBlurRadius = 0;
+  double _baseSpreadRadius = 0;
+  double _baseOpacity = 1;
+
+  @override
+  void dispose() {
+    _offsetController.dispose();
+    _alphaController.dispose();
+    _radiusController.dispose();
+    super.dispose();
+  }
+
+  void updateTouch(
+    Offset offset, {
+    required double radius,
+    required Color color,
+    double blurRadius = 0,
+    double spreadRadius = 0,
+    double opacity = 1,
+  }) {
+    setState(() {
+      _baseRadius = radius;
+      _baseColor = color;
+      _baseBlurRadius = blurRadius;
+      _baseSpreadRadius = spreadRadius;
+      _baseOpacity = opacity.clamp(0.0, 1.0);
+    });
+
+    if (!_dragging) {
+      _dragging = true;
+      // Snap to the exact touch point immediately so the glow appears right
+      // where the finger lands — not at Offset.zero drifting over. Alpha then
+      // fades in at the correct position instead of mid-spring.
+      _offsetController.value = offset;
+      _alphaController.spring = GlassSpring.interactive();
+      _radiusController.spring = GlassSpring.interactive();
+      // Switch position tracking to interactive spring so the glow follows
+      // the finger at the same responsive speed as alpha/radius.
+      _offsetController.spring = GlassSpring.interactive();
+      _alphaController.animateTo(1, fromVelocity: 0);
+      _radiusController.animateTo(1, fromVelocity: 0);
+    }
+
+    _offsetController.animateTo(offset);
+  }
+
+  void removeTouch() {
+    if (!_dragging) return;
+    _alphaController.spring = GlassSpring.smooth();
+    _radiusController.spring = GlassSpring.smooth();
+    // Restore smooth spring for the position fade-out drift.
+    _offsetController.spring = GlassSpring.smooth(
+      duration: const Duration(seconds: 1),
+    );
+    _dragging = false;
+    _radiusController.animateTo(1.2);
+    _alphaController.animateTo(0);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: Listenable.merge([
+        _offsetController,
+        _alphaController,
+        _radiusController,
+      ]),
+      builder: (context, child) {
+        final animatedAlpha = _baseColor.a * _alphaController.value;
+        return _RenderGlassGlowLayerWidget(
+          clipper: widget.clipper,
+          pulse: widget.pulse,
+          glowRadius: _baseRadius * _radiusController.value,
+          glowColor: _baseColor.withValues(
+            alpha: animatedAlpha * _baseOpacity,
+          ),
+          glowOffset: _offsetController.value,
+          glowBlurRadius: _baseBlurRadius,
+          glowSpreadRadius: _baseSpreadRadius,
+          child: child,
+        );
+      },
+      child: widget.child,
+    );
+  }
+}
+
+class _RenderGlassGlowLayerWidget extends SingleChildRenderObjectWidget {
+  const _RenderGlassGlowLayerWidget({
+    required this.clipper,
+    required this.pulse,
+    required this.glowRadius,
+    required this.glowColor,
+    required this.glowOffset,
+    required this.glowBlurRadius,
+    required this.glowSpreadRadius,
+    required super.child,
+  });
+
+  final CustomClipper<Path>? clipper;
+  final double pulse;
+  final double glowRadius;
+  final Color glowColor;
+  final Offset glowOffset;
+  final double glowBlurRadius;
+  final double glowSpreadRadius;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderGlassGlowLayer(
+      clipper: clipper,
+      pulse: pulse,
+      glowRadius: glowRadius,
+      glowColor: glowColor,
+      glowOffset: glowOffset,
+      glowBlurRadius: glowBlurRadius,
+      glowSpreadRadius: glowSpreadRadius,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    _RenderGlassGlowLayer renderObject,
+  ) {
+    renderObject
+      ..clipper = clipper
+      ..pulse = pulse
+      ..glowRadius = glowRadius
+      ..glowColor = glowColor
+      ..glowOffset = glowOffset
+      ..glowBlurRadius = glowBlurRadius
+      ..glowSpreadRadius = glowSpreadRadius;
+  }
+}
+
+class _RenderGlassGlowLayer extends RenderProxyBox {
+  _RenderGlassGlowLayer({
+    required double glowRadius,
+    required Color glowColor,
+    required Offset glowOffset,
+    required double glowBlurRadius,
+    required double glowSpreadRadius,
+    required double pulse,
+    CustomClipper<Path>? clipper,
+  })  : _glowRadius = glowRadius,
+        _glowColor = glowColor,
+        _glowOffset = glowOffset,
+        _glowBlurRadius = glowBlurRadius,
+        _glowSpreadRadius = glowSpreadRadius,
+        _pulse = pulse,
+        _clipper = clipper;
+
+  CustomClipper<Path>? _clipper;
+  CustomClipper<Path>? get clipper => _clipper;
+  set clipper(CustomClipper<Path>? value) {
+    if (_clipper == value) return;
+    _clipper = value;
+    markNeedsPaint();
+  }
+
+  double _pulse;
+  double get pulse => _pulse;
+  set pulse(double value) {
+    if (_pulse == value) return;
+    _pulse = value;
+    markNeedsPaint();
+  }
+
+  double _glowRadius;
+  double get glowRadius => _glowRadius;
+  set glowRadius(double value) {
+    if (_glowRadius == value) return;
+    _glowRadius = value;
+    markNeedsPaint();
+  }
+
+  Color _glowColor;
+  Color get glowColor => _glowColor;
+  set glowColor(Color value) {
+    if (_glowColor == value) return;
+    _glowColor = value;
+    markNeedsPaint();
+  }
+
+  Offset _glowOffset;
+  Offset get glowOffset => _glowOffset;
+  set glowOffset(Offset value) {
+    if (_glowOffset == value) return;
+    _glowOffset = value;
+    markNeedsPaint();
+  }
+
+  double _glowBlurRadius;
+  double get glowBlurRadius => _glowBlurRadius;
+  set glowBlurRadius(double value) {
+    if (_glowBlurRadius == value) return;
+    _glowBlurRadius = value;
+    markNeedsPaint();
+  }
+
+  double _glowSpreadRadius;
+  double get glowSpreadRadius => _glowSpreadRadius;
+  set glowSpreadRadius(double value) {
+    if (_glowSpreadRadius == value) return;
+    _glowSpreadRadius = value;
+    markNeedsPaint();
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    // 1. Paint the children (which includes AdaptiveGlass taking its backdrop snapshot)
+    super.paint(context, offset);
+
+    final canvas = context.canvas;
+
+    // 2. Global Specular Pulse (full-window additive highlight, driven by GlassModalSheet
+    //    saturation controller during high-velocity drag interactions).
+    if (_pulse > 0) {
+      final pulsePaint = Paint()
+        ..color = Colors.white.withValues(alpha: 0.08 * _pulse)
+        ..blendMode = BlendMode.plus;
+
+      if (_clipper != null) {
+        canvas.save();
+        canvas.clipPath(_clipper!.getClip(size).shift(offset));
+        canvas.drawRect(offset & size, pulsePaint);
+        canvas.restore();
+      } else {
+        canvas.drawRect(offset & size, pulsePaint);
+      }
+    }
+
+    // 3. Local Interactive Glow (finger glare — radial gradient following the touch point)
+    if (_glowColor.a > 0 && _glowRadius > 0) {
+      final glowPosition = offset + _glowOffset;
+      // Use the shortest side so that wide pills don't generate massive glow
+      // spilling vertically off the surface.
+      final shortSide = math.min(size.width, size.height);
+      final radius = _glowRadius * shortSide + _glowSpreadRadius * shortSide;
+
+      // RadialGradient.createShader() bakes the center position into the shader
+      // via the Rect passed to it — caching across position changes is incorrect.
+      // Per-frame creation is cheap for a simple radial gradient (uniform-only).
+      final paint = Paint()
+        ..shader = RadialGradient(
+          colors: [_glowColor, _glowColor.withValues(alpha: 0)],
+          stops: const [0.0, 1.0],
+        ).createShader(Rect.fromCircle(center: glowPosition, radius: radius))
+        ..blendMode = BlendMode.plus;
+
+      // Optional Gaussian blur to soften the glow halo. Only create the
+      // MaskFilter when non-zero to avoid a no-op allocation every frame.
+      if (_glowBlurRadius > 0) {
+        paint.maskFilter = MaskFilter.blur(BlurStyle.normal, _glowBlurRadius);
+      }
+
+      // 2. Additive light over geometry boundary only
+      if (_clipper != null) {
+        canvas.save();
+        canvas.clipPath(_clipper!.getClip(size).shift(offset));
+        canvas.drawCircle(glowPosition, radius, paint);
+        canvas.restore();
+      } else {
+        canvas.drawCircle(glowPosition, radius, paint);
+      }
+    }
+  }
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/internal/glass_drag_builder.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/internal/glass_drag_builder.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
+import 'interaction_notification.dart';
+
+@internal
+class GlassDragBuilder extends StatefulWidget {
+  const GlassDragBuilder({
+    required this.builder,
+    this.behavior = HitTestBehavior.opaque,
+    this.suppressInteractionOnChildren = true,
+    this.child,
+    super.key,
+  });
+
+  final HitTestBehavior behavior;
+  final bool suppressInteractionOnChildren;
+  final ValueWidgetBuilder<Offset?> builder;
+  final Widget? child;
+
+  @override
+  State<GlassDragBuilder> createState() => _GlassDragBuilderState();
+}
+
+class _GlassDragBuilderState extends State<GlassDragBuilder> {
+  Offset? currentDragOffset;
+  bool _shouldIgnoreCurrentPointer = false;
+
+  bool get isDragging => currentDragOffset != null;
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<InteractionNotification>(
+      onNotification: (notification) {
+        if (widget.suppressInteractionOnChildren) {
+          _shouldIgnoreCurrentPointer = true;
+        }
+        return false; // Let it bubble
+      },
+      child: Listener(
+        behavior: widget.behavior,
+        onPointerDown: (event) {
+          if (widget.suppressInteractionOnChildren &&
+              _shouldIgnoreCurrentPointer) {
+            _shouldIgnoreCurrentPointer = false;
+            return;
+          }
+          if (!mounted) return;
+          setState(() => currentDragOffset = Offset.zero);
+        },
+        onPointerMove: (event) {
+          if (currentDragOffset == null) return;
+          if (!mounted) return;
+          setState(() {
+            currentDragOffset =
+                (currentDragOffset ?? Offset.zero) + event.delta;
+          });
+        },
+        onPointerUp: (event) {
+          _shouldIgnoreCurrentPointer = false;
+          if (!mounted) return;
+          setState(() => currentDragOffset = null);
+        },
+        onPointerCancel: (event) {
+          _shouldIgnoreCurrentPointer = false;
+          if (!mounted) return;
+          setState(() => currentDragOffset = null);
+        },
+        child: widget.builder(context, currentDragOffset, widget.child),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/internal/interaction_notification.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/internal/interaction_notification.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/widgets.dart';
+
+/// A notification that informs parent widgets that an interaction has started.
+///
+/// Used by [GlassSheet] to suppress its own scaling/glow when a child
+/// widget is being touched.
+class InteractionNotification extends Notification {
+  /// The pointer event that triggered this notification.
+  final PointerDownEvent event;
+
+  /// Creates an [InteractionNotification].
+  InteractionNotification(this.event);
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/internal/multi_shader_builder.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/internal/multi_shader_builder.dart
@@ -1,0 +1,175 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/widgets.dart';
+
+/// A callback used by [MultiShaderBuilder].
+typedef MultiShaderBuilderCallback = Widget Function(
+  BuildContext,
+  List<ui.FragmentShader>,
+  Widget?,
+);
+
+/// A widget that loads and caches [ui.FragmentProgram]s based on asset keys.
+///
+/// Usage of this widget avoids the need for a user authored stateful widget
+/// for managing the lifecycle of loading shaders. Once shaders are cached,
+/// subsequent usages of them via a [MultiShaderBuilder] will always be
+/// available synchronously. These shaders can also be precached imperatively
+/// with [MultiShaderBuilder.precacheShader].
+///
+/// If the shaders are not yet loaded, the provided child widget or a [SizedBox]
+/// is returned instead of invoking the builder callback.
+///
+/// Example: providing access to [ui.FragmentShader] instances.
+///
+/// ```dart
+/// Widget build(BuildContext context) {
+///  return ShaderBuilder(
+///    builder: (BuildContext context, List<ui.FragmentShader> shaders, Widget?
+/// child) {
+///      return WidgetThatUsesFragmentShaders(
+///        shaders: shaders,
+///        child: child,
+///      );
+///    },
+///    assetKeys: ['shader1.frag', 'shader2.frag'],
+///    child: Text('Hello, Shaders'),
+///  );
+/// }
+/// ```
+class MultiShaderBuilder extends StatefulWidget {
+  /// Create a new [MultiShaderBuilder].
+  const MultiShaderBuilder(
+    this.builder, {
+    required this.assetKeys,
+    super.key,
+    this.child,
+  });
+
+  /// The asset keys used to lookup shaders.
+  final List<String> assetKeys;
+
+  /// The child widget to pass through to the [builder], optional.
+  final Widget? child;
+
+  /// The builder that provides access to [ui.FragmentShader]s.
+  final MultiShaderBuilderCallback builder;
+
+  @override
+  State<StatefulWidget> createState() {
+    return _MultiShaderBuilderState();
+  }
+
+  /// Precache a [ui.FragmentProgram] based on its [assetKey].
+  ///
+  /// When this future has completed, any newly created [MultiShaderBuilder]s
+  /// that reference this asset will be guaranteed to immediately have access to
+  /// the shader.
+  static Future<void> precacheShader(String assetKey) {
+    if (_MultiShaderBuilderState._shaderCache.containsKey(assetKey)) {
+      return Future<void>.value();
+    }
+    return ui.FragmentProgram.fromAsset(assetKey).then(
+      (ui.FragmentProgram program) {
+        _MultiShaderBuilderState._shaderCache[assetKey] = program;
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        FlutterError.reportError(
+          FlutterErrorDetails(exception: error, stack: stackTrace),
+        );
+      },
+    );
+  }
+
+  /// Precache multiple [ui.FragmentProgram]s based on their [assetKeys].
+  ///
+  /// When this future has completed, any newly created [MultiShaderBuilder]s
+  /// that reference these assets will be guaranteed to immediately have access
+  /// to the shaders.
+  static Future<void> precacheShaders(List<String> assetKeys) {
+    return Future.wait(
+      assetKeys.map(precacheShader),
+    );
+  }
+}
+
+class _MultiShaderBuilderState extends State<MultiShaderBuilder> {
+  final Map<String, ui.FragmentProgram> _programs = {};
+  final Map<String, ui.FragmentShader> _shaders = {};
+
+  static final Map<String, ui.FragmentProgram> _shaderCache =
+      <String, ui.FragmentProgram>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadShaders(widget.assetKeys);
+  }
+
+  @override
+  void didUpdateWidget(covariant MultiShaderBuilder oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.assetKeys != widget.assetKeys) {
+      _loadShaders(widget.assetKeys);
+    }
+  }
+
+  void _loadShaders(List<String> assetKeys) {
+    _programs.clear();
+    _shaders.clear();
+
+    // Check which shaders are already cached
+    final uncachedKeys = <String>[];
+    for (final assetKey in assetKeys) {
+      if (_shaderCache.containsKey(assetKey)) {
+        _programs[assetKey] = _shaderCache[assetKey]!;
+        _shaders[assetKey] = _programs[assetKey]!.fragmentShader();
+      } else {
+        uncachedKeys.add(assetKey);
+      }
+    }
+
+    // If all shaders are cached, we're done
+    if (uncachedKeys.isEmpty) {
+      return;
+    }
+
+    // Load uncached shaders
+    for (final assetKey in uncachedKeys) {
+      ui.FragmentProgram.fromAsset(assetKey).then(
+        (ui.FragmentProgram program) {
+          if (!mounted) {
+            return;
+          }
+          setState(() {
+            _programs[assetKey] = program;
+            _shaders[assetKey] = program.fragmentShader();
+            _shaderCache[assetKey] = program;
+          });
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          FlutterError.reportError(
+            FlutterErrorDetails(exception: error, stack: stackTrace),
+          );
+        },
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Check if all shaders are loaded
+    if (_shaders.length != widget.assetKeys.length) {
+      return widget.child ?? const SizedBox.shrink();
+    }
+
+    // Build shader list in the same order as assetKeys
+    final shaders = widget.assetKeys.map((key) => _shaders[key]!).toList();
+
+    return widget.builder(context, shaders, widget.child);
+  }
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/internal/render_liquid_glass_geometry.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/internal/render_liquid_glass_geometry.dart
@@ -1,0 +1,583 @@
+import 'dart:ui';
+
+import 'package:equatable/equatable.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_shaders/flutter_shaders.dart';
+import '../liquid_glass_renderer.dart';
+import 'snap_rect_to_pixels.dart';
+import '../liquid_glass.dart';
+import '../liquid_glass_blend_group.dart';
+import '../logging.dart';
+import '../rendering/liquid_glass_render_object.dart';
+import 'package:meta/meta.dart';
+
+/// The state of liquid glass geometry, used to determine if it needs to be
+/// updated.
+enum LiquidGlassGeometryState {
+  /// The geometry is up to date and does not need to be updated.
+  updated,
+
+  /// The geometry might need to be updated, but could potentially be reused.
+  ///
+  /// This happens mainly when all of the geometry itself is unchanged, but all
+  /// of the geometry has been uniformly transformed.
+  ///
+  /// In this case, we can use the existing geometry matte and transform it to
+  /// save GPU cycles.
+  mightNeedUpdate,
+
+  /// The geometry definitely needs to be updated.
+  needsUpdate,
+}
+
+/// A base class for any render object that represents liquid glass geometry.
+///
+/// This will paint to the screen normally, but use a [GlassGroupLink] to gather
+/// shape information and generate a geometry matte using the provided
+/// [geometryShader].
+@internal
+abstract class RenderLiquidGlassGeometry extends RenderProxyBox {
+  /// Creates a new [RenderLiquidGlassGeometry] with the given
+  /// [geometryShader].
+  RenderLiquidGlassGeometry({
+    required GeometryRenderLink renderLink,
+    required this.geometryShader,
+    required LiquidGlassSettings settings,
+    required double devicePixelRatio,
+  })  : _renderLink = renderLink,
+        _settings = settings,
+        _devicePixelRatio = devicePixelRatio {
+    updateShaderWithSettings(settings, devicePixelRatio);
+  }
+
+  /// The logger for liquid glass geometry.
+  final Logger logger = Logger(LgrLogNames.geometry);
+
+  /// The shader that generates the geometry matte.
+  final FragmentShader geometryShader;
+
+  LiquidGlassSettings? _settings;
+
+  /// The settings used for liquid glass rendering.
+  ///
+  /// If these settings change in a way that affects geometry, the geometry
+  /// will be marked as needing an update.
+  LiquidGlassSettings get settings => _settings!;
+  set settings(LiquidGlassSettings value) {
+    if (_settings == value) return;
+
+    if (value.requiresGeometryRebuild(_settings)) {
+      logger.finer('$hashCode rebuild ');
+      markGeometryNeedsUpdate(force: true);
+    }
+
+    _settings = value;
+    updateShaderWithSettings(value, _devicePixelRatio);
+    markNeedsPaint();
+  }
+
+  double _devicePixelRatio;
+
+  /// The device pixel ratio used for rendering.
+  ///
+  /// If this changes, the geometry will be marked as needing an update.
+  double get devicePixelRatio => _devicePixelRatio;
+  set devicePixelRatio(double value) {
+    if (_devicePixelRatio == value) return;
+    _devicePixelRatio = value;
+    markGeometryNeedsUpdate(force: true);
+    updateShaderWithSettings(settings, value);
+    markNeedsPaint();
+  }
+
+  GeometryRenderLink? _renderLink;
+  GeometryRenderLink? get renderLink => _renderLink;
+  set renderLink(GeometryRenderLink? value) {
+    if (_renderLink == value) return;
+    _renderLink?.unregisterGeometry(this);
+    _renderLink = value;
+    _renderLink?.registerGeometry(this);
+  }
+
+  /// The current state of the geometry.
+  @visibleForTesting
+  @protected
+  LiquidGlassGeometryState geometryState = LiquidGlassGeometryState.needsUpdate;
+
+  /// The current geometry matte image.
+  @visibleForTesting
+  @protected
+  GeometryCache? geometry;
+
+  /// Marks the geometry as needing an update.
+  ///
+  /// If [force] is true, the geometry will be marked as definitely needing an
+  /// update. Otherwise, it will be marked as possibly needing an update,
+  /// unless it is already marked as definitely needing an update.
+  @protected
+  void markGeometryNeedsUpdate({bool force = false}) {
+    final newState = force
+        ? LiquidGlassGeometryState.needsUpdate
+        : LiquidGlassGeometryState.mightNeedUpdate;
+
+    geometryState = switch ((geometryState, newState)) {
+      (LiquidGlassGeometryState.needsUpdate, _) =>
+        LiquidGlassGeometryState.needsUpdate,
+      (_, LiquidGlassGeometryState.needsUpdate) =>
+        LiquidGlassGeometryState.needsUpdate,
+      _ => LiquidGlassGeometryState.mightNeedUpdate,
+    };
+  }
+
+  @override
+  @mustCallSuper
+  void attach(PipelineOwner owner) {
+    _renderLink?.registerGeometry(this);
+    super.attach(owner);
+  }
+
+  @override
+  @mustCallSuper
+  void detach() {
+    _renderLink?.unregisterGeometry(this);
+    super.detach();
+  }
+
+  @override
+  @mustCallSuper
+  void dispose() {
+    _renderLink?.unregisterGeometry(this);
+    geometry?.dispose();
+    geometry = null;
+    super.dispose();
+  }
+
+  /// Updates the shader with the current settings and device pixel ratio.
+  void updateShaderWithSettings(
+    LiquidGlassSettings settings,
+    double devicePixelRatio,
+  );
+
+  /// Uploads shape data to geometry shader in screen space coordinates
+  void updateGeometryShaderShapes(
+    List<ShapeGeometry> shapes,
+  );
+
+  /// Paints the contents of all shapes to the given [context] at the given
+  /// [offset].
+  void paintShapeContents(
+    RenderObject from,
+    PaintingContext context,
+    Offset offset, {
+    required bool insideGlass,
+  });
+
+  /// Gathers all shapes and computes them in both layer and screen space
+  /// Returns (layerBounds, shapes, anyShapeChangedInLayer)
+  (
+    Rect bounds,
+    List<ShapeGeometry> geometries,
+    bool needsUpdate,
+  ) gatherShapeData();
+
+  Path getPath(
+    List<ShapeGeometry> geometries,
+  ) {
+    final path = Path();
+    for (final shape in geometries) {
+      path.addPath(
+        shape.renderObject.getPath(),
+        Offset.zero,
+        matrix4: shape.shapeToGeometry?.storage,
+      );
+    }
+    return path;
+  }
+
+  /// Should be called from within [paint] to maybe rebuild the [geometry].
+  GeometryCache? maybeRebuildGeometry() {
+    if (geometryState == LiquidGlassGeometryState.updated && geometry != null) {
+      return geometry;
+    }
+
+    final (layerBounds, shapes, anyShapeChangedInLayer) = gatherShapeData();
+
+    if (geometryState == LiquidGlassGeometryState.mightNeedUpdate &&
+        !anyShapeChangedInLayer &&
+        geometry != null) {
+      logger.finer('$hashCode Skipping geometry rebuild.');
+      renderLink?.notifyGeometryChanged(this);
+
+      // Only render once we are done building
+      geometry = geometry!.render();
+      geometryState = LiquidGlassGeometryState.updated;
+      return geometry;
+    }
+
+    logger.finer('$hashCode Rebuilding geometry');
+
+    geometry?.dispose();
+    geometry = null;
+    geometryState = LiquidGlassGeometryState.updated;
+
+    if (shapes.isEmpty) {
+      return null;
+    }
+
+    final snappedBounds = layerBounds.snapToPixels(devicePixelRatio);
+    final matteBounds = Rect.fromLTWH(
+      snappedBounds.left * devicePixelRatio,
+      snappedBounds.top * devicePixelRatio,
+      snappedBounds.width * devicePixelRatio,
+      snappedBounds.height * devicePixelRatio,
+    ).snapToPixels(1);
+
+    // Set the new geometry
+    final newGeo = geometry = UnrenderedGeometryCache(
+      matte: _buildGeometryPicture(snappedBounds, shapes),
+      bounds: snappedBounds,
+      matteBounds: matteBounds,
+      shapes: shapes,
+      path: getPath(shapes),
+    );
+
+    // We have updated the geometry.
+    _renderLink?.notifyGeometryChanged(this);
+    return newGeo;
+  }
+
+  Picture _buildGeometryPicture(
+    Rect geometryBounds,
+    List<ShapeGeometry> shapes,
+  ) {
+    final bounds = geometryBounds.snapToPixels(devicePixelRatio);
+
+    final width = (bounds.width * devicePixelRatio).ceil();
+    final height = (bounds.height * devicePixelRatio).ceil();
+
+    geometryShader.setFloatUniforms((value) {
+      value
+        ..setFloat(width.toDouble())
+        ..setFloat(height.toDouble());
+    });
+
+    updateGeometryShaderShapes(shapes);
+
+    final recorder = PictureRecorder();
+    final canvas = Canvas(recorder);
+    final paint = Paint()..shader = geometryShader;
+
+    final leftPixel = (geometryBounds.left * devicePixelRatio).roundToDouble();
+    final topPixel = (geometryBounds.top * devicePixelRatio).roundToDouble();
+
+    canvas
+      // This translation might seem redundant, but we do it to ensure pixel
+      // snapping
+      ..translate(-leftPixel, -topPixel)
+      ..drawRect(
+        Rect.fromLTWH(
+          leftPixel,
+          topPixel,
+          width.toDouble(),
+          height.toDouble(),
+        ),
+        paint,
+      );
+
+    return recorder.endRecording();
+  }
+}
+
+@immutable
+@internal
+sealed class GeometryCache {
+  const GeometryCache({
+    required this.matteBounds,
+    required this.bounds,
+    required this.shapes,
+    required this.path,
+  });
+
+  /// The bounds of the geometry in the coordinate space of its
+  /// [RenderLiquidGlassGeometry] parent.
+  final Rect bounds;
+
+  /// The bounds of the matte image in physical pixels.
+  final Rect matteBounds;
+
+  final List<ShapeGeometry> shapes;
+
+  final Path path;
+
+  /// Ensure that this geometry is rendered and potentially dispose this
+  /// instance.
+  ///
+  /// Using this object isn't safe after calling this method.
+  /// Make sure to only use the returned object after calling this.
+  ///
+  /// If this is a [UnrenderedGeometryCache], this will produce a
+  /// [RenderedGeometryCache].
+  ///
+  /// If this is already rendered, it will return itself.
+  RenderedGeometryCache render();
+
+  Future<RenderedGeometryCache> renderAsync();
+
+  void dispose();
+}
+
+/// Represents a current snapshot of the geometry used for liquid glass
+/// rendering.
+@immutable
+@internal
+class UnrenderedGeometryCache extends GeometryCache {
+  const UnrenderedGeometryCache({
+    required this.matte,
+    required super.matteBounds,
+    required super.bounds,
+    required super.shapes,
+    required super.path,
+  });
+
+  /// The matte image representing the geometry.
+  final Picture matte;
+
+  @override
+  Future<RenderedGeometryCache> renderAsync() async {
+    final width = matteBounds.width.ceil();
+    final height = matteBounds.height.ceil();
+    // Guard: zero/negative dimensions can corrupt Mali GPU driver state during
+    // rapid layout changes (jelly animations, modal expansion). Return a
+    // minimal 1×1 cache rather than handing the GPU an invalid texture request.
+    if (width < 1 || height < 1) {
+      final recorder = PictureRecorder();
+      Canvas(recorder);
+      final fallback = recorder.endRecording();
+      final image = fallback.toImageSync(1, 1);
+      fallback.dispose();
+      return RenderedGeometryCache(
+        matte: image,
+        matteBounds: const Rect.fromLTWH(0, 0, 1, 1),
+        bounds: bounds,
+        shapes: shapes,
+        path: path,
+      );
+    }
+    final image = await matte.toImage(width, height);
+    return RenderedGeometryCache(
+      matte: image,
+      matteBounds: matteBounds,
+      bounds: bounds,
+      shapes: shapes,
+      path: path,
+    );
+  }
+
+  @override
+  RenderedGeometryCache render() {
+    final width = matteBounds.width.ceil();
+    final height = matteBounds.height.ceil();
+    // Guard: zero/negative dimensions during jelly squash or rapid layout
+    // transitions can produce invalid GPU texture requests on Mali GPUs.
+    if (width < 1 || height < 1) {
+      dispose();
+      final recorder = PictureRecorder();
+      Canvas(recorder);
+      final fallback = recorder.endRecording();
+      final image = fallback.toImageSync(1, 1);
+      fallback.dispose();
+      return RenderedGeometryCache(
+        matte: image,
+        matteBounds: const Rect.fromLTWH(0, 0, 1, 1),
+        bounds: bounds,
+        shapes: shapes,
+        path: path,
+      );
+    }
+    try {
+      final image = matte.toImageSync(width, height);
+      dispose();
+      return RenderedGeometryCache(
+        matte: image,
+        matteBounds: matteBounds,
+        bounds: bounds,
+        shapes: shapes,
+        path: path,
+      );
+    } catch (_) {
+      // Mali GPU driver failure during toImageSync — return a safe 1×1 fallback
+      // rather than crashing the entire app. The next paint frame will rebuild
+      // the geometry with valid dimensions.
+      dispose();
+      final recorder = PictureRecorder();
+      Canvas(recorder);
+      final fallback = recorder.endRecording();
+      final image = fallback.toImageSync(1, 1);
+      fallback.dispose();
+      return RenderedGeometryCache(
+        matte: image,
+        matteBounds: const Rect.fromLTWH(0, 0, 1, 1),
+        bounds: bounds,
+        shapes: shapes,
+        path: path,
+      );
+    }
+  }
+
+  /// Disposes of the resources used by the geometry.
+  @override
+  void dispose() {
+    matte.dispose();
+  }
+}
+
+/// Represents a current snapshot of the geometry used for liquid glass
+/// rendering.
+@immutable
+@internal
+class RenderedGeometryCache extends GeometryCache {
+  const RenderedGeometryCache({
+    required this.matte,
+    required super.matteBounds,
+    required super.bounds,
+    required super.shapes,
+    required super.path,
+  });
+
+  /// The matte image representing the geometry.
+  final Image matte;
+
+  @override
+  RenderedGeometryCache render() => this;
+
+  @override
+  Future<RenderedGeometryCache> renderAsync() => Future.value(this);
+
+  /// Disposes of the resources used by the geometry.
+  @override
+  void dispose() {
+    matte.dispose();
+  }
+}
+
+extension on LiquidGlassSettings {
+  bool requiresGeometryRebuild(LiquidGlassSettings? other) {
+    if (other == null) return false;
+
+    // blend is intentionally excluded here — it is set directly on
+    // RenderLiquidGlassBlendGroup and triggers a forced geometry rebuild via
+    // its own setter. If blend is ever pulled into LiquidGlassSettings, add it
+    // to this check at that point.
+    return effectiveThickness != other.effectiveThickness ||
+        refractiveIndex != other.refractiveIndex;
+  }
+}
+
+@internal
+enum RawShapeType {
+  // none(0), unused in CPU code
+  squircle(1),
+  ellipse(2),
+  roundedRectangle(3);
+
+  const RawShapeType(this.shaderIndex);
+
+  final double shaderIndex;
+
+  static RawShapeType fromLiquidGlassShape(LiquidShape shape) {
+    switch (shape) {
+      case LiquidRoundedSuperellipse():
+        return RawShapeType.squircle;
+      case LiquidOval():
+        return RawShapeType.ellipse;
+      case LiquidRoundedRectangle():
+        return RawShapeType.roundedRectangle;
+      case LiquidVerticalRoundedRectangle():
+        return RawShapeType.roundedRectangle;
+      case LiquidVerticalRoundedSuperellipse():
+        return RawShapeType.squircle;
+    }
+  }
+}
+
+/// The geometry of a single shape.
+///
+/// Can be part of multiple blended shapes in [RenderLiquidGlassGeometry], or on
+/// its own.
+@internal
+class ShapeGeometry extends Equatable {
+  ShapeGeometry({
+    required this.renderObject,
+    required this.shape,
+    required this.glassContainsChild,
+    required this.shapeBounds,
+    this.shapeToGeometry,
+  })  : rawCornerRadius = _getRadiusFromGlassShape(shape),
+        rawBottomCornerRadius = _getBottomRadiusFromGlassShape(shape),
+        rawShapeType = RawShapeType.fromLiquidGlassShape(shape);
+
+  static double _getRadiusFromGlassShape(LiquidShape shape) {
+    switch (shape) {
+      case LiquidRoundedSuperellipse():
+        return shape.borderRadius;
+      case LiquidRoundedRectangle():
+        return shape.borderRadius;
+      case LiquidVerticalRoundedRectangle():
+        return shape.topRadius;
+      case LiquidOval():
+        return 0;
+      case LiquidVerticalRoundedSuperellipse():
+        return shape.topRadius;
+    }
+  }
+
+  /// Bottom corner radius. For symmetric shapes this returns the same value
+  /// as [_getRadiusFromGlassShape]; for vertically-asymmetric shapes
+  /// ([LiquidVerticalRoundedSuperellipse], [LiquidVerticalRoundedRectangle])
+  /// it returns the distinct bottom radius. Consumed by the geometry shader
+  /// via the per-shape `[base+6]` slot so the SDF can paint different top vs.
+  /// bottom corners (e.g. iOS modal sheets whose bottom curves track the
+  /// device chassis radius).
+  static double _getBottomRadiusFromGlassShape(LiquidShape shape) {
+    switch (shape) {
+      case LiquidRoundedSuperellipse():
+        return shape.borderRadius;
+      case LiquidRoundedRectangle():
+        return shape.borderRadius;
+      case LiquidVerticalRoundedRectangle():
+        return shape.bottomRadius;
+      case LiquidOval():
+        return 0;
+      case LiquidVerticalRoundedSuperellipse():
+        return shape.bottomRadius;
+    }
+  }
+
+  final RenderLiquidGlass renderObject;
+
+  final LiquidShape shape;
+
+  final RawShapeType rawShapeType;
+
+  final double rawCornerRadius;
+
+  /// Bottom corner radius — equal to [rawCornerRadius] for symmetric shapes,
+  /// distinct for vertically-asymmetric shapes. See
+  /// [_getBottomRadiusFromGlassShape].
+  final double rawBottomCornerRadius;
+
+  final bool glassContainsChild;
+
+  /// Bounds in geometry-local coordinates (for painting)
+  final Rect shapeBounds;
+
+  final Matrix4? shapeToGeometry;
+
+  @override
+  List<Object?> get props => [
+        renderObject,
+        shape,
+        glassContainsChild,
+        shapeBounds,
+      ];
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/internal/snap_rect_to_pixels.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/internal/snap_rect_to_pixels.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/rendering.dart';
+import 'package:meta/meta.dart';
+
+@internal
+extension SnapRectToPixels on Rect {
+  Rect snapToPixels(double devicePixelRatio) {
+    return Rect.fromLTRB(
+      left.snapToPixel(devicePixelRatio: devicePixelRatio),
+      top.snapToPixel(devicePixelRatio: devicePixelRatio),
+      right.snapToPixel(devicePixelRatio: devicePixelRatio),
+      bottom.snapToPixel(devicePixelRatio: devicePixelRatio),
+    );
+  }
+}
+
+extension on double {
+  double snapToPixel({required double devicePixelRatio}) {
+    return (this * devicePixelRatio).roundToDouble() / devicePixelRatio;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/internal/transform_tracking_repaint_boundary_mixin.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/internal/transform_tracking_repaint_boundary_mixin.dart
@@ -1,0 +1,97 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/rendering.dart';
+import 'package:meta/meta.dart';
+
+@internal
+mixin TransformTrackingRepaintBoundaryMixin on RenderProxyBox {
+  @override
+  GeometryTransformTrackingLayer? get layer =>
+      super.layer as GeometryTransformTrackingLayer?;
+
+  @override
+  bool get isRepaintBoundary => true;
+
+  @override
+  OffsetLayer updateCompositedLayer({
+    covariant GeometryTransformTrackingLayer? oldLayer,
+  }) {
+    final layer = oldLayer ??= GeometryTransformTrackingLayer();
+
+    // ignore: cascade_invocations
+    layer
+      ..renderObject = this
+      ..onTransformChanged = () {
+        if (attached) {
+          onTransformChanged();
+        }
+      };
+
+    return layer;
+  }
+
+  @mustCallSuper
+  @override
+  void paint(PaintingContext context, ui.Offset offset) {
+    layer!.offset = offset;
+    super.paint(context, offset);
+  }
+
+  void onTransformChanged();
+}
+
+@internal
+mixin TransformTrackingRenderObjectMixin on RenderProxyBox {
+  @override
+  GeometryTransformTrackingLayer? get layer =>
+      super.layer as GeometryTransformTrackingLayer?;
+
+  @override
+  @nonVirtual
+  bool get isRepaintBoundary => false;
+
+  @override
+  bool get alwaysNeedsCompositing => true;
+
+  @mustCallSuper
+  @override
+  void paint(PaintingContext context, ui.Offset offset) {
+    setUpLayer(offset);
+    context.pushLayer(layer!, (context, offset) {}, offset);
+    super.paint(context, offset);
+  }
+
+  GeometryTransformTrackingLayer setUpLayer(Offset offset) {
+    // ignore: unnecessary_this
+    return (this.layer ??= GeometryTransformTrackingLayer())
+      ..renderObject = this
+      ..onTransformChanged = () {
+        if (attached) {
+          onTransformChanged();
+        }
+      };
+  }
+
+  void onTransformChanged();
+}
+
+@internal
+class GeometryTransformTrackingLayer extends OffsetLayer {
+  GeometryTransformTrackingLayer();
+
+  RenderObject? renderObject;
+  VoidCallback? onTransformChanged;
+  Matrix4? _lastTransform;
+
+  @override
+  bool get alwaysNeedsAddToScene => true;
+
+  @override
+  void addToScene(ui.SceneBuilder builder) {
+    final currentTransform = renderObject?.getTransformTo(null);
+    if (!MatrixUtils.matrixEquals(currentTransform, _lastTransform)) {
+      onTransformChanged?.call();
+      _lastTransform = currentTransform;
+    }
+  }
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/liquid_glass.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/liquid_glass.dart
@@ -1,0 +1,362 @@
+// ignore_for_file: avoid_setters_without_getters
+
+import 'dart:ui';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'liquid_glass_renderer.dart';
+import 'internal/transform_tracking_repaint_boundary_mixin.dart';
+import 'liquid_glass_blend_group.dart';
+import 'package:meta/meta.dart';
+
+/// A liquid glass shape.
+///
+/// To render liquid glass, you probably want to wrap this in a
+/// [LiquidGlassLayer], where the glass effect will be rendered.
+///
+/// This can either create a single shape, or be blended together with other
+/// shapes in a parent [LiquidGlassBlendGroup] by using the
+/// [LiquidGlass.grouped] constructor.
+///
+/// If you only need a single shape with its own settings, you can also use the
+/// [LiquidGlass.withOwnLayer] constructor, which will create its own
+/// [LiquidGlassLayer] internally.
+/// Be mindful that creating many individual layers can be expensive.
+///
+/// See the [LiquidGlassLayer] documentation for more information.
+class LiquidGlass extends StatelessWidget {
+  /// Creates a new [LiquidGlass] with the given [child] and [shape].
+  ///
+  /// This will expect a parent [LiquidGlassLayer] to be present in the widget
+  /// tree, where the liquid glass effect will be rendered.
+  const LiquidGlass({
+    required this.child,
+    required this.shape,
+    this.glassContainsChild = false,
+    this.clipBehavior = Clip.hardEdge,
+    super.key,
+  })  : grouped = false,
+        blendGroupLink = null,
+        clipExpansion = EdgeInsets.zero,
+        shadows = const <BoxShadow>[],
+        ownLayerConfig = null,
+        _captureImage = null,
+        _captureOriginInScreenSpace = Offset.zero;
+
+  /// Creates a new [LiquidGlass] that is part of a [LiquidGlassBlendGroup].
+  ///
+  /// This will expect a parent [LiquidGlassBlendGroup] to be present in the
+  /// widget tree, as well as a parent [LiquidGlassLayer] above that, where the
+  /// result will be rendered.
+  const LiquidGlass.grouped({
+    required this.child,
+    required this.shape,
+    super.key,
+    this.glassContainsChild = false,
+    this.clipBehavior = Clip.hardEdge,
+    this.blendGroupLink,
+  })  : ownLayerConfig = null,
+        clipExpansion = EdgeInsets.zero,
+        shadows = const <BoxShadow>[],
+        _captureImage = null,
+        _captureOriginInScreenSpace = Offset.zero,
+        grouped = true;
+
+  /// Creates a new [LiquidGlass] that creates its own [LiquidGlassLayer].
+  ///
+  /// While this might seem convenient, creating many individual layers can be
+  /// expensive.
+  ///
+  /// You should prefer rendering multiple [LiquidGlass] shapes that share the
+  /// same settings inside a single [LiquidGlassLayer] for better performance.
+  const LiquidGlass.withOwnLayer({
+    required this.child,
+    required this.shape,
+    LiquidGlassSettings settings = const LiquidGlassSettings(),
+    this.shadows = const <BoxShadow>[],
+    super.key,
+    this.glassContainsChild = false,
+    this.clipBehavior = Clip.hardEdge,
+    this.blendGroupLink,
+    this.clipExpansion = EdgeInsets.zero,
+    ui.Image? captureImage,
+    Offset captureOriginInScreenSpace = Offset.zero,
+  })  : ownLayerConfig = settings,
+        _captureImage = captureImage,
+        _captureOriginInScreenSpace = captureOriginInScreenSpace,
+        grouped = false;
+
+  /// The child of this widget.
+  ///
+  /// You can choose whether this should be rendered "inside" of the glass, or
+  /// on top using [glassContainsChild].
+  final Widget child;
+
+  /// {@template liquid_glass_renderer.LiquidGlass.shape}
+  /// The shape of this glass.
+  ///
+  /// This is the shape of the glass that will be rendered.
+  /// {@endtemplate}
+  final LiquidShape shape;
+
+  /// Whether this glass should be rendered "inside" of the glass, or on top.
+  ///
+  /// If it is rendered inside, the color tint
+  /// of the glass will affect the child, and it will also be refracted.
+  ///
+  /// Defaults to `false`.
+  final bool glassContainsChild;
+
+  /// The clip behavior of this glass.
+  ///
+  /// Defaults to [Clip.none], so [child] will not be clipped.
+  final Clip clipBehavior;
+
+  /// Whether this glass is part of a blend group.
+  final bool grouped;
+
+  /// The link to this glass's blend group if it is part of one.
+  final GlassGroupLink? blendGroupLink;
+
+  /// The settings for this glass if it is supposed to create its own layer.
+  final LiquidGlassSettings? ownLayerConfig;
+
+  /// The shadow to pass to the created layer (only applies for withOwnLayer).
+  final List<BoxShadow> shadows;
+
+  /// Extra clip expansion forwarded to [LiquidGlassLayer.clipExpansion].
+  ///
+  /// Only meaningful when using [LiquidGlass.withOwnLayer]. Has no effect on
+  /// the grouped or default constructors.
+  final EdgeInsets clipExpansion;
+
+  // Capture-path fields — only set by LiquidGlass.withOwnLayer.
+  // When non-null, LiquidGlassLayer bypasses its BackdropFilterLayer and
+  // feeds this image directly to the shader as uBackgroundTexture.
+  final ui.Image? _captureImage;
+  final Offset _captureOriginInScreenSpace;
+
+  @override
+  Widget build(BuildContext context) {
+    // If we have our own layer config, we create our own layer.
+    if (ownLayerConfig case final settings?) {
+      return LiquidGlassLayer(
+        settings: settings,
+        shadows: shadows,
+        clipExpansion: clipExpansion,
+        captureImage: _captureImage,
+        captureOriginInScreenSpace: _captureOriginInScreenSpace,
+        child: LiquidGlassBlendGroup(
+          blend: 0,
+          child: Builder(
+            builder: _buildContent,
+          ),
+        ),
+      );
+    }
+
+    final blendGroupLink = grouped
+        ? this.blendGroupLink ?? LiquidGlassBlendGroup.maybeOf(context)
+        : null;
+
+    if (blendGroupLink == null) {
+      // For now we create our own blend group until we support non-blended
+      // geometry generation
+      return LiquidGlassBlendGroup(
+        blend: 0,
+        child: Builder(
+          builder: (context) => _buildContent(
+            context,
+            LiquidGlassBlendGroup.of(context),
+          ),
+        ),
+      );
+    }
+
+    return _buildContent(
+      context,
+      blendGroupLink,
+    );
+  }
+
+  Widget _buildContent(BuildContext context, [GlassGroupLink? blendGroupLink]) {
+    final settings = LiquidGlassSettings.of(context);
+
+    if (!ImageFilter.isShaderFilterSupported) {
+      // No Impeller — render child without glass effect.
+      // Use AdaptiveLiquidGlassLayer / LightweightLiquidGlass for non-Impeller.
+      return child;
+    }
+
+    return _RawLiquidGlass(
+      blendGroupLink: blendGroupLink ?? LiquidGlassBlendGroup.of(context),
+      shape: shape,
+      glassContainsChild: glassContainsChild,
+      child: ClipPath(
+        clipper: ShapeBorderClipper(shape: shape),
+        clipBehavior: clipBehavior,
+        child: Opacity(
+          opacity: settings.visibility.clamp(0, 1),
+          child: child,
+        ),
+      ),
+    );
+  }
+}
+
+class _RawLiquidGlass extends SingleChildRenderObjectWidget {
+  const _RawLiquidGlass({
+    required super.child,
+    required this.shape,
+    required this.glassContainsChild,
+    required this.blendGroupLink,
+  });
+
+  final LiquidShape shape;
+
+  final bool glassContainsChild;
+
+  final GlassGroupLink? blendGroupLink;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return RenderLiquidGlass(
+      shape: shape,
+      glassContainsChild: glassContainsChild,
+      blendGroupLink: blendGroupLink,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    RenderLiquidGlass renderObject,
+  ) {
+    renderObject
+      ..shape = shape
+      ..glassContainsChild = glassContainsChild
+      ..blendGroupLink = blendGroupLink;
+  }
+}
+
+@internal
+class RenderLiquidGlass extends RenderProxyBox
+    with TransformTrackingRenderObjectMixin {
+  RenderLiquidGlass({
+    required LiquidShape shape,
+    required bool glassContainsChild,
+    required GlassGroupLink? blendGroupLink,
+  })  : _shape = shape,
+        _glassContainsChild = glassContainsChild,
+        _blendGroupLink = blendGroupLink;
+
+  late LiquidShape _shape;
+  LiquidShape get shape => _shape;
+  set shape(LiquidShape value) {
+    if (_shape == value) return;
+    _shape = value;
+    markNeedsPaint();
+    _updateBlendGroupLink();
+  }
+
+  bool _glassContainsChild = true;
+  bool get glassContainsChild => _glassContainsChild;
+  set glassContainsChild(bool value) {
+    if (_glassContainsChild == value) return;
+    _glassContainsChild = value;
+    _updateBlendGroupLink();
+  }
+
+  GlassGroupLink? _blendGroupLink;
+  set blendGroupLink(GlassGroupLink? value) {
+    if (_blendGroupLink == value) return;
+    _unregisterFromParentLayer();
+    _blendGroupLink = value;
+    _registerWithLink();
+  }
+
+  final transformLayerHandle = LayerHandle<TransformLayer>();
+
+  @override
+  void attach(PipelineOwner owner) {
+    super.attach(owner);
+    _registerWithLink();
+  }
+
+  @override
+  void detach() {
+    _unregisterFromParentLayer();
+    transformLayerHandle.layer = null;
+    super.detach();
+  }
+
+  void _registerWithLink() {
+    if (_blendGroupLink != null) {
+      _blendGroupLink!.registerShape(
+        this,
+        _shape,
+        glassContainsChild: _glassContainsChild,
+      );
+    }
+  }
+
+  void _unregisterFromParentLayer() {
+    _blendGroupLink?.unregisterShape(this);
+  }
+
+  void _updateBlendGroupLink() {
+    _blendGroupLink?.updateShape(
+      this,
+      _shape,
+      glassContainsChild: _glassContainsChild,
+    );
+  }
+
+  late Path _lastPath;
+
+  @override
+  void performLayout() {
+    super.performLayout();
+    // Notify parent layer when our layout changes
+    _lastPath = shape.getOuterPath(Offset.zero & size);
+    _blendGroupLink?.notifyShapeLayoutChanged(this);
+  }
+
+  @override
+  void onTransformChanged() {
+    _blendGroupLink?.notifyShapeTransformChanged(this);
+  }
+
+  @override
+  // ignore: must_call_super
+  void paint(PaintingContext context, Offset offset) {
+    setUpLayer(offset);
+    // Push the tracking layer during the normal paint traversal.
+    // We pass an empty painter because the child is NOT drawn here;
+    // it is drawn by the blend group via paintFromLayer.
+    // Pushing the layer ensures it is added to the scene, which
+    // allows onTransformChanged to fire when the user scrolls.
+    context.pushLayer(layer!, (context, offset) {}, offset);
+  }
+
+  void paintFromLayer(
+    PaintingContext context,
+    Matrix4 transform,
+    Offset offset,
+  ) {
+    if (attached) {
+      transformLayerHandle.layer = context.pushTransform(
+        needsCompositing,
+        offset,
+        transform,
+        super.paint,
+        oldLayer: transformLayerHandle.layer,
+      );
+    }
+  }
+
+  Path getPath() {
+    return _lastPath;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/liquid_glass_blend_group.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/liquid_glass_blend_group.dart
@@ -1,0 +1,477 @@
+import 'dart:ui';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_shaders/flutter_shaders.dart';
+import 'liquid_glass_renderer.dart';
+import 'internal/render_liquid_glass_geometry.dart';
+import 'internal/transform_tracking_repaint_boundary_mixin.dart';
+import 'liquid_glass.dart';
+import 'liquid_glass_render_scope.dart';
+import 'rendering/liquid_glass_render_object.dart';
+import 'shaders.dart';
+import 'package:meta/meta.dart';
+
+/// A widget that groups multiple liquid glass shapes for blending.
+///
+/// Any [LiquidGlass.grouped] widgets inside this group will blend together.
+///
+/// This widget will expect a parent [LiquidGlassLayer] to render the liquid
+/// glass effect on.
+class LiquidGlassBlendGroup extends StatefulWidget {
+  /// Creates a new [LiquidGlassBlendGroup].
+  const LiquidGlassBlendGroup({
+    required this.child,
+    this.blend = 20.0,
+    super.key,
+  });
+
+  /// The amount of blending between shapes in this group.
+  ///
+  /// Roughly corresponds to distance of logical pixels at which shapes start to
+  /// blend.
+  final double blend;
+
+  /// The child widget containing liquid glass shapes.
+  final Widget child;
+
+  /// Maximum number of shapes supported per layer.
+  static const int maxShapesPerLayer = 16;
+
+  /// Retrieves the [GlassGroupLink] from the nearest ancestor
+  /// [LiquidGlassBlendGroup].
+  ///
+  /// Can be used by child shapes to register themselves for blending.
+  static GlassGroupLink of(BuildContext context) {
+    final inherited = _InheritedLiquidGlassBlendGroup.of(context);
+    assert(inherited != null, 'No LiquidGlassBlendGroup found in context');
+    return inherited!.link;
+  }
+
+  /// Retrieves the [GlassGroupLink] from the nearest ancestor
+  /// [LiquidGlassBlendGroup], or null if none is found.
+  static GlassGroupLink? maybeOf(BuildContext context) {
+    final inherited = _InheritedLiquidGlassBlendGroup.of(context);
+    return inherited?.link;
+  }
+
+  @override
+  State<LiquidGlassBlendGroup> createState() => _LiquidGlassBlendGroupState();
+}
+
+class _LiquidGlassBlendGroupState extends State<LiquidGlassBlendGroup> {
+  late final GlassGroupLink _geometryLink = GlassGroupLink();
+
+  @override
+  void dispose() {
+    _geometryLink.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // On non-Impeller backends (Skia, web) the geometry shader cannot be
+    // compiled.  Pass through to children so the widget tree still builds.
+    if (!ImageFilter.isShaderFilterSupported) {
+      return _InheritedLiquidGlassBlendGroup(
+        link: _geometryLink,
+        child: widget.child,
+      );
+    }
+
+    return _InheritedLiquidGlassBlendGroup(
+      link: _geometryLink,
+      child: ShaderBuilder(
+        (context, shader, child) {
+          final renderLink = InheritedGeometryRenderLink.of(context);
+
+          assert(
+            renderLink != null,
+            '\n'
+            '[liquid_glass_widgets] LiquidGlassBlendGroup could not find an '
+            'InheritedGeometryRenderLink in the widget tree.\n\n'
+            'This happens when GlassQuality.premium is used outside of a '
+            'LiquidGlassLayer (or AdaptiveLiquidGlassLayer).\n\n'
+            'To fix this, either:\n'
+            '  • Wrap the widget in a LiquidGlassLayer / AdaptiveLiquidGlassLayer, OR\n'
+            '  • Set useOwnLayer: true on your GlassButton / AdaptiveGlass, which '
+            'provisions its own layer automatically.\n\n'
+            'Example:\n'
+            '  GlassButton(\n'
+            '    quality: GlassQuality.premium,\n'
+            '    useOwnLayer: true, // ← add this\n'
+            '    ...\n'
+            '  )\n',
+          );
+
+          // In release builds, if no render link is available, fall back
+          // gracefully by rendering the child without the glass blend effect
+          // rather than crashing the app.
+          if (renderLink == null) return child!;
+
+          return _RawLiquidGlassBlendGroup(
+            blend: widget.blend,
+            shader: shader,
+            link: _geometryLink,
+            renderLink: renderLink,
+            settings: LiquidGlassRenderScope.of(context).settings,
+            child: child,
+          );
+        },
+        assetKey: ShaderKeys.blendedGeometry,
+        child: widget.child,
+      ),
+    );
+  }
+}
+
+class _InheritedLiquidGlassBlendGroup extends InheritedWidget {
+  const _InheritedLiquidGlassBlendGroup({
+    required this.link,
+    required super.child,
+  });
+
+  final GlassGroupLink link;
+
+  static _InheritedLiquidGlassBlendGroup? of(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<_InheritedLiquidGlassBlendGroup>();
+  }
+
+  @override
+  bool updateShouldNotify(covariant InheritedWidget oldWidget) {
+    return oldWidget is! _InheritedLiquidGlassBlendGroup ||
+        oldWidget.link != link;
+  }
+}
+
+class _RawLiquidGlassBlendGroup extends SingleChildRenderObjectWidget {
+  const _RawLiquidGlassBlendGroup({
+    required this.blend,
+    required this.shader,
+    required this.renderLink,
+    required this.link,
+    required this.settings,
+    super.child,
+  });
+
+  final double blend;
+  final FragmentShader shader;
+  final GeometryRenderLink renderLink;
+  final GlassGroupLink link;
+  final LiquidGlassSettings settings;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return RenderLiquidGlassBlendGroup(
+      renderLink: renderLink,
+      devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
+      geometryShader: shader,
+      settings: settings,
+      link: link,
+      blend: blend,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    RenderLiquidGlassBlendGroup renderObject,
+  ) {
+    renderObject
+      ..blend = blend
+      ..devicePixelRatio = MediaQuery.devicePixelRatioOf(context)
+      ..settings = settings
+      ..link = link;
+  }
+}
+
+@visibleForTesting
+@internal
+class RenderLiquidGlassBlendGroup extends RenderLiquidGlassGeometry
+    with TransformTrackingRenderObjectMixin {
+  RenderLiquidGlassBlendGroup({
+    required super.renderLink,
+    required super.devicePixelRatio,
+    required super.geometryShader,
+    required super.settings,
+    required GlassGroupLink link,
+    required double blend,
+  })  : _link = link,
+        _blend = blend {
+    link.addListener(_onLinkUpdate);
+    link.onShapeTransformChanged = _onShapeTransformChanged;
+  }
+
+  GlassGroupLink _link;
+
+  /// The link that provides shape information to this geometry.
+  GlassGroupLink get link => _link;
+
+  set link(GlassGroupLink value) {
+    if (_link == value) return;
+    _link.removeListener(_onLinkUpdate);
+    _link.onShapeTransformChanged = null;
+    _link = value;
+    value.addListener(_onLinkUpdate);
+    value.onShapeTransformChanged = _onShapeTransformChanged;
+    markNeedsPaint();
+  }
+
+  double _blend = 0;
+  double get blend => _blend;
+  set blend(double value) {
+    if (_blend == value) return;
+    _blend = value;
+    updateShaderWithSettings(settings, devicePixelRatio);
+    markGeometryNeedsUpdate(force: true);
+    markNeedsPaint();
+  }
+
+  void _onLinkUpdate() {
+    markGeometryNeedsUpdate();
+    markNeedsPaint();
+  }
+
+  void _onShapeTransformChanged(RenderObject renderObject) {
+    markGeometryNeedsUpdate();
+    markNeedsPaint();
+  }
+
+  @override
+  void onTransformChanged() {
+    markNeedsPaint();
+    renderLink?.notifyGeometryChanged(this);
+  }
+
+  @override
+  void updateShaderWithSettings(
+    LiquidGlassSettings settings,
+    double devicePixelRatio,
+  ) {
+    geometryShader.setFloatUniforms(initialIndex: 2, (value) {
+      value.setFloats([
+        settings.effectiveRefractiveIndex,
+        settings.effectiveChromaticAberration,
+        settings.effectiveThickness,
+        blend * devicePixelRatio,
+      ]);
+    });
+  }
+
+  @override
+  void updateGeometryShaderShapes(
+    List<ShapeGeometry> shapes,
+  ) {
+    if (shapes.length > LiquidGlassBlendGroup.maxShapesPerLayer) {
+      throw UnsupportedError(
+        'Only ${LiquidGlassBlendGroup.maxShapesPerLayer} shapes are supported '
+        'at the moment!',
+      );
+    }
+
+    geometryShader.setFloatUniforms(initialIndex: 6, (value) {
+      value.setFloat(shapes.length.toDouble());
+      value.setFloat(devicePixelRatio);
+      for (final shape in shapes) {
+        final center = shape.shapeBounds.center;
+        final size = shape.shapeBounds.size;
+        // 7-float per-shape stride: type, center.xy, size.xy, top corner
+        // radius, bottom corner radius. For symmetric shapes top == bottom
+        // so the shader's `sdfRRectAsym` collapses to plain `sdfRRect`
+        // (mathematical identity, no behavior change). See sdf.glsl's
+        // shape-slot layout comment.
+        value
+          ..setFloat(shape.rawShapeType.shaderIndex)
+          ..setFloat(center.dx * devicePixelRatio)
+          ..setFloat(center.dy * devicePixelRatio)
+          ..setFloat(size.width * devicePixelRatio)
+          ..setFloat(size.height * devicePixelRatio)
+          ..setFloat(shape.rawCornerRadius * devicePixelRatio)
+          ..setFloat(shape.rawBottomCornerRadius * devicePixelRatio);
+      }
+    });
+  }
+
+  @override
+  (Rect, List<ShapeGeometry>, bool) gatherShapeData() {
+    final shapes = <ShapeGeometry>[];
+    final cachedShapes = geometry?.shapes ?? [];
+
+    var anyShapeChangedInLayer =
+        cachedShapes.length != link.shapeEntries.length;
+
+    Rect? layerBounds;
+
+    for (final (
+          index,
+          MapEntry(
+            key: renderObject,
+            value: (shape, glassContainsChild),
+          )
+        ) in link.shapeEntries.indexed) {
+      if (!renderObject.attached || !renderObject.hasSize) continue;
+
+      try {
+        final shapeData = _computeShapeInfo(
+          renderObject,
+          shape,
+          glassContainsChild,
+        );
+        shapes.add(shapeData);
+
+        layerBounds = layerBounds?.expandToInclude(shapeData.shapeBounds) ??
+            shapeData.shapeBounds;
+
+        final existingShape =
+            cachedShapes.length > index ? cachedShapes[index] : null;
+
+        if (existingShape == null) {
+          anyShapeChangedInLayer = true;
+        } else if (existingShape.shapeBounds != shapeData.shapeBounds ||
+            existingShape.shape != shapeData.shape) {
+          anyShapeChangedInLayer = true;
+        }
+      } catch (e) {
+        debugPrint('Failed to compute shape info: $e');
+      }
+    }
+
+    return (
+      (layerBounds ?? Rect.zero).inflate(blend * .25),
+      shapes,
+      anyShapeChangedInLayer,
+    );
+  }
+
+  @override
+  void paintShapeContents(
+    RenderObject from,
+    PaintingContext context,
+    Offset offset, {
+    required bool insideGlass,
+  }) {
+    for (final shapeEntry in link.shapeEntries) {
+      final renderObject = shapeEntry.key;
+      if (!renderObject.attached ||
+          renderObject.glassContainsChild != insideGlass) {
+        continue;
+      }
+
+      // Fetch the true live paint transform. Since paint-only animations
+      // (LiquidStretch, scale) bypass SDF geometry rebuilds, we must NOT use
+      // transforming caches derived from the old layout geometry.
+      final transform = renderObject.getTransformTo(from);
+
+      renderObject.paintFromLayer(context, transform, offset);
+    }
+  }
+
+  ShapeGeometry _computeShapeInfo(
+    RenderLiquidGlass renderObject,
+    LiquidShape shape,
+    bool glassContainsChild,
+  ) {
+    if (!hasSize) {
+      throw StateError(
+        'Cannot compute shape info for $renderObject because '
+        '$this LiquidGlassGeometry has no size yet.',
+      );
+    }
+
+    if (!renderObject.hasSize) {
+      throw StateError(
+        'Cannot compute shape info for LiquidGlass $renderObject because it '
+        'has no size yet.',
+      );
+    }
+
+    // We remember the shapes transform to this blend group.
+    final transformToGeometry = renderObject.getTransformTo(this);
+
+    final blendGroupRect = MatrixUtils.transformRect(
+      transformToGeometry,
+      Offset.zero & renderObject.size,
+    );
+
+    return ShapeGeometry(
+      renderObject: renderObject,
+      shape: shape,
+      glassContainsChild: glassContainsChild,
+      shapeBounds: blendGroupRect,
+      shapeToGeometry: transformToGeometry,
+    );
+  }
+}
+
+/// A link that connects liquid glass shapes to their parent
+/// [LiquidGlassBlendGroup] for efficient communication of position, size, and
+/// transform changes.
+@internal
+class GlassGroupLink with ChangeNotifier {
+  /// Creates a new [GlassGroupLink].
+  GlassGroupLink();
+
+  /// Information about a shape registered with this link.
+  final Map<RenderLiquidGlass, (LiquidShape shape, bool glassContainsChild)>
+      _shapes = {};
+
+  /// Shape entries as an iterable — returned directly from the underlying Map
+  /// without allocating a new List. All call sites only need to iterate, never
+  /// index, so Iterable is sufficient and avoids 2–3 heap allocations per frame.
+  Iterable<
+      MapEntry<RenderLiquidGlass,
+          (LiquidShape shape, bool glassContainsChild)>> get shapeEntries =>
+      _shapes.entries;
+
+  /// Check if any shapes are registered.
+  bool get hasShapes => _shapes.isNotEmpty;
+
+  /// Register a shape with this link.
+  void registerShape(
+    RenderLiquidGlass renderObject,
+    LiquidShape shape, {
+    required bool glassContainsChild,
+  }) {
+    _shapes[renderObject] = (shape, glassContainsChild);
+    notifyListeners();
+  }
+
+  /// Unregister a shape from this link.
+  void unregisterShape(RenderLiquidGlass renderObject) {
+    _shapes.remove(renderObject);
+    notifyListeners();
+  }
+
+  /// Update the shape properties for a registered render object.
+  void updateShape(
+    RenderLiquidGlass renderObject,
+    LiquidShape shape, {
+    required bool glassContainsChild,
+  }) {
+    _shapes[renderObject] = (shape, glassContainsChild);
+    notifyListeners();
+  }
+
+  /// Notify that a shape's layout has changed.
+  void notifyShapeLayoutChanged(RenderObject renderObject) {
+    if (_shapes.containsKey(renderObject)) {
+      notifyListeners();
+    }
+  }
+
+  /// Called when a shape's transform changes, requesting a repaint without a geometry rebuild.
+  void Function(RenderObject)? onShapeTransformChanged;
+
+  /// Notify that a shape's transform has changed.
+  void notifyShapeTransformChanged(RenderObject renderObject) {
+    if (_shapes.containsKey(renderObject)) {
+      onShapeTransformChanged?.call(renderObject);
+    }
+  }
+
+  @override
+  void dispose() {
+    _shapes.clear();
+    super.dispose();
+  }
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/liquid_glass_render_scope.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/liquid_glass_render_scope.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/widgets.dart';
+import 'liquid_glass_renderer.dart';
+import 'package:meta/meta.dart';
+
+@internal
+class LiquidGlassRenderScope extends InheritedWidget {
+  /// Creates a new [LiquidGlassRenderScope].
+  const LiquidGlassRenderScope({
+    required this.settings,
+    required super.child,
+    super.key,
+  });
+
+  final LiquidGlassSettings settings;
+
+  static LiquidGlassRenderScope of(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<LiquidGlassRenderScope>();
+    assert(
+      scope != null,
+      'No liquid glass renderer found in context. '
+      'Make sure to wrap your liquid glass widgets in a LiquidGlassLayer.',
+    );
+    return scope!;
+  }
+
+  @override
+  bool updateShouldNotify(covariant InheritedWidget oldWidget) {
+    return oldWidget is! LiquidGlassRenderScope ||
+        oldWidget.settings != settings;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/liquid_glass_renderer.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/liquid_glass_renderer.dart
@@ -1,0 +1,26 @@
+// Vendored from liquid_glass_renderer MIT © whynotmake.it
+// Source: https://github.com/whynotmake-it/flutter_liquid_glass/tree/main/packages/liquid_glass_renderer
+// Vendored at version 0.2.0-dev.4 on 2026-03-28.
+import 'package:flutter/foundation.dart' show kDebugMode;
+
+export 'glass_glow.dart' show GlassGlow, GlassGlowLayer;
+export 'liquid_glass.dart' show LiquidGlass;
+export 'liquid_glass_blend_group.dart' show LiquidGlassBlendGroup;
+export 'liquid_glass_settings.dart' show LiquidGlassSettings;
+export 'liquid_shape.dart';
+export 'rendering/liquid_glass_layer.dart' show LiquidGlassLayer;
+export 'stretch.dart'
+    show
+        AnchorStretchSettings,
+        LiquidStretch,
+        OffsetResistanceExtension,
+        RawLiquidStretch;
+
+/// Whether to paint the liquid glass geometry texture for debugging purposes.
+///
+/// When enabled, geometry textures will be drawn directly instead of the
+/// liquid glass effect.
+///
+/// Will be set to `false` in release builds.
+@pragma('vm:platform-const-if', !kDebugMode)
+bool debugPaintLiquidGlassGeometry = false;

--- a/packages/liquid_glass_widgets/lib/src/renderer/liquid_glass_settings.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/liquid_glass_settings.dart
@@ -1,0 +1,514 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/widgets.dart';
+// [LOCAL PATCH]: GlassSpecularSharpness is our own type (not vendored).
+// It lives in lib/types/ not lib/src/renderer/.
+import '../../constants/glass_defaults.dart';
+import '../../constants/glass_shadow.dart';
+import '../../types/glass_specular_sharpness.dart';
+import 'liquid_glass_renderer.dart';
+import 'liquid_glass_render_scope.dart';
+
+/// Represents the settings for a liquid glass effect.
+class LiquidGlassSettings extends Equatable {
+  /// Creates a new [LiquidGlassSettings] with the given settings.
+  /// Public constructor — all material glass properties.
+  ///
+  /// [pinchStrength] is intentionally absent here. It is an internal
+  /// shader-transport value set only by [AnimatedGlassIndicator] via
+  /// [copyWithPinch]. Users configure the effect through the hosting
+  /// widget's `indicatorPinchStrength` parameter instead.
+  const LiquidGlassSettings({
+    this.visibility = 1.0,
+    this.glassColor = const Color.fromARGB(0, 255, 255, 255),
+    this.thickness = 20,
+    this.blur = 5,
+    this.chromaticAberration = .01,
+    this.lightAngle = GlassDefaults.lightAngle,
+    this.lightIntensity = .5,
+    this.ambientStrength = 0,
+    this.ambientRim = 0,
+    this.refractiveIndex = 1.2,
+    this.saturation = 1.5,
+    this.glowIntensity = 0.75,
+    this.specularSharpness = GlassSpecularSharpness.medium,
+    this.standardOpacityMultiplier = 1.0,
+    this.shadowElevation = 1.0,
+    this.shadow,
+    this.whitenStrength = 0.0,
+    this.whitenGated = true,
+    this.backerColor,
+    this.platformViewFallbackColor,
+  }) : pinchStrength = 0.0;
+
+  /// Private constructor used exclusively by [copyWithPinch].
+  ///
+  /// Carries the full field set including [pinchStrength] so that
+  /// [AnimatedGlassIndicator] can thread the animated pinch value to
+  /// the render shader without exposing [pinchStrength] in the public API.
+  const LiquidGlassSettings._withPinch({
+    required this.visibility,
+    required this.glassColor,
+    required this.thickness,
+    required this.blur,
+    required this.chromaticAberration,
+    required this.lightAngle,
+    required this.lightIntensity,
+    required this.ambientStrength,
+    this.ambientRim = 0,
+    required this.refractiveIndex,
+    required this.saturation,
+    required this.glowIntensity,
+    required this.specularSharpness,
+    required this.standardOpacityMultiplier,
+    required this.shadowElevation,
+    required this.shadow,
+    required this.whitenStrength,
+    required this.whitenGated,
+    this.backerColor,
+    this.platformViewFallbackColor,
+    required this.pinchStrength,
+  });
+
+  /// Creates [LiquidGlassSettings] using Figma-inspired parameter names.
+  ///
+  /// **Important — units are not Figma percentages:**
+  ///
+  /// | Parameter | Range | Maps to |
+  /// |-----------|-------|---------|
+  /// | [refraction] | 0–100 % | [refractiveIndex] via `1 + (v/100) × 0.2` |
+  /// | [depth] | logical pixels | [thickness] **directly** (not a Figma %) |
+  /// | [dispersion] | 0–100 % | [chromaticAberration] via `4 × (v/100)` |
+  /// | [frost] | logical pixels | [blur] **directly** (not a Figma %) |
+  ///
+  /// Figma's internal `depth` and `frost` use proprietary units with no public
+  /// pixel-equivalent formula. Pass [depth] and [frost] as the logical-pixel
+  /// values you want — typical ranges: depth 10–40, frost 2–8.
+  const LiquidGlassSettings.figma({
+    required double refraction,
+    required double depth,
+    required double dispersion,
+    required double frost,
+    double visibility = 1.0,
+    double lightIntensity = 50,
+    double lightAngle = GlassDefaults.lightAngle,
+    Color glassColor = const Color.fromARGB(0, 255, 255, 255),
+    GlassSpecularSharpness specularSharpness = GlassSpecularSharpness.medium,
+    double standardOpacityMultiplier = 1.0,
+  }) : this(
+          visibility: visibility,
+          refractiveIndex: 1 + (refraction / 100) * 0.2,
+          thickness: depth,
+          chromaticAberration: 4 * (dispersion / 100),
+          lightIntensity: lightIntensity / 100,
+          blur: frost,
+          lightAngle: lightAngle,
+          ambientStrength: 0.1,
+          saturation: 1.5,
+          glassColor: glassColor,
+          specularSharpness: specularSharpness,
+          standardOpacityMultiplier: standardOpacityMultiplier,
+          // shadowElevation and shadow use their defaults (1.0 / null)
+        );
+
+  /// Retrieves the nearest [LiquidGlassSettings] from the widget tree.
+  ///
+  /// This will look for the nearest ancestor [LiquidGlassLayer] or
+  /// [LiquidGlassRenderScope] widget in the widget tree.
+  static LiquidGlassSettings of(BuildContext context) {
+    return LiquidGlassRenderScope.of(context).settings;
+  }
+
+  /// A factor that can be used to scale all thickness-related properties.
+  ///
+  /// Defaults to 1.0.
+  final double visibility;
+
+  /// The color tint of the glass effect.
+  ///
+  /// Opacity defines the intensity of the tint.
+  final Color glassColor;
+
+  /// The effective glass color taking visibility into account.
+  Color get effectiveGlassColor =>
+      glassColor.withValues(alpha: glassColor.a * visibility);
+
+  /// The thickness of the glass surface.
+  ///
+  /// Thicker surfaces refract the light more intensely.
+  final double thickness;
+
+  /// The effective thickness taking visibility into account.
+  double get effectiveThickness => thickness * visibility;
+
+  /// The blur of the glass effect.
+  ///
+  /// Higher values create a more frosted appearance.
+  ///
+  /// Defaults to 0.
+  final double blur;
+
+  /// The effective blur taking visibility into account.
+  double get effectiveBlur => blur * visibility;
+
+  /// The chromatic aberration of the glass effect (WIP).
+  ///
+  /// This is a little ugly still.
+  ///
+  /// Higher values create more pronounced color fringes.
+  final double chromaticAberration;
+
+  /// The effective chromatic aberration taking visibility into account.
+  double get effectiveChromaticAberration => chromaticAberration * visibility;
+
+  /// The angle of the light source in radians.
+  ///
+  /// This determines where the highlights on shapes will come from.
+  final double lightAngle;
+
+  /// The intensity of the light source.
+  ///
+  /// Higher values create more pronounced highlights.
+  final double lightIntensity;
+
+  /// The effective light intensity taking visibility into account.
+  double get effectiveLightIntensity => lightIntensity * visibility;
+
+  /// The strength of the ambient light.
+  ///
+  /// Higher values create more pronounced ambient light.
+  final double ambientStrength;
+
+  /// Full-perimeter rim ("ring") boost, 0 to ~1.
+  ///
+  /// Premium: added to the Fresnel edge-luminosity strength (base 0.12), so
+  /// the glass edge reads as a bright ring regardless of light direction —
+  /// the iOS 26 in-motion pill look. Standard interactive glass: overrides
+  /// the hardcoded ambientRim floor in [AnimatedGlassIndicator]. Default 0 =
+  /// existing rendering everywhere.
+  final double ambientRim;
+
+  /// The effective ambient strength taking visibility into account.
+  double get effectiveAmbientStrength => ambientStrength * visibility;
+
+  /// The strength of the refraction.
+  ///
+  /// Higher values create more pronounced refraction.
+  /// Defaults to 1.51
+  final double refractiveIndex;
+
+  /// The saturation adjustment for pixels that shine through the glass.
+  ///
+  /// 1.0 means no change, values < 1.0 desaturate the background,
+  /// values > 1.0 increase saturation.
+  /// Defaults to 1.0
+  final double saturation;
+
+  /// The intensity of the fresnel edge glow on the glass rim.
+  ///
+  /// Controls how visible the glass-edge luminosity is on the Standard
+  /// (2D shader) rendering path. Higher values create a more pronounced
+  /// glowing edge. Premium (Impeller) path ignores this value.
+  ///
+  /// Defaults to 0.75.
+  final double glowIntensity;
+
+  /// The sharpness of the specular highlight on the glass rim.
+  ///
+  /// Controls how tightly focused the specular lobe is. Each variant maps to
+  /// a fixed power-of-2 exponent the shader computes with a zero-transcendental
+  /// multiply chain — 3–5× faster than `pow()` on mobile GPUs.
+  ///
+  /// Defaults to [GlassSpecularSharpness.medium] which matches iOS 26.
+  final GlassSpecularSharpness specularSharpness;
+
+  /// A multiplier applied to the alpha channel of [glassColor] when rendering
+  /// in Standard mode. This allows tuning the Standard 2D compositing opacity
+  /// to achieve parity with the Premium 3D volumetric refraction, without
+  /// needing separate color values for each mode.
+  ///
+  /// Defaults to 1.0. A common "magic number" for light mode is ~0.4.
+  final double standardOpacityMultiplier;
+
+  /// Scales the built-in light-mode drop shadow on glass surfaces.
+  ///
+  /// The shadow only appears in light mode and uses Apple's iOS 26 elevation
+  /// values as the baseline. This multiplier scales opacity and blur
+  /// proportionally:
+  ///
+  /// - `0.0` — no shadow (flat glass)
+  /// - `1.0` — default Apple-matching elevation (6% opacity, 8px blur)
+  /// - `2.0` — double intensity (12% opacity, 16px blur)
+  ///
+  /// Has no effect in dark mode.
+  ///
+  /// For full control over shadow appearance, use [shadow] instead.
+  /// If [shadow] is non-null, [shadowElevation] is ignored.
+  ///
+  /// Defaults to 1.0.
+  final double shadowElevation;
+
+  /// Custom light-mode drop shadow for glass surfaces.
+  ///
+  /// When non-null, this replaces the built-in elevation shadow entirely.
+  /// The shadows are inverse-clipped to only appear outside the glass
+  /// boundary, preventing the glass from blurring its own shadow.
+  ///
+  /// When null (the default), the built-in Apple-matching shadow is used,
+  /// scaled by [shadowElevation].
+  ///
+  /// Has no effect in dark mode.
+  final List<BoxShadow>? shadow;
+
+  /// Returns the effective shadow list for light-mode rendering.
+  ///
+  /// Resolves [shadow] (full override) vs [shadowElevation] (scalar).
+  /// Returns an empty list when the shadow is effectively disabled.
+  List<BoxShadow> get effectiveShadow {
+    if (shadow != null) return shadow!;
+    return GlassShadow.scaled(shadowElevation);
+  }
+
+  /// Light-mode whitening ("legibility veil") amount, from 0 to 1.
+  ///
+  /// On the Premium (Impeller) path this is applied as the last step of the
+  /// render: the finished glass is mixed uniformly toward white,
+  /// `mix(glass, white, whitenStrength)`. Because it is a single control-wide
+  /// value (not per-pixel) there is no spatial seam, so no halo or outline
+  /// artifacts. This models iOS 26 light-mode glass, which lays an even
+  /// whitening layer over the refracted content for legibility on bright
+  /// backgrounds — content stays visible, just whiter.
+  ///
+  /// The Standard and Frosted paths approximate the same knob by lifting the
+  /// glass tint toward white (a "veil"), so a single value reads consistently
+  /// across all quality tiers.
+  ///
+  /// Defaults to 0.0, which disables whitening entirely.
+  final double whitenStrength;
+
+  /// Whether [whitenStrength] is luminance-gated (true, the default) or
+  /// applied uniformly (false).
+  ///
+  /// Gated: the lift only affects brighter pixels and leaves dark content
+  /// (text, icons) crisp — the light-mode behaviour. Ungated: an even lift
+  /// across the whole control — useful in dark mode to give dark glass a
+  /// subtle frost, where a per-pixel gate over an all-dark backdrop would
+  /// zero the whitening out entirely.
+  ///
+  /// Only affects the Premium (Impeller) path; the Standard and Frosted
+  /// approximations are always uniform.
+  final bool whitenGated;
+
+  /// Internal shader transport — the animated pinch strength for the concave
+  /// lens effect on indicator pills.
+  ///
+  /// Always `0.0` on instances created via the public constructor.
+  /// Only non-zero when set by [AnimatedGlassIndicator] via [copyWithPinch].
+  /// Configure from outside via the hosting widget's `indicatorPinchStrength`.
+  final double pinchStrength;
+
+  /// Returns a copy of these settings with [pinchStrength] set to [value].
+  ///
+  /// **Internal use only** — called exclusively by [AnimatedGlassIndicator]
+  /// to thread the animated pinch value into the render shader.
+  /// Users should configure this via `indicatorPinchStrength` on
+  /// [GlassBottomBar], [GlassTabBar], [GlassSegmentedControl], or
+  /// [GlassSearchableBottomBar].
+  LiquidGlassSettings copyWithPinch(double value) =>
+      LiquidGlassSettings._withPinch(
+        visibility: visibility,
+        glassColor: glassColor,
+        thickness: thickness,
+        blur: blur,
+        chromaticAberration: chromaticAberration,
+        lightAngle: lightAngle,
+        lightIntensity: lightIntensity,
+        ambientStrength: ambientStrength,
+        ambientRim: ambientRim,
+        refractiveIndex: refractiveIndex,
+        saturation: saturation,
+        glowIntensity: glowIntensity,
+        specularSharpness: specularSharpness,
+        standardOpacityMultiplier: standardOpacityMultiplier,
+        shadowElevation: shadowElevation,
+        shadow: shadow,
+        whitenStrength: whitenStrength,
+        whitenGated: whitenGated,
+        backerColor: backerColor,
+        platformViewFallbackColor: platformViewFallbackColor,
+        pinchStrength: value,
+      );
+
+  /// Optional dimming "backer" painted directly behind the glass.
+  ///
+  /// A shape-matched, color-filled pad composited *behind* the glass surface —
+  /// the inverse of [shadow], which sits outside the boundary. It provides
+  /// contrast for a control's content over rich or colorful backdrops where the
+  /// glass tint alone can't: video, maps, photography, or any control floating
+  /// over busy content. This is Apple's "dimming layer" guidance for keeping
+  /// glass controls legible (see the Materials section of the Human Interface
+  /// Guidelines, and SwiftUI's clear `Glass` variant).
+  ///
+  /// The color's alpha *is* the dimming opacity. Apple suggests roughly 35% as
+  /// a starting point — e.g. `Color(0x59000000)` for a neutral dark dim.
+  ///
+  /// Rendered at the widget level (like [shadow]), clipped to the glass shape,
+  /// so it composites correctly even over a PlatformView — where a shader-side
+  /// tint cannot reach.
+  ///
+  /// Defaults to null: no backer, and no change to existing rendering.
+  final Color? backerColor;
+
+  /// Solid stand-in color the lens composites where the engine can't capture the
+  /// backdrop — i.e. behind a PlatformView past the glass, which the lens would
+  /// otherwise render black (see `platformViewBackdrop` on the glass widgets).
+  ///
+  /// Distinct from [backerColor]: [backerColor] is an *aesthetic* dimming pad
+  /// painted behind the glass everywhere; this is the *fallback fill* used only
+  /// where the shader has no backdrop to sample. Splitting them lets a control
+  /// have one without the other (e.g. a transparent over-map fill with no dim, or
+  /// a dim pad off-PlatformView with no fill).
+  ///
+  /// Defaults to null, in which case it falls back to [backerColor] — so existing
+  /// recipes that relied on `backerColor` doubling as the PlatformView fill are
+  /// unchanged.
+  final Color? platformViewFallbackColor;
+
+  /// The effective saturation taking visibility into account.
+  double get effectiveSaturation => 1 + (saturation - 1) * visibility;
+
+  /// The effective refractive index taking visibility into account.
+  ///
+  /// Lerps from 1.0 (no refraction) at [visibility]=0 toward the configured
+  /// [refractiveIndex] as visibility increases. This matches how [Opacity]
+  /// would fade the refraction distortion — at zero visibility there is no
+  /// lens warp, at full visibility the warp is at its configured strength.
+  double get effectiveRefractiveIndex =>
+      1.0 + (refractiveIndex - 1.0) * visibility;
+
+  /// Linearly interpolates between two [LiquidGlassSettings].
+  static LiquidGlassSettings lerp(
+    LiquidGlassSettings? a,
+    LiquidGlassSettings? b,
+    double t,
+  ) {
+    if (a == null && b == null) return const LiquidGlassSettings();
+    if (a == null) return b!;
+    if (b == null) return a;
+
+    return LiquidGlassSettings._withPinch(
+        visibility: lerpDouble(a.visibility, b.visibility, t)!,
+        glassColor: Color.lerp(a.glassColor, b.glassColor, t)!,
+        thickness: lerpDouble(a.thickness, b.thickness, t)!,
+        blur: lerpDouble(a.blur, b.blur, t)!,
+        chromaticAberration:
+            lerpDouble(a.chromaticAberration, b.chromaticAberration, t)!,
+        lightAngle: lerpDouble(a.lightAngle, b.lightAngle, t)!,
+        lightIntensity: lerpDouble(a.lightIntensity, b.lightIntensity, t)!,
+        ambientStrength: lerpDouble(a.ambientStrength, b.ambientStrength, t)!,
+        ambientRim: lerpDouble(a.ambientRim, b.ambientRim, t)!,
+        refractiveIndex: lerpDouble(a.refractiveIndex, b.refractiveIndex, t)!,
+        saturation: lerpDouble(a.saturation, b.saturation, t)!,
+        glowIntensity: lerpDouble(a.glowIntensity, b.glowIntensity, t)!,
+        specularSharpness: t < 0.5 ? a.specularSharpness : b.specularSharpness,
+        standardOpacityMultiplier: lerpDouble(
+            a.standardOpacityMultiplier, b.standardOpacityMultiplier, t)!,
+        shadowElevation: lerpDouble(a.shadowElevation, b.shadowElevation, t)!,
+        shadow: t < 0.5 ? a.shadow : b.shadow,
+        whitenStrength: lerpDouble(a.whitenStrength, b.whitenStrength, t)!,
+        whitenGated: t < 0.5 ? a.whitenGated : b.whitenGated,
+        // Lerp the color so the backer fades smoothly (from/to transparent when
+        // one side is null), rather than popping at the midpoint.
+        backerColor: Color.lerp(a.backerColor, b.backerColor, t),
+        platformViewFallbackColor: Color.lerp(
+            a.platformViewFallbackColor, b.platformViewFallbackColor, t),
+        // pinchStrength is interaction state — lerp it so transitions are smooth
+        // when the indicator fades between active/resting states.
+        pinchStrength: lerpDouble(a.pinchStrength, b.pinchStrength, t)!);
+  }
+
+  /// Helper for linear interpolation of doubles.
+  static double? lerpDouble(num? a, num? b, double t) {
+    if (a == null && b == null) return null;
+    a ??= 0.0;
+    b ??= 0.0;
+    return a + (b - a) * t;
+  }
+
+  /// Creates a new [LiquidGlassSettings] with the given settings.
+  LiquidGlassSettings copyWith({
+    double? visibility,
+    Color? glassColor,
+    double? thickness,
+    double? blur,
+    double? chromaticAberration,
+    double? blend,
+    double? lightAngle,
+    double? lightIntensity,
+    double? ambientStrength,
+    double? ambientRim,
+    double? refractiveIndex,
+    double? saturation,
+    double? glowIntensity,
+    GlassSpecularSharpness? specularSharpness,
+    double? standardOpacityMultiplier,
+    double? shadowElevation,
+    List<BoxShadow>? shadow,
+    double? whitenStrength,
+    bool? whitenGated,
+    Color? backerColor,
+    Color? platformViewFallbackColor,
+  }) =>
+      LiquidGlassSettings._withPinch(
+        visibility: visibility ?? this.visibility,
+        glassColor: glassColor ?? this.glassColor,
+        thickness: thickness ?? this.thickness,
+        blur: blur ?? this.blur,
+        chromaticAberration: chromaticAberration ?? this.chromaticAberration,
+        lightAngle: lightAngle ?? this.lightAngle,
+        lightIntensity: lightIntensity ?? this.lightIntensity,
+        ambientStrength: ambientStrength ?? this.ambientStrength,
+        ambientRim: ambientRim ?? this.ambientRim,
+        refractiveIndex: refractiveIndex ?? this.refractiveIndex,
+        saturation: saturation ?? this.saturation,
+        glowIntensity: glowIntensity ?? this.glowIntensity,
+        specularSharpness: specularSharpness ?? this.specularSharpness,
+        standardOpacityMultiplier:
+            standardOpacityMultiplier ?? this.standardOpacityMultiplier,
+        shadowElevation: shadowElevation ?? this.shadowElevation,
+        shadow: shadow ?? this.shadow,
+        whitenStrength: whitenStrength ?? this.whitenStrength,
+        whitenGated: whitenGated ?? this.whitenGated,
+        backerColor: backerColor ?? this.backerColor,
+        platformViewFallbackColor:
+            platformViewFallbackColor ?? this.platformViewFallbackColor,
+        // Preserve current pinchStrength — copyWith is called by AnimatedGlassIndicator
+        // to change visibility while keeping the live pinch value alive.
+        // To set a new pinch value, call copyWithPinch() instead.
+        pinchStrength: pinchStrength,
+      );
+
+  @override
+  List<Object?> get props => [
+        visibility,
+        glassColor,
+        thickness,
+        blur,
+        chromaticAberration,
+        lightAngle,
+        lightIntensity,
+        ambientStrength,
+        ambientRim,
+        refractiveIndex,
+        saturation,
+        glowIntensity,
+        specularSharpness,
+        standardOpacityMultiplier,
+        shadowElevation,
+        shadow,
+        whitenStrength,
+        whitenGated,
+        backerColor,
+        platformViewFallbackColor,
+        pinchStrength,
+      ];
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/liquid_shape.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/liquid_shape.dart
@@ -1,0 +1,252 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'liquid_glass_renderer.dart';
+
+/// Represents a shape that can be used by a [LiquidGlass] widget.
+// ignore: deprecated_member_use
+sealed class LiquidShape extends OutlinedBorder with EquatableMixin {
+  const LiquidShape({super.side = BorderSide.none});
+
+  @protected
+  OutlinedBorder get _equivalentOutlinedBorder;
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) {
+    return _equivalentOutlinedBorder.getInnerPath(
+      rect,
+      textDirection: textDirection,
+    );
+  }
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) {
+    return _equivalentOutlinedBorder.getOuterPath(
+      rect,
+      textDirection: textDirection,
+    );
+  }
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {
+    _equivalentOutlinedBorder.paint(canvas, rect, textDirection: textDirection);
+  }
+
+  @override
+  List<Object?> get props => [side];
+}
+
+/// Represents a squircle shape that can be used by a [LiquidGlass] widget.
+///
+/// Works like a [RoundedSuperellipseBorder].
+class LiquidRoundedSuperellipse extends LiquidShape {
+  /// Creates a new [LiquidRoundedSuperellipse] with the given [borderRadius].
+  const LiquidRoundedSuperellipse({
+    required this.borderRadius,
+    super.side = BorderSide.none,
+  });
+
+  /// The radius of the squircle.
+  ///
+  /// This is the radius of the corners of the squircle.
+  final double borderRadius;
+
+  @override
+  OutlinedBorder get _equivalentOutlinedBorder => RoundedSuperellipseBorder(
+        borderRadius: BorderRadius.all(Radius.circular(borderRadius)),
+        side: side,
+      );
+
+  @override
+  LiquidRoundedSuperellipse copyWith({
+    BorderSide? side,
+    double? borderRadius,
+  }) {
+    return LiquidRoundedSuperellipse(
+      side: side ?? this.side,
+      borderRadius: borderRadius ?? this.borderRadius,
+    );
+  }
+
+  @override
+  ShapeBorder scale(double t) {
+    return LiquidRoundedSuperellipse(
+      borderRadius: borderRadius * t,
+      side: side.scale(t),
+    );
+  }
+
+  @override
+  List<Object?> get props => [...super.props, borderRadius];
+}
+
+/// Represents an ellipse shape that can be used by a [LiquidGlass] widget.
+///
+/// Works like an [OvalBorder].
+class LiquidOval extends LiquidShape {
+  /// Creates a new [LiquidOval] with the given [side].
+  const LiquidOval({super.side = BorderSide.none});
+
+  @override
+  OutlinedBorder get _equivalentOutlinedBorder => const OvalBorder();
+
+  @override
+  OutlinedBorder copyWith({BorderSide? side}) {
+    return LiquidOval(
+      side: side ?? this.side,
+    );
+  }
+
+  @override
+  ShapeBorder scale(double t) {
+    return LiquidOval(
+      side: side.scale(t),
+    );
+  }
+}
+
+/// Represents a rounded rectangle shape that can be used by a [LiquidGlass]
+/// widget.
+///
+/// Works like a [RoundedRectangleBorder].
+class LiquidRoundedRectangle extends LiquidShape {
+  /// Creates a new [LiquidRoundedRectangle] with the given [borderRadius].
+  const LiquidRoundedRectangle({
+    required this.borderRadius,
+    super.side = BorderSide.none,
+  });
+
+  /// The radius of the rounded rectangle.
+  ///
+  /// This is the radius of the corners of the rounded rectangle.
+  final double borderRadius;
+
+  @override
+  OutlinedBorder get _equivalentOutlinedBorder => RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(borderRadius)),
+        side: side,
+      );
+
+  @override
+  LiquidRoundedRectangle copyWith({
+    BorderSide? side,
+    double? borderRadius,
+  }) {
+    return LiquidRoundedRectangle(
+      side: side ?? this.side,
+      borderRadius: borderRadius ?? this.borderRadius,
+    );
+  }
+
+  @override
+  ShapeBorder scale(double t) {
+    return LiquidRoundedRectangle(
+      borderRadius: borderRadius * t,
+      side: side.scale(t),
+    );
+  }
+
+  @override
+  List<Object?> get props => [...super.props, borderRadius];
+}
+
+/// Represents a rounded rectangle shape with different radii for top and bottom.
+class LiquidVerticalRoundedRectangle extends LiquidShape {
+  /// Creates a new [LiquidVerticalRoundedRectangle].
+  const LiquidVerticalRoundedRectangle({
+    required this.topRadius,
+    required this.bottomRadius,
+    super.side = BorderSide.none,
+  });
+
+  /// The radius of the top corners.
+  final double topRadius;
+
+  /// The radius of the bottom corners.
+  final double bottomRadius;
+
+  @override
+  OutlinedBorder get _equivalentOutlinedBorder => RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(topRadius),
+          bottom: Radius.circular(bottomRadius),
+        ),
+        side: side,
+      );
+
+  @override
+  LiquidVerticalRoundedRectangle copyWith({
+    BorderSide? side,
+    double? topRadius,
+    double? bottomRadius,
+  }) {
+    return LiquidVerticalRoundedRectangle(
+      side: side ?? this.side,
+      topRadius: topRadius ?? this.topRadius,
+      bottomRadius: bottomRadius ?? this.bottomRadius,
+    );
+  }
+
+  @override
+  ShapeBorder scale(double t) {
+    return LiquidVerticalRoundedRectangle(
+      topRadius: topRadius * t,
+      bottomRadius: bottomRadius * t,
+      side: side.scale(t),
+    );
+  }
+
+  @override
+  List<Object?> get props => [...super.props, topRadius, bottomRadius];
+}
+
+/// Represents a squircle shape with different radii for top and bottom.
+///
+/// Works like a [RoundedSuperellipseBorder] with vertical border radii.
+class LiquidVerticalRoundedSuperellipse extends LiquidShape {
+  /// Creates a new [LiquidVerticalRoundedSuperellipse].
+  const LiquidVerticalRoundedSuperellipse({
+    required this.topRadius,
+    required this.bottomRadius,
+    super.side = BorderSide.none,
+  });
+
+  /// The radius of the top corners.
+  final double topRadius;
+
+  /// The radius of the bottom corners.
+  final double bottomRadius;
+
+  @override
+  OutlinedBorder get _equivalentOutlinedBorder => RoundedSuperellipseBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(topRadius),
+          bottom: Radius.circular(bottomRadius),
+        ),
+        side: side,
+      );
+
+  @override
+  LiquidVerticalRoundedSuperellipse copyWith({
+    BorderSide? side,
+    double? topRadius,
+    double? bottomRadius,
+  }) {
+    return LiquidVerticalRoundedSuperellipse(
+      side: side ?? this.side,
+      topRadius: topRadius ?? this.topRadius,
+      bottomRadius: bottomRadius ?? this.bottomRadius,
+    );
+  }
+
+  @override
+  ShapeBorder scale(double t) {
+    return LiquidVerticalRoundedSuperellipse(
+      topRadius: topRadius * t,
+      bottomRadius: bottomRadius * t,
+      side: side.scale(t),
+    );
+  }
+
+  @override
+  List<Object?> get props => [...super.props, topRadius, bottomRadius];
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/logging.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/logging.dart
@@ -1,0 +1,78 @@
+// ignore_for_file: avoid_print, lines_longer_than_80_chars
+
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+
+export 'package:logging/logging.dart' show Level, Logger;
+
+@internal
+abstract class LgrLogNames {
+  static const _root = 'lgr';
+
+  static const render = '$_root.render';
+  static const layer = '$_root.render.layer';
+  static const geometry = '$_root.geometry';
+}
+
+/// Logging utilities for the Liquid Glass Renderer package.
+abstract class LgrLogs {
+  static final _root = Logger(LgrLogNames._root);
+
+  static final _activeLoggers = <Logger>{};
+
+  /// Initialize the given [loggers] using the minimum [level].
+  ///
+  /// To enable all the loggers, use [LgrLogs.initAllLogs].
+  static void initLoggers(Set<Logger> loggers, [Level level = Level.ALL]) {
+    hierarchicalLoggingEnabled = true;
+
+    for (final logger in loggers) {
+      if (!_activeLoggers.contains(logger)) {
+        print('Initializing logger: ${logger.name}');
+        logger
+          ..level = level
+          ..onRecord.listen(_printLog);
+
+        _activeLoggers.add(logger);
+      }
+    }
+  }
+
+  /// Initializes all the available loggers.
+  ///
+  /// To control which loggers are initialized, use [LgrLogs.initLoggers].
+  static void initAllLogs([Level level = Level.ALL]) {
+    initLoggers({_root}, level);
+  }
+
+  /// Returns `true` if the given [logger] is currently logging, or
+  /// `false` otherwise.
+  ///
+  /// Generally, developers should call loggers, regardless of whether
+  /// a given logger is active. However, sometimes you may want to log
+  /// information that's costly to compute. In such a case, you can
+  /// choose to compute the expensive information only if the given
+  /// logger will actually log the information.
+  static bool isLogActive(Logger logger) {
+    return _activeLoggers.contains(logger);
+  }
+
+  /// Deactivates the given [loggers].
+  static void deactivateLoggers(Set<Logger> loggers) {
+    for (final logger in loggers) {
+      if (_activeLoggers.contains(logger)) {
+        print('Deactivating logger: ${logger.name}');
+        logger.clearListeners();
+
+        _activeLoggers.remove(logger);
+      }
+    }
+  }
+
+  /// Logs a record using a print statement.
+  static void _printLog(LogRecord record) {
+    print(
+      '${record.loggerName} > ${record.level.name}: ${record.message}',
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/rendering/liquid_glass_layer.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/rendering/liquid_glass_layer.dart
@@ -1,0 +1,477 @@
+// ignore_for_file: avoid_setters_without_getters
+
+import 'dart:ui';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_shaders/flutter_shaders.dart';
+import '../liquid_glass_renderer.dart';
+import '../internal/render_liquid_glass_geometry.dart';
+import '../internal/transform_tracking_repaint_boundary_mixin.dart';
+import '../liquid_glass_render_scope.dart';
+import '../logging.dart';
+import 'liquid_glass_render_object.dart';
+import '../shaders.dart';
+import 'package:meta/meta.dart';
+
+/// Represents a layer of multiple [LiquidGlass] shapes or
+/// [LiquidGlassBlendGroup]s that have shared [LiquidGlassSettings] and will be
+/// rendered together.
+///
+/// If you create a [LiquidGlassLayer] with one or more [LiquidGlass] or
+/// [LiquidGlassBlendGroup] widgets, the liquid glass effect will be rendered
+/// where this layer is.
+///
+/// Make sure not to stack any other widgets between the [LiquidGlassLayer] and
+/// the [LiquidGlass] widgets, otherwise the liquid glass effect will be behind
+/// them.
+///
+/// ## Example
+///
+/// ```dart
+/// Widget build(BuildContext context) {
+///   return LiquidGlassLayer(
+///     child: Column(
+///       children: [
+///         LiquidGlass(
+///           shape: LiquidRoundedSuperellipse(
+///             borderRadius: 10,
+///           ),
+///           child: const SizedBox.square(
+///             dimension: 100,
+///           ),
+///         ),
+///         const SizedBox(height: 100),
+///         LiquidGlassBlendGroup(
+///          blend: 20,
+///          child: Row(
+///             children: [
+///               LiquidGlass.grouped(
+///                 shape: const LiquidOval(),
+///                 child: const SizedBox.square(
+///                   dimension: 100,
+///                 ),
+///               ),
+///               LiquidGlass.grouped(
+///                 shape: const LiquidRoundedSuperellipse(
+///                   borderRadius: 20,
+///                 ),
+///                 child: const SizedBox.square(
+///                   dimension: 100,
+///                 ),
+///               ),
+///             ],
+///           ),
+///         ),
+///       ],
+///     ),
+///   );
+/// }
+class LiquidGlassLayer extends StatefulWidget {
+  /// Creates a new [LiquidGlassLayer] with the given [child] and [settings].
+  const LiquidGlassLayer({
+    required this.child,
+    this.settings = const LiquidGlassSettings(),
+    this.shadows = const <BoxShadow>[],
+    this.clipExpansion = EdgeInsets.zero,
+    this.captureImage,
+    this.captureOriginInScreenSpace = Offset.zero,
+    super.key,
+  });
+
+  /// The subtree in which you should include at least one [LiquidGlass] widget.
+  ///
+  /// The [LiquidGlassLayer] will automatically register all [LiquidGlass]
+  /// widgets in the subtree as shapes and render them.
+  final Widget child;
+
+  /// The settings for the liquid glass effect for all shapes in this layer.
+  final LiquidGlassSettings settings;
+
+  /// The shadows to render using the merged SDF geometry.
+  final List<BoxShadow> shadows;
+
+  /// Extra space to add around the geometry bounding box before clipping the
+  /// [BackdropFilterLayer] that runs the glass shader.
+  ///
+  /// The clip rect is normally tight to the glass shape's geometry.  Any
+  /// ancestor [Transform] (e.g. jelly squash-and-stretch on an indicator)
+  /// can push painted pixels outside that tight rect, producing a hard edge
+  /// cutoff.  Set [clipExpansion] to a safe margin that covers the maximum
+  /// expected deformation so the shader is applied over the full animated area.
+  ///
+  /// Defaults to [EdgeInsets.zero] — zero extra GPU cost for static glass.
+  final EdgeInsets clipExpansion;
+
+  /// Pre-captured background image to use instead of a live [BackdropFilterLayer].
+  ///
+  /// When non-null, the glass shader reads from this image directly (sampler
+  /// slot 0) instead of letting the compositor extract the backdrop. This
+  /// eliminates the Impeller compositor ordering dependency that caused the
+  /// opaque-white indicator bug (#99). The image must come from a
+  /// [RenderRepaintBoundary.toImageSync] call on a boundary that covers the
+  /// full background region behind the glass.
+  ///
+  /// Defaults to null — falls through to the BackdropFilterLayer path.
+  final ui.Image? captureImage;
+
+  /// The global (screen-space) logical-pixel origin of the [RepaintBoundary]
+  /// that produced [captureImage]. Used to compute [uCaptureOffset] inside
+  /// the shader so [FlutterFragCoord()] fragments are correctly mapped into
+  /// the capture image's coordinate space.
+  ///
+  /// Ignored when [captureImage] is null.
+  final Offset captureOriginInScreenSpace;
+
+  @override
+  State<LiquidGlassLayer> createState() => _LiquidGlassLayerState();
+}
+
+class _LiquidGlassLayerState extends State<LiquidGlassLayer>
+    with SingleTickerProviderStateMixin {
+  late final GeometryRenderLink _link = GeometryRenderLink();
+
+  late final logger = Logger(LgrLogNames.layer);
+
+  @override
+  void dispose() {
+    _link.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!ImageFilter.isShaderFilterSupported) {
+      logger.warning(
+          'LiquidGlassLayer requires Impeller. No glass effect will be '
+          'rendered on this platform.');
+      return LiquidGlassRenderScope(
+        settings: widget.settings,
+        child: InheritedGeometryRenderLink(
+          link: _link,
+          child: widget.child,
+        ),
+      );
+    }
+
+    return BackdropGroup(
+      child: RepaintBoundary(
+        child: LiquidGlassRenderScope(
+          settings: widget.settings,
+          child: InheritedGeometryRenderLink(
+            link: _link,
+            child: ShaderBuilder(
+              assetKey: ShaderKeys.liquidGlassRender,
+              (context, shader, child) => _RawShapes(
+                renderShader: shader,
+                backdropKey: BackdropGroup.of(context)?.backdropKey,
+                settings: widget.settings,
+                shadows: widget.shadows,
+                link: _link,
+                clipExpansion: widget.clipExpansion,
+                captureImage: widget.captureImage,
+                captureOriginInScreenSpace: widget.captureOriginInScreenSpace,
+                child: child!,
+              ),
+              child: widget.child,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RawShapes extends SingleChildRenderObjectWidget {
+  const _RawShapes({
+    required this.renderShader,
+    required this.backdropKey,
+    required this.settings,
+    required this.shadows,
+    required Widget super.child,
+    required this.link,
+    this.clipExpansion = EdgeInsets.zero,
+    this.captureImage,
+    this.captureOriginInScreenSpace = Offset.zero,
+  });
+
+  final FragmentShader renderShader;
+  final BackdropKey? backdropKey;
+  final LiquidGlassSettings settings;
+  final List<BoxShadow> shadows;
+  final GeometryRenderLink link;
+  final EdgeInsets clipExpansion;
+  final ui.Image? captureImage;
+  final Offset captureOriginInScreenSpace;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return RenderLiquidGlassLayer(
+      devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
+      renderShader: renderShader,
+      backdropKey: backdropKey,
+      settings: settings,
+      shadows: shadows,
+      link: link,
+      clipExpansion: clipExpansion,
+      captureImage: captureImage,
+      captureOriginInScreenSpace: captureOriginInScreenSpace,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    RenderLiquidGlassLayer renderObject,
+  ) {
+    renderObject
+      ..link = link
+      ..devicePixelRatio = MediaQuery.devicePixelRatioOf(context)
+      ..settings = settings
+      ..shadows = shadows
+      ..backdropKey = backdropKey
+      ..clipExpansion = clipExpansion
+      ..captureImage = captureImage
+      ..captureOriginInScreenSpace = captureOriginInScreenSpace;
+  }
+}
+
+@internal
+class RenderLiquidGlassLayer extends LiquidGlassRenderObject
+    with TransformTrackingRenderObjectMixin {
+  RenderLiquidGlassLayer({
+    required super.renderShader,
+    required super.devicePixelRatio,
+    required super.settings,
+    required this.shadows,
+    required super.link,
+    super.backdropKey,
+    super.captureImage,
+    super.captureOriginInScreenSpace,
+    EdgeInsets clipExpansion = EdgeInsets.zero,
+  }) : _clipExpansion = clipExpansion;
+
+  // ── Cached blur filter ──────────────────────────────────────────────────
+  // The BackdropFilterLayer's blur filter is rebuilt only when blurSigma
+  // changes — not on every paint frame during jelly/morph animations.
+  ImageFilter? _cachedBlur;
+  double _cachedBlurSigma = -1;
+
+  final _shaderHandle = LayerHandle<BackdropFilterLayer>();
+  final _blurLayerHandle = LayerHandle<BackdropFilterLayer>();
+  final _clipRectLayerHandle = LayerHandle<ClipRectLayer>();
+  final _clipPathLayerHandle = LayerHandle<ClipPathLayer>();
+
+  EdgeInsets _clipExpansion;
+  set clipExpansion(EdgeInsets value) {
+    if (_clipExpansion == value) return;
+    _clipExpansion = value;
+    markNeedsPaint();
+  }
+
+  List<BoxShadow> shadows;
+
+  @override
+  Size get desiredMatteSize => switch (owner?.rootNode) {
+        final RenderView rv => rv.size,
+        final RenderBox rb => rb.size,
+        _ => Size.zero,
+      };
+
+  @override
+  Matrix4 get matteTransform => getTransformTo(null);
+
+  @override
+  void onTransformChanged() {
+    // Transform changes (position, jelly scale, scroll) no longer require a
+    // geometry rebuild. The geometry image is in LOCAL space; matteTransform is
+    // applied synchronously at paint time so the screen position is always
+    // exact with zero async lag.  Only layout() still sets needsGeometryUpdate.
+    markNeedsPaint();
+  }
+
+  @override
+  void paintLiquidGlass(
+    PaintingContext context,
+    Offset offset,
+    List<(RenderLiquidGlassGeometry, GeometryCache, Matrix4)> shapes,
+    Rect boundingBox,
+  ) {
+    if (!attached) return;
+
+    // ── Pass 0: SDF Shadows ──────────────────────────────────────────────────
+    if (shadows.isNotEmpty && geometryImage != null) {
+      final localBounds = geometryLocalBounds.shift(offset);
+
+      for (final shadow in shadows) {
+        if (shadow.color.a == 0) continue;
+
+        // Inflate clip rect to ensure large blurs aren't cut off
+        final shadowClip = localBounds.shift(shadow.offset).inflate(
+              shadow.spreadRadius + shadow.blurRadius * 3,
+            );
+
+        context.canvas.saveLayer(shadowClip, Paint());
+
+        // 1. Draw the geometry matte as a blurred, tinted shadow
+        final shadowPaint = Paint()
+          ..colorFilter = ColorFilter.mode(shadow.color, BlendMode.srcIn)
+          ..imageFilter = ImageFilter.blur(
+            sigmaX: shadow.blurSigma,
+            sigmaY: shadow.blurSigma,
+            tileMode: TileMode.decal,
+          );
+
+        context.canvas.drawImageRect(
+          geometryImage!,
+          Rect.fromLTWH(
+            0,
+            0,
+            geometryImage!.width.toDouble(),
+            geometryImage!.height.toDouble(),
+          ),
+          localBounds.shift(shadow.offset),
+          shadowPaint,
+        );
+
+        // 2. GPU Cutout (dstOut): punch out the interior using the same geometry
+        // matte to prevent the glass from blurring its own shadow (dirty rim).
+        context.canvas.drawImageRect(
+          geometryImage!,
+          Rect.fromLTWH(
+            0,
+            0,
+            geometryImage!.width.toDouble(),
+            geometryImage!.height.toDouble(),
+          ),
+          localBounds,
+          Paint()..blendMode = BlendMode.dstOut,
+        );
+
+        context.canvas.restore();
+      }
+    }
+
+    // ── Pass 1: Blur ─────────────────────────────────────────────────────────
+    // Use Flutter's native ImageFilter.blur for smooth, multi-pass Gaussian
+    // quality (the inline 9-tap shader approximation was pixelated with text).
+    // Clip tightly to the actual pill shape path — no expansion needed here.
+    if (settings.effectiveBlur > 0) {
+      final blurSigma = settings.effectiveBlur;
+      // Reuse cached blur filter when sigma hasn't changed.
+      if (_cachedBlur == null || _cachedBlurSigma != blurSigma) {
+        _cachedBlur = ImageFilter.blur(
+          tileMode: TileMode.mirror,
+          sigmaX: blurSigma,
+          sigmaY: blurSigma,
+        );
+        _cachedBlurSigma = blurSigma;
+      }
+
+      final blurLayer = (_blurLayerHandle.layer ??= BackdropFilterLayer())
+        ..backdropKey =
+            backdropKey // Scoped to this LiquidGlassLayer's BackdropGroup
+        ..filter = _cachedBlur!;
+
+      final clipPath = Path();
+      for (final geometry in shapes) {
+        if (!geometry.$1.attached) continue;
+        clipPath.addPath(
+          geometry.$2.path,
+          Offset.zero,
+          matrix4: geometry.$3.storage,
+        );
+      }
+      _clipPathLayerHandle.layer = context.pushClipPath(
+        needsCompositing,
+        offset,
+        boundingBox,
+        clipPath,
+        (context, offset) {
+          context.pushLayer(
+            blurLayer,
+            (context, offset) {
+              paintShapeContents(context, offset, shapes, insideGlass: true);
+            },
+            offset,
+          );
+        },
+        oldLayer: _clipPathLayerHandle.layer,
+      );
+    } else {
+      _blurLayerHandle.layer = null;
+      _clipPathLayerHandle.layer = null;
+    }
+
+    // ── Pass 2: Glass refraction + lighting shader ────────────────────────────
+    // Inflate the clip rect by _clipExpansion so jelly squash-and-stretch can
+    // push deformed pixels beyond the tight bounding box without a hard clip
+    // edge. For static glass _clipExpansion == EdgeInsets.zero (no-op).
+    final clipRect = _clipExpansion == EdgeInsets.zero
+        ? boundingBox
+        : Rect.fromLTRB(
+            boundingBox.left - _clipExpansion.left,
+            boundingBox.top - _clipExpansion.top,
+            boundingBox.right + _clipExpansion.right,
+            boundingBox.bottom + _clipExpansion.bottom,
+          );
+
+    // Capture path: when a pre-captured background image is available, bypass
+    // the BackdropFilterLayer entirely and draw the shader directly onto the
+    // canvas, binding the captured image as uBackgroundTexture (slot 0).
+    // This eliminates the live compositor read, making the indicator rendering
+    // deterministic and immune to Impeller compositor ordering bugs (#99).
+    if (captureImage case final capture?) {
+      paintLiquidGlassWithCapture(
+        context,
+        offset,
+        shapes,
+        clipRect,
+        capture,
+      );
+      // paintLiquidGlassWithCapture handles all three passes (blur, shader, contents).
+      // Release the stale BackdropFilter layer handles so the engine can collect
+      // the offscreen surface when we're no longer using the backdrop path.
+      _shaderHandle.layer = null;
+      _clipRectLayerHandle.layer = null;
+      return;
+    }
+
+    // BackdropFilter path (default): live compositor read via BackdropFilterLayer.
+    final shaderLayer = (_shaderHandle.layer ??= BackdropFilterLayer())
+      ..filter = ImageFilter.shader(renderShader);
+
+    _clipRectLayerHandle.layer = context.pushClipRect(
+      needsCompositing,
+      offset,
+      clipRect,
+      (context, offset) {
+        context.pushLayer(
+          shaderLayer,
+          (context, offset) {
+            paintShapeContents(context, offset, shapes, insideGlass: false);
+          },
+          offset,
+        );
+      },
+      oldLayer: _clipRectLayerHandle.layer,
+    );
+  }
+
+  @override
+  void dispose() {
+    // Eagerly clear filter references on the backdrop layers before nulling
+    // the handles. During isolate shutdown on Mali GPUs, GC finalization of
+    // BackdropFilterLayer retains DlRuntimeEffectColorSource → TextureVK →
+    // Vulkan mutex chains that outlive the GPU context (Crash 2). Clearing
+    // the filter property breaks this retention chain immediately.
+    _shaderHandle.layer?.filter = ImageFilter.blur(sigmaX: 0, sigmaY: 0);
+    _blurLayerHandle.layer?.filter = ImageFilter.blur(sigmaX: 0, sigmaY: 0);
+    _shaderHandle.layer = null;
+    _blurLayerHandle.layer = null;
+    _clipRectLayerHandle.layer = null;
+    _clipPathLayerHandle.layer = null;
+    super.dispose();
+  }
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/rendering/liquid_glass_render_object.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/rendering/liquid_glass_render_object.dart
@@ -1,0 +1,721 @@
+import 'dart:collection';
+import 'dart:math';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_shaders/flutter_shaders.dart';
+import '../liquid_glass_renderer.dart';
+import '../internal/render_liquid_glass_geometry.dart';
+import '../internal/snap_rect_to_pixels.dart';
+import '../logging.dart';
+import 'package:meta/meta.dart';
+
+/// A render object that can assemble [RenderLiquidGlassGeometry] shapes and
+/// render them to the screen with the liquid glass effect.
+@internal
+abstract class LiquidGlassRenderObject extends RenderProxyBox {
+  LiquidGlassRenderObject({
+    required GeometryRenderLink link,
+    required this.renderShader,
+    required LiquidGlassSettings settings,
+    required double devicePixelRatio,
+    BackdropKey? backdropKey,
+    ui.Image? captureImage,
+    Offset captureOriginInScreenSpace = Offset.zero,
+  })  : _settings = settings,
+        _devicePixelRatio = devicePixelRatio,
+        _backdropKey = backdropKey,
+        _captureImage = captureImage,
+        _captureOriginInScreenSpace = captureOriginInScreenSpace,
+        _link = link,
+        _cachedLightDir = Offset(
+          cos(settings.lightAngle),
+          -sin(settings.lightAngle),
+        );
+
+  static final logger = Logger(LgrLogNames.render);
+
+  final FragmentShader renderShader;
+
+  /// Cached light direction vector — updated only when [settings.lightAngle]
+  /// changes. Avoids recomputing cos/sin on every setting change.
+  Offset _cachedLightDir;
+
+  /// The size that the geometry texture should have.
+  Size get desiredMatteSize;
+
+  Matrix4 get matteTransform;
+
+  late GeometryRenderLink _link;
+  GeometryRenderLink get link => _link;
+  set link(GeometryRenderLink value) {
+    if (_link == value) return;
+    markNeedsPaint();
+    _link = value;
+  }
+
+  LiquidGlassSettings? _settings;
+  LiquidGlassSettings get settings => _settings!;
+  set settings(LiquidGlassSettings value) {
+    if (_settings == value) return;
+    // Only recompute the trig if lightAngle actually changed.
+    if (value.lightAngle != _settings?.lightAngle) {
+      _cachedLightDir = Offset(
+        cos(value.lightAngle),
+        -sin(value.lightAngle),
+      );
+    }
+    _settings = value;
+    markNeedsPaint();
+  }
+
+  double _devicePixelRatio;
+  double get devicePixelRatio => _devicePixelRatio;
+  set devicePixelRatio(double value) {
+    if (_devicePixelRatio == value) return;
+    _devicePixelRatio = value;
+    markNeedsPaint();
+  }
+
+  /// The [BackdropKey] for blur-sharing via the layer's own [BackdropGroup].
+  /// Set to [BackdropGroup.of(context)?.backdropKey] from the layer's local
+  /// [BackdropGroup]; null when no group exists (no-op).
+  BackdropKey? _backdropKey;
+  BackdropKey? get backdropKey => _backdropKey;
+  set backdropKey(BackdropKey? value) {
+    if (_backdropKey == value) return;
+    _backdropKey = value;
+    markNeedsPaint();
+  }
+
+  // ── Capture-path fields ───────────────────────────────────────────────────
+  //
+  // When [captureImage] is non-null, [paintLiquidGlass] implementations MUST
+  // use [paintLiquidGlassWithCapture] instead of the BackdropFilterLayer path.
+  // The captured image is the background texture fed directly to the shader,
+  // bypassing the live compositor read entirely.
+  //
+  // [captureOriginInScreenSpace] is the global (screen-space) logical-pixel
+  // position of the RepaintBoundary that produced [captureImage]. It is used
+  // to derive [uCaptureOffset]: the physical-pixel shift from the render
+  // surface's canvas origin to the capture boundary's origin, which corrects
+  // [FlutterFragCoord()] (canvas-local) into capture-image space.
+
+  ui.Image? _captureImage;
+  ui.Image? get captureImage => _captureImage;
+  set captureImage(ui.Image? value) {
+    if (identical(_captureImage, value)) return;
+    _captureImage = value;
+    markNeedsPaint();
+  }
+
+  Offset _captureOriginInScreenSpace = Offset.zero;
+  Offset get captureOriginInScreenSpace => _captureOriginInScreenSpace;
+  set captureOriginInScreenSpace(Offset value) {
+    if (_captureOriginInScreenSpace == value) return;
+    _captureOriginInScreenSpace = value;
+    markNeedsPaint();
+  }
+
+  @override
+  bool get alwaysNeedsCompositing => _geometryImage != null;
+
+  /// Pre-rendered geometry texture in the render object's LOCAL coordinate space.
+  /// Because the geometry is recorded without `matteTransform`, its screen-space
+  /// position is always derived synchronously at paint time — zero async lag.
+  ui.Image? _geometryImage;
+  @protected
+  ui.Image? get geometryImage => _geometryImage;
+
+  /// Bounding box of [_geometryImage] in the render object's LOCAL logical-pixel
+  /// coordinate space (snapped to physical pixels).
+  /// Apply `matteTransform` at paint time to get the current screen-space bounds.
+  Rect _geometryLocalBounds = Rect.zero;
+  @protected
+  Rect get geometryLocalBounds => _geometryLocalBounds;
+
+  @override
+  @mustCallSuper
+  void attach(PipelineOwner owner) {
+    super.attach(owner);
+  }
+
+  @override
+  @mustCallSuper
+  void detach() {
+    super.detach();
+  }
+
+  @override
+  void layout(Constraints constraints, {bool parentUsesSize = false}) {
+    needsGeometryUpdate = true;
+    super.layout(constraints, parentUsesSize: parentUsesSize);
+  }
+
+  ui.Rect _paintBounds = ui.Rect.zero;
+
+  @override
+  ui.Rect get paintBounds => _paintBounds;
+
+  // Reusable list to avoid per-frame allocations during paint traversal.
+  final _shapesWithGeometry =
+      <(RenderLiquidGlassGeometry, GeometryCache, Matrix4)>[];
+
+  // MARK: Painting
+
+  @override
+  @nonVirtual
+  void paint(PaintingContext context, Offset offset) {
+    // Guard: if this render object has been detached mid-frame (e.g. rapid
+    // widget removal during isolate shutdown), skip all GPU operations to
+    // prevent use-after-free on Mali GPU Vulkan resources.
+    if (!attached) return;
+
+    if (LgrLogs.isLogActive(logger)) {
+      logger.finest(
+        '$hashCode Painting liquid glass with '
+        '${link._shapeGeometries.length} shapes.',
+      );
+    }
+
+    _shapesWithGeometry.clear();
+
+    Rect? boundingBox;
+
+    for (final geometryRo in link.shapes) {
+      final geometry = geometryRo.maybeRebuildGeometry();
+
+      if (geometry == null) continue;
+
+      final transform = geometryRo.getTransformTo(this);
+      _shapesWithGeometry.add((geometryRo, geometry, transform));
+
+      final geoBounds = MatrixUtils.transformRect(
+        transform,
+        geometry.bounds,
+      );
+      boundingBox = boundingBox == null
+          ? geoBounds
+          : boundingBox.expandToInclude(geoBounds);
+    }
+
+    if (boundingBox == null) {
+      _clearGeometryImage();
+
+      super.paint(context, offset);
+      return;
+    }
+
+    _paintBounds = boundingBox;
+
+    // Fast-path: if there is no geometric thickness AND no blur, there is
+    // nothing to render — skip the expensive async geometry build entirely.
+    // If blur > 0 but thickness == 0, we must still run paintLiquidGlass so
+    // the BackdropFilterLayer blur pass fires in liquid_glass_layer.dart.
+    if (settings.effectiveThickness <= 0 && settings.effectiveBlur <= 0) {
+      _clearGeometryImage();
+      paintShapeContents(
+        context,
+        offset,
+        _shapesWithGeometry,
+        insideGlass: true,
+      );
+      paintShapeContents(
+        context,
+        offset,
+        _shapesWithGeometry,
+        insideGlass: false,
+      );
+      super.paint(context, offset);
+      return;
+    }
+
+    if (needsGeometryUpdate || _geometryImage == null || link._dirty) {
+      link.updateAllGeometries();
+      link._dirty = false;
+      needsGeometryUpdate = false;
+
+      // Synchronous rasterization (toImageSync) eliminates 1-frame jitter
+      // during size animations (like modal sheet expansion).
+      _updateGeometrySync(_shapesWithGeometry, boundingBox);
+
+      // The image is now current — no latency. On the very first frame there
+      // is no previous image — fall through to the early-return below via the
+      // null check on _geometryImage.
+    }
+
+    if (debugPaintLiquidGlassGeometry) {
+      _debugPaintGeometry(context, offset);
+      paintShapeContents(
+        context,
+        offset,
+        _shapesWithGeometry,
+        insideGlass: true,
+      );
+      paintShapeContents(
+        context,
+        offset,
+        _shapesWithGeometry,
+        insideGlass: false,
+      );
+    } else {
+      if (_geometryImage case final geometryImage?) {
+        // Map the texture to exactly the bounds it was originally built for
+        // (_geometryLocalBounds) rather than the newly expanding current frame
+        // bounds (_paintBounds).
+        //
+        // Using _paintBounds causes severe multi-button jitter during animations:
+        // as one button scales, _paintBounds expands/shifts to contain it. Since
+        // the asynchronous texture lags 1 frame behind, rendering the old texture
+        // using the new origin visually shifted entire group of buttons on the
+        // screen until the next texture arrived.
+        //
+        // Locking the shader mapping to the precise bounds the texture was built
+        // with ensures stable pixel positioning for the life of the texture.
+        final activeBounds = MatrixUtils.transformRect(
+          matteTransform,
+          _geometryLocalBounds,
+        ).snapToPixels(devicePixelRatio);
+
+        renderShader
+          // Slot 0-1: uSize — physical-pixel size of the backdrop layer.
+          // Must be set before painting so the shader can derive correct screen UVs.
+          ..setFloatUniforms(initialIndex: 0, (value) {
+            value.setSize(desiredMatteSize * devicePixelRatio);
+          })
+          // Slots 2-5: uGeometryOffset + uGeometrySize in physical pixels.
+          ..setFloatUniforms(initialIndex: 2, (value) {
+            value
+              ..setOffset(activeBounds.topLeft * devicePixelRatio)
+              ..setSize(activeBounds.size * devicePixelRatio);
+          })
+          ..setFloatUniforms(initialIndex: 6, (value) {
+            value
+              ..setColor(settings.effectiveGlassColor)
+              ..setFloats([
+                settings.effectiveRefractiveIndex,
+                settings.effectiveChromaticAberration,
+                settings.effectiveThickness,
+                settings.effectiveLightIntensity,
+                settings.effectiveAmbientStrength,
+                settings.effectiveSaturation,
+              ])
+              ..setOffset(_cachedLightDir);
+          })
+          // Slot 18: uWhiten (whitening amount); slot 19: uWhitenGated
+          // (1 = luminance-gated, the light-mode behaviour; 0 = uniform lift).
+          // Slot 20: uPinchStrength (concave horizontal-pinch for indicator pills).
+          ..setFloatUniforms(initialIndex: 18, (value) {
+            value
+              ..setFloat(settings.whitenStrength)
+              ..setFloat(settings.whitenGated ? 1.0 : 0.0)
+              ..setFloat(settings.pinchStrength);
+          })
+          // Slots 21-24: uBackgroundFallback (straight RGBA). An opaque stand-in
+          // for backdrop regions the engine can't capture (e.g. a PlatformView
+          // past the glass, which the lens would otherwise render black); a == 0
+          // (the default) disables it. See the over-composite in textureBilinear
+          // (liquid_glass_final_render.frag).
+          //
+          // Sourced from platformViewFallbackColor, falling back to backerColor
+          // when unset — so backerColor keeps doubling as the fill for existing
+          // recipes, while platformViewFallbackColor lets callers decouple the
+          // PlatformView fill from the aesthetic backer.
+          ..setFloatUniforms(initialIndex: 21, (value) {
+            final b = settings.platformViewFallbackColor ??
+                settings.backerColor ??
+                const Color(0x00000000);
+            value.setFloats(<double>[b.r, b.g, b.b, b.a]);
+          })
+          // Slots 25-26: uCaptureOffset — zero in BackdropFilter mode (no-op).
+          // The capture path sets this non-zero via paintLiquidGlassWithCapture.
+          ..setFloatUniforms(initialIndex: 25, (value) {
+            value.setOffset(Offset.zero);
+          })
+          // Slot 27: uAmbientRim — full-perimeter Fresnel rim boost.
+          ..setFloatUniforms(initialIndex: 27, (value) {
+            value.setFloat(settings.ambientRim);
+          })
+          ..setImageSampler(
+            1,
+            geometryImage,
+            filterQuality: FilterQuality.medium,
+          );
+        paintLiquidGlass(
+          context,
+          offset,
+          _shapesWithGeometry,
+          _paintBounds,
+        );
+      }
+    }
+
+    super.paint(context, offset);
+  }
+
+  void _clearGeometryImage() {
+    _geometryImage?.dispose();
+    _geometryImage = null;
+  }
+
+  /// Subclasses implement the actual glass rendering
+  /// (e.g., with backdrop filters)
+  void paintLiquidGlass(
+    PaintingContext context,
+    Offset offset,
+    List<(RenderLiquidGlassGeometry, GeometryCache, Matrix4)> shapes,
+    Rect boundingBox,
+  );
+
+  /// Direct-draw paint path used when [captureImage] is non-null.
+  ///
+  /// Instead of emitting a [BackdropFilterLayer] (which reads from the live
+  /// compositor), this draws the shader as a plain rect onto the current canvas,
+  /// binding the pre-captured background image to sampler slot 0.
+  ///
+  /// Coordinate math:
+  ///   [FlutterFragCoord()] in a plain canvas.drawRect gives the fragment
+  ///   position within the current compositing layer (the RepaintBoundary that
+  ///   [LiquidGlassLayer] creates). [captureOriginInScreenSpace] is the global
+  ///   logical-pixel origin of the capture boundary (from localToGlobal).
+  ///   The physical-pixel offset between the two coordinate origins is:
+  ///
+  ///     uCaptureOffset = (captureOriginGlobal - thisRenderOriginGlobal) * dpr
+  ///
+  ///   Adding this to [FlutterFragCoord()] maps each fragment into capture-image
+  ///   space, so [screenUV] correctly addresses the pre-captured bar texture.
+  @protected
+  void paintLiquidGlassWithCapture(
+    PaintingContext context,
+    Offset offset,
+    List<(RenderLiquidGlassGeometry, GeometryCache, Matrix4)> shapes,
+    Rect boundingBox,
+    ui.Image capture,
+  ) {
+    if (!attached) return;
+
+    final dpr = devicePixelRatio;
+
+    // Our render object's global logical-pixel origin.
+    final thisOriginGlobal = getTransformTo(null).getTranslation();
+    final thisOriginLogical = Offset(thisOriginGlobal.x, thisOriginGlobal.y);
+
+    // Physical-pixel offset from our canvas origin → capture-boundary origin.
+    // This is the uCaptureOffset uniform: it shifts FlutterFragCoord() (which
+    // is relative to the compositing layer, i.e. our RepaintBoundary surface)
+    // into the capture image's coordinate space.
+    final captureOffset =
+        (_captureOriginInScreenSpace - thisOriginLogical) * dpr;
+
+    // uSize: physical pixel dimensions of the captured image.
+    final captureSize =
+        ui.Size(capture.width.toDouble(), capture.height.toDouble());
+
+    // Geometry bounds in screen space, snapped to pixels.
+    final activeBounds = MatrixUtils.transformRect(
+      matteTransform,
+      _geometryLocalBounds,
+    ).snapToPixels(dpr);
+
+    // uGeometryOffset/uGeometrySize are relative to the capture image origin
+    // (not screen origin) so that geometryUV = (fragCoord + uCaptureOffset -
+    // uGeometryOffset) / uGeometrySize resolves correctly.
+    final geometryOffsetInCapture =
+        (activeBounds.topLeft - _captureOriginInScreenSpace) * dpr;
+    final geometrySizePhysical = activeBounds.size * dpr;
+
+    renderShader
+      // Slot 0-1: uSize — physical size of the capture image.
+      ..setFloatUniforms(initialIndex: 0, (value) {
+        value.setSize(captureSize);
+      })
+      // Slots 2-5: uGeometryOffset + uGeometrySize, relative to capture origin.
+      ..setFloatUniforms(initialIndex: 2, (value) {
+        value
+          ..setOffset(geometryOffsetInCapture)
+          ..setSize(geometrySizePhysical);
+      })
+      ..setFloatUniforms(initialIndex: 6, (value) {
+        value
+          ..setColor(settings.effectiveGlassColor)
+          ..setFloats([
+            settings.effectiveRefractiveIndex,
+            settings.effectiveChromaticAberration,
+            settings.effectiveThickness,
+            settings.effectiveLightIntensity,
+            settings.effectiveAmbientStrength,
+            settings.effectiveSaturation,
+          ])
+          ..setOffset(_cachedLightDir);
+      })
+      ..setFloatUniforms(initialIndex: 18, (value) {
+        value
+          ..setFloat(settings.whitenStrength)
+          ..setFloat(settings.whitenGated ? 1.0 : 0.0)
+          ..setFloat(settings.pinchStrength);
+      })
+      ..setFloatUniforms(initialIndex: 21, (value) {
+        final b = settings.platformViewFallbackColor ??
+            settings.backerColor ??
+            const Color(0x00000000);
+        value.setFloats(<double>[b.r, b.g, b.b, b.a]);
+      })
+      // Slot 25-26: uCaptureOffset — shift fragCoord into capture-image space.
+      ..setFloatUniforms(initialIndex: 25, (value) {
+        value.setOffset(captureOffset);
+      })
+      // Slot 27: uAmbientRim — full-perimeter Fresnel rim boost.
+      ..setFloatUniforms(initialIndex: 27, (value) {
+        value.setFloat(settings.ambientRim);
+      })
+      // Slot 0: captured background image (replaces the BackdropFilter read).
+      ..setImageSampler(0, capture)
+      ..setImageSampler(1, geometryImage!, filterQuality: FilterQuality.medium);
+
+    // Draw the capture path: no BackdropFilterLayer needed — draw directly
+    // onto the canvas over the expanded clip rect.
+    final clipRect = boundingBox.expandToInclude(
+      Rect.fromLTRB(
+        boundingBox.left - 20,
+        boundingBox.top - 15,
+        boundingBox.right + 20,
+        boundingBox.bottom + 15,
+      ),
+    );
+
+    // Pass 1 (blur): retained even in capture mode — the blur layer reads from
+    // the BackdropGroup which is the internal bar blur, not the external capture.
+    // This is correct: the inner blur pass blurs icon content inside the glass,
+    // the capture provides the bar background behind the glass.
+    paintShapeContents(context, offset, shapes, insideGlass: true);
+
+    // Pass 2: glass refraction shader as a plain canvas.drawRect.
+    // No BackdropFilter wrapper; the captured image is already bound to slot 0.
+    context.canvas
+      ..save()
+      ..clipRect(clipRect.shift(offset))
+      ..drawRect(
+        clipRect.shift(offset),
+        Paint()..shader = renderShader,
+      )
+      ..restore();
+
+    // Pass 3: shape contents painted on top (non-glass child layer).
+    paintShapeContents(context, offset, shapes, insideGlass: false);
+  }
+
+  @protected
+  void paintShapeContents(
+    PaintingContext context,
+    Offset offset,
+    List<(RenderLiquidGlassGeometry, GeometryCache, Matrix4)> shapes, {
+    required bool insideGlass,
+  }) {
+    for (final (geometryRenderObject, _, _) in shapes) {
+      geometryRenderObject.paintShapeContents(
+        this,
+        context,
+        offset,
+        insideGlass: insideGlass,
+      );
+    }
+  }
+
+  void _debugPaintGeometry(PaintingContext context, Offset offset) {
+    if (_geometryImage case final geometryImage?) {
+      // The geometry image is in local space. Draw it at the local bounds
+      // position so it overlays the glass content at the correct on-screen
+      // location (the rendering canvas already applies the correct transform).
+      context.canvas
+        ..save()
+        ..translate(_geometryLocalBounds.left, _geometryLocalBounds.top)
+        ..scale(1 / devicePixelRatio)
+        ..drawImage(
+          geometryImage,
+          Offset.zero,
+          Paint()..blendMode = BlendMode.src,
+        )
+        ..restore();
+    }
+  }
+
+  /// Synchronously rasterizes the geometry picture using [ui.Picture.toImageSync].
+  /// This eliminates the 1-frame async lag that caused visible ghosting during
+  /// modal sheet and button-group animations. For the small pill-shape geometry
+  /// used here, synchronous GPU upload is sub-millisecond and safe.
+  void _updateGeometrySync(
+    List<(RenderLiquidGlassGeometry, GeometryCache, Matrix4)> geometries,
+    Rect bounds,
+  ) {
+    // Record canvas commands synchronously — pure CPU work.
+    final (picture, localBounds, imageSize) =
+        _recordGeometryPicture(geometries, bounds);
+
+    try {
+      // Synchronous GPU rasterization — no async lag.
+      // Clamp to ≥1: jelly squash can push geometry to near-zero size and
+      // toImageSync(0, n) throws "Invalid image dimensions".
+      final image = picture.toImageSync(
+        max(1, imageSize.width.ceil()),
+        max(1, imageSize.height.ceil()),
+      );
+
+      _clearGeometryImage();
+      _geometryImage = image;
+      _geometryLocalBounds = localBounds;
+      // No markNeedsPaint() needed — we are already inside paint().
+    } finally {
+      picture.dispose();
+    }
+  }
+
+  @override
+  @mustCallSuper
+  void dispose() {
+    _clearGeometryImage();
+    // Break reference chains to prevent stale GPU resource retention during
+    // isolate shutdown. The render shader holds a DlRuntimeEffectColorSource
+    // that retains Vulkan textures — nulling _settings ensures no closure
+    // retains a path back to the shader's GPU resources past the Vulkan
+    // context lifetime (Crash 2 in Mali GPU crash analysis).
+    _settings = null;
+    super.dispose();
+  }
+
+  // MARK: Geometry
+
+  @protected
+  bool needsGeometryUpdate = true;
+
+  /// Records all geometry drawing commands into a [ui.Picture] synchronously.
+  /// Returns the picture, the LOCAL-SPACE bounding rect, and the physical
+  /// pixel size needed for rasterization. The caller is responsible for
+  /// disposing the picture after rasterization.
+  ///
+  /// ## Local-space rasterization (A3)
+  ///
+  /// The geometry is recorded WITHOUT applying [matteTransform] (position,
+  /// jelly scale, global screen offset). This means:
+  ///
+  /// - The image represents the pill SDF purely in the render object's own
+  ///   coordinate space, at its current LOCAL size.
+  /// - [matteTransform] is applied SYNCHRONOUSLY at paint time to derive the
+  ///   screen-space [uGeometryOffset] / [uGeometrySize] uniforms — no 1-2
+  ///   frame async lag, no correction needed.
+  /// - Geometry rebuilds are only needed when the LOCAL shape changes
+  ///   (layout/style), not for every position or jelly-scale animation frame.
+  (ui.Picture, Rect, Size) _recordGeometryPicture(
+    List<(RenderLiquidGlassGeometry, GeometryCache, Matrix4)> geometries,
+    Rect bounds,
+  ) {
+    // Work in local coordinate space — no matteTransform applied.
+    // Inflate by 2 logical pixels (= 2×DPR physical pixels after snapToPixels
+    // aligns to the pixel grid) to ensure the anti-aliased SDF edge is fully
+    // captured. Without this, the picture boundaries tightly crop the fractional
+    // edge pixels, abruptly cutting off the rim lighting at the pill boundary.
+    final localBounds = bounds.snapToPixels(devicePixelRatio).inflate(2.0);
+    final size = localBounds.size * devicePixelRatio;
+
+    final logging = LgrLogs.isLogActive(logger);
+    final buffer = logging
+        ? StringBuffer(
+            '$hashCode Recording geometry picture (local space) with '
+            '${geometries.length} shapes at size '
+            '${size.width}x${size.height}:\n',
+          )
+        : null;
+
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+
+    for (final (_, geometry, transform) in geometries) {
+      canvas
+        ..save()
+        ..scale(devicePixelRatio)
+        // Shift so localBounds.topLeft is the texture origin.
+        ..translate(-localBounds.left, -localBounds.top)
+        // Apply geometry-local → glass-local transform only (no matteTransform).
+        ..transform(transform.storage)
+        ..scale(1 / devicePixelRatio)
+        ..translate(
+          geometry.matteBounds.topLeft.dx,
+          geometry.matteBounds.topLeft.dy,
+        );
+
+      switch (geometry) {
+        case UnrenderedGeometryCache(matte: final picture):
+          buffer?.writeln('\t- Unrendered @ ${geometry.bounds}');
+          canvas.drawPicture(picture);
+        case RenderedGeometryCache(matte: final image):
+          buffer?.writeln('\t- Rendered @ ${geometry.bounds}');
+          canvas.drawImage(image, Offset.zero, Paint());
+      }
+
+      canvas.restore();
+    }
+
+    if (buffer != null) logger.fine(buffer.toString());
+    return (recorder.endRecording(), localBounds, size);
+  }
+}
+
+@internal
+class GeometryRenderLink {
+  final List<RenderLiquidGlassGeometry> _shapeGeometries = [];
+
+  UnmodifiableListView<RenderLiquidGlassGeometry> get shapes =>
+      UnmodifiableListView(_shapeGeometries);
+
+  bool _dirty = false;
+
+  void updateAllGeometries() {
+    for (final renderObject in _shapeGeometries) {
+      renderObject.maybeRebuildGeometry();
+    }
+  }
+
+  void registerGeometry(
+    RenderLiquidGlassGeometry renderObject,
+  ) {
+    _dirty = true;
+    _shapeGeometries.add(renderObject);
+  }
+
+  /// Signals that a geometry object has completed a rebuild and the render
+  /// layer should integrate the updated result on the next paint.
+  void notifyGeometryChanged(RenderLiquidGlassGeometry renderObject) {
+    _dirty = true;
+  }
+
+  void unregisterGeometry(RenderLiquidGlassGeometry renderObject) {
+    _shapeGeometries.remove(renderObject);
+  }
+
+  void dispose() {
+    _shapeGeometries.clear();
+  }
+}
+
+@internal
+class InheritedGeometryRenderLink extends InheritedWidget {
+  const InheritedGeometryRenderLink({
+    required this.link,
+    required super.child,
+    super.key,
+  });
+
+  final GeometryRenderLink link;
+
+  static GeometryRenderLink? of(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<InheritedGeometryRenderLink>()
+        ?.link;
+  }
+
+  @override
+  bool updateShouldNotify(covariant InheritedGeometryRenderLink oldWidget) {
+    return oldWidget.link != link;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/shaders.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/shaders.dart
@@ -1,0 +1,20 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:meta/meta.dart';
+
+import '_env_web.dart' if (dart.library.io) '_env_io.dart';
+
+final String _shadersRoot =
+    !kIsWeb && isTestEnvironment ? '' : 'packages/liquid_glass_widgets/';
+
+@internal
+abstract class ShaderKeys {
+  const ShaderKeys._();
+
+  static final blendedGeometry =
+      '${_shadersRoot}shaders/liquid_glass_geometry_blended.frag';
+
+  static final liquidGlassRender =
+      '${_shadersRoot}shaders/liquid_glass_final_render.frag';
+}

--- a/packages/liquid_glass_widgets/lib/src/renderer/stretch.dart
+++ b/packages/liquid_glass_widgets/lib/src/renderer/stretch.dart
@@ -1,0 +1,683 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'internal/glass_drag_builder.dart';
+import 'package:meta/meta.dart';
+import '../../utils/glass_spring.dart';
+
+/// Configuration for the anchor stretch effect on interactive glass widgets.
+///
+/// This bundles the fine-tuning parameters for how a widget stretches when
+/// the user presses and drags — just like [LiquidGlassSettings] bundles
+/// glass rendering parameters.
+///
+/// Most developers won't need to change these — the defaults match iOS 26
+/// button behaviour. Use this when you want to fine-tune the feel:
+///
+/// ```dart
+/// GlassButton(
+///   anchorStretchSettings: AnchorStretchSettings(
+///     intensity: 0.8,  // more stretchy
+///     bounciness: 0.2, // more elastic snap-back
+///   ),
+/// )
+/// ```
+class AnchorStretchSettings {
+  /// Creates anchor stretch settings.
+  ///
+  /// All values have sensible defaults matching iOS 26 behaviour.
+  const AnchorStretchSettings({
+    this.intensity = 0.5,
+    this.squashFactor = 0.3,
+    this.translationDamping = 0.15,
+    this.bounciness = 0.15,
+  });
+
+  /// How much the widget elongates in the drag direction.
+  ///
+  /// `0.0` = no elongation, `1.0` = matches drag distance 1:1 relative
+  /// to widget size. Higher values = stretchier.
+  ///
+  /// Defaults to `0.5`.
+  final double intensity;
+
+  /// How much the perpendicular dimension compresses during stretch.
+  ///
+  /// `0.0` = no squash (shape stays round), `1.0` = full volume-preserving
+  /// squash. Lower values keep content (text, icons) from distorting.
+  ///
+  /// Defaults to `0.3`.
+  final double squashFactor;
+
+  /// How far the widget's center shifts toward the finger.
+  ///
+  /// `0.0` = perfectly anchored, `1.0` = follows finger fully.
+  /// Small values (0.1–0.2) give a satisfying bounce-back.
+  ///
+  /// Defaults to `0.15`.
+  final double translationDamping;
+
+  /// Extra bounciness added to the release spring.
+  ///
+  /// `0.0` = standard elastic snap-back. `0.1`–`0.3` = more pronounced
+  /// overshoot that makes the widget visibly bounce past rest.
+  ///
+  /// Defaults to `0.15` — a subtle overshoot matching native iOS 26 buttons.
+  final double bounciness;
+}
+
+/// A widget that provides a squash and stretch effect to its child based on
+/// user interaction.
+///
+/// Will listen to drag gestures from the user without interfering with other
+/// gestures.
+class LiquidStretch extends StatelessWidget {
+  /// Creates a new [LiquidStretch] widget with the given [child],
+  /// [interactionScale], and [stretch].
+  const LiquidStretch({
+    required this.child,
+    this.interactionScale = 1.05,
+    this.stretch = .5,
+    this.resistance = .01,
+    this.hitTestBehavior = HitTestBehavior.opaque,
+    this.axis,
+    this.allowPositive = true,
+    this.allowNegative = true,
+    this.allowPositiveX,
+    this.allowNegativeX,
+    this.allowPositiveY,
+    this.allowNegativeY,
+    this.suppressInteractionOnChildren = true,
+    this.anchorStretch = true,
+    this.anchorStretchSettings = const AnchorStretchSettings(),
+    super.key,
+  });
+
+  /// The scale factor to apply when the user is interacting with the widget.
+  ///
+  /// A value of 1.0 means no scaling.
+  ///
+  /// A value greater than 2.0 means the widget will grow to double its
+  /// original size.
+  ///
+  /// A value less than 1.0 means the widget will scale down.
+  ///
+  /// Defaults to 1.05.
+  final double interactionScale;
+
+  /// The factor to multiply the drag offset by to determine the stretch
+  /// amount in pixels.
+  ///
+  /// A value of 0.0 means no stretch, while a value of 1.0 means the stretch
+  /// would match the drag offset exactly (which you probably don't want).
+  ///
+  /// Defaults to 0.5.
+  final double stretch;
+
+  /// The resistance factor to apply to the drag offset.
+  ///
+  /// The higher the resisance, the more sticky the drag will feel.
+  /// See [OffsetResistanceExtension.withResistance] for details on how this
+  /// works.
+  ///
+  /// Defaults to 0.01.
+  final double resistance;
+
+  /// The hit test behavior for the internal gesture Listener.
+  ///
+  /// Defaults to [HitTestBehavior.opaque].
+  final HitTestBehavior hitTestBehavior;
+
+  /// The child widget to apply the stretch effect to.
+  final Widget child;
+
+  /// The axis to constrain the stretch to. If null, stretches in both axes.
+  final Axis? axis;
+
+  /// Whether to allow stretch in the positive direction of the axis.
+  /// If [axis] is vertical, positive is down. If horizontal, positive is right.
+  final bool allowPositive;
+
+  /// Whether to allow stretch in the negative direction of the axis.
+  /// If [axis] is vertical, negative is up. If horizontal, negative is left.
+  final bool allowNegative;
+
+  /// Per-axis overrides for [allowPositive]. When non-null, overrides
+  /// [allowPositive] for that specific axis only.
+  final bool? allowPositiveX;
+
+  /// Per-axis overrides for [allowNegative]. When non-null, overrides
+  /// [allowNegative] for that specific axis only.
+  final bool? allowNegativeX;
+
+  /// Per-axis overrides for [allowPositive]. When non-null, overrides
+  /// [allowPositive] for the Y axis only.
+  final bool? allowPositiveY;
+
+  /// Per-axis overrides for [allowNegative]. When non-null, overrides
+  /// [allowNegative] for the Y axis only.
+  final bool? allowNegativeY;
+
+  /// Whether to prevent scaling when interacting with children.
+  final bool suppressInteractionOnChildren;
+
+  /// Whether the stretch anchors the widget in place.
+  ///
+  /// When `true`, the widget's center stays fixed and the shape elongates
+  /// toward the drag direction — like pulling taffy with one end pinned.
+  /// This matches iOS 26 button behaviour (e.g. phone app X button).
+  ///
+  /// When `false`, the widget both stretches and translates
+  /// toward the finger, matching the original jelly-follow behaviour
+  /// used by bottom bars and modals.
+  ///
+  /// Only affects the unconstrained-axis path (when [axis] is null).
+  /// Axis-constrained modes already anchor to the opposite edge.
+  ///
+  /// Defaults to `true`.
+  final bool anchorStretch;
+
+  /// Fine-tuning for the anchor stretch effect.
+  ///
+  /// Controls intensity, squash, translation damping, and bounciness.
+  /// Most developers won't need to change these — the defaults match
+  /// iOS 26 button behaviour.
+  ///
+  /// See [AnchorStretchSettings] for details on each parameter.
+  final AnchorStretchSettings anchorStretchSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    // NOTE: Do NOT add a fast-path that returns `child` directly when
+    // `stretch == 0 && interactionScale == 1.0`.  The GlassModalSheet lerps
+    // these values through 0 / 1.0 as the sheet expands, so a fast-path
+    // causes the widget type at this slot to switch between the bare child
+    // widget and `GlassDragBuilder` on the frame where the lerp crosses the
+    // threshold.  That type change forces Flutter to deactivate the entire
+    // existing element subtree (firing `initState` on all descendants) and
+    // mount a fresh one — which is exactly the regression we fixed in
+    // lightweight_liquid_glass.dart.  Always returning `GlassDragBuilder`
+    // keeps the tree structure stable throughout the animation.
+
+    return GlassDragBuilder(
+      behavior: hitTestBehavior,
+      suppressInteractionOnChildren: suppressInteractionOnChildren,
+      builder: (context, value, child) {
+        final scale = value == null ? 1.0 : interactionScale;
+        return SpringBuilder(
+          value: scale,
+          spring:
+              GlassSpring.smooth(duration: const Duration(milliseconds: 300)),
+          builder: (context, value, child) => Transform.scale(
+            // Avoid exact 1.0 to prevent RenderTransform layer drops on resting
+            scale: value == 1.0 ? 1.00001 : value,
+            child: child,
+          ),
+          child: OffsetSpringBuilder(
+            value: () {
+              if (value == null) return Offset.zero;
+              Offset o = value.withResistance(resistance);
+              if (axis == Axis.horizontal) {
+                o = Offset(o.dx, 0);
+              } else if (axis == Axis.vertical) {
+                o = Offset(0, o.dy);
+              }
+              // Apply per-axis overrides, falling back to the shared flags.
+              final effectiveAllowPositiveX = allowPositiveX ?? allowPositive;
+              final effectiveAllowNegativeX = allowNegativeX ?? allowNegative;
+              final effectiveAllowPositiveY = allowPositiveY ?? allowPositive;
+              final effectiveAllowNegativeY = allowNegativeY ?? allowNegative;
+              o = Offset(
+                (!effectiveAllowPositiveX && o.dx > 0)
+                    ? 0
+                    : (!effectiveAllowNegativeX && o.dx < 0)
+                        ? 0
+                        : o.dx,
+                (!effectiveAllowPositiveY && o.dy > 0)
+                    ? 0
+                    : (!effectiveAllowNegativeY && o.dy < 0)
+                        ? 0
+                        : o.dy,
+              );
+              return o;
+            }(),
+            spring: value == null
+                ? GlassSpring.bouncy(
+                    extraBounce: anchorStretchSettings.bounciness,
+                  )
+                : GlassSpring.interactive(),
+            builder: (context, value, child) => RawLiquidStretch(
+              stretchPixels: value * stretch,
+              axis: axis,
+              anchorStretch: anchorStretch,
+              anchorStretchIntensity: anchorStretchSettings.intensity,
+              anchorSquashFactor: anchorStretchSettings.squashFactor,
+              anchorTranslationDamping:
+                  anchorStretchSettings.translationDamping,
+              child: child,
+            ),
+            child: child,
+          ),
+        );
+      },
+      child: child,
+    );
+  }
+}
+
+/// {@template raw_liquid_stretch}
+/// Use this widget to apply a custom stretch effect in pixels to its child.
+///
+/// You can control the stretch effect by providing an [Offset] in pixels
+/// via the [stretchPixels] property.
+///
+/// If you simply want to apply a stretch effect based on user drag gestures,
+/// consider using [LiquidStretch] instead, which provides built-in drag
+/// handling and resistance.
+/// {@endtemplate}
+class RawLiquidStretch extends SingleChildRenderObjectWidget {
+  const RawLiquidStretch({
+    required this.stretchPixels,
+    required super.child,
+    this.axis,
+    this.anchorStretch = false,
+    this.anchorStretchIntensity = 0.5,
+    this.anchorSquashFactor = 0.3,
+    this.anchorTranslationDamping = 0.15,
+    super.key,
+  });
+
+  /// The stretch offset in pixels.
+  final Offset stretchPixels;
+
+  /// The axis to constrain the stretch to.
+  final Axis? axis;
+
+  /// Whether to anchor the stretch at center (no translation).
+  final bool anchorStretch;
+
+  /// How much the shape elongates along the drag direction.
+  final double anchorStretchIntensity;
+
+  /// How much the perpendicular dimension compresses.
+  final double anchorSquashFactor;
+
+  /// How far the center shifts toward the finger (0 = fixed, 1 = follows).
+  final double anchorTranslationDamping;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return RenderRawLiquidStretch(
+      stretchPixels: stretchPixels,
+      axis: axis,
+      anchorStretch: anchorStretch,
+      anchorStretchIntensity: anchorStretchIntensity,
+      anchorSquashFactor: anchorSquashFactor,
+      anchorTranslationDamping: anchorTranslationDamping,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    RenderRawLiquidStretch renderObject,
+  ) {
+    renderObject.stretchPixels = stretchPixels;
+    renderObject.axis = axis;
+    renderObject.anchorStretch = anchorStretch;
+    renderObject.anchorStretchIntensity = anchorStretchIntensity;
+    renderObject.anchorSquashFactor = anchorSquashFactor;
+    renderObject.anchorTranslationDamping = anchorTranslationDamping;
+  }
+}
+
+@internal
+class RenderRawLiquidStretch extends RenderProxyBox {
+  RenderRawLiquidStretch({
+    required Offset stretchPixels,
+    Axis? axis,
+    bool anchorStretch = false,
+    double anchorStretchIntensity = 0.5,
+    double anchorSquashFactor = 0.3,
+    double anchorTranslationDamping = 0.15,
+  })  : _stretchPixels = stretchPixels,
+        _axis = axis,
+        _anchorStretch = anchorStretch,
+        _anchorStretchIntensity = anchorStretchIntensity,
+        _anchorSquashFactor = anchorSquashFactor,
+        _anchorTranslationDamping = anchorTranslationDamping;
+
+  Offset _stretchPixels;
+  Axis? _axis;
+  bool _anchorStretch;
+  double _anchorStretchIntensity;
+  double _anchorSquashFactor;
+  double _anchorTranslationDamping;
+
+  /// The axis to constrain the stretch to.
+  Axis? get axis => _axis;
+  set axis(Axis? value) {
+    if (_axis == value) return;
+    _axis = value;
+    markNeedsPaint();
+  }
+
+  /// Whether to anchor the stretch at center (no translation).
+  bool get anchorStretch => _anchorStretch;
+  set anchorStretch(bool value) {
+    if (_anchorStretch == value) return;
+    _anchorStretch = value;
+    markNeedsPaint();
+  }
+
+  /// How much the shape elongates along the drag direction.
+  double get anchorStretchIntensity => _anchorStretchIntensity;
+  set anchorStretchIntensity(double value) {
+    if (_anchorStretchIntensity == value) return;
+    _anchorStretchIntensity = value;
+    markNeedsPaint();
+  }
+
+  /// How much the perpendicular dimension compresses.
+  double get anchorSquashFactor => _anchorSquashFactor;
+  set anchorSquashFactor(double value) {
+    if (_anchorSquashFactor == value) return;
+    _anchorSquashFactor = value;
+    markNeedsPaint();
+  }
+
+  /// How far the center shifts toward the finger.
+  double get anchorTranslationDamping => _anchorTranslationDamping;
+  set anchorTranslationDamping(double value) {
+    if (_anchorTranslationDamping == value) return;
+    _anchorTranslationDamping = value;
+    markNeedsPaint();
+  }
+
+  /// The stretch offset in pixels.
+  Offset get stretchPixels => _stretchPixels;
+  set stretchPixels(Offset value) {
+    if (_stretchPixels == value) {
+      return;
+    }
+    _stretchPixels = value;
+    markNeedsPaint();
+  }
+
+  /// Signed smoothstep: maps [-edge..+edge] → [-1..+1] with smooth
+  /// cubic easing. Values beyond ±edge clamp to ±1.
+  /// Used for pivot interpolation to prevent position jumps.
+  static double _signedSmoothStep(double x, double edge) {
+    final t = (x / edge).clamp(-1.0, 1.0);
+    final a = t.abs();
+    final smooth = a * a * (3.0 - 2.0 * a);
+    return t >= 0 ? smooth : -smooth;
+  }
+
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    return hitTestChildren(result, position: position);
+  }
+
+  @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    final transform = _getEffectiveTransform();
+    if (transform == null) {
+      return super.hitTestChildren(result, position: position);
+    }
+
+    return result.addWithPaintTransform(
+      transform: transform,
+      position: position,
+      hitTest: (BoxHitTestResult result, Offset position) {
+        return super.hitTestChildren(result, position: position);
+      },
+    );
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    if (child == null) {
+      return;
+    }
+
+    final transform = _getEffectiveTransform();
+    if (transform == null) {
+      super.paint(context, offset);
+      return;
+    }
+
+    // Check if the matrix is singular or produces near-zero scale.
+    // A determinant of 0 or NaN signals a degenerate transform; painting
+    // through it causes Impeller glyph-bounds crashes on extreme stretch.
+    final det = transform.determinant();
+    if (det == 0 || !det.isFinite) {
+      layer = null;
+      return;
+    }
+
+    // Guard against extreme squash that produces sub-pixel glyph rects.
+    final scale = getScale(stretchPixels: _stretchPixels, size: size);
+    if (scale.dx < 0.0001 || scale.dy < 0.0001) {
+      layer = null;
+      return;
+    }
+
+    layer = context.pushTransform(
+      needsCompositing,
+      offset,
+      transform,
+      super.paint,
+      oldLayer: layer is TransformLayer ? layer as TransformLayer? : null,
+    );
+  }
+
+  @override
+  void applyPaintTransform(RenderBox child, Matrix4 transform) {
+    final effectiveTransform = _getEffectiveTransform();
+    if (effectiveTransform != null) {
+      transform.multiply(effectiveTransform);
+    }
+  }
+
+  Matrix4? _getEffectiveTransform() {
+    if (_stretchPixels == Offset.zero) {
+      // Avoid exact identity to prevent TransformLayer detachment on rest
+      // ignore: deprecated_member_use
+      return Matrix4.identity()..translateByDouble(0.0001, 0.0, 0.0, 1.0);
+    }
+
+    final scale = getScale(
+      stretchPixels: _stretchPixels,
+      size: size,
+    );
+
+    final matrix = Matrix4.identity();
+
+    // If axis is constrained, scale from the opposite edge
+    if (_axis == Axis.vertical) {
+      // Scale from bottom if stretching up, or top if stretching down
+      // Actually, for a bottom sheet, we usually want to scale from the bottom
+      final pivotY = _stretchPixels.dy <= 0 ? size.height : 0.0;
+      matrix
+        ..translateByDouble(size.width / 2, pivotY, 0.0, 1.0)
+        ..scaleByDouble(scale.dx, scale.dy, 1.0, 1.0)
+        ..translateByDouble(-size.width / 2, -pivotY, 0.0, 1.0);
+    } else if (_axis == Axis.horizontal) {
+      final pivotX = _stretchPixels.dx <= 0 ? size.width : 0.0;
+      matrix
+        ..translateByDouble(pivotX, size.height / 2, 0.0, 1.0)
+        ..scaleByDouble(scale.dx, scale.dy, 1.0, 1.0)
+        ..translateByDouble(-pivotX, -size.height / 2, 0.0, 1.0);
+    } else {
+      if (_anchorStretch) {
+        // iOS 26 anchored stretch: the button stays mostly in place but
+        // elongates toward the finger from its opposite edge.
+        //
+        // Algorithm: scale X and Y independently based on their respective
+        // drag components, pivoting from the opposite boundary edge.
+        // Drag down → only Y stretches from top edge.
+        // Drag right → only X stretches from left edge.
+        // Drag diagonal → both stretch from the opposite corner.
+        final absDx = _stretchPixels.dx.abs();
+        final absDy = _stretchPixels.dy.abs();
+
+        if (absDx > 0.001 || absDy > 0.001) {
+          // Normalise both axes against the SAME reference dimension
+          // (the larger of width/height). This prevents extreme aspect-ratio
+          // buttons from producing exaggerated stretch on the short axis.
+          //
+          // For round buttons (w ≈ h) this is identical to per-axis division.
+          // For wide buttons (w >> h) a 20 px vertical drag now produces the
+          // same relative value as a 20 px drag on a square button of side
+          // max(w, h), preventing the "merge & twitch" reported on full-width
+          // buttons between two small buttons.
+          final refDim = math.max(size.width, size.height);
+          final relativeX = refDim > 0 ? absDx / refDim : 0.0;
+          final relativeY = refDim > 0 ? absDy / refDim : 0.0;
+
+          // Aspect-ratio correction: dampen stretch along the already-long
+          // axis. A 300×56 wide button has aspectRatio ≈ 5.36, so horizontal
+          // stretch is reduced to ~19% while vertical stays at 100%.
+          // For square buttons (AR=1), both corrections are 1.0 (no change).
+          final aspectRatio = size.width > 0 && size.height > 0
+              ? size.width / size.height
+              : 1.0;
+          final xDamping = aspectRatio > 1.0 ? 1.0 / aspectRatio : 1.0;
+          final yDamping = aspectRatio < 1.0 ? aspectRatio : 1.0;
+
+          // Elongate along the drag direction.
+          // Cap at 30% to prevent extreme transforms on long drags.
+          final stretchX = 1.0 +
+              (relativeX * _anchorStretchIntensity * xDamping).clamp(0.0, 0.3);
+          final stretchY = 1.0 +
+              (relativeY * _anchorStretchIntensity * yDamping).clamp(0.0, 0.3);
+
+          // Perpendicular compression (balloon-squeeze): dragging right
+          // elongates X and compresses Y, and vice versa.
+          // Cap squash at 15% to avoid extreme narrowing on wide buttons.
+          final squashX = 1.0 -
+              (relativeY * _anchorSquashFactor * xDamping).clamp(0.0, 0.15);
+          final squashY = 1.0 -
+              (relativeX * _anchorSquashFactor * yDamping).clamp(0.0, 0.15);
+
+          final scaleX = (stretchX * squashX).clamp(0.01, double.infinity);
+          final scaleY = (stretchY * squashY).clamp(0.01, double.infinity);
+
+          // Smooth pivot: instead of snapping between edges (which causes
+          // a visible position jump when drag direction reverses near zero),
+          // glide the pivot through center using a signed smoothstep.
+          //
+          // At ±20px the pivot is fully at the target edge. Near zero it
+          // passes through center, and the stretch itself is negligible
+          // so the pivot position doesn't produce visible artifacts.
+          final pivotX = size.width *
+              (0.5 - _signedSmoothStep(_stretchPixels.dx, 20.0) * 0.5);
+          final pivotY = size.height *
+              (0.5 - _signedSmoothStep(_stretchPixels.dy, 20.0) * 0.5);
+
+          matrix
+            ..translateByDouble(pivotX, pivotY, 0.0, 1.0)
+            ..scaleByDouble(scaleX, scaleY, 1.0, 1.0)
+            ..translateByDouble(-pivotX, -pivotY, 0.0, 1.0);
+
+          // Small dampened translation so the button shifts slightly
+          // toward the finger — gives bounce-back something to snap.
+          // Apply aspect-ratio correction to prevent wide buttons from
+          // sliding too far horizontally.
+          if (_anchorTranslationDamping > 0) {
+            matrix.translateByDouble(
+              _stretchPixels.dx * _anchorTranslationDamping * xDamping,
+              _stretchPixels.dy * _anchorTranslationDamping * yDamping,
+              0.0,
+              1.0,
+            );
+          }
+        }
+      } else {
+        // Original behaviour: scale from center + translate toward the finger.
+        matrix
+          ..translateByDouble(size.width / 2, size.height / 2, 0.0, 1.0)
+          ..scaleByDouble(scale.dx, scale.dy, 1.0, 1.0)
+          ..translateByDouble(-size.width / 2, -size.height / 2, 0.0, 1.0)
+          ..translateByDouble(_stretchPixels.dx, _stretchPixels.dy, 0.0, 1.0);
+      }
+    }
+
+    return matrix;
+  }
+
+  @internal
+  Offset getScale({
+    required Offset stretchPixels,
+    required Size size,
+  }) {
+    if (size.isEmpty) {
+      return const Offset(1, 1);
+    }
+
+    final stretchX = stretchPixels.dx.abs();
+    final stretchY = stretchPixels.dy.abs();
+
+    // Convert pixel stretch to relative stretch based on size
+    final relativeStretchX = size.width > 0 ? stretchX / size.width : 0.0;
+    final relativeStretchY = size.height > 0 ? stretchY / size.height : 0.0;
+
+    // Use a consistent stretch factor for both dimensions
+    const stretchFactor = 1.0;
+    const volumeFactor = 0.5;
+
+    final baseScaleX = 1 + relativeStretchX * stretchFactor;
+    final baseScaleY = 1 + relativeStretchY * stretchFactor;
+
+    // Calculate magnitude in relative space for volume preservation
+    final magnitude = math.sqrt(
+      relativeStretchX * relativeStretchX + relativeStretchY * relativeStretchY,
+    );
+    final targetVolume = 1 + magnitude * volumeFactor;
+    final currentVolume = baseScaleX * baseScaleY;
+    final volumeCorrection = math.sqrt(targetVolume / currentVolume);
+
+    var finalScaleX = baseScaleX * volumeCorrection;
+    var finalScaleY = baseScaleY * volumeCorrection;
+
+    // If axis is constrained, don't affect the other dimension
+    if (_axis == Axis.vertical) {
+      finalScaleX = 1.0;
+    } else if (_axis == Axis.horizontal) {
+      finalScaleY = 1.0;
+    }
+
+    // Clamp to a safe minimum so the transform never becomes degenerate.
+    // Values below 0.01 produce near-singular matrices that cause
+    // Impeller glyph-bounds assertions on extreme stretch.
+    finalScaleX = finalScaleX.clamp(0.01, double.infinity);
+    finalScaleY = finalScaleY.clamp(0.01, double.infinity);
+
+    return Offset(finalScaleX, finalScaleY);
+  }
+}
+
+/// Provides [withResistance] method to apply drag resistance to an [Offset].
+extension OffsetResistanceExtension on Offset {
+  /// Returns a new [Offset] with a given [resistance] applied, which will
+  /// hold it back the further it deviates from [Offset.zero].
+  ///
+  /// Applies a non-linear damping effect that reduces the offset's magnitude
+  /// while preserving its direction. Higher resistance values create stronger
+  /// damping.
+  /// Larger offsets are reduced more aggressively than smaller ones,
+  /// creating a natural "stretch resistance" effect commonly used in scrolling.
+  Offset withResistance(double resistance) {
+    if (resistance == 0) return this;
+
+    final magnitude = math.sqrt(dx * dx + dy * dy);
+    if (magnitude == 0) return Offset.zero;
+
+    final resistedMagnitude = magnitude / (1 + magnitude * resistance);
+    final scale = resistedMagnitude / magnitude;
+
+    return Offset(dx * scale, dy * scale);
+  }
+}

--- a/packages/liquid_glass_widgets/lib/src/types/glass_interaction_behavior.dart
+++ b/packages/liquid_glass_widgets/lib/src/types/glass_interaction_behavior.dart
@@ -1,0 +1,59 @@
+/// Controls which physical interaction effects are active on a glass surface
+/// when the user presses it.
+///
+/// iOS 26 uses a layered interaction model where press events can trigger
+/// two independent visual responses: a light-catching directional glow
+/// (ambient refraction at the finger position) and a physical scale/squish
+/// of the glass body itself.
+///
+/// Use [GlassBottomBar.interactionBehavior] and
+/// [GlassSearchableBottomBar.interactionBehavior] to select the desired mode.
+/// Fine-tune each axis independently with [GlassBottomBar.pressScale] /
+/// [GlassSearchableBottomBar.pressScale] for the scale amount, and
+/// [GlassBottomBar.interactionGlowColor] /
+/// [GlassSearchableBottomBar.interactionGlowColor] for the light color.
+///
+/// ### Physical model
+///
+/// | Behavior     | Glow | Scale | Typical use-case                          |
+/// |--------------|------|-------|-------------------------------------------|
+/// | [none]       | ✗    | ✗     | Decorative / background glass             |
+/// | [glowOnly]   | ✓    | ✗     | Spatially-stable navigation bars          |
+/// | [scaleOnly]  | ✗    | ✓     | Branded bars where glow competes with UI  |
+/// | [full]       | ✓    | ✓     | Native iOS 26 Apple News / Safari (default)|
+enum GlassInteractionBehavior {
+  /// No interaction feedback — fully rigid glass, no directional glow.
+  ///
+  /// Use for background or decorative glass elements that should not respond
+  /// visually to touch at all.
+  none,
+
+  /// Directional glow only — the glass catches ambient light at the touch
+  /// point, but the body does not physically deform.
+  ///
+  /// Suitable for flat navigation bars that should remain spatially stable
+  /// while still feeling reactive to touch.
+  glowOnly,
+
+  /// Physical spring-scale only — the bar inflates subtly on press and snaps
+  /// back on release, but does not respond with a directional glow.
+  ///
+  /// Useful for custom-branded bars where the ambient glow would compete with
+  /// foreground content colours.
+  scaleOnly,
+
+  /// Full iOS 26 interaction — directional glow **and** physical spring-scale.
+  ///
+  /// Matches the default Apple News / Safari bottom-bar behaviour: the glass
+  /// inflates subtly (bottom-anchored spring) on touch and simultaneously
+  /// projects a soft directional highlight at the finger position.
+  ///
+  /// This is the default for all liquid-glass bar widgets.
+  full;
+
+  /// Whether this behavior includes the directional glow effect.
+  bool get hasGlow => this == glowOnly || this == full;
+
+  /// Whether this behavior includes the spring-scale (squish) effect.
+  bool get hasScale => this == scaleOnly || this == full;
+}

--- a/packages/liquid_glass_widgets/lib/theme/glass_interaction_settings.dart
+++ b/packages/liquid_glass_widgets/lib/theme/glass_interaction_settings.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import '../src/renderer/liquid_glass_renderer.dart';
+
+/// Theme-level configuration for glass widget interaction physics.
+///
+/// Controls how glass buttons and chips respond to touch — the jelly-like
+/// squash & stretch, press scaling, and drag resistance that replicate
+/// iOS 26 button behaviour.
+///
+/// This class lives on [GlassThemeData] (not per-brightness [GlassThemeVariant])
+/// because interaction physics don't change between light and dark mode.
+///
+/// ## Resolution order
+///
+/// Each interactive glass widget resolves its interaction parameters as:
+///
+/// **explicit widget parameter > theme > hardcoded default**
+///
+/// This matches Flutter's standard pattern (like [TextStyle] resolution).
+///
+/// ## Usage
+///
+/// ### Set globally via theme:
+/// ```dart
+/// GlassTheme(
+///   data: GlassThemeData(
+///     interaction: GlassInteractionSettings(
+///       stretch: 0.2,        // subtler stretch globally
+///       interactionScale: 1.03, // less scale-up on press
+///     ),
+///   ),
+///   child: child!,
+/// )
+/// ```
+///
+/// ### Disable stretch app-wide:
+/// ```dart
+/// GlassTheme(
+///   data: GlassThemeData(
+///     interaction: GlassInteractionSettings(
+///       stretch: 0.0,  // no drag-following, keeps press-scale
+///     ),
+///   ),
+///   child: child!,
+/// )
+/// ```
+///
+/// ### Per-button override still works:
+/// ```dart
+/// GlassButton(
+///   stretch: 0.8,  // overrides the theme's 0.2
+///   icon: Icon(CupertinoIcons.play),
+///   onTap: () {},
+/// )
+/// ```
+@immutable
+class GlassInteractionSettings {
+  /// Creates interaction settings for glass widgets.
+  ///
+  /// All values are optional. When null, the widget's own hardcoded default
+  /// is used (preserving backward compatibility). When set, the value acts
+  /// as a theme-level default that individual widgets can override.
+  const GlassInteractionSettings({
+    this.stretch,
+    this.interactionScale,
+    this.resistance,
+    this.anchorStretch,
+    this.anchorStretchSettings,
+  });
+
+  /// Default interaction settings — all null, meaning each widget uses
+  /// its own hardcoded default.
+  static const GlassInteractionSettings defaults = GlassInteractionSettings();
+
+  /// The factor to multiply the drag offset by to determine the stretch
+  /// amount in pixels.
+  ///
+  /// - `0.0` = no drag-following (keeps press-scale effect)
+  /// - `0.5` (widget default) = balanced natural stretch
+  /// - `1.0` = matches drag offset exactly (usually too much)
+  ///
+  /// When `null`, each widget uses its own default (typically `0.5`).
+  final double? stretch;
+
+  /// The scale factor applied when the user presses the widget.
+  ///
+  /// - `1.0` = no scaling
+  /// - `1.05` (widget default) = 5% grow on press
+  /// - `1.1` = 10% grow on press
+  ///
+  /// When `null`, each widget uses its own default (typically `1.05`).
+  final double? interactionScale;
+
+  /// The resistance factor applied to the drag offset.
+  ///
+  /// Higher values make the drag feel heavier/stickier. Uses non-linear
+  /// damping that increases with distance from rest.
+  ///
+  /// When `null`, each widget uses its own default (typically `0.01`).
+  final double? resistance;
+
+  /// Whether the stretch anchors the widget in place.
+  ///
+  /// - `true` (widget default): Widget stays fixed, elongates toward finger
+  ///   (iOS 26 button behaviour)
+  /// - `false`: Widget follows the finger (jelly-follow mode)
+  ///
+  /// When `null`, each widget uses its own default (typically `true`).
+  final bool? anchorStretch;
+
+  /// Fine-tuning for the anchor stretch effect.
+  ///
+  /// Controls intensity, squash, translation damping, and bounciness.
+  ///
+  /// When `null`, each widget uses its own default
+  /// (`AnchorStretchSettings()` with iOS 26 defaults).
+  final AnchorStretchSettings? anchorStretchSettings;
+
+  /// Creates a copy with overridden values.
+  GlassInteractionSettings copyWith({
+    double? stretch,
+    double? interactionScale,
+    double? resistance,
+    bool? anchorStretch,
+    AnchorStretchSettings? anchorStretchSettings,
+  }) {
+    return GlassInteractionSettings(
+      stretch: stretch ?? this.stretch,
+      interactionScale: interactionScale ?? this.interactionScale,
+      resistance: resistance ?? this.resistance,
+      anchorStretch: anchorStretch ?? this.anchorStretch,
+      anchorStretchSettings:
+          anchorStretchSettings ?? this.anchorStretchSettings,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GlassInteractionSettings &&
+          runtimeType == other.runtimeType &&
+          stretch == other.stretch &&
+          interactionScale == other.interactionScale &&
+          resistance == other.resistance &&
+          anchorStretch == other.anchorStretch &&
+          anchorStretchSettings == other.anchorStretchSettings;
+
+  @override
+  int get hashCode => Object.hash(
+        stretch,
+        interactionScale,
+        resistance,
+        anchorStretch,
+        anchorStretchSettings,
+      );
+}

--- a/packages/liquid_glass_widgets/lib/theme/glass_theme.dart
+++ b/packages/liquid_glass_widgets/lib/theme/glass_theme.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import '../utils/glass_brightness.dart';
+import 'glass_theme_data.dart';
+
+/// Provides glass theme configuration to descendant widgets.
+///
+/// This [InheritedWidget] allows glass widgets to access centralized theme
+/// settings without passing them explicitly through the widget tree.
+///
+/// ## Usage
+///
+/// Wrap your app (or a section of it) with [GlassTheme]:
+///
+/// ```dart
+/// MaterialApp(
+///   builder: (context, child) => GlassTheme(
+///     data: GlassThemeData(
+///       light: GlassThemeVariant(
+///         settings: LiquidGlassSettings(thickness: 30),
+///         quality: GlassQuality.standard,
+///       ),
+///       dark: GlassThemeVariant(
+///         settings: LiquidGlassSettings(thickness: 40),
+///         quality: GlassQuality.standard,
+///       ),
+///     ),
+///     child: child!,
+///   ),
+/// )
+/// ```
+///
+/// Access theme in widgets:
+///
+/// ```dart
+/// final theme = GlassThemeData.of(context);
+/// final settings = theme.settingsFor(context); // Auto light/dark
+/// ```
+///
+/// ## Theme Inheritance
+///
+/// Widgets automatically inherit theme settings from the nearest [GlassTheme]
+/// ancestor. Individual widgets can override theme values by explicitly
+/// passing `settings`, `quality`, or `glowColor` parameters.
+///
+/// ## Light/Dark Mode
+///
+/// The theme automatically switches between light and dark variants using a
+/// four-level priority cascade (highest first):
+///
+/// 1. **[GlassThemeData.brightness]** — explicit override on this theme.
+/// 2. **Cupertino theme brightness** — explicit pin in [CupertinoThemeData].
+/// 3. **Material [ThemeMode]** — honours [ThemeMode.light] / [ThemeMode.dark].
+/// 4. **[MediaQuery.platformBrightnessOf]** — device/OS system setting.
+///
+/// Use [GlassTheme.brightnessOf] to resolve brightness inside glass widgets.
+/// Never read [MediaQuery.platformBrightnessOf] or [CupertinoTheme.brightnessOf]
+/// directly in glass widget code — those bypass the cascade.
+class GlassTheme extends InheritedWidget {
+  /// Creates a glass theme.
+  ///
+  /// The [data] parameter contains theme configuration for light and dark modes.
+  const GlassTheme({
+    required this.data,
+    required super.child,
+    super.key,
+  });
+
+  /// The theme data containing light and dark configurations.
+  final GlassThemeData data;
+
+  /// Retrieves the [GlassTheme] from the widget tree.
+  ///
+  /// Returns null if no [GlassTheme] ancestor exists.
+  static GlassTheme? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<GlassTheme>();
+  }
+
+  /// Retrieves the [GlassTheme] from the widget tree.
+  ///
+  /// Throws if no [GlassTheme] ancestor exists. Use [maybeOf] for a
+  /// null-safe alternative.
+  static GlassTheme of(BuildContext context) {
+    final theme = maybeOf(context);
+    assert(
+      theme != null,
+      'No GlassTheme found in context. '
+      'Wrap your app with GlassTheme to provide theme configuration.',
+    );
+    return theme!;
+  }
+
+  /// Resolves the effective brightness for all glass widgets in this context.
+  ///
+  /// This is the **single authority** for brightness within the package.
+  /// All glass widgets must call this instead of querying
+  /// [CupertinoTheme.brightnessOf] or [MediaQuery.platformBrightnessOf]
+  /// directly.
+  ///
+  /// Resolution cascade (highest priority first):
+  ///
+  /// 1. **[GlassThemeData.brightness]** — an explicit brightness override set
+  ///    by the developer on the nearest [GlassTheme] ancestor.
+  /// 2. **[CupertinoThemeData.brightness]** — an explicit Cupertino brightness
+  ///    pin (non-null only when the developer set it intentionally).
+  /// 3. **Material [Theme] brightness** — honours [ThemeMode.light],
+  ///    [ThemeMode.dark], and [ThemeMode.system].
+  /// 4. **[MediaQuery.platformBrightnessOf]** — the device/OS system setting
+  ///    (historical default, safe fallback).
+  ///
+  /// This ensures glass widgets always follow the **app's** intended
+  /// brightness even when the device OS and app theme disagree (e.g. device
+  /// is in Dark Mode but the app is pinned to Light Mode).
+  static Brightness brightnessOf(BuildContext context) {
+    // Level 1: explicit glass-theme override.
+    final override = GlassTheme.maybeOf(context)?.data.brightness;
+    if (override != null) return override;
+    // Levels 2-4: framework cascade (Cupertino pin → Material → system).
+    return resolveGlassBrightness(context);
+  }
+
+  @override
+  bool updateShouldNotify(GlassTheme oldWidget) {
+    return data != oldWidget.data;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<GlassThemeData>('data', data));
+  }
+}

--- a/packages/liquid_glass_widgets/lib/theme/glass_theme_data.dart
+++ b/packages/liquid_glass_widgets/lib/theme/glass_theme_data.dart
@@ -1,0 +1,643 @@
+import 'dart:ui' show lerpDouble;
+
+import 'package:flutter/material.dart';
+import '../src/renderer/liquid_glass_renderer.dart';
+import '../utils/glass_brightness.dart';
+import 'glass_interaction_settings.dart';
+import 'glass_theme_settings.dart';
+
+import '../types/glass_quality.dart';
+import 'glass_theme_helpers.dart';
+
+/// Color palette for glass glow effects.
+///
+/// Provides semantic colors for different interaction states and contexts.
+/// Colors are used for glow effects on buttons, active states, and highlights.
+@immutable
+class GlassGlowColors {
+  /// Creates a glow color palette.
+  const GlassGlowColors({
+    this.primary,
+    this.secondary,
+    this.success,
+    this.warning,
+    this.danger,
+    this.info,
+    this.glowBlurRadius = 4.0,
+    this.glowSpreadRadius = 0,
+    this.glowOpacity = 1,
+  });
+
+  /// Primary brand color for default interactive elements
+  final Color? primary;
+
+  /// Secondary brand color for alternative actions
+  final Color? secondary;
+
+  /// Success state color (typically green)
+  final Color? success;
+
+  /// Warning state color (typically orange/yellow)
+  final Color? warning;
+
+  /// Danger/error state color (typically red)
+  final Color? danger;
+
+  /// Informational color (typically blue)
+  final Color? info;
+
+  /// Gaussian blur sigma applied to the glow halo.
+  ///
+  /// Defaults to `4.0` — softens the glow edge into a natural, liquid-glass
+  /// specular halo. Set to `0` for a crisp hard edge.
+  /// Values in the 4–16 range give progressively more diffuse softening.
+  /// Applied via [MaskFilter.blur] on the additive paint layer inside
+  /// [GlassGlowLayer]; guarded so no GPU work occurs when the value is 0.
+  ///
+  /// Passed directly to [GlassGlow.glowBlurRadius].
+  final double glowBlurRadius;
+
+  /// Extra spread added to the drawn glow circle as a fraction of the
+  /// layer's shortest side.
+  ///
+  /// 0 (the default) keeps the circle at the physics radius. A value of
+  /// 0.2 expands it by 20 % of the layer's height (or width, whichever
+  /// is smaller), making the glow bleed further without inflating the
+  /// spring animation radius.
+  ///
+  /// Passed directly to [GlassGlow.glowSpreadRadius].
+  final double glowSpreadRadius;
+
+  /// Master opacity multiplier applied on top of the glow color's own alpha.
+  ///
+  /// Range 0–1, defaults to 1 (no change). Use this to uniformly dim the
+  /// glow across all semantic colors without touching the raw color values.
+  ///
+  /// Passed directly to [GlassGlow.glowOpacity].
+  final double glowOpacity;
+
+  /// Creates a copy with overridden values.
+  GlassGlowColors copyWith({
+    Color? primary,
+    Color? secondary,
+    Color? success,
+    Color? warning,
+    Color? danger,
+    Color? info,
+    double? glowBlurRadius,
+    double? glowSpreadRadius,
+    double? glowOpacity,
+  }) {
+    return GlassGlowColors(
+      primary: primary ?? this.primary,
+      secondary: secondary ?? this.secondary,
+      success: success ?? this.success,
+      warning: warning ?? this.warning,
+      danger: danger ?? this.danger,
+      info: info ?? this.info,
+      glowBlurRadius: glowBlurRadius ?? this.glowBlurRadius,
+      glowSpreadRadius: glowSpreadRadius ?? this.glowSpreadRadius,
+      glowOpacity: glowOpacity ?? this.glowOpacity,
+    );
+  }
+
+  /// Linearly interpolates between two glow palettes.
+  ///
+  /// Color fields that are non-null on both sides interpolate smoothly via
+  /// [Color.lerp]; a field that is null on either side switches discretely at
+  /// the midpoint, because `null` means "resolve a brightness-aware default
+  /// at runtime" (see [GlassThemeData.glowColorsFor]) — fading through
+  /// transparent would misrepresent that. The appearance scalars
+  /// ([glowBlurRadius], [glowSpreadRadius], [glowOpacity]) always
+  /// interpolate smoothly.
+  ///
+  /// Returns null when both [a] and [b] are null. Used by
+  /// [GlassThemeVariant.lerp] to cross-fade between light and dark theme
+  /// variants during content-aware brightness flips.
+  static GlassGlowColors? lerp(
+    GlassGlowColors? a,
+    GlassGlowColors? b,
+    double t,
+  ) {
+    if (identical(a, b)) return a;
+    if (a == null || b == null) return t < 0.5 ? a : b;
+    return GlassGlowColors(
+      primary: _lerpColorField(a.primary, b.primary, t),
+      secondary: _lerpColorField(a.secondary, b.secondary, t),
+      success: _lerpColorField(a.success, b.success, t),
+      warning: _lerpColorField(a.warning, b.warning, t),
+      danger: _lerpColorField(a.danger, b.danger, t),
+      info: _lerpColorField(a.info, b.info, t),
+      glowBlurRadius: lerpDouble(a.glowBlurRadius, b.glowBlurRadius, t)!,
+      glowSpreadRadius: lerpDouble(a.glowSpreadRadius, b.glowSpreadRadius, t)!,
+      glowOpacity: lerpDouble(a.glowOpacity, b.glowOpacity, t)!,
+    );
+  }
+
+  static Color? _lerpColorField(Color? a, Color? b, double t) {
+    if (a != null && b != null) return Color.lerp(a, b, t);
+    return t < 0.5 ? a : b;
+  }
+
+  /// Fallback glow colors with sensible defaults.
+  ///
+  /// The primary color is intentionally left null here so that
+  /// [GlassThemeData.glowColorsFor] can substitute a brightness-aware warm
+  /// specular highlight at runtime (more visible in light mode, more restrained
+  /// in dark mode where the glass surface is already luminous).
+  static const GlassGlowColors fallback = GlassGlowColors(
+    // primary is null — resolved at runtime by glowColorsFor() based on
+    // current brightness. See GlassThemeData.glowColorsFor.
+    secondary: Color(0xFF5856D6), // iOS purple
+    success: Color(0xFF34C759), // iOS green
+    warning: Color(0xFFFF9500), // iOS orange
+    danger: Color(0xFFFF3B30), // iOS red
+    info: Color(0xFF5AC8FA), // iOS light blue
+    // Appearance defaults — sigma-4 blur softens the glow edge for a natural
+    // liquid-glass feel. Zero-cost when inactive (guarded by > 0 check).
+    glowBlurRadius: 4.0,
+    glowSpreadRadius: 0,
+    glowOpacity: 1,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GlassGlowColors &&
+          runtimeType == other.runtimeType &&
+          primary == other.primary &&
+          secondary == other.secondary &&
+          success == other.success &&
+          warning == other.warning &&
+          danger == other.danger &&
+          info == other.info &&
+          glowBlurRadius == other.glowBlurRadius &&
+          glowSpreadRadius == other.glowSpreadRadius &&
+          glowOpacity == other.glowOpacity;
+
+  @override
+  int get hashCode => Object.hash(
+        primary,
+        secondary,
+        success,
+        warning,
+        danger,
+        info,
+        glowBlurRadius,
+        glowSpreadRadius,
+        glowOpacity,
+      );
+}
+
+/// Theme configuration for a specific brightness (light or dark).
+///
+/// Contains all styling information for glass widgets in a single theme mode.
+@immutable
+class GlassThemeVariant {
+  /// Creates a theme variant for light or dark mode.
+  const GlassThemeVariant({
+    this.settings,
+    this.quality,
+    this.glowColors,
+    this.borderRadius,
+  });
+
+  /// Partial glass visual settings applied on top of each widget's own defaults.
+  ///
+  /// Only non-null fields in the override replace the corresponding widget
+  /// default — unset fields are left alone. This prevents a single-property
+  /// theme override from silently zeroing out unrelated properties (e.g. setting
+  /// only `thickness` no longer clears `glassColor` back to fully transparent).
+  ///
+  /// To override a specific widget entirely, pass explicit `settings` directly
+  /// to that widget constructor.
+  final GlassThemeSettings? settings;
+
+  /// Default rendering quality for all widgets.
+  ///
+  /// Individual widgets can override this via their `quality` parameter.
+  final GlassQuality? quality;
+
+  /// Semantic color palette for glow effects.
+  final GlassGlowColors? glowColors;
+
+  /// Default corner radius for all glass widgets in this variant.
+  ///
+  /// If null, widgets will use their own defaults or [GlassThemeHelpers.resolveAdaptiveRadius].
+  final double? borderRadius;
+
+  /// Creates a copy with overridden values.
+  GlassThemeVariant copyWith({
+    GlassThemeSettings? settings,
+    GlassQuality? quality,
+    GlassGlowColors? glowColors,
+    double? borderRadius,
+  }) {
+    return GlassThemeVariant(
+      settings: settings ?? this.settings,
+      quality: quality ?? this.quality,
+      glowColors: glowColors ?? this.glowColors,
+      borderRadius: borderRadius ?? this.borderRadius,
+    );
+  }
+
+  /// Linearly interpolates between two theme variants.
+  ///
+  /// Continuous values interpolate smoothly; discrete or optional values
+  /// switch at the midpoint:
+  ///
+  /// - [settings] delegates to [GlassThemeSettings.lerp] (per-field smooth
+  ///   lerp with midpoint switching for one-sided `null`s).
+  /// - [glowColors] delegates to [GlassGlowColors.lerp].
+  /// - [borderRadius] interpolates when set on both sides, otherwise
+  ///   switches at the midpoint.
+  /// - [quality] is discrete and always switches at the midpoint.
+  ///
+  /// Used to cross-fade between the light and dark variants when a
+  /// content-aware brightness flip animates (see `GlassContentAwareScope`).
+  static GlassThemeVariant lerp(
+    GlassThemeVariant a,
+    GlassThemeVariant b,
+    double t,
+  ) {
+    if (identical(a, b)) return a;
+    final double? radius;
+    if (a.borderRadius != null && b.borderRadius != null) {
+      radius = lerpDouble(a.borderRadius, b.borderRadius, t);
+    } else {
+      radius = t < 0.5 ? a.borderRadius : b.borderRadius;
+    }
+    return GlassThemeVariant(
+      settings: GlassThemeSettings.lerp(a.settings, b.settings, t),
+      quality: t < 0.5 ? a.quality : b.quality,
+      glowColors: GlassGlowColors.lerp(a.glowColors, b.glowColors, t),
+      borderRadius: radius,
+    );
+  }
+
+  /// Default light theme variant.
+  ///
+  /// [quality] is intentionally `null` here so that each widget's own
+  /// documented default quality is respected (e.g. [GlassBottomBar] defaults
+  /// to [GlassQuality.premium]). Set quality explicitly in your
+  /// [GlassThemeVariant] to override all widgets globally.
+  static const GlassThemeVariant light = GlassThemeVariant(
+    settings: GlassThemeSettings(
+      thickness: 12.0, // Slightly thicker than dark — needs more body on white
+      blur: 5.0, // Matched with dark for consistency
+      glassColor: Color.fromRGBO(210, 220, 240, 0.12), // ~12% cool blue-white
+      lightAngle: 2.356, // 0.75 * pi ≈ 135° — upper-left, matches iOS 26
+      lightIntensity: 0.85, // Softer — bright backgrounds need less highlight
+      ambientStrength: 0.15, // Touch of ambient keeps glass visible on white
+      refractiveIndex: 1.2,
+      saturation: 1.2,
+      chromaticAberration: 0.02, // Subtle prismatic edge, not distracting
+    ),
+    quality: null,
+    glowColors: GlassGlowColors.fallback,
+  );
+
+  /// Default dark theme variant.
+  ///
+  /// [quality] is intentionally `null` here so that each widget's own
+  /// documented default quality is respected (e.g. [GlassBottomBar] defaults
+  /// to [GlassQuality.premium]). Set quality explicitly in your
+  /// [GlassThemeVariant] to override all widgets globally.
+  static const GlassThemeVariant dark = GlassThemeVariant(
+    settings: GlassThemeSettings(
+      thickness: 10.0,
+      blur: 4.0,
+      glassColor: Color.fromRGBO(255, 255, 255, 0.08),
+      lightAngle: 2.356, // 0.75 * pi ≈ 135° — upper-left, matches iOS 26
+      lightIntensity: 0.7,
+      ambientStrength: 0.0,
+      refractiveIndex: 1.2,
+      saturation: 1.2,
+      chromaticAberration: 0.01,
+    ),
+    quality: null,
+    glowColors: GlassGlowColors.fallback,
+  );
+
+  /// Shader-free theme variant for maximum compatibility.
+  ///
+  /// All glass widgets in this subtree use [GlassQuality.minimal]: plain
+  /// BackdropFilter blur with a tinted container. No fragment shaders,
+  /// no texture capture, no specular effects.
+  ///
+  /// Use this as your global theme when targeting pre-iPhone 13 / pre-A15
+  /// devices, or when the [GlassPerformanceMonitor] consistently warns about
+  /// GPU budget overruns:
+  ///
+  /// ```dart
+  /// GlassTheme(
+  ///   data: GlassThemeData(
+  ///     light: GlassThemeVariant.minimal,
+  ///     dark: GlassThemeVariant.minimal,
+  ///   ),
+  ///   child: child!,
+  /// )
+  /// ```
+  static const GlassThemeVariant minimal = GlassThemeVariant(
+    settings: GlassThemeSettings(
+      thickness: 10.0, // Consistent with light/dark
+      blur: 8.0, // BackdropFilter sigma — enough frosting to see shapes through
+      glassColor: Color.fromRGBO(
+          200, 210, 230, 0.15), // Visible tint for the container overlay
+    ),
+    quality: GlassQuality.minimal,
+    glowColors: GlassGlowColors.fallback,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GlassThemeVariant &&
+          runtimeType == other.runtimeType &&
+          settings == other.settings &&
+          quality == other.quality &&
+          glowColors == other.glowColors &&
+          borderRadius == other.borderRadius;
+
+  @override
+  int get hashCode => Object.hash(settings, quality, glowColors, borderRadius);
+}
+
+/// Theme data for liquid glass widgets.
+///
+/// Provides centralized styling for all glass widgets in your app, with
+/// automatic light/dark mode support. Brightness is resolved via a priority
+/// cascade: [GlassThemeData.brightness] override → Cupertino explicit pin →
+/// Material [ThemeMode] → system/device setting. This ensures glass widgets
+/// always follow the **app's** intended brightness, not the device OS setting.
+///
+/// ## Usage
+///
+/// Wrap your app with [GlassTheme] to provide theme data:
+///
+/// ```dart
+/// MaterialApp(
+///   theme: ThemeData.light(),
+///   darkTheme: ThemeData.dark(),
+///   builder: (context, child) => GlassTheme(
+///     data: GlassThemeData(
+///       light: GlassThemeVariant(
+///         settings: LiquidGlassSettings(thickness: 30, blur: 3),
+///         quality: GlassQuality.standard,
+///       ),
+///       dark: GlassThemeVariant(
+///         settings: LiquidGlassSettings(thickness: 40, blur: 5),
+///         quality: GlassQuality.standard,
+///       ),
+///     ),
+///     child: child!,
+///   ),
+/// )
+/// ```
+///
+/// Access theme data in widgets:
+///
+/// ```dart
+/// final theme = GlassThemeData.of(context);
+/// final settings = theme.settings; // Automatically uses light/dark variant
+/// ```
+@immutable
+class GlassThemeData {
+  /// Creates glass theme data with separate light and dark configurations.
+  ///
+  /// Both [light] and [dark] default to sensible values — if you only want
+  /// to tweak a single property, use [GlassThemeData.simple] instead.
+  const GlassThemeData({
+    this.light = GlassThemeVariant.light,
+    this.dark = GlassThemeVariant.dark,
+    this.interaction = const GlassInteractionSettings(),
+    this.brightness,
+  });
+
+  /// Creates glass theme data from a flat set of common properties.
+  ///
+  /// This is the **recommended constructor for most apps**. It applies the
+  /// same [settings] and [quality] to both light and dark modes using the
+  /// library's built-in light/dark defaults as a base — you only need to
+  /// specify what you want to change.
+  ///
+  /// ```dart
+  /// // Minimal — just set blur and thickness, everything else uses defaults:
+  /// GlassThemeData.simple(
+  ///   blur: 10,
+  ///   thickness: 30,
+  /// )
+  ///
+  /// // With quality:
+  /// GlassThemeData.simple(
+  ///   blur: 10,
+  ///   thickness: 30,
+  ///   quality: GlassQuality.standard,
+  /// )
+  /// ```
+  ///
+  /// For fine-grained per-mode control (different blur in dark mode, custom
+  /// glow colors, etc.) use the default [GlassThemeData] constructor instead.
+  factory GlassThemeData.simple({
+    double? blur,
+    double? thickness,
+    GlassQuality? quality,
+    double? chromaticAberration,
+    double? lightIntensity,
+    double? ambientStrength,
+    double? refractiveIndex,
+    double? saturation,
+    double? borderRadius,
+    GlassInteractionSettings? interaction,
+    Brightness? brightness,
+  }) {
+    final settings = GlassThemeSettings(
+      blur: blur,
+      thickness: thickness,
+      chromaticAberration: chromaticAberration,
+      lightIntensity: lightIntensity,
+      ambientStrength: ambientStrength,
+      refractiveIndex: refractiveIndex,
+      saturation: saturation,
+    );
+
+    return GlassThemeData(
+      light: GlassThemeVariant.light.copyWith(
+        settings: GlassThemeVariant.light.settings?.copyWith(
+              blur: blur,
+              thickness: thickness,
+              chromaticAberration: chromaticAberration,
+              lightIntensity: lightIntensity,
+              ambientStrength: ambientStrength,
+              refractiveIndex: refractiveIndex,
+              saturation: saturation,
+            ) ??
+            settings,
+        quality: quality,
+        borderRadius: borderRadius,
+      ),
+      dark: GlassThemeVariant.dark.copyWith(
+        settings: GlassThemeVariant.dark.settings?.copyWith(
+              blur: blur,
+              thickness: thickness,
+              chromaticAberration: chromaticAberration,
+              lightIntensity: lightIntensity,
+              ambientStrength: ambientStrength,
+              refractiveIndex: refractiveIndex,
+              saturation: saturation,
+            ) ??
+            settings,
+        quality: quality,
+        borderRadius: borderRadius,
+      ),
+      interaction: interaction ?? const GlassInteractionSettings(),
+      brightness: brightness,
+    );
+  }
+
+  /// Theme variant for light mode.
+  final GlassThemeVariant light;
+
+  /// Theme variant for dark mode.
+  final GlassThemeVariant dark;
+
+  /// Interaction physics settings (brightness-agnostic).
+  ///
+  /// Controls stretch, press scale, drag resistance, and anchor stretch
+  /// for all interactive glass widgets. Individual widgets can override
+  /// any parameter via their constructor.
+  ///
+  /// Lives at the top level (not per-variant) because interaction physics
+  /// don't change between light and dark mode.
+  final GlassInteractionSettings interaction;
+
+  /// Explicit brightness override for all glass widgets under this theme.
+  ///
+  /// When non-null, **all** glass widgets in this subtree render at this
+  /// fixed brightness, regardless of the device OS setting, Material
+  /// [ThemeMode], or Cupertino theme brightness.
+  ///
+  /// This is the highest-priority level in the four-level brightness cascade:
+  /// `GlassThemeData.brightness` → Cupertino pin → Material ThemeMode → system.
+  ///
+  /// **Use cases**
+  /// - Force a specific section of your UI to always render in light mode
+  ///   (e.g. a camera viewfinder overlay that should always be dark).
+  /// - Testing: pin brightness to a known value in widget tests.
+  ///
+  /// When null (default), brightness resolves automatically through the
+  /// cascade. See [GlassTheme.brightnessOf] for the resolution logic.
+  final Brightness? brightness;
+
+  /// Retrieves the theme data from the widget tree.
+  ///
+  /// Returns the current [GlassThemeData] from the nearest GlassTheme
+  /// ancestor. If no theme is found, returns [GlassThemeData.fallback].
+  static GlassThemeData of(BuildContext context) {
+    return GlassThemeHelpers.of(context);
+  }
+
+  /// Retrieves the appropriate theme variant based on the resolved brightness.
+  ///
+  /// Uses the four-level cascade: [brightness] override → Cupertino pin →
+  /// Material [ThemeMode] → system/device. This ensures the correct variant
+  /// is selected even when the device OS and app theme differ.
+  GlassThemeVariant variantFor(BuildContext context) {
+    // Level 1: own brightness override takes absolute priority.
+    // Levels 2-4: delegated to the package-private utility.
+    final b = brightness ?? resolveGlassBrightness(context);
+    return b == Brightness.dark ? dark : light;
+  }
+
+  /// Gets the partial glass settings override for the current brightness.
+  ///
+  /// Returns a [GlassThemeSettings] rather than a full
+  /// [LiquidGlassSettings] — callers should merge this on top of their own
+  /// defaults via [GlassThemeSettings.applyTo].
+  GlassThemeSettings? settingsFor(BuildContext context) {
+    return variantFor(context).settings;
+  }
+
+  /// Gets rendering quality for current brightness.
+  GlassQuality? qualityFor(BuildContext context) {
+    return variantFor(context).quality;
+  }
+
+  /// Gets default corner radius for current brightness.
+  double? borderRadiusFor(BuildContext context) {
+    return variantFor(context).borderRadius;
+  }
+
+  /// Gets glow colors for current brightness.
+  ///
+  /// If the caller has not set an explicit [GlassGlowColors.primary], this
+  /// method substitutes a brightness-aware neutral white specular highlight
+  /// matching the iOS 26 press feedback model. iOS 26 glass surfaces produce
+  /// a bright, grey-white highlight on interaction — like light diffracting
+  /// through frosted glass — not a colored or dim tint.
+  ///
+  /// Opacity is higher in light mode (glass is more transparent, highlight
+  /// needs more presence) and slightly lower in dark mode (the glass surface
+  /// is already luminous from the dark blurred background).
+  GlassGlowColors glowColorsFor(BuildContext context) {
+    final colors = variantFor(context).glowColors ?? GlassGlowColors.fallback;
+
+    // Only inject the adaptive primary when the caller has not provided one.
+    if (colors.primary != null) return colors;
+
+    // Resolve brightness consistently with variantFor — own override first,
+    // then the package cascade. Do NOT call MediaQuery.platformBrightnessOf
+    // directly here, or the glow and the variant would use different sources.
+    final isDark =
+        (brightness ?? resolveGlassBrightness(context)) == Brightness.dark;
+    // 0x3D = ~24% opacity in light mode (matches the pre-0.9.1 Colors.white24
+    // default that GlassButton used before theme propagation was introduced).
+    // 0x2A = ~16% opacity in dark mode — dark glass surfaces are already
+    // luminous, so a slightly dimmer highlight looks more natural.
+    // BlendMode.plus compositing keeps both from blowing out.
+    final adaptivePrimary =
+        isDark ? const Color(0x2AFFFFFF) : const Color(0x3DFFFFFF);
+
+    return colors.copyWith(primary: adaptivePrimary);
+  }
+
+  /// Creates a copy with overridden values.
+  GlassThemeData copyWith({
+    GlassThemeVariant? light,
+    GlassThemeVariant? dark,
+    GlassInteractionSettings? interaction,
+    Object? brightness = _sentinel,
+  }) {
+    return GlassThemeData(
+      light: light ?? this.light,
+      dark: dark ?? this.dark,
+      interaction: interaction ?? this.interaction,
+      // Use sentinel so callers can explicitly clear the override with null.
+      brightness:
+          brightness == _sentinel ? this.brightness : brightness as Brightness?,
+    );
+  }
+
+  static const Object _sentinel = Object();
+
+  /// Default fallback theme when no [GlassTheme] is present in widget tree.
+  factory GlassThemeData.fallback() {
+    return const GlassThemeData(
+      light: GlassThemeVariant.light,
+      dark: GlassThemeVariant.dark,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GlassThemeData &&
+          runtimeType == other.runtimeType &&
+          light == other.light &&
+          dark == other.dark &&
+          interaction == other.interaction &&
+          brightness == other.brightness;
+
+  @override
+  int get hashCode => Object.hash(light, dark, interaction, brightness);
+}

--- a/packages/liquid_glass_widgets/lib/theme/glass_theme_helpers.dart
+++ b/packages/liquid_glass_widgets/lib/theme/glass_theme_helpers.dart
@@ -1,0 +1,331 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../liquid_glass_setup.dart';
+import '../src/renderer/liquid_glass_renderer.dart';
+import '../types/glass_quality.dart';
+import '../widgets/shared/glass_adaptive_scope.dart';
+import '../widgets/shared/glass_isolation_scope.dart';
+import '../widgets/shared/inherited_liquid_glass.dart';
+import 'glass_theme.dart';
+import 'glass_theme_data.dart';
+
+/// Helper functions for working with Glass Theme.
+class GlassThemeHelpers {
+  GlassThemeHelpers._();
+
+  /// Retrieves the theme data from the widget tree.
+  ///
+  /// Returns the current [GlassThemeData] from the nearest [GlassTheme]
+  /// ancestor. If no theme is found, returns [GlassThemeData.fallback].
+  static GlassThemeData of(BuildContext context) {
+    final theme = context.dependOnInheritedWidgetOfExactType<GlassTheme>();
+    return theme?.data ?? GlassThemeData.fallback();
+  }
+
+  /// Resolves the effective [GlassQuality] for a widget.
+  ///
+  /// Every glass widget calls this once per build to determine its actual
+  /// rendering quality. The resolution follows a strict five-level priority
+  /// chain. Read from highest to lowest priority:
+  ///
+  /// ---
+  ///
+  /// ### Level 1 — Widget-level explicit quality
+  ///
+  /// The `quality:` parameter on an individual widget.
+  ///
+  /// ```dart
+  /// GlassButton(quality: GlassQuality.minimal, ...) // always resolved first
+  /// ```
+  ///
+  /// **Wins over**: theme, inherited, and widget-class defaults.
+  /// **Subject to**: [GlassAdaptiveScope] ceiling (see Level 3).
+  ///
+  /// `quality: GlassQuality.premium` means *"I want premium **if the device can
+  /// handle it**"*. The adaptive scope is the arbiter of device capability and
+  /// will cap this down when necessary. This is the correct mental model — you
+  /// are expressing intent, not issuing a guarantee.
+  ///
+  /// ---
+  ///
+  /// ### Level 2 — Inherited ancestor quality
+  ///
+  /// The [GlassQuality] provided by the nearest [AdaptiveLiquidGlassLayer]
+  /// ancestor via [InheritedLiquidGlass]. Only consulted if Level 1 is null.
+  ///
+  /// ```dart
+  /// AdaptiveLiquidGlassLayer(
+  ///   quality: GlassQuality.standard, // all descendants without explicit quality get standard
+  ///   child: ...,
+  /// )
+  /// ```
+  ///
+  /// ---
+  ///
+  /// ### Level 3 — GlassAdaptiveScope ceiling (applied uniformly to all levels)
+  ///
+  /// If a [GlassAdaptiveScope] ancestor is present, the quality resolved at
+  /// any of Levels 1, 2, 4, or 5 is **capped** to the scope's
+  /// [GlassAdaptiveScopeData.effectiveQuality]. The scope never raises quality —
+  /// it only lowers it.
+  ///
+  /// ```dart
+  /// // Scope decides device can sustain standard.
+  /// // A premium widget gets standard. A minimal widget stays minimal.
+  /// GlassAdaptiveScope(
+  ///   child: Column(children: [
+  ///     GlassBottomBar(quality: GlassQuality.premium),// → standard (capped)
+  ///     GlassButton(quality: GlassQuality.minimal),  // → minimal  (not raised)
+  ///     GlassButton(),                               // → standard (from fallback, capped)
+  ///   ]),
+  /// )
+  /// ```
+  ///
+  /// To **bypass the scope ceiling** on a specific subtree — for a hero widget
+  /// you've verified runs well on the target device — wrap it in its own
+  /// locked scope:
+  ///
+  /// ```dart
+  /// GlassAdaptiveScope(
+  ///   minQuality: GlassQuality.premium, // floor = premium
+  ///   maxQuality: GlassQuality.premium, // ceiling = premium → locked
+  ///   child: GlassBottomBar(quality: GlassQuality.premium),
+  /// )
+  /// ```
+  ///
+  /// ---
+  ///
+  /// ### Level 4 — GlassTheme quality
+  ///
+  /// The `quality` field of the [GlassThemeVariant] from the nearest [GlassTheme]
+  /// ancestor. Controls all widgets in the subtree that don't have a
+  /// widget-level or inherited quality set.
+  ///
+  /// ```dart
+  /// GlassTheme(
+  ///   data: GlassThemeData(
+  ///     light: GlassThemeVariant(quality: GlassQuality.standard), // all widgets → standard
+  ///     dark:  GlassThemeVariant(quality: GlassQuality.standard),
+  ///   ),
+  ///   child: ...,
+  /// )
+  /// ```
+  ///
+  /// **Default theme variants** ([GlassThemeVariant.light] and
+  /// [GlassThemeVariant.dark]) have `quality: null`, so theme quality is
+  /// transparent by default and falls through to Level 5.
+  ///
+  /// ---
+  ///
+  /// ### Level 5 — Widget-class default (the `fallback` parameter)
+  ///
+  /// The last resort. Each widget class hard-codes the quality that makes
+  /// sense for its role when nothing else is specified:
+  ///
+  /// | Widget class | Default quality | Rationale |
+  /// |---|---|---|
+  /// | [GlassBottomBar] | `premium` | Static footer — full quality expected |
+  /// | [GlassToolbar] | `premium` | Static surface |
+  /// | [GlassTabBar] | `standard` | May be in a scrollable context |
+  /// | [GlassButton] | `standard` | Interactive, potentially many on screen |
+  /// | [GlassTextField] | `standard` | Interactive |
+  /// | [GlassSlider] | `standard` | Animated during interaction |
+  /// | [GlassDialog] | `standard` | Overlay |
+  /// | [GlassSheet] | `standard` | Overlay |
+  /// | [GlassContainer] | `standard` | General purpose container |
+  ///
+  /// Widgets pass their own default as the [fallback] parameter when calling
+  /// [resolveQuality]. You do not set this — it is an implementation detail.
+  ///
+  /// ---
+  ///
+  /// ### Complete priority summary
+  ///
+  /// ```
+  /// Highest priority
+  ///   1. widget explicit quality:  GlassButton(quality: GlassQuality.minimal)
+  ///   2. inherited ancestor:       AdaptiveLiquidGlassLayer(quality: ...)
+  ///   ── GlassAdaptiveScope ceiling applied to levels 1 & 2 above ──
+  ///   3. theme quality:            GlassThemeVariant(quality: GlassQuality.standard)
+  ///   4. widget-class default:     GlassBottomBar → premium, GlassButton → standard
+  ///   ── GlassAdaptiveScope ceiling applied to levels 3 & 4 above ──
+  /// Lowest priority
+  /// ```
+  ///
+  /// Note: Level 2 ([AdaptiveLiquidGlassLayer]) is a lower-level internal
+  /// mechanism. In most apps you will only interact with Levels 1, 3, 4, and
+  /// the scope ceiling.
+  ///
+  static GlassQuality resolveQuality(
+    BuildContext context, {
+    GlassQuality? widgetQuality,
+    GlassQuality fallback = GlassQuality.standard,
+  }) {
+    // Read the adaptive ceiling once — applied uniformly to every step.
+    final adaptiveData = GlassAdaptiveScopeData.maybeOf(context);
+
+    // Step 1: Widget-level quality wins over theme and inherited.
+    //
+    // It is NOT exempt from the adaptive scope. `quality: GlassQuality.premium`
+    // means "I want premium if the device can handle it." GlassAdaptiveScope
+    // is the arbiter of device capability and caps the result when necessary.
+    //
+    // To unconditionally force a quality floor on a specific subtree regardless
+    // of the enclosing ceiling, wrap it with:
+    //   GlassAdaptiveScope(minQuality: GlassQuality.premium, child: ...)
+    if (widgetQuality != null) {
+      return adaptiveData != null
+          ? _applyCeiling(widgetQuality, adaptiveData.effectiveQuality)
+          : widgetQuality;
+    }
+
+    // Step 2: inherited ancestor quality (e.g. from AdaptiveLiquidGlassLayer).
+    //
+    // SKIP when:
+    // - Inside a GlassIsolationScope with `isolated: true` — isolated surfaces
+    //   create their own glass layers and should not inherit from the page layer.
+    // - A GlassIsolationScope provides a `defaultQuality` — the scope is
+    //   explicitly overriding the ambient quality (e.g. GlassScaffold wraps bars
+    //   with `defaultQuality: premium`). Without this guard, the page-level
+    //   `standard` quality would short-circuit before the scope's premium hint
+    //   at Step 4 can take effect.
+    final scopeDefault = GlassIsolationScope.defaultQualityOf(context);
+    GlassQuality? resolved;
+    if (!GlassIsolationScope.isIsolated(context) && scopeDefault == null) {
+      final inherited =
+          context.dependOnInheritedWidgetOfExactType<InheritedLiquidGlass>();
+      if (inherited != null) resolved = inherited.quality;
+    }
+
+    // Step 3: cap inherited quality by adaptive ceiling.
+    if (adaptiveData != null && resolved != null) {
+      resolved = _applyCeiling(resolved, adaptiveData.effectiveQuality);
+    }
+
+    if (resolved != null) return resolved;
+
+    // Step 4: theme-level quality, capped by adaptive ceiling.
+    //
+    // scopeDefault was already resolved above (Step 2). GlassScaffold sets
+    // `defaultQuality: premium` on bar wrappers. This ensures buttons in bars
+    // default to premium without requiring explicit quality.
+    // GlassAdaptiveScope ceiling still caps this on low-end devices.
+    final themeData = GlassThemeData.of(context);
+    GlassQuality result =
+        themeData.qualityFor(context) ?? scopeDefault ?? fallback;
+    if (adaptiveData != null) {
+      result = _applyCeiling(result, adaptiveData.effectiveQuality);
+    }
+
+    return result;
+  }
+
+  /// Returns the lower of [quality] and [ceiling] using the correct ordinal.
+  static GlassQuality _applyCeiling(
+      GlassQuality quality, GlassQuality ceiling) {
+    return _qualityOrdinal(quality) > _qualityOrdinal(ceiling)
+        ? ceiling
+        : quality;
+  }
+
+  /// Quality ordinal for comparison. Higher = better visual quality.
+  ///
+  /// **Must NOT use [GlassQuality.index]** — the enum declaration order is
+  /// `standard=0, premium=1, minimal=2` which is non-monotonic with quality.
+  static int _qualityOrdinal(GlassQuality q) {
+    switch (q) {
+      case GlassQuality.premium:
+        return 2;
+      case GlassQuality.standard:
+        return 1;
+      case GlassQuality.minimal:
+        return 0;
+    }
+  }
+
+  /// Resolves [LiquidGlassSettings] for a widget using the full priority chain.
+  ///
+  /// This is the theme-aware counterpart to [InheritedLiquidGlass.ofOrDefault].
+  /// Unlike that method, it adds a final [GlassThemeData] fallback so that
+  /// standalone widgets (not wrapped in [AdaptiveLiquidGlassLayer]) still
+  /// receive a visible `glassColor` on light and dark backgrounds.
+  ///
+  /// **Priority chain (highest → lowest):**
+  /// 1. `explicit` — the widget's own `settings:` parameter (non-null wins).
+  /// 2. [InheritedLiquidGlass] — settings from nearest parent layer.
+  /// 3. [LiquidGlassWidgets.globalSettings] — app-level global override.
+  /// 4. [GlassThemeData] — brightness-aware theme settings (light/dark).
+  /// 5. [LiquidGlassSettings] default — absolute last resort.
+  ///
+  /// Call sites in [GlassButton], [GlassContainer], and [GlassTextField] use
+  /// this instead of `InheritedLiquidGlass.ofOrDefault()` so that a standalone
+  /// `GlassButton(useOwnLayer: true)` is never invisible on a white background.
+  static LiquidGlassSettings resolveSettings(
+    BuildContext context, {
+    LiquidGlassSettings? explicit,
+    LiquidGlassSettings fallback = const LiquidGlassSettings(),
+  }) {
+    // 1. Widget-level explicit setting wins unconditionally.
+    if (explicit != null) return explicit;
+
+    // 2. Inherited settings from the nearest AdaptiveLiquidGlassLayer.
+    final inherited = InheritedLiquidGlass.of(context);
+    if (inherited != null) return inherited;
+
+    // 3. App-level global override (set via LiquidGlassWidgets.globalSettings).
+    if (LiquidGlassWidgets.globalSettings != null) {
+      return LiquidGlassWidgets.globalSettings!;
+    }
+
+    // 4. Theme fallback — ensures glass is visible even when no settings are
+    //    provided anywhere.  Mirrors the logic in AdaptiveLiquidGlassLayer:
+    //    start from the zero-alpha default, then overlay any non-null fields
+    //    from the theme's brightness-appropriate variant.
+    final themeOverride = GlassThemeData.of(context).settingsFor(context);
+    return themeOverride?.applyTo(fallback) ?? fallback;
+  }
+
+  /// Resolves an adaptive border radius based on the device's physical geometry.
+  ///
+  /// This algorithm uses [MediaQuery] safe area insets to infer the ideal
+  /// corner radius, handling Dynamic Island, Notch iPhones, and Android devices
+  /// without hardcoding specific model names.
+  static double resolveAdaptiveRadius(BuildContext context) {
+    // D2: Use scoped MediaQuery accessors instead of MediaQuery.of(context).
+    // MediaQuery.of() subscribes to ALL MediaQuery changes (keyboard, status bar,
+    // orientation, text scale, etc.) — causing every glass widget to rebuild when
+    // the keyboard appears/dismisses. We only need viewPadding and screen height.
+    final viewPadding = MediaQuery.viewPaddingOf(context);
+    final bottom = viewPadding.bottom;
+    final top = viewPadding.top;
+    final theme = GlassThemeData.of(context);
+    final themeRadius = theme.borderRadiusFor(context);
+
+    // 0. If user specified a global radius in the theme, respect it.
+    if (themeRadius != null) return themeRadius;
+
+    final platform = defaultTargetPlatform;
+    final height = MediaQuery.sizeOf(context).height;
+    final isIOS = platform == TargetPlatform.iOS;
+
+    // 1. Devices with physical home buttons or desktop (no bottom safe area)
+    if (bottom == 0) return 0.0;
+
+    if (isIOS) {
+      // 2. iPhone Pro Max / Plus with Dynamic Island (e.g. 15 Pro Max: height 932)
+      // Height is the most reliable indicator; top padding can fluctuate.
+      if (height >= 900) return 54.0;
+
+      // 3. iPhone Pro / Base with Dynamic Island (e.g. 15 Pro: height 852)
+      if (height >= 800 || top >= 54) return 46.0;
+
+      // 4. iPhone with Notch (typically top padding between 44 and 50)
+      return 46.0;
+    } else {
+      // 4. Android devices with gesture navigation (bottom > 0)
+      // Android flags often have softer, smaller curves than Apple.
+      return 28.0;
+    }
+  }
+}

--- a/packages/liquid_glass_widgets/lib/theme/glass_theme_settings.dart
+++ b/packages/liquid_glass_widgets/lib/theme/glass_theme_settings.dart
@@ -1,0 +1,234 @@
+import 'dart:ui' show lerpDouble;
+
+import 'package:flutter/widgets.dart';
+
+import '../src/renderer/liquid_glass_settings.dart';
+import '../types/glass_specular_sharpness.dart';
+
+/// A partial override of [LiquidGlassSettings] for use in [GlassThemeVariant].
+///
+/// Unlike [LiquidGlassSettings], every field here is optional (`null`).
+/// A `null` value means "do not override — use the widget's own default".
+///
+/// This solves the footgun where setting a single property like `thickness`
+/// in the theme would silently zero out all other settings (e.g. `glassColor`
+/// would revert to fully transparent because the constructor default is
+/// `Color.fromARGB(0, …)`).
+///
+/// ## Usage
+///
+/// ```dart
+/// GlassTheme(
+///   data: GlassThemeData(
+///     light: GlassThemeVariant(
+///       // Only thickness and blur are overridden — glassColor, refractiveIndex,
+///       // lightIntensity, etc. continue to use each widget's own defaults.
+///       settings: GlassThemeSettings(
+///         thickness: 40,
+///         blur: 6,
+///       ),
+///     ),
+///   ),
+///   child: …,
+/// )
+/// ```
+///
+/// ## Merge order
+///
+/// 1. Widget's own explicit `settings` parameter (highest priority)
+/// 2. Theme `GlassThemeSettings` — only non-null fields applied
+/// 3. Widget's built-in per-widget defaults (lowest priority)
+@immutable
+class GlassThemeSettings {
+  /// Creates a partial settings override.
+  ///
+  /// Every parameter is optional. Omitted (null) parameters leave the
+  /// corresponding property on the target widget unchanged.
+  const GlassThemeSettings({
+    this.visibility,
+    this.glassColor,
+    this.thickness,
+    this.blur,
+    this.chromaticAberration,
+    this.lightAngle,
+    this.lightIntensity,
+    this.ambientStrength,
+    this.refractiveIndex,
+    this.saturation,
+    this.specularSharpness,
+  });
+
+  /// See [LiquidGlassSettings.visibility].
+  final double? visibility;
+
+  /// See [LiquidGlassSettings.glassColor].
+  final Color? glassColor;
+
+  /// See [LiquidGlassSettings.thickness].
+  final double? thickness;
+
+  /// See [LiquidGlassSettings.blur].
+  final double? blur;
+
+  /// See [LiquidGlassSettings.chromaticAberration].
+  final double? chromaticAberration;
+
+  /// See [LiquidGlassSettings.lightAngle].
+  final double? lightAngle;
+
+  /// See [LiquidGlassSettings.lightIntensity].
+  final double? lightIntensity;
+
+  /// See [LiquidGlassSettings.ambientStrength].
+  final double? ambientStrength;
+
+  /// See [LiquidGlassSettings.refractiveIndex].
+  final double? refractiveIndex;
+
+  /// See [LiquidGlassSettings.saturation].
+  final double? saturation;
+
+  /// See [LiquidGlassSettings.specularSharpness].
+  final GlassSpecularSharpness? specularSharpness;
+
+  /// Returns a new [LiquidGlassSettings] by applying this override onto [base].
+  ///
+  /// Only non-null fields in this override replace the corresponding
+  /// value in [base]. Null fields leave [base]'s value untouched.
+  LiquidGlassSettings applyTo(LiquidGlassSettings base) {
+    return LiquidGlassSettings(
+      visibility: visibility ?? base.visibility,
+      glassColor: glassColor ?? base.glassColor,
+      thickness: thickness ?? base.thickness,
+      blur: blur ?? base.blur,
+      chromaticAberration: chromaticAberration ?? base.chromaticAberration,
+      lightAngle: lightAngle ?? base.lightAngle,
+      lightIntensity: lightIntensity ?? base.lightIntensity,
+      ambientStrength: ambientStrength ?? base.ambientStrength,
+      refractiveIndex: refractiveIndex ?? base.refractiveIndex,
+      saturation: saturation ?? base.saturation,
+      specularSharpness: specularSharpness ?? base.specularSharpness,
+    );
+  }
+
+  /// Linearly interpolates between two partial overrides.
+  ///
+  /// Because every field is an *optional* override, interpolation has to
+  /// respect the meaning of `null` ("use the widget's own default") rather
+  /// than treating it as zero:
+  ///
+  /// - When a field is non-null on **both** sides it is smoothly
+  ///   interpolated.
+  /// - When a field is null on **either** side it switches discretely at the
+  ///   midpoint (`t < 0.5` keeps [a]'s value, otherwise [b]'s). Interpolating
+  ///   against an unknown widget default would produce a visible flash
+  ///   through zero.
+  /// - [specularSharpness] is an enum and always switches at the midpoint.
+  ///
+  /// Returns null when both [a] and [b] are null. Used by
+  /// [GlassThemeVariant.lerp] to cross-fade between light and dark theme
+  /// variants during content-aware brightness flips.
+  static GlassThemeSettings? lerp(
+    GlassThemeSettings? a,
+    GlassThemeSettings? b,
+    double t,
+  ) {
+    if (identical(a, b)) return a;
+    if (a == null || b == null) return t < 0.5 ? a : b;
+    return GlassThemeSettings(
+      visibility: _lerpDoubleField(a.visibility, b.visibility, t),
+      glassColor: _lerpColorField(a.glassColor, b.glassColor, t),
+      thickness: _lerpDoubleField(a.thickness, b.thickness, t),
+      blur: _lerpDoubleField(a.blur, b.blur, t),
+      chromaticAberration:
+          _lerpDoubleField(a.chromaticAberration, b.chromaticAberration, t),
+      lightAngle: _lerpDoubleField(a.lightAngle, b.lightAngle, t),
+      lightIntensity: _lerpDoubleField(a.lightIntensity, b.lightIntensity, t),
+      ambientStrength:
+          _lerpDoubleField(a.ambientStrength, b.ambientStrength, t),
+      refractiveIndex:
+          _lerpDoubleField(a.refractiveIndex, b.refractiveIndex, t),
+      saturation: _lerpDoubleField(a.saturation, b.saturation, t),
+      specularSharpness: t < 0.5 ? a.specularSharpness : b.specularSharpness,
+    );
+  }
+
+  static double? _lerpDoubleField(double? a, double? b, double t) {
+    if (a != null && b != null) return lerpDouble(a, b, t);
+    return t < 0.5 ? a : b;
+  }
+
+  static Color? _lerpColorField(Color? a, Color? b, double t) {
+    if (a != null && b != null) return Color.lerp(a, b, t);
+    return t < 0.5 ? a : b;
+  }
+
+  /// Creates a copy with overridden values.
+  GlassThemeSettings copyWith({
+    double? visibility,
+    Color? glassColor,
+    double? thickness,
+    double? blur,
+    double? chromaticAberration,
+    double? lightAngle,
+    double? lightIntensity,
+    double? ambientStrength,
+    double? refractiveIndex,
+    double? saturation,
+    GlassSpecularSharpness? specularSharpness,
+  }) {
+    return GlassThemeSettings(
+      visibility: visibility ?? this.visibility,
+      glassColor: glassColor ?? this.glassColor,
+      thickness: thickness ?? this.thickness,
+      blur: blur ?? this.blur,
+      chromaticAberration: chromaticAberration ?? this.chromaticAberration,
+      lightAngle: lightAngle ?? this.lightAngle,
+      lightIntensity: lightIntensity ?? this.lightIntensity,
+      ambientStrength: ambientStrength ?? this.ambientStrength,
+      refractiveIndex: refractiveIndex ?? this.refractiveIndex,
+      saturation: saturation ?? this.saturation,
+      specularSharpness: specularSharpness ?? this.specularSharpness,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GlassThemeSettings &&
+          runtimeType == other.runtimeType &&
+          visibility == other.visibility &&
+          glassColor == other.glassColor &&
+          thickness == other.thickness &&
+          blur == other.blur &&
+          chromaticAberration == other.chromaticAberration &&
+          lightAngle == other.lightAngle &&
+          lightIntensity == other.lightIntensity &&
+          ambientStrength == other.ambientStrength &&
+          refractiveIndex == other.refractiveIndex &&
+          saturation == other.saturation &&
+          specularSharpness == other.specularSharpness;
+
+  @override
+  int get hashCode => Object.hash(
+        visibility,
+        glassColor,
+        thickness,
+        blur,
+        chromaticAberration,
+        lightAngle,
+        lightIntensity,
+        ambientStrength,
+        refractiveIndex,
+        saturation,
+        specularSharpness,
+      );
+
+  @override
+  String toString() => 'GlassThemeSettings('
+      'visibility: $visibility, '
+      'thickness: $thickness, '
+      'blur: $blur, '
+      'glassColor: $glassColor'
+      ')';
+}

--- a/packages/liquid_glass_widgets/lib/types/glass_button_style.dart
+++ b/packages/liquid_glass_widgets/lib/types/glass_button_style.dart
@@ -1,0 +1,22 @@
+/// Visual style of a glass button.
+enum GlassButtonStyle {
+  /// Standard button with glass background and shape.
+  ///
+  /// Maps to iOS 26's `.glass` button configuration — a translucent, adaptive
+  /// surface that blends with the content behind it.
+  filled,
+
+  /// Prominent button with higher-opacity glass for primary actions.
+  ///
+  /// Maps to iOS 26's `.prominentGlass` / `.glassProminent` button
+  /// configuration — a thicker, more opaque glass surface that stands out
+  /// from surrounding controls. Use for primary call-to-action buttons.
+  ///
+  /// Renders with increased glass thickness and reduced transparency compared
+  /// to [filled], making the button visually heavier and more prominent.
+  prominent,
+
+  /// Transparent button (no background shape), usable within groups.
+  /// Still renders interactions (glow, stretch) and content.
+  transparent,
+}

--- a/packages/liquid_glass_widgets/lib/types/glass_quality.dart
+++ b/packages/liquid_glass_widgets/lib/types/glass_quality.dart
@@ -1,0 +1,119 @@
+/// Rendering quality for glass effects.
+///
+/// Controls the rendering method used for glass effects, balancing
+/// visual quality with performance and compatibility.
+enum GlassQuality {
+  /// Lightweight shader-based rendering for optimal performance.
+  ///
+  /// **Use when:**
+  /// - Widget is in a scrollable list (ListView, GridView, etc.)
+  /// - Inside forms or settings pages
+  /// - Performance is important
+  /// - Widget needs to work reliably in all contexts
+  ///
+  /// **Characteristics:**
+  /// - Uses lightweight fragment shader
+  /// - 5-10x faster than BackdropFilter
+  /// - Better visual quality than BackdropFilter
+  /// - Works correctly during scrolling
+  /// - Suitable for interactive widgets
+  /// - Universal platform support (Skia, Impeller, Web)
+  ///
+  /// This is the recommended default for most use cases.
+  standard,
+
+  /// High-quality shader-based glass rendering.
+  ///
+  /// **Use when:**
+  /// - Widget is in a static header or footer
+  /// - Creating hero sections or showcase UI
+  /// - Visual quality is paramount
+  /// - Widget won't be scrolled
+  /// - Device is iPhone 13 / A15 Bionic or newer (iOS)
+  /// - Device is Pixel 6 / Tensor G1 or newer (Android)
+  ///
+  /// **Characteristics:**
+  /// - Uses custom shaders and texture capture
+  /// - Higher visual quality with specular highlights and chromatic aberration
+  /// - More computationally expensive
+  /// - May not render correctly in scrollable contexts
+  ///
+  /// Only use in static, non-scrollable layouts on modern hardware.
+  /// On pre-A15 devices, sustained animations at this quality may exceed
+  /// GPU budget — consider [standard] or [minimal] for broader compatibility.
+  premium,
+
+  /// Shader-free fallback rendering. Zero custom shader activity.
+  ///
+  /// **Use when:**
+  ///
+  /// *Device compatibility* — when even [standard] is too heavy:
+  /// - Targeting very old Android devices with limited shader driver support
+  /// - Devices where custom fragment shaders fail to compile entirely
+  /// - `ImageFilter.isShaderFilterSupported` returns `false`
+  ///
+  /// *GPU budget management* — when you have many glass surfaces on one screen:
+  /// - List items with glass cards (each scroll frame would invoke the shader
+  ///   once per visible card — [minimal] keeps the cumulative cost flat)
+  /// - Screens with 10+ simultaneous glass widgets where total shader load
+  ///   matters more than individual widget quality
+  /// - Background panels or decorative containers where the frosted blur
+  ///   is the entire intended effect and specular highlights aren't noticed
+  /// - Simple UI surfaces where visual richness is secondary to smoothness
+  ///
+  /// A good pattern: use [standard] or [premium] for focal elements (the
+  /// primary widget the user is interacting with) and [minimal] for
+  /// background or supporting surfaces on the same screen.
+  ///
+  /// **Characteristics:**
+  /// - Uses [BackdropFilter] blur + Rec. 709 saturation + specular rim stroke
+  /// - Zero custom fragment shader execution or compilation
+  /// - Cross-platform: works on Skia, Impeller, Web, Windows, Linux
+  /// - Visually similar to frosted glass — saturation and specular rim match
+  ///   the upstream FakeGlass approach (whynotmake.it)
+  ///
+  /// This is the safe mode tier. Prefer it whenever [standard] still feels
+  /// heavy, or when you want to keep shader load low on busy screens.
+  minimal,
+}
+
+/// Extension to convert [GlassQuality] to the underlying rendering method.
+extension GlassQualityExtension on GlassQuality {
+  /// Whether to use the lightweight fragment shader.
+  ///
+  /// - [GlassQuality.standard]  → true  (lightweight shader)
+  /// - [GlassQuality.premium]   → false (full LiquidGlass shader pipeline)
+  /// - [GlassQuality.minimal]   → false (no shader at all — BackdropFilter only)
+  bool get usesLightweightShader {
+    switch (this) {
+      case GlassQuality.standard:
+        return true;
+      case GlassQuality.premium:
+      case GlassQuality.minimal:
+        return false;
+    }
+  }
+
+  /// Whether this quality level uses any custom fragment shader.
+  ///
+  /// - [GlassQuality.standard]  → true  (lightweight shader)
+  /// - [GlassQuality.premium]   → true  (full LiquidGlass shader)
+  /// - [GlassQuality.minimal]   → false (BackdropFilter only, zero shaders)
+  bool get usesAnyShader {
+    switch (this) {
+      case GlassQuality.standard:
+      case GlassQuality.premium:
+        return true;
+      case GlassQuality.minimal:
+        return false;
+    }
+  }
+
+  /// Whether to use backdrop filter (deprecated, kept for compatibility).
+  ///
+  /// This is now an alias for [usesLightweightShader] for backward
+  /// compatibility. The lightweight shader provides better performance
+  /// than BackdropFilter while maintaining visual quality.
+  @Deprecated('Use usesLightweightShader instead')
+  bool get usesBackdropFilter => usesLightweightShader;
+}

--- a/packages/liquid_glass_widgets/lib/types/glass_quality_change_reason.dart
+++ b/packages/liquid_glass_widgets/lib/types/glass_quality_change_reason.dart
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------------
+// GlassQualityChangeReason — why GlassAdaptiveScope changed quality
+// ---------------------------------------------------------------------------
+
+/// Describes what triggered a [GlassAdaptiveScope] quality change.
+///
+/// Passed inside [GlassAdaptiveDiagnostic] to [GlassAdaptiveScope.onDiagnostic].
+///
+/// Use this to filter analytics events — e.g. only log [warmupComplete] and
+/// [thermalDegradation] to avoid noise from [restoredFromCache].
+enum GlassQualityChangeReason {
+  /// Phase 1 — the device failed the static capability probe.
+  ///
+  /// Either `ImageFilter.isShaderFilterSupported` is `false` (software
+  /// renderer / broken driver) or the app is running on web (`kIsWeb`).
+  /// The adapter forced a lower quality tier immediately at startup, without
+  /// collecting any frame timings.
+  staticProbe,
+
+  /// The adapter started from a persisted or in-session cached quality,
+  /// skipping Phase 2 (the warm-up benchmark).
+  ///
+  /// This fires when [GlassAdaptiveScope.initialQuality] is non-null, or
+  /// when the in-session cache was populated by an earlier adapter instance
+  /// in the same app process. The change happens immediately at startup
+  /// with no P75/P95 data.
+  restoredFromCache,
+
+  /// Phase 2 completed — the warm-up benchmark measured the baseline P75
+  /// raster time and selected a quality tier.
+  ///
+  /// [GlassAdaptiveDiagnostic.p75Ms] will be set. This is the most useful
+  /// event for threshold calibration — please post it to the
+  /// [Threshold Calibration Discussion](https://github.com/sdegenaar/liquid_glass_widgets/discussions).
+  warmupComplete,
+
+  /// Phase 3 — sustained over-budget raster frames triggered a quality
+  /// step-down (e.g. thermal throttling or background CPU load).
+  ///
+  /// [GlassAdaptiveDiagnostic.p95Ms] will be set.
+  thermalDegradation,
+
+  /// Phase 3 — sustained under-budget raster frames triggered a quality
+  /// step-up after a period of thermal throttling.
+  ///
+  /// Only fires when [GlassAdaptiveScope.allowStepUp] is `true`.
+  /// [GlassAdaptiveDiagnostic.p95Ms] will be set.
+  thermalRecovery,
+}

--- a/packages/liquid_glass_widgets/lib/types/glass_specular_sharpness.dart
+++ b/packages/liquid_glass_widgets/lib/types/glass_specular_sharpness.dart
@@ -1,0 +1,43 @@
+/// Specular highlight sharpness for liquid glass surfaces.
+///
+/// Controls how tightly focused the specular highlight is on the glass rim.
+/// Each variant maps to a fixed power-of-2 exponent that the GPU resolves
+/// using a zero-transcendental multiply chain — no `exp(n·log(x))` overhead.
+///
+/// ## Why not a `double`?
+///
+/// A float uniform is a runtime variable to the GPU compiler; it cannot
+/// optimise `pow(x, uniform)` regardless of the value. By restricting to a
+/// small set of known exponents, the shader can use fully-unrolled multiply
+/// chains per branch with no transcendental operations. With wave coherency
+/// (all fragments in a glass surface share the same value) the GPU driver also
+/// eliminates the dead branches for that draw call entirely.
+///
+/// ## Choosing a value
+///
+/// | Variant | Exponent | Visual |
+/// |---------|----------|--------|
+/// | [soft]  | n=8      | Wide, diffuse — frosted glass, blurry highlight |
+/// | [medium]| n=16     | Default — matches iOS 26 glass highlight |
+/// | [sharp] | n=32     | Tight, polished — mirror-like glass surface |
+enum GlassSpecularSharpness {
+  /// Wide, diffuse specular lobe (n=8).
+  ///
+  /// Suitable for frosted, matte, or low-reflectivity glass surfaces.
+  soft,
+
+  /// Default iOS 26-calibrated highlight (n=16).
+  ///
+  /// Matches Apple's liquid glass specular model. Use for most surfaces.
+  medium,
+
+  /// Tight, mirror-like highlight (n=32).
+  ///
+  /// For polished, high-reflectivity surfaces where the specular point
+  /// should be a tight bright dot rather than a broad glow.
+  sharp;
+
+  /// The GLSL integer passed as a uniform (0, 1, 2).
+  /// Used internally by the shader writer — not part of the public API.
+  int get glslIndex => index;
+}

--- a/packages/liquid_glass_widgets/lib/utils/accessibility_config.dart
+++ b/packages/liquid_glass_widgets/lib/utils/accessibility_config.dart
@@ -1,0 +1,13 @@
+// Internal bridge — holds the single global accessibility flag set by
+// LiquidGlassWidgets.initialize(). Kept in its own file to avoid circular
+// imports between liquid_glass_setup.dart and glass_accessibility_scope.dart.
+//
+// NOT part of the public API. Do not export from the barrel.
+library;
+
+/// Whether glass widgets should auto-read system accessibility flags from
+/// [MediaQuery] when no [GlassAccessibilityScope] is present.
+///
+/// Set by [LiquidGlassWidgets.wrap(respectSystemAccessibility: ...)].
+/// Defaults to `true`.
+bool respectSystemAccessibility = true;

--- a/packages/liquid_glass_widgets/lib/utils/draggable_indicator_physics.dart
+++ b/packages/liquid_glass_widgets/lib/utils/draggable_indicator_physics.dart
@@ -1,0 +1,278 @@
+// Using deprecated Colors.withOpacity for backwards compatibility with
+// existing code patterns in the codebase.
+// ignore_for_file: deprecated_member_use
+
+// Physics calculations adapted from example code in the liquid_glass_renderer
+// package by whynotmake-it team (https://github.com/whynotmake-it/flutter_liquid_glass).
+// Used under MIT License.
+
+import 'package:flutter/widgets.dart';
+
+/// Shared physics and animation utilities for draggable indicators.
+///
+/// This utility class contains common physics calculations used by widgets
+/// with draggable indicators.
+///
+/// Key features:
+/// - Rubber band resistance for iOS-style overdrag
+/// - Jelly physics for organic squash and stretch animations
+/// - Alignment calculations for indicator positioning
+/// - Velocity-based snapping for natural gesture handling
+class DraggableIndicatorPhysics {
+  DraggableIndicatorPhysics._();
+
+  // ===========================================================================
+  // Rubber Band Physics
+  // ===========================================================================
+
+  /// Applies iOS-style rubber band resistance when dragging beyond edges.
+  ///
+  /// Values outside the 0-1 range are compressed with decreasing resistance,
+  /// creating a "pulling against rubber band" feel.
+  ///
+  /// Parameters:
+  /// - [value]: The normalized drag position (typically 0-1, but can exceed)
+  /// - [resistance]: Lower values = more resistance (default: 0.4)
+  /// - [maxOverdrag]: Maximum overdrag as fraction of range (default: 0.3)
+  ///
+  /// Returns: Adjusted value with rubber band resistance applied.
+  ///
+  /// Example:
+  /// ```dart
+  /// final adjusted = DraggableIndicatorPhysics.applyRubberBandResistance(1.5);
+  /// // Returns approximately 1.2 instead of 1.5
+  /// ```
+  static double applyRubberBandResistance(
+    double value, {
+    double resistance = 0.4,
+    double maxOverdrag = 0.3,
+  }) {
+    if (value < 0) {
+      // Overdrag to the left
+      final overdrag = -value;
+      final resistedOverdrag = overdrag * resistance;
+      return -resistedOverdrag.clamp(0.0, maxOverdrag);
+    } else if (value > 1) {
+      // Overdrag to the right
+      final overdrag = value - 1;
+      final resistedOverdrag = overdrag * resistance;
+      return 1 + resistedOverdrag.clamp(0.0, maxOverdrag);
+    }
+
+    // Normal range, no resistance
+    return value;
+  }
+
+  // ===========================================================================
+  // Jelly Physics Transform
+  // ===========================================================================
+
+  /// Creates a jelly transform matrix based on velocity.
+  ///
+  /// Applies organic squash and stretch effects that create a satisfying
+  /// "jelly" animation:
+  /// - Squashes in the direction of movement
+  /// - Stretches perpendicular to movement
+  /// - Intensity scales with velocity magnitude
+  ///
+  /// This creates the iOS-style elastic effect seen when dragging indicators.
+  ///
+  /// Parameters:
+  /// - [velocity]: Direction and speed of movement as an Offset
+  /// - [maxDistortion]: Maximum distortion factor 0-1 (default: 0.7)
+  /// - [velocityScale]: Scale factor for velocity; higher = less
+  ///   distortion (default: 1000.0)
+  ///
+  /// Returns: A [Matrix4] transform that can be applied to a widget.
+  ///
+  /// Example:
+  /// ```dart
+  /// Transform(
+  ///   alignment: Alignment.center,
+  ///   transform: DraggableIndicatorPhysics.buildJellyTransform(
+  ///     velocity: Offset(velocityX, 0),
+  ///     maxDistortion: 0.8,
+  ///     velocityScale: 10,
+  ///   ),
+  ///   child: indicator,
+  /// )
+  /// ```
+  static Matrix4 buildJellyTransform({
+    required Offset velocity,
+    double maxDistortion = 0.7,
+    double velocityScale = 1000.0,
+  }) {
+    final speed = velocity.distance;
+    if (speed == 0 || !speed.isFinite) {
+      // speed == 0: no movement, avoid division by zero.
+      // !isFinite: NaN or Infinity from synthetic/custom velocity — fall back
+      // to a neutral transform. Keep a sub-pixel translation so the
+      // TransformLayer stays mounted and avoids edge-snapping artifacts.
+      return Matrix4.identity()..translate(0.0001, 0.0);
+    }
+
+    // Normalize velocity direction
+    final direction = velocity / speed;
+
+    // Calculate distortion intensity based on speed
+    final distortionFactor =
+        (speed / velocityScale).clamp(0.0, 1.0) * maxDistortion;
+
+    // Squash in direction of movement
+    final squashX = 1.0 - (direction.dx.abs() * distortionFactor * 0.5);
+    final squashY = 1.0 - (direction.dy.abs() * distortionFactor * 0.5);
+
+    // Stretch perpendicular to movement
+    final stretchX = 1.0 + (direction.dy.abs() * distortionFactor * 0.3);
+    final stretchY = 1.0 + (direction.dx.abs() * distortionFactor * 0.3);
+
+    // Combine effects
+    final scaleX = squashX * stretchX;
+    final scaleY = squashY * stretchY;
+
+    final matrix = Matrix4.identity()..scale(scaleX, scaleY);
+    if (matrix.isIdentity()) {
+      // Catch floating-point rounding rendering drops when speed is > 0 but microscopic
+      matrix.translate(0.0001, 0.0);
+    }
+    return matrix;
+  }
+
+  // ===========================================================================
+  // Alignment Calculations
+  // ===========================================================================
+
+  /// Converts an item index to horizontal alignment (-1 to 1).
+  ///
+  /// Used to position the indicator at the correct location for a given item.
+  ///
+  /// Parameters:
+  /// - [index]: The item index (0-based)
+  /// - [itemCount]: Total number of items
+  ///
+  /// Returns: Alignment value from -1 (leftmost) to 1 (rightmost).
+  ///
+  /// Example:
+  /// ```dart
+  /// // For 3 items (indices 0, 1, 2):
+  /// computeAlignment(0, 3) // Returns -1.0 (left)
+  /// computeAlignment(1, 3) // Returns  0.0 (center)
+  /// computeAlignment(2, 3) // Returns  1.0 (right)
+  /// ```
+  static double computeAlignment(int index, int itemCount) {
+    final relativeIndex = (index / (itemCount - 1)).clamp(0.0, 1.0);
+    return (relativeIndex * 2) - 1;
+  }
+
+  /// Converts a global drag position to horizontal alignment (-1 to 1).
+  ///
+  /// Applies rubber band resistance when dragging beyond edges.
+  ///
+  /// Parameters:
+  /// - [globalPosition]: The global position from drag details
+  /// - [context]: Build context to find the render box
+  /// - [itemCount]: Total number of items
+  ///
+  /// Returns: Alignment value with rubber band resistance applied.
+  static double getAlignmentFromGlobalPosition(
+    Offset globalPosition,
+    BuildContext context,
+    int itemCount,
+  ) {
+    final box = context.findRenderObject()! as RenderBox;
+    final localPosition = box.globalToLocal(globalPosition);
+
+    // Calculate the effective draggable range
+    final indicatorWidth = 1.0 / itemCount;
+    final draggableRange = 1.0 - indicatorWidth;
+    final padding = indicatorWidth / 2;
+
+    // Map drag position to 0-1 range
+    final rawRelativeX = (localPosition.dx / box.size.width).clamp(0.0, 1.0);
+    final normalizedX = (rawRelativeX - padding) / draggableRange;
+
+    // Apply rubber band resistance for overdrag
+    final adjustedRelativeX = applyRubberBandResistance(normalizedX);
+
+    // Convert to -1 to 1 range
+    return (adjustedRelativeX * 2) - 1;
+  }
+
+  // ===========================================================================
+  // Velocity-Based Snapping
+  // ===========================================================================
+
+  /// Computes the target item index based on drag position and velocity.
+  ///
+  /// Uses velocity-based snapping for iOS-style flick gestures:
+  /// - High velocity: Project forward and snap to the projected item
+  /// - Low velocity: Snap to nearest item
+  ///
+  /// This creates the satisfying "flick to jump" behavior seen in iOS.
+  ///
+  /// Parameters:
+  /// - [currentRelativeX]: Current position in 0-1 range
+  /// - [velocityX]: Horizontal velocity in relative units
+  /// - [itemWidth]: Width of each item as a fraction (1 / itemCount)
+  /// - [itemCount]: Total number of items
+  /// - [velocityThreshold]: Velocity threshold for flick detection
+  ///   (default: 0.5)
+  /// - [projectionTime]: Time to project velocity forward in seconds
+  ///   (default: 0.3)
+  ///
+  /// Returns: The target item index (0-based).
+  ///
+  /// Example:
+  /// ```dart
+  /// final targetIndex = DraggableIndicatorPhysics.computeTargetIndex(
+  ///   currentRelativeX: 0.4,
+  ///   velocityX: 2.0, // Fast swipe right
+  ///   itemWidth: 1.0 / 3,
+  ///   itemCount: 3,
+  /// );
+  /// // Returns 2 (jumped to last item due to high velocity)
+  /// ```
+  static int computeTargetIndex({
+    required double currentRelativeX,
+    required double velocityX,
+    required double itemWidth,
+    required int itemCount,
+    double velocityThreshold = 0.5,
+    double projectionTime = 0.3,
+  }) {
+    // Handle overdrag scenarios
+    if (currentRelativeX < 0) return 0;
+    if (currentRelativeX > 1) return itemCount - 1;
+
+    // Guard against NaN / Infinity from synthetic or injected velocity values.
+    // Fall through to nearest-item snap rather than projecting an invalid position.
+    final safeVelocityX = velocityX.isFinite ? velocityX : 0.0;
+
+    if (safeVelocityX.abs() > velocityThreshold) {
+      // High velocity - project where we would end up
+      final projectedX =
+          (currentRelativeX + safeVelocityX * projectionTime).clamp(0.0, 1.0);
+      var targetIndex =
+          (projectedX / itemWidth).round().clamp(0, itemCount - 1);
+
+      // Ensure we move at least one item with strong velocity
+      final currentIndex =
+          (currentRelativeX / itemWidth).round().clamp(0, itemCount - 1);
+
+      if (safeVelocityX > velocityThreshold &&
+          targetIndex <= currentIndex &&
+          currentIndex < itemCount - 1) {
+        targetIndex = currentIndex + 1;
+      } else if (safeVelocityX < -velocityThreshold &&
+          targetIndex >= currentIndex &&
+          currentIndex > 0) {
+        targetIndex = currentIndex - 1;
+      }
+
+      return targetIndex;
+    }
+
+    // Low velocity - snap to nearest
+    return (currentRelativeX / itemWidth).round().clamp(0, itemCount - 1);
+  }
+}

--- a/packages/liquid_glass_widgets/lib/utils/glass_brightness.dart
+++ b/packages/liquid_glass_widgets/lib/utils/glass_brightness.dart
@@ -1,0 +1,50 @@
+// Package-private brightness resolution utility.
+//
+// NOT part of the public API — do not export from liquid_glass_widgets.dart.
+library;
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// Resolves the effective brightness for glass widgets using a priority cascade:
+///
+/// 1. **Explicit [CupertinoThemeData.brightness]** — a developer-pinned
+///    brightness on the Cupertino theme. Non-null means intentional.
+/// 2. **Material [Theme] brightness** — honours [ThemeMode.light],
+///    [ThemeMode.dark], and [ThemeMode.system] via [Theme.maybeBrightnessOf].
+///    Returns null if no Material ancestor exists (e.g. pure CupertinoApp),
+///    so this level is a safe no-op in pure-Cupertino apps.
+/// 3. **[MediaQuery.platformBrightnessOf]** — the device/OS system setting.
+///    This is the historical default and the safe fallback.
+///
+/// Level 4 (the [GlassThemeData.brightness] explicit glass-theme override) is
+/// checked by [GlassTheme.brightnessOf] **before** calling this function, so
+/// that this function remains free of glass-package imports (avoiding circular
+/// dependencies in the theme hierarchy).
+///
+/// **Never call this function directly from widgets.** Always use
+/// [GlassTheme.brightnessOf] so the glass-theme override at level 4 is
+/// correctly honoured.
+Brightness resolveGlassBrightness(BuildContext context) {
+  // Level 1: explicit Cupertino brightness pin.
+  //
+  // CupertinoTheme.of(context).brightness returns null when the developer has
+  // not explicitly set brightness in CupertinoThemeData. Only use it when it
+  // is non-null, i.e. when the intent is explicit.
+  final cupertinoBrightness = CupertinoTheme.of(context).brightness;
+  if (cupertinoBrightness != null) return cupertinoBrightness;
+
+  // Level 2: Material ThemeMode.
+  //
+  // Theme.maybeBrightnessOf returns null if no Material ancestor exists
+  // (e.g. pure CupertinoApp). It correctly resolves ThemeMode: returns
+  // Brightness.light for ThemeMode.light, Brightness.dark for ThemeMode.dark,
+  // and follows the platform setting for ThemeMode.system.
+  final materialBrightness = Theme.maybeBrightnessOf(context);
+  if (materialBrightness != null) return materialBrightness;
+
+  // Level 3: device/OS system brightness.
+  //
+  // This is the safe fallback and the historical behaviour before this fix.
+  return MediaQuery.platformBrightnessOf(context);
+}

--- a/packages/liquid_glass_widgets/lib/utils/glass_morph_controller.dart
+++ b/packages/liquid_glass_widgets/lib/utils/glass_morph_controller.dart
@@ -1,0 +1,321 @@
+import 'package:flutter/animation.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/physics.dart';
+
+import 'liquid_morph_physics.dart';
+
+export 'liquid_morph_physics.dart' show LiquidMorphState, MorphPhase;
+
+/// Controls the speed profile of a liquid glass morph animation.
+///
+/// Each case maps to a tuned spring description that preserves the 0.73
+/// underdamped ratio — so the rubber-band closing bounce is present at every
+/// speed, just scaled proportionally.
+enum MorphSpeed {
+  /// Slow, deliberate morph. Suitable for tutorials or accessibility contexts.
+  slow,
+
+  /// Default iOS 26 speed with native-parity spring response (375 ms profile).
+  normal,
+
+  /// Fast, snappy morph. Suitable for power users or high-frequency interactions.
+  fast,
+
+  /// Near-instant transition. Use for [ReducedMotion] environments or testing.
+  instant,
+}
+
+/// Describes the visual shape style of the liquid glass morph transition.
+///
+/// Additional styles (e.g. [bloom]) are planned for future releases and will
+/// be powered by the same [LiquidMorphPhysics] engine with a different curve
+/// profile.
+enum MorphStyle {
+  /// Classic iOS 26 liquid teardrop — Blob B pulls away from Blob A along a
+  /// J-curve trajectory while the SDF metaball shader creates the bridging neck.
+  teardrop,
+
+  /// Radial bloom expansion originating from the trigger center outward.
+  ///
+  /// Intended for long-press / force-touch context menus (future release).
+  bloom,
+}
+
+/// A Flutter-idiomatic controller for liquid glass morph animations.
+///
+/// Works like [AnimationController] but encapsulates the iOS 26 spring physics,
+/// J-curve interpolation, and [LiquidMorphState] computation behind a clean,
+/// semantic API.
+///
+/// ## Lifecycle
+///
+/// [GlassMorphController] must be created inside a [State] that mixes in
+/// [TickerProviderStateMixin] and disposed in [State.dispose].
+///
+/// ```dart
+/// class _MyWidgetState extends State<MyWidget> with TickerProviderStateMixin {
+///   late final GlassMorphController _morph;
+///
+///   @override
+///   void initState() {
+///     super.initState();
+///     _morph = GlassMorphController(vsync: this);
+///     _morph.addListener(_onFrame);
+///   }
+///
+///   @override
+///   void dispose() {
+///     _morph.dispose();
+///     super.dispose();
+///   }
+///
+///   void _open()  => _morph.open();
+///   void _close() => _morph.close();
+///
+///   void _onFrame() {
+///     if (!mounted) return;
+///     setState(() {});
+///   }
+/// }
+/// ```
+///
+/// ## Computing render state
+///
+/// ```dart
+/// final state = _morph.computeState(
+///   finalDx: finalDx,
+///   finalDy: finalDy,
+///   horizontalOffset: _horizontalOffset,
+///   verticalOffset: _verticalOffset,
+/// );
+///
+/// // Use state.pathT, state.anchorScale, state.blend, etc. in your layout.
+/// ```
+///
+/// ## Customisation
+///
+/// Use [speed] and [style] for safe, semantic control. Avoid constructing
+/// [LiquidMorphPhysics] manually with custom spring constants — the physics
+/// parameters are interdependent and incorrect values produce unstable
+/// animations.
+class GlassMorphController extends ChangeNotifier {
+  /// Creates a [GlassMorphController].
+  ///
+  /// [vsync] must be a valid [TickerProvider], typically obtained from
+  /// [TickerProviderStateMixin].
+  GlassMorphController({
+    required TickerProvider vsync,
+    this.speed = MorphSpeed.normal,
+    this.style = MorphStyle.teardrop,
+  }) : _animationController = AnimationController.unbounded(vsync: vsync) {
+    _animationController.addListener(_onTick);
+    _animationController.addStatusListener(_onStatusChange);
+  }
+
+  // ─── Public parameters ────────────────────────────────────────────────────
+
+  /// Speed profile for the morph animation.
+  ///
+  /// Maps to a tuned spring description that preserves the 0.73 underdamped
+  /// ratio. Change this to control the overall feel without touching raw
+  /// spring constants.
+  final MorphSpeed speed;
+
+  /// Visual shape style of the morph transition.
+  ///
+  /// Currently only [MorphStyle.teardrop] is fully implemented.
+  final MorphStyle style;
+
+  // ─── Internal state ───────────────────────────────────────────────────────
+
+  final AnimationController _animationController;
+  bool _isClosing = false;
+  bool _hasHandedOff = false;
+
+  /// Whether the reduced-motion accessibility flag is currently active.
+  ///
+  /// When `true`, [_effectiveSpring] returns the [MorphSpeed.instant] spring
+  /// regardless of the [speed] parameter, producing a near-instant transition
+  /// that respects the platform accessibility setting.
+  ///
+  /// Set this from `didChangeDependencies()` in your widget using
+  /// `MediaQuery.of(context).disableAnimations`.
+  bool _disableAnimations = false;
+
+  // ─── Public accessors ─────────────────────────────────────────────────────
+
+  /// The raw, unclamped spring simulation value.
+  ///
+  /// Mirrors [AnimationController.value]. Can legitimately exceed `[0, 1]`
+  /// during underdamped overshoot phases.
+  double get value => _animationController.value;
+
+  /// Instantaneous velocity of the spring simulation.
+  double get velocity => _animationController.velocity;
+
+  /// Current [AnimationStatus] of the underlying controller.
+  AnimationStatus get status => _animationController.status;
+
+  /// The underlying [AnimationController] for callers that need to listen to
+  /// [AnimationStatus] changes or drive additional [Animation]s from it.
+  AnimationController get animation => _animationController;
+
+  /// Whether the morph overlay should currently be visible.
+  ///
+  /// `true` from the moment [open] is called until the spring has fully
+  /// settled back at `0.0` after [close].
+  bool get isShowing =>
+      _animationController.value > 0.001 || (_isClosing && !_hasSettled);
+
+  /// Whether the controller is in the closing phase.
+  bool get isClosing => _isClosing;
+
+  /// Whether the anchor blob has handed off back to the real trigger.
+  ///
+  /// Latches `true` on the first zero-crossing during close, remaining `true`
+  /// until the next [open] call. Use this to swap the ghost overlay for the
+  /// real trigger widget at the exact right moment.
+  bool get hasHandedOff => _hasHandedOff;
+
+  // ─── Accessibility ────────────────────────────────────────────────────────
+
+  /// Updates the reduced-motion override.
+  ///
+  /// Call this from `State.didChangeDependencies()` to automatically respect
+  /// the platform accessibility setting:
+  ///
+  /// ```dart
+  /// @override
+  /// void didChangeDependencies() {
+  ///   super.didChangeDependencies();
+  ///   _morph.setDisableAnimations(
+  ///     MediaQuery.of(context).disableAnimations,
+  ///   );
+  /// }
+  /// ```
+  ///
+  /// When [disableAnimations] is `true`, both [open] and [close] use the
+  /// [MorphSpeed.instant] spring profile — the overlay appears and disappears
+  /// in a single frame with no bouncing. This satisfies iOS and Android
+  /// "Reduce Motion" / "Remove Animations" accessibility requirements.
+  void setDisableAnimations(bool disableAnimations) {
+    if (_disableAnimations == disableAnimations) return;
+    _disableAnimations = disableAnimations;
+  }
+
+  /// Whether reduced-motion override is currently active.
+  bool get disableAnimations => _disableAnimations;
+
+  /// Opens the morph animation from the current position.
+  ///
+  /// Resets the handoff latch and runs the spring toward `1.0` from rest.
+  /// Safe to call while the close animation is still running.
+  void open() {
+    _isClosing = false;
+    _hasHandedOff = false;
+    _runSpring(1.0, velocityHint: 0.0);
+  }
+
+  /// Closes the morph animation with the iOS 26 rubber-band bounce.
+  ///
+  /// Injects [LiquidMorphPhysics.closeVelocityHint] to immediately drive the
+  /// spring toward zero with momentum, creating the satisfying "snap-back" feel.
+  void close() {
+    _isClosing = true;
+    _runSpring(0.0, velocityHint: LiquidMorphPhysics.closeVelocityHint);
+  }
+
+  // ─── Physics computation ──────────────────────────────────────────────────
+
+  /// Computes the current [LiquidMorphState] for the given layout geometry.
+  ///
+  /// Call this once per frame from your [AnimatedBuilder] or [addListener]
+  /// callback to get pre-calculated render values.
+  ///
+  /// - [finalDx] / [finalDy] — target displacement from trigger center to
+  ///   menu center, in logical pixels.
+  /// - [horizontalOffset] / [verticalOffset] — screen-edge clamping
+  ///   corrections from the menu positioning logic.
+  LiquidMorphState computeState({
+    required double finalDx,
+    required double finalDy,
+    double horizontalOffset = 0.0,
+    double verticalOffset = 0.0,
+  }) {
+    return LiquidMorphPhysics.compute(
+      rawValue: _animationController.value,
+      finalDx: finalDx,
+      finalDy: finalDy,
+      horizontalOffset: horizontalOffset,
+      verticalOffset: verticalOffset,
+    );
+  }
+
+  // ─── Lifecycle ────────────────────────────────────────────────────────────
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  // ─── Private ──────────────────────────────────────────────────────────────
+
+  bool get _hasSettled =>
+      _animationController.value <= 0.001 &&
+      _animationController.velocity.abs() < 0.5;
+
+  /// Returns the spring description for the current [speed].
+  ///
+  /// All springs share the 0.73 underdamped ratio
+  /// (ζ = damping / (2 × √(stiffness × mass))).
+  SpringDescription get _effectiveSpring {
+    // Reduced-motion override: always use the instant (stiffest) spring so the
+    // animation completes in a single frame — no bounce, no teardrop neck.
+    if (_disableAnimations) {
+      return const SpringDescription(
+          mass: 1.0, stiffness: 500.0, damping: 32.4);
+    }
+    switch (speed) {
+      case MorphSpeed.slow:
+        // ω₀ ≈ 7.7 rad/s, ζ ≈ 0.73
+        return const SpringDescription(
+            mass: 1.0, stiffness: 60.0, damping: 11.3);
+      case MorphSpeed.normal:
+        // ω₀ ≈ 11 rad/s, ζ ≈ 0.73 — iOS 26 native parity
+        return LiquidMorphPhysics.openSpring;
+      case MorphSpeed.fast:
+        // ω₀ ≈ 14 rad/s, ζ ≈ 0.73
+        return const SpringDescription(
+            mass: 1.0, stiffness: 200.0, damping: 20.5);
+      case MorphSpeed.instant:
+        // ω₀ ≈ 22 rad/s, ζ ≈ 0.73 — very stiff, near-instant
+        return const SpringDescription(
+            mass: 1.0, stiffness: 500.0, damping: 32.4);
+    }
+  }
+
+  void _runSpring(double target, {required double velocityHint}) {
+    final sim = SpringSimulation(
+      _effectiveSpring,
+      _animationController.value,
+      target,
+      velocityHint,
+    );
+    _animationController.animateWith(sim);
+  }
+
+  void _onTick() {
+    // Handoff latch: fires exactly once when the spring first crosses zero
+    // during a close animation. The latch prevents it from re-triggering if
+    // the underdamped spring bounces back above zero briefly.
+    if (_isClosing && _animationController.value <= 0.0 && !_hasHandedOff) {
+      _hasHandedOff = true;
+    }
+    notifyListeners();
+  }
+
+  void _onStatusChange(AnimationStatus status) {
+    notifyListeners();
+  }
+}

--- a/packages/liquid_glass_widgets/lib/utils/glass_performance_monitor.dart
+++ b/packages/liquid_glass_widgets/lib/utils/glass_performance_monitor.dart
@@ -1,0 +1,257 @@
+/// Glass Performance Monitor
+///
+/// A debug/profile-only tool that watches raster frame durations while
+/// [GlassQuality.premium] surfaces are active, emitting a single actionable
+/// [FlutterError] warning when the GPU budget is consistently exceeded.
+///
+/// ## Zero production overhead
+///
+/// The monitor never registers with [SchedulerBinding] in release builds.
+/// The [kReleaseMode] guard at [start] means no callbacks, no ring-buffer
+/// allocations, and no CPU cycles in shipped apps.
+///
+/// ## Usage
+///
+/// Enabled automatically when you pass `enablePerformanceMonitor: true`
+/// to [LiquidGlassWidgets.initialize] (which is the default in non-release
+/// builds). You can also control it manually:
+///
+/// ```dart
+/// GlassPerformanceMonitor.start();   // begin monitoring
+/// GlassPerformanceMonitor.stop();    // stop and reset
+/// GlassPerformanceMonitor.reset();   // clear warning latch, keep running
+/// ```
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+
+/// Monitors raster frame durations and emits a developer warning when
+/// [GlassQuality.premium] surfaces are active and GPU budget is exceeded.
+///
+/// This class is entirely static — it acts as a process-wide singleton so
+/// that multiple glass widgets share one callback and one ring buffer.
+class GlassPerformanceMonitor {
+  GlassPerformanceMonitor._();
+
+  // ── Configuration ──────────────────────────────────────────────────────────
+
+  /// Number of consecutive frames that must exceed [rasterBudget] before the
+  /// warning fires. Reduces false positives caused by animation spikes.
+  ///
+  /// Defaults to 60 (≈ 1 second at 60 fps).
+  static int sustainedFrameThreshold = 60;
+
+  /// Raster duration budget per frame. Frames that exceed this value count
+  /// toward [sustainedFrameThreshold].
+  ///
+  /// Defaults to 16 ms (60 fps budget). On 120 Hz ProMotion displays you
+  /// may wish to lower this to `Duration(microseconds: 8333)`.
+  static Duration rasterBudget = const Duration(milliseconds: 16);
+
+  // ── Internal state ─────────────────────────────────────────────────────────
+
+  static bool _running = false;
+  static bool _warningEmitted = false;
+
+  /// Number of frames in a row that exceeded [rasterBudget] while at least
+  /// one premium widget was active.
+  static int _consecutiveOverBudget = 0;
+
+  /// Number of [GlassQuality.premium] surfaces currently mounted.
+  ///
+  /// Incremented by [trackPremiumMount], decremented by [trackPremiumUnmount].
+  /// The monitor stays silent when this is zero — avoiding false positives
+  /// caused by other parts of the app being slow.
+  static int _premiumCount = 0;
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /// Whether the monitor is currently active.
+  static bool get isRunning => _running;
+
+  /// Whether the performance warning has already been emitted this session.
+  static bool get warningEmitted => _warningEmitted;
+
+  /// Number of premium glass surfaces currently mounted.
+  static int get activePremiumCount => _premiumCount;
+
+  /// Starts the monitor.
+  ///
+  /// No-op in release builds ([kReleaseMode] guard). Safe to call multiple
+  /// times — subsequent calls are ignored if already running.
+  static void start() {
+    if (kReleaseMode || _running) return;
+    _running = true;
+    _consecutiveOverBudget = 0;
+    SchedulerBinding.instance.addTimingsCallback(_onFrameTimings);
+    if (kDebugMode) {
+      debugPrint('[LiquidGlass] PerformanceMonitor started '
+          '(budget: ${rasterBudget.inMilliseconds} ms, '
+          'threshold: $sustainedFrameThreshold frames)');
+    }
+  }
+
+  /// Stops the monitor and detaches the frame callback.
+  ///
+  /// The warning-emitted latch is preserved so the warning does not repeat
+  /// if the monitor is restarted. Call [reset] to clear it.
+  static void stop() {
+    if (!_running) return;
+    _running = false;
+    SchedulerBinding.instance.removeTimingsCallback(_onFrameTimings);
+  }
+
+  /// Resets the consecutive-frame counter and the warning latch.
+  ///
+  /// Useful in tests or if you want to re-enable the warning after it fired.
+  static void reset() {
+    _consecutiveOverBudget = 0;
+    _warningEmitted = false;
+    _premiumCount = 0;
+  }
+
+  /// Injects synthetic [FrameTiming] data directly into [_onFrameTimings].
+  ///
+  /// **For testing only.** Allows unit tests to exercise the budget-exceeded
+  /// and warning-emitted paths without requiring a real GPU raster loop.
+  ///
+  /// ```dart
+  /// GlassPerformanceMonitor.trackPremiumMount();
+  /// GlassPerformanceMonitor.sustainedFrameThreshold = 1;
+  /// GlassPerformanceMonitor.simulateFrameTimings([
+  ///   FrameTiming(rasterFinish: 100000 /* 100 ms */),
+  /// ]);
+  /// expect(GlassPerformanceMonitor.warningEmitted, isTrue);
+  /// ```
+  @visibleForTesting
+  static void simulateFrameTimings(List<FrameTiming> timings) {
+    _onFrameTimings(timings);
+  }
+
+  // ── Widget integration ─────────────────────────────────────────────────────
+
+  /// Called by [_PremiumGlassTracker] when a premium glass surface mounts.
+  ///
+  /// Internal — do not call directly.
+  @visibleForTesting
+  static void trackPremiumMount() {
+    if (kReleaseMode) return;
+    _premiumCount++;
+  }
+
+  /// Called by [_PremiumGlassTracker] when a premium glass surface unmounts.
+  ///
+  /// Internal — do not call directly.
+  @visibleForTesting
+  static void trackPremiumUnmount() {
+    if (kReleaseMode) return;
+    _premiumCount = (_premiumCount - 1).clamp(0, 999);
+  }
+
+  // ── Frame callback ─────────────────────────────────────────────────────────
+
+  static void _onFrameTimings(List<FrameTiming> timings) {
+    // Silent when no premium surfaces are active — avoids blaming glass for
+    // slowdowns caused by other parts of the app.
+    if (_premiumCount == 0 || _warningEmitted) return;
+
+    for (final timing in timings) {
+      if (timing.rasterDuration > rasterBudget) {
+        _consecutiveOverBudget++;
+      } else {
+        // Reset on any frame that comes in under budget — we only want to
+        // warn about *sustained* slowdowns, not transient animation spikes.
+        _consecutiveOverBudget = 0;
+      }
+
+      if (_consecutiveOverBudget >= sustainedFrameThreshold) {
+        _emitWarning(timing.rasterDuration);
+        return; // warning emitted, callback stays registered but is silenced
+      }
+    }
+  }
+
+  static void _emitWarning(Duration avgRaster) {
+    _warningEmitted = true;
+    final ms = (avgRaster.inMicroseconds / 1000).toStringAsFixed(1);
+
+    FlutterError.reportError(
+      FlutterErrorDetails(
+        exception:
+            Exception('GlassQuality.premium performance budget exceeded'),
+        library: 'liquid_glass_widgets',
+        context: ErrorDescription(
+          'sustained raster frames > ${rasterBudget.inMilliseconds} ms '
+          'while $_premiumCount premium glass surface(s) are active',
+        ),
+        informationCollector: () => [
+          DiagnosticsNode.message(
+            '\n'
+            '════════ [LiquidGlass] Performance Warning ════════════════════\n'
+            'GlassQuality.premium is sustaining raster frames over budget.\n'
+            '\n'
+            '  Measured raster duration  : $ms ms\n'
+            '  Budget                    : ${rasterBudget.inMilliseconds} ms '
+            '(${rasterBudget.inMilliseconds > 0 ? (1000 / rasterBudget.inMilliseconds).round() : 'N/A'} fps)\n'
+            '  Active premium surfaces   : $_premiumCount\n'
+            '  Consecutive over-budget   : $_consecutiveOverBudget frames\n'
+            '\n'
+            'This is consistent with pre-A15 GPU constraints (iPhone 12 and\n'
+            'older, Pixel 5 and older). GlassQuality.premium targets A15 /\n'
+            'iPhone 13+ for animated surfaces.\n'
+            '\n'
+            'Recommended fixes:\n'
+            '  1. Use quality: GlassQuality.standard on this widget\n'
+            '     → Lightweight shader, no texture capture, runs on any device\n'
+            '  2. Use quality: GlassQuality.minimal for a shader-free fallback\n'
+            '     → BackdropFilter only, zero custom shader cost\n'
+            '  3. Set GlassThemeVariant(quality: GlassQuality.standard) globally\n'
+            '     → All widgets default to standard unless explicitly overridden\n'
+            '  4. On GlassBottomBar: maskingQuality: MaskingQuality.off\n'
+            '     → Disables dual-layer rendering (biggest single win on old GPUs)\n'
+            '\n'
+            'This warning only appears in debug/profile builds.\n'
+            'To disable: LiquidGlassWidgets.initialize(enablePerformanceMonitor: false)\n'
+            'To adjust threshold: GlassPerformanceMonitor.rasterBudget = Duration(...)\n'
+            '═══════════════════════════════════════════════════════════════\n',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Minimal stateful widget that tracks one premium glass surface's
+/// lifecycle with [GlassPerformanceMonitor].
+///
+/// Wrap any widget subtree that uses the Impeller premium path with this
+/// to ensure the monitor's active-surface count stays accurate.
+class PremiumGlassTracker extends StatefulWidget {
+  /// Creates a tracker that notifies [GlassPerformanceMonitor] on mount/unmount.
+  const PremiumGlassTracker({required this.child, super.key});
+
+  /// The widget subtree to track.
+  final Widget child;
+
+  @override
+  State<PremiumGlassTracker> createState() => _PremiumGlassTrackerState();
+}
+
+class _PremiumGlassTrackerState extends State<PremiumGlassTracker> {
+  @override
+  void initState() {
+    super.initState();
+    GlassPerformanceMonitor.trackPremiumMount();
+  }
+
+  @override
+  void dispose() {
+    GlassPerformanceMonitor.trackPremiumUnmount();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/packages/liquid_glass_widgets/lib/utils/glass_quality_adapter.dart
+++ b/packages/liquid_glass_widgets/lib/utils/glass_quality_adapter.dart
@@ -1,0 +1,756 @@
+/// Glass Quality Adapter
+///
+/// A pure-Dart state machine that drives automatic `GlassQuality` adaptation
+/// based on real device raster performance. Contains all logic for the three
+/// phases of [GlassAdaptiveScope]:
+///
+///   **Phase 1 — Static probe** (~0 ms, at scope construction):
+///   - `ImageFilter.isShaderFilterSupported == false` → force `minimal`
+///   - `kIsWeb` → cap at `standard`
+///   - Otherwise → proceed to Phase 2
+///
+///   **Phase 2 — Warm-up benchmark** (first 180 measured frames ≈ 3 s at 60 fps):
+///   - Skips the first [GlassQualityAdapter.skipInitialFrames] frames (default
+///     60 ≈ 1 s) to let shader compilation and first-route transitions settle.
+///   - Collects `rasterDuration` via [SchedulerBinding.addTimingsCallback]
+///   - Computes the P75 raster time across the collected frames
+///   - P75 < 20 ms  → remain at [GlassQuality.premium]
+///   - P75 20–28 ms → step to [GlassQuality.standard]
+///   - P75 > 28 ms  → step to [GlassQuality.minimal]
+///   - Transitions to Phase 3 once `skipInitialFrames + warmupFrames` have been seen
+///
+///   **Phase 3 — Runtime hysteresis** (ongoing, very low overhead):
+///   - Maintains a rolling ring buffer of the last 120 raster durations
+///   - Degrades one tier when P95 > targetFrameMs × 1.5 for 2 consecutive
+///     sliding windows
+///   - Upgrades one tier when P95 < targetFrameMs × 0.6 for 10 consecutive
+///     sliding windows (only if [allowStepUp] is `true`)
+///   - Hard cooldown: minimum 8 seconds between any quality change
+///   - Degradation is 3× faster than recovery — jank is noticed immediately,
+///     but quality recovery must be invisible (slow and stable)
+///
+/// **This class is internal — do NOT export from the barrel file.**
+///
+/// All logic is pure Dart (no widgets, no [BuildContext]). The adapter is
+/// owned and started/stopped by [_GlassAdaptiveScopeState].
+///
+/// ```dart
+/// final adapter = GlassQualityAdapter(
+///   minQuality: GlassQuality.minimal,
+///   maxQuality: GlassQuality.premium,
+///   targetFrameMs: 16,
+///   allowStepUp: false,
+///   onQualityChanged: (from, to) { ... },
+/// );
+/// adapter.start(); // attaches SchedulerBinding callback
+/// adapter.reset(); // call on AppLifecycleState.resumed
+/// adapter.stop();  // detaches callback (dispose)
+/// ```
+library;
+
+import 'dart:collection';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
+
+import '../types/glass_quality.dart';
+import '../types/glass_quality_change_reason.dart';
+
+// ---------------------------------------------------------------------------
+// Enums and constants
+// ---------------------------------------------------------------------------
+
+/// Internal phase of the [GlassQualityAdapter] state machine.
+enum AdaptivePhase {
+  /// Checking static device capabilities at construction time.
+  probe,
+
+  /// Collecting raster timing data to estimate baseline device performance.
+  warmup,
+
+  /// Ongoing runtime monitoring with sliding-window hysteresis.
+  runtime,
+}
+
+// ---------------------------------------------------------------------------
+// GlassQualityAdapter
+// ---------------------------------------------------------------------------
+
+/// Pure-Dart state machine that automatically selects and adjusts
+/// [GlassQuality] based on observed raster frame performance.
+///
+/// **Usage** — see file-level documentation above.
+///
+/// **Testing** — inject synthetic timings via [simulateFrameTimings] without
+/// needing a real GPU raster loop:
+///
+/// ```dart
+/// adapter.start();
+/// adapter.simulateFrameTimings([
+///   FakeFrameTiming(rasterUs: 25000), // 25 ms → over budget
+/// ]);
+/// ```
+class GlassQualityAdapter {
+  /// Creates a [GlassQualityAdapter].
+  ///
+  /// [onQualityChanged] is called on the Dart main thread whenever the
+  /// effective quality changes. The callback receives `(from, to)`.
+  ///
+  /// [initialQuality] overrides both the session cache and Phase 2 — the
+  /// adapter skips the warm-up benchmark and jumps directly to Phase 3 using
+  /// the provided quality as its starting point. Use this to restore a quality
+  /// level previously persisted to storage (e.g. `SharedPreferences`) so
+  /// repeat launches skip the warm-up jank window entirely.
+  GlassQualityAdapter({
+    required this.minQuality,
+    required this.maxQuality,
+    required this.targetFrameMs,
+    required this.allowStepUp,
+    required void Function(GlassQuality from, GlassQuality to) onQualityChanged,
+    this.initialQuality,
+    this.warmupPremiumThresholdMs = 20.0,
+    this.warmupStandardThresholdMs = 28.0,
+    void Function(GlassQuality settled, double p75Ms, int frames)?
+        onWarmupComplete,
+  })  : _onQualityChanged = onQualityChanged,
+        _onWarmupComplete = onWarmupComplete,
+        _currentQuality = maxQuality;
+
+  // ── Configuration ──────────────────────────────────────────────────────────
+
+  /// The lowest quality tier the adapter may step down to.
+  final GlassQuality minQuality;
+
+  /// The highest quality tier the adapter may step up to.
+  final GlassQuality maxQuality;
+
+  /// The target frame duration in milliseconds (e.g. 16 for 60 Hz, 8 for
+  /// ProMotion / 120 Hz). Thresholds for degradation and upgrade are derived
+  /// from this value.
+  final int targetFrameMs;
+
+  /// When `true`, the adapter may step quality **up** after a sustained period
+  /// of good performance. When `false` (the default), only step-downs occur —
+  /// the starting quality from Phase 2 is the permanent ceiling for the
+  /// session (or until [reset] is called).
+  final bool allowStepUp;
+
+  /// The quality tier to start at, bypassing Phase 2 (the warm-up benchmark).
+  ///
+  /// When non-null, [start] skips the warm-up benchmark and jumps directly to
+  /// Phase 3 (runtime hysteresis) using this quality as the starting point.
+  ///
+  /// Two use cases:
+  /// - **Developer-provided persistence** — restore a quality previously saved
+  ///   to `SharedPreferences` so repeat launches skip warmup jank entirely.
+  /// - **In-session cache** — the static session cache is checked automatically
+  ///   if this field is null, so scopes remounted within the same app process
+  ///   skip Phase 2 without any extra code.
+  final GlassQuality? initialQuality;
+
+  /// The P75 warmup threshold (ms) **below which** the device is classified as
+  /// capable of [GlassQuality.premium].
+  ///
+  /// Defaults to `20.0`. This threshold is set slightly higher than the 16.0 ms
+  /// frame budget because Android GPU clock-scaling and JIT shader compilation
+  /// frequently inflate timings during the initial warm-up phase (Phase 2), even
+  /// on highly capable devices. Setting it to 20.0 ms avoids prematurely
+  /// penalizing capable mid-range devices.
+  ///
+  /// If a device actually struggles to maintain premium performance, Phase 3
+  /// runtime monitoring acts as a safety net and will step it down within ~4 s
+  /// (2 windows of jank).
+  ///
+  /// Values ≥ this threshold (and ≤ [warmupStandardThresholdMs]) result in
+  /// [GlassQuality.standard]; values above [warmupStandardThresholdMs] result
+  /// in [GlassQuality.minimal].
+  final double warmupPremiumThresholdMs;
+
+  /// The P75 warmup threshold (ms) **at or below which** the device is
+  /// classified as capable of [GlassQuality.standard] (when P75 ≥
+  /// [warmupPremiumThresholdMs]).
+  ///
+  /// Defaults to `28.0`. Devices with P75 above this value are classified as
+  /// [GlassQuality.minimal] (BackdropFilter-only, zero shader cost).
+  ///
+  /// Standard quality uses BackdropFilter blur without custom fragment shaders,
+  /// which is safe for mid-range devices. Minimal should be reserved for
+  /// genuinely incapable hardware (P75 > 28 ms). The production crashes
+  /// (Mali GPU / Impeller) are shader-related (premium path) — standard
+  /// quality does not trigger those code paths.
+  final double warmupStandardThresholdMs;
+
+  // ── Session cache ──────────────────────────────────────────────────────────
+
+  /// In-session cache of the quality tier settled by Phase 2.
+  ///
+  /// Written when Phase 2 completes. On the next [start] call (e.g. the scope
+  /// is disposed and remounted), the adapter skips Phase 2 and jumps directly
+  /// to Phase 3 using the cached quality — eliminating repeat warmup jank
+  /// within a single app process.
+  ///
+  /// Intentionally NOT persisted across cold starts. Developers who want
+  /// cross-launch persistence should use [initialQuality] with a storage
+  /// mechanism of their choice (e.g. `SharedPreferences`).
+  static GlassQuality? _sessionSettledQuality;
+
+  /// Clears the in-session quality cache.
+  ///
+  /// **For testing only.** Call between tests to prevent cache leakage across
+  /// test cases.
+  @visibleForTesting
+  static void clearSessionCache() => _sessionSettledQuality = null;
+
+  /// The currently cached quality for this session, or `null` if Phase 2 has
+  /// not yet completed on any adapter instance.
+  ///
+  /// Used by [_GlassAdaptiveScopeState] to seed its initial display quality so
+  /// the first rendered frame matches the adapter's starting point, avoiding a
+  /// one-frame flash from [maxQuality] to the cached lower value.
+  static GlassQuality? get sessionSettledQuality => _sessionSettledQuality;
+
+  /// Whether the adapter is using a previously settled quality (either from
+  /// [initialQuality] or [_sessionSettledQuality]) and has skipped Phase 2.
+  bool get usedCachedQuality => _usedCachedQuality;
+  bool _usedCachedQuality = false;
+
+  // ── Tunable constants (override in tests) ──────────────────────────────────
+
+  /// Frames to skip at the very start of Phase 2 before collecting warmup
+  /// data. This lets shader compilation, first-route transitions, and provider
+  /// initialisation settle so they don't pollute the warmup benchmark.
+  ///
+  /// Raised to 90 (≈ 1.5 s at 60 Hz) to give Android GPU clock-scaling and
+  /// shader-cache warm-up enough time to settle before benchmarking starts.
+  /// Community data (P75 ≈ 17–18 ms on capable mid-range Android devices)
+  /// showed that the original 60-frame skip was not long enough to clear
+  /// shader-compile inflation on the Android/Vulkan/Impeller path.
+  static int skipInitialFrames = 90;
+
+  /// Frames to collect in Phase 2 (warm-up) before making the initial quality
+  /// decision. Default: 180 ≈ 3 seconds at 60 Hz.
+  static int warmupFrames = 180;
+
+  /// Size of the rolling window used in Phase 3 for P95 calculation.
+  /// Default: 120 ≈ 2 seconds at 60 Hz.
+  static int windowSize = 120;
+
+  /// Number of consecutive over-budget windows that trigger a quality
+  /// step-down. Default: 2.
+  static int degradeWindowCount = 2;
+
+  /// Number of consecutive under-budget windows that trigger a quality
+  /// step-up (only when [allowStepUp] is `true`). Default: 10.
+  static int upgradeWindowCount = 10;
+
+  /// Minimum time between consecutive quality changes.
+  static Duration cooldownDuration = const Duration(seconds: 8);
+
+  /// When `true`, the static-probe step (Phase 1) is skipped and the adapter
+  /// proceeds directly to Phase 2 (warm-up) even on headless test VMs where
+  /// [ImageFilter.isShaderFilterSupported] returns `false`.
+  ///
+  /// **For testing only.** Set this before calling [start] in any test that
+  /// needs to exercise Phase 2 or Phase 3 logic.
+  @visibleForTesting
+  static bool skipStaticProbeForTesting = false;
+
+  // ── Phase 2 — warm-up ──────────────────────────────────────────────────────
+
+  final List<int> _warmupDurations = []; // raster durations in microseconds
+  int _skippedWarmupFrames = 0; // frames dropped during the startup-skip window
+
+  // ── Phase 3 — runtime ring buffer ─────────────────────────────────────────
+
+  // We use a fixed-capacity queue for O(1) append/evict.
+  final Queue<int> _window = Queue<int>();
+
+  // Pre-allocated sort buffer — avoids heap allocation on every window
+  // evaluation (every windowSize frames ≈ every 2 s). Filled from _window
+  // before sorting in-place. Cleared in reset().
+  List<int> _sortBuffer = [];
+
+  int _overBudgetWindowCount = 0;
+  int _underBudgetWindowCount = 0;
+  int _windowFrameCount = 0; // frames into the current evaluation window
+  DateTime? _lastChangeAt;
+
+  // ── Diagnostic tracking (set before every _applyQuality call) ───────────
+
+  /// The P75 raster time (ms) that informed the most recent Phase 2 decision.
+  /// `null` until warmup completes, or after a Phase 3 runtime change.
+  double? _lastP75Ms;
+
+  /// The P95 raster time (ms) from the most recent Phase 3 window evaluation.
+  /// `null` until Phase 3 fires its first quality change.
+  double? _lastP95Ms;
+
+  /// Cached P95 from the current/last window evaluation — used by step-down
+  /// and step-up helpers which don't have direct access to the ring buffer.
+  double? _lastComputedP95Ms;
+
+  /// Number of frames measured when the most recent quality decision was made.
+  int? _lastFramesMeasured;
+
+  /// The reason for the most recent quality change.
+  GlassQualityChangeReason _lastChangeReason =
+      GlassQualityChangeReason.staticProbe;
+
+  /// The P75 raster time (ms) from the most recent Phase 2 warmup decision.
+  double? get lastP75Ms => _lastP75Ms;
+
+  /// The P95 raster time (ms) from the most recent Phase 3 runtime decision.
+  double? get lastP95Ms => _lastP95Ms;
+
+  /// Frames measured when the most recent quality decision was made.
+  int? get lastFramesMeasured => _lastFramesMeasured;
+
+  /// The reason for the most recent quality change.
+  GlassQualityChangeReason get lastChangeReason => _lastChangeReason;
+
+  // ── State ──────────────────────────────────────────────────────────────────
+
+  AdaptivePhase _phase = AdaptivePhase.probe;
+  GlassQuality _currentQuality;
+  bool _running = false;
+  final void Function(GlassQuality from, GlassQuality to) _onQualityChanged;
+
+  /// Always called at the end of Phase 2, regardless of whether quality
+  /// changed. Receives the settled quality, P75 (ms), and frame count.
+  ///
+  /// Use this in [_GlassAdaptiveScopeState] to emit a diagnostic even on
+  /// fast devices that stay at [maxQuality] through warmup — those devices
+  /// never fire [_onQualityChanged], so their P75 would otherwise be invisible.
+  final void Function(GlassQuality settled, double p75Ms, int frames)?
+      _onWarmupComplete;
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /// The currently effective quality this adapter has decided on.
+  GlassQuality get currentQuality => _currentQuality;
+
+  /// The current internal phase (probe → warmup → runtime).
+  AdaptivePhase get phase => _phase;
+
+  /// Whether the adapter is currently collecting frame timings.
+  bool get isRunning => _running;
+
+  /// Starts the adapter.
+  ///
+  /// Runs Phase 1 (static probe) synchronously. If the probe does not force
+  /// a terminal quality, registers a [SchedulerBinding.addTimingsCallback]
+  /// and begins Phase 2 (warm-up).
+  ///
+  /// Safe to call multiple times — subsequent calls are no-ops if already
+  /// running.
+  void start() {
+    if (_running) return;
+
+    // Phase 1 — static probe
+    _phase = AdaptivePhase.probe;
+    if (!skipStaticProbeForTesting) {
+      final forced = _staticProbe();
+      if (forced != null) {
+        _lastChangeReason = GlassQualityChangeReason.staticProbe;
+        _lastP75Ms = null;
+        _lastP95Ms = null;
+        _lastFramesMeasured = 0;
+        // Respect minQuality even when the static probe forces a low quality.
+        // e.g. minQuality: GlassQuality.standard prevents fallback to minimal
+        // on devices where isShaderFilterSupported is a false negative.
+        _applyQuality(_floorQuality(forced, minQuality));
+        // No frame callback needed — static probe gives us a definitive answer.
+        return;
+      }
+    }
+
+    // Check for a usable cached quality — either developer-provided
+    // (initialQuality) or in-session cache (_sessionSettledQuality).
+    // Developer-provided takes priority over the session cache.
+    final cached = initialQuality ?? _sessionSettledQuality;
+    if (cached != null) {
+      // Apply the settled quality from the cache and skip Phase 2.
+      // Keep it within [minQuality, maxQuality] in case the config changed.
+      final clamped =
+          _floorQuality(_capQuality(maxQuality, cached), minQuality);
+      _lastChangeReason = GlassQualityChangeReason.restoredFromCache;
+      _lastP75Ms = null;
+      _lastP95Ms = null;
+      _lastFramesMeasured = 0;
+      _applyQuality(clamped);
+      _phase = AdaptivePhase.runtime;
+      _usedCachedQuality = true;
+      _running = true;
+      SchedulerBinding.instance.addTimingsCallback(_onFrameTimings);
+      return;
+    }
+
+    // Phase 2 — warm-up begins (no cache available)
+    _phase = AdaptivePhase.warmup;
+    _running = true;
+    SchedulerBinding.instance.addTimingsCallback(_onFrameTimings);
+  }
+
+  /// Stops the adapter and detaches its frame timing callback.
+  ///
+  /// Call in your widget's `dispose()` method.
+  void stop() {
+    if (!_running) return;
+    _running = false;
+    SchedulerBinding.instance.removeTimingsCallback(_onFrameTimings);
+  }
+
+  /// Resets the adapter to Phase 2 and clears all accumulated data.
+  ///
+  /// Call when the app resumes from background (thermal recovery). The warm-up
+  /// benchmark re-runs from scratch; the current quality is preserved until the
+  /// new benchmark completes, at which point it may change.
+  ///
+  /// If the adapter was stopped, this restarts it.
+  void reset() {
+    _warmupDurations.clear();
+    _window.clear();
+    _sortBuffer = [];
+    _overBudgetWindowCount = 0;
+    _underBudgetWindowCount = 0;
+    _windowFrameCount = 0;
+    _lastChangeAt = null;
+    _skippedWarmupFrames = 0; // restart the startup-skip window
+    _usedCachedQuality = false; // accurate: we are re-running Phase 2
+
+    if (_running) {
+      // Already running — just reset to warm-up phase without toggling callback.
+      _phase = AdaptivePhase.warmup;
+    } else {
+      // Not running (e.g. tests, or after a static-probe terminal result).
+      // Just reset the phase; start() may be called later by the widget.
+      _phase = AdaptivePhase.warmup;
+    }
+  }
+
+  /// Injects synthetic [FrameTiming] data directly into the phase handlers,
+  /// bypassing the [SchedulerBinding] listener registration.
+  ///
+  /// **For testing only.** Allows unit tests to exercise Phase 2 and Phase 3
+  /// logic without a real GPU raster loop or a widget binding.
+  ///
+  /// If the adapter is still in the [AdaptivePhase.probe] phase (i.e. [start]
+  /// was never called), this automatically advances to [AdaptivePhase.warmup]
+  /// before processing the timings.
+  ///
+  /// ```dart
+  /// final adapter = GlassQualityAdapter(...);
+  /// adapter.simulateFrameTimings(_frames(180, 15000)); // 15 ms → standard
+  /// expect(adapter.currentQuality, GlassQuality.standard);
+  /// ```
+  @visibleForTesting
+  void simulateFrameTimings(List<FrameTiming> timings) {
+    // Auto-advance out of probe so tests don't need to call start().
+    if (_phase == AdaptivePhase.probe) {
+      _phase = AdaptivePhase.warmup;
+    }
+    for (final timing in timings) {
+      final rasterUs = timing.rasterDuration.inMicroseconds;
+      if (_phase == AdaptivePhase.warmup) {
+        _processWarmupFrame(rasterUs);
+      } else if (_phase == AdaptivePhase.runtime) {
+        _processRuntimeFrame(rasterUs);
+      }
+    }
+  }
+
+  // ── Phase 1 — static probe ─────────────────────────────────────────────────
+
+  /// Returns a forced quality if the device can't support higher tiers, or
+  /// `null` if we should proceed to Phase 2.
+  GlassQuality? _staticProbe() {
+    // No custom shader support (e.g. software renderer, some broken Android
+    // drivers) — force minimal: BackdropFilter only, zero shader cost.
+    if (!ui.ImageFilter.isShaderFilterSupported) {
+      return GlassQuality.minimal;
+    }
+
+    // On web, the Impeller/premium path is unavailable. Cap at standard.
+    if (kIsWeb) {
+      final capped = _capQuality(maxQuality, GlassQuality.standard);
+      return capped == maxQuality ? null : capped;
+    }
+
+    return null; // No forced quality — proceed to warm-up.
+  }
+
+  // ── Phase 2 — warm-up ──────────────────────────────────────────────────────
+
+  void _processWarmupFrame(int rasterUs) {
+    // Drop the first `skipInitialFrames` frames so that shader compilation,
+    // first-route animation and provider/localisation initialisation noise does
+    // not pollute the warmup benchmark on otherwise capable devices.
+    if (_skippedWarmupFrames < skipInitialFrames) {
+      _skippedWarmupFrames++;
+      return;
+    }
+
+    _warmupDurations.add(rasterUs);
+
+    if (_warmupDurations.length < warmupFrames) return;
+
+    // Warm-up complete — compute P75 and decide initial quality.
+    final p75 = _percentile(_warmupDurations, 75);
+    final p75Ms = p75 / 1000.0;
+
+    final GlassQuality decided;
+    // Warmup thresholds are intentionally more lenient than the 60-fps frame
+    // budget (16 ms). Even after skipping the first 90 frames, Android GPU
+    // clock-scaling and JIT warm-up can inflate P75 by 4–6 ms on otherwise
+    // capable hardware — community data showed P75 ≈ 17–18 ms on mid-range
+    // Android devices that sustain full premium quality at steady state.
+    //
+    //   P75 < warmupPremiumThresholdMs  → premium
+    //   P75 ≤ warmupStandardThresholdMs → standard
+    //   P75 > warmupStandardThresholdMs → minimal
+    //
+    // Both thresholds are user-configurable via GlassAdaptiveScopeConfig so
+    // community members can experiment and report optimal values for their
+    // hardware.
+    //
+    // Phase 3 runtime hysteresis will still step down quickly (2 windows,
+    // ~4 s) if the device cannot actually sustain premium after warmup.
+    if (p75Ms < warmupPremiumThresholdMs) {
+      decided = _capQuality(maxQuality, maxQuality); // stay at ceiling
+    } else if (p75Ms <= warmupStandardThresholdMs) {
+      decided = _capQuality(maxQuality, GlassQuality.standard);
+    } else {
+      decided = _capQuality(maxQuality, GlassQuality.minimal);
+    }
+
+    // Ensure we never go below minQuality floor.
+    final effective = _floorQuality(decided, minQuality);
+
+    // Write to session cache so remounts within this app process skip Phase 2.
+    _sessionSettledQuality = effective;
+
+    // Record diagnostic data before applying quality.
+    _lastChangeReason = GlassQualityChangeReason.warmupComplete;
+    _lastP75Ms = p75Ms;
+    _lastP95Ms = null;
+    _lastFramesMeasured = _warmupDurations.length;
+
+    _applyQuality(effective);
+
+    // Transition to Phase 3.
+    _phase = AdaptivePhase.runtime;
+    _warmupDurations.clear();
+
+    // Always notify about warmup completion — even when quality didn't change.
+    // This lets the scope surface a diagnostic on fast devices that stay at
+    // maxQuality throughout Phase 2, where _onQualityChanged never fires.
+    _onWarmupComplete?.call(effective, p75Ms, _lastFramesMeasured!);
+  }
+
+  // ── Phase 3 — runtime hysteresis ──────────────────────────────────────────
+
+  void _processRuntimeFrame(int rasterUs) {
+    // Maintain rolling ring buffer.
+    _window.addLast(rasterUs);
+    if (_window.length > windowSize) _window.removeFirst();
+    _windowFrameCount++;
+
+    // Only evaluate the window once every windowSize frames (non-overlapping
+    // windows). This ensures "3 consecutive windows" means 3 × windowSize
+    // frames of data, not 3 individual frames, preventing runaway degradation.
+    if (_window.length < windowSize) return;
+    if (_windowFrameCount % windowSize != 0) return;
+
+    // Reuse pre-allocated sort buffer to avoid heap allocation on the
+    // frame timing callback path (GC pressure → frame drops).
+    // We rebuild from scratch only when the window size changes (rare —
+    // typically only on the first evaluation). Otherwise we overwrite in-place.
+    if (_sortBuffer.length != _window.length) {
+      _sortBuffer = List<int>.filled(_window.length, 0, growable: true);
+    }
+    var i = 0;
+    for (final v in _window) {
+      _sortBuffer[i++] = v;
+    }
+    final p95 = _percentileInPlace(_sortBuffer, 95);
+    final p95Ms = p95 / 1000.0;
+    final budgetMs = targetFrameMs.toDouble();
+
+    // Cache the current P95 so _tryStepDown / _tryStepUp can record it.
+    _lastComputedP95Ms = p95Ms;
+
+    if (p95Ms > budgetMs * 1.5) {
+      // Over budget
+      _overBudgetWindowCount++;
+      _underBudgetWindowCount = 0;
+    } else if (p95Ms < budgetMs * 0.6) {
+      // Comfortably under budget
+      _underBudgetWindowCount++;
+      _overBudgetWindowCount = 0;
+    } else {
+      // In the acceptable range — no change signal
+      _overBudgetWindowCount = 0;
+      _underBudgetWindowCount = 0;
+    }
+
+    if (_overBudgetWindowCount >= degradeWindowCount) {
+      _overBudgetWindowCount = 0;
+      _tryStepDown();
+    } else if (_underBudgetWindowCount >= upgradeWindowCount && allowStepUp) {
+      _underBudgetWindowCount = 0;
+      _tryStepUp();
+    }
+  }
+
+  void _tryStepDown() {
+    if (!_canChange()) return;
+    final next = _stepDown(_currentQuality);
+    if (next == _currentQuality) return; // already at minQuality
+    _lastChangeReason = GlassQualityChangeReason.thermalDegradation;
+    _lastP75Ms = null;
+    _lastP95Ms = _lastComputedP95Ms;
+    _lastFramesMeasured = windowSize;
+    _applyQuality(next);
+  }
+
+  void _tryStepUp() {
+    if (!_canChange()) return;
+    final next = _stepUp(_currentQuality);
+    if (next == _currentQuality) return; // already at maxQuality
+    _lastChangeReason = GlassQualityChangeReason.thermalRecovery;
+    _lastP75Ms = null;
+    _lastP95Ms = _lastComputedP95Ms;
+    _lastFramesMeasured = windowSize;
+    _applyQuality(next);
+  }
+
+  bool _canChange() {
+    if (_lastChangeAt == null) return true;
+    return DateTime.now().difference(_lastChangeAt!) >= cooldownDuration;
+  }
+
+  // ── Frame timing callback ─────────────────────────────────────────────────
+
+  void _onFrameTimings(List<FrameTiming> timings) {
+    if (!_running) return;
+
+    for (final timing in timings) {
+      final rasterUs = timing.rasterDuration.inMicroseconds;
+      if (_phase == AdaptivePhase.warmup) {
+        _processWarmupFrame(rasterUs);
+      } else if (_phase == AdaptivePhase.runtime) {
+        _processRuntimeFrame(rasterUs);
+      }
+    }
+  }
+
+  // ── State mutation ─────────────────────────────────────────────────────────
+
+  void _applyQuality(GlassQuality newQuality) {
+    if (newQuality == _currentQuality) return;
+    final old = _currentQuality;
+    _currentQuality = newQuality;
+    _lastChangeAt = DateTime.now();
+    _onQualityChanged(old, newQuality);
+  }
+
+  // ── Quality math helpers ───────────────────────────────────────────────────
+
+  /// Steps quality one tier down (premium → standard → minimal).
+  GlassQuality _stepDown(GlassQuality q) {
+    switch (q) {
+      case GlassQuality.premium:
+        return _floorQuality(GlassQuality.standard, minQuality);
+      case GlassQuality.standard:
+        return _floorQuality(GlassQuality.minimal, minQuality);
+      case GlassQuality.minimal:
+        return GlassQuality.minimal; // already at bottom
+    }
+  }
+
+  /// Steps quality one tier up (minimal → standard → premium).
+  GlassQuality _stepUp(GlassQuality q) {
+    switch (q) {
+      case GlassQuality.minimal:
+        return _capQuality(GlassQuality.standard, maxQuality);
+      case GlassQuality.standard:
+        return _capQuality(GlassQuality.premium, maxQuality);
+      case GlassQuality.premium:
+        return GlassQuality.premium; // already at top
+    }
+  }
+
+  /// Maps a [GlassQuality] to a monotonic ordinal for comparison.
+  ///
+  /// The [GlassQuality] enum is defined as `standard=0, premium=1, minimal=2`,
+  /// which is NOT monotonic with respect to quality. This helper normalises
+  /// the ordering so that higher ordinal = higher quality:
+  ///   - [GlassQuality.premium]  → 2 (best)
+  ///   - [GlassQuality.standard] → 1
+  ///   - [GlassQuality.minimal]  → 0 (worst)
+  static int _qualityOrdinal(GlassQuality q) {
+    switch (q) {
+      case GlassQuality.premium:
+        return 2;
+      case GlassQuality.standard:
+        return 1;
+      case GlassQuality.minimal:
+        return 0;
+    }
+  }
+
+  /// Returns the lower of [requested] and [ceiling].
+  ///
+  /// "Lower" here means lower quality (descending: premium → standard → minimal).
+  /// Capping prevents exceeding the quality ceiling.
+  static GlassQuality _capQuality(
+      GlassQuality requested, GlassQuality ceiling) {
+    // If requested is BETTER than ceiling, cap it at ceiling.
+    if (_qualityOrdinal(requested) > _qualityOrdinal(ceiling)) return ceiling;
+    return requested;
+  }
+
+  /// Returns the higher of [requested] and [floor].
+  ///
+  /// "Higher" means higher quality. Flooring prevents going below the minimum.
+  static GlassQuality _floorQuality(
+      GlassQuality requested, GlassQuality floor) {
+    // If requested is WORSE than floor, elevate it to floor.
+    if (_qualityOrdinal(requested) < _qualityOrdinal(floor)) return floor;
+    return requested;
+  }
+
+  // ── Percentile math ───────────────────────────────────────────────────────
+
+  /// Computes the [percentile]-th percentile (0–100) from a list of integer
+  /// values. The list is not modified; a sorted copy is made internally.
+  ///
+  /// Uses the "nearest rank" definition — appropriate for frame timing data
+  /// where we care about real observed samples, not interpolated values.
+  ///
+  /// Used by Phase 2 (warmup) where the list is discarded afterward.
+  static int _percentile(List<int> data, int percentile) {
+    assert(data.isNotEmpty);
+    assert(percentile >= 0 && percentile <= 100);
+    if (data.length == 1) return data.first;
+    final sorted = List<int>.from(data)..sort();
+    // Nearest-rank formula: ceil(p/100 * n) − 1 (0-indexed)
+    final rank = ((percentile / 100.0) * sorted.length).ceil();
+    final index = (rank - 1).clamp(0, sorted.length - 1);
+    return sorted[index];
+  }
+
+  /// In-place variant of [_percentile] — sorts [data] directly, avoiding a
+  /// heap allocation. Used by Phase 3 runtime with a pre-allocated sort buffer
+  /// to eliminate GC pressure on the frame timing callback path.
+  static int _percentileInPlace(List<int> data, int percentile) {
+    assert(data.isNotEmpty);
+    assert(percentile >= 0 && percentile <= 100);
+    if (data.length == 1) return data.first;
+    data.sort();
+    final rank = ((percentile / 100.0) * data.length).ceil();
+    final index = (rank - 1).clamp(0, data.length - 1);
+    return data[index];
+  }
+}

--- a/packages/liquid_glass_widgets/lib/utils/glass_spring.dart
+++ b/packages/liquid_glass_widgets/lib/utils/glass_spring.dart
@@ -1,0 +1,538 @@
+// ignore_for_file: public_member_api_docs
+// Internal spring animation utilities — drop-in replacement for the motor
+// package, implemented entirely on top of Flutter's built-in physics.
+//
+// Only the subset of motor that is actually used in this package is
+// implemented here.  Public API is intentionally not exported.
+
+import 'package:flutter/physics.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+
+import '../widgets/shared/glass_accessibility_scope.dart';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Spring presets
+// These match motor's CupertinoMotion presets exactly.
+// motor delegates to SpringDescription.withDurationAndBounce — same here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Static spring-description factories that mirror motor's named presets.
+///
+/// Every preset uses [SpringDescription.withDurationAndBounce], which is the
+/// same factory motor's `CupertinoMotion` uses internally.
+abstract final class GlassSpring {
+  /// Bouncy spring — motor's `Motion.bouncySpring`.
+  /// Default duration 500 ms, bounce 0.3.
+  static SpringDescription bouncy({
+    Duration duration = const Duration(milliseconds: 500),
+    double extraBounce = 0.0,
+  }) =>
+      SpringDescription.withDurationAndBounce(
+        duration: duration,
+        bounce: 0.3 + extraBounce,
+      );
+
+  /// Snappy spring — motor's `Motion.snappySpring`.
+  /// Default duration 500 ms, bounce 0.15.
+  static SpringDescription snappy({
+    Duration duration = const Duration(milliseconds: 500),
+    double extraBounce = 0.0,
+  }) =>
+      SpringDescription.withDurationAndBounce(
+        duration: duration,
+        bounce: 0.15 + extraBounce,
+      );
+
+  /// Smooth spring — motor's `Motion.smoothSpring`.
+  /// Default duration 500 ms, bounce 0.0 (critically-damped).
+  static SpringDescription smooth({
+    Duration duration = const Duration(milliseconds: 500),
+    double extraBounce = 0.0,
+  }) =>
+      SpringDescription.withDurationAndBounce(
+        duration: duration,
+        bounce: 0.0 + extraBounce,
+      );
+
+  /// Interactive spring — motor's `Motion.interactiveSpring`.
+  /// Short 150 ms response, light bounce 0.14.
+  static SpringDescription interactive({
+    Duration duration = const Duration(milliseconds: 150),
+    double extraBounce = 0.0,
+  }) =>
+      SpringDescription.withDurationAndBounce(
+        duration: duration,
+        bounce: 0.14 + extraBounce,
+      );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SingleSpringController  (replaces SingleMotionController /
+//                          BoundedSingleMotionController / MotionController)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A lightweight controller that drives a single [double] value using
+/// [SpringSimulation].  Equivalent to motor's `SingleMotionController`.
+///
+/// Features:
+/// * [value] — current animated value.
+/// * [velocity] — current spring velocity (units/second).
+/// * [animateTo] — start/redirect a spring toward a new target, preserving
+///   current velocity.
+/// * [spring] can be changed at any time; a running simulation is redirected
+///   immediately (mirrors motor's hot-swap behaviour).
+/// * Optional [lowerBound]/[upperBound] clamping (mirrors
+///   `BoundedSingleMotionController`).
+/// * Implements [Listenable] so it works directly with [ListenableBuilder].
+class SingleSpringController extends ChangeNotifier {
+  SingleSpringController({
+    required TickerProvider vsync,
+    required SpringDescription spring,
+    double initialValue = 0.0,
+    double? lowerBound,
+    double? upperBound,
+  })  : _spring = spring,
+        _value = initialValue,
+        _lowerBound = lowerBound,
+        _upperBound = upperBound {
+    _ticker = vsync.createTicker(_tick);
+  }
+
+  SpringDescription _spring;
+  double _value;
+  double _tickerElapsed = 0.0; // total time since ticker.start()
+  double _simStartTime = 0.0; // ticker time when the current sim was created
+  double _target = 0.0;
+  SpringSimulation? _sim;
+  late final Ticker _ticker;
+
+  final double? _lowerBound;
+  final double? _upperBound;
+
+  // Public API ----------------------------------------------------------------
+
+  /// The current animated value.
+  double get value => _value;
+
+  double get velocity {
+    final sim = _sim;
+    if (sim == null) return 0.0;
+    final t = (_tickerElapsed - _simStartTime).clamp(0.0, double.infinity);
+    return sim.dx(t);
+  }
+
+  /// The spring description.  Changing it will redirect any running
+  /// simulation immediately, preserving current velocity.
+  SpringDescription get spring => _spring;
+  set spring(SpringDescription value) {
+    if (_spring == value) return;
+    _spring = value;
+    if (_ticker.isActive) _startSim(target: _target, fromVelocity: velocity);
+  }
+
+  /// Animates toward [target], preserving current velocity.
+  /// If [fromVelocity] is provided it overrides the current velocity.
+  void animateTo(double target, {double? fromVelocity}) {
+    _target = _clamp(target);
+    _startSim(target: _target, fromVelocity: fromVelocity ?? velocity);
+  }
+
+  /// Immediately sets the value without animating.
+  void setValue(double value) {
+    _ticker.stop();
+    _sim = null;
+    _value = _clamp(value);
+    _tickerElapsed = 0.0;
+    _simStartTime = 0.0;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _ticker.dispose();
+    super.dispose();
+  }
+
+  // Internal ------------------------------------------------------------------
+
+  double _clamp(double v) {
+    if (_lowerBound != null && v < _lowerBound) return _lowerBound;
+    if (_upperBound != null && v > _upperBound) return _upperBound;
+    return v;
+  }
+
+  void _startSim({required double target, required double fromVelocity}) {
+    _sim = SpringSimulation(
+      _spring,
+      _value,
+      target,
+      fromVelocity,
+    );
+    if (!_ticker.isActive) {
+      // The Dart Ticker resets its elapsed counter to zero on each start().
+      // _simStartTime must match so that sim.x/dx are evaluated at t=0 on the
+      // first tick — not at (0 - stale_elapsed) which extrapolates backward
+      // and can produce astronomically large velocity/position values.
+      _tickerElapsed = 0.0;
+      _simStartTime = 0.0;
+      _ticker.start();
+    } else {
+      // Ticker is already running; anchor the new sim to the current position
+      // in the ticker timeline so it starts at t=0 relative to now.
+      _simStartTime = _tickerElapsed;
+    }
+  }
+
+  void _tick(Duration elapsed) {
+    _tickerElapsed = elapsed.inMicroseconds / Duration.microsecondsPerSecond;
+    // Guard: simElapsed must always be ≥ 0.  Negative values can occur during
+    // rapid-fire redirects where _simStartTime was set from a _tickerElapsed
+    // that was incremented after _startSim returned.  SpringSimulation.x(t<0)
+    // extrapolates backward and can produce huge/NaN values.
+    final simElapsed =
+        (_tickerElapsed - _simStartTime).clamp(0.0, double.infinity);
+    final sim = _sim;
+    if (sim == null) {
+      _ticker.stop();
+      return;
+    }
+
+    _value = _clamp(sim.x(simElapsed));
+
+    if (sim.isDone(simElapsed)) {
+      _value = _clamp(_target);
+      _sim = null;
+      _ticker.stop();
+    }
+    notifyListeners();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OffsetSpringController  (replaces MotionController<Offset> with
+//                          OffsetMotionConverter — used by GlassGlowLayerState)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A controller that drives an [Offset] value using two independent
+/// [SingleSpringController]s (one per axis).
+///
+/// Implements [Listenable]; listeners fire whenever either axis ticks.
+class OffsetSpringController extends ChangeNotifier {
+  OffsetSpringController({
+    required TickerProvider vsync,
+    required SpringDescription spring,
+    Offset initialValue = Offset.zero,
+  }) {
+    _x = SingleSpringController(
+      vsync: vsync,
+      spring: spring,
+      initialValue: initialValue.dx,
+    )..addListener(notifyListeners);
+    _y = SingleSpringController(
+      vsync: vsync,
+      spring: spring,
+      initialValue: initialValue.dy,
+    )..addListener(notifyListeners);
+  }
+
+  late final SingleSpringController _x;
+  late final SingleSpringController _y;
+
+  /// Current animated offset.
+  Offset get value => Offset(_x.value, _y.value);
+
+  /// Current spring velocity as an [Offset].
+  Offset get velocity => Offset(_x.velocity, _y.velocity);
+
+  /// Animate toward [target], preserving current velocity.
+  void animateTo(Offset target) {
+    _x.animateTo(target.dx);
+    _y.animateTo(target.dy);
+  }
+
+  /// Immediately set both axes without animating.
+  set value(Offset v) {
+    _x.setValue(v.dx);
+    _y.setValue(v.dy);
+  }
+
+  /// Change the spring for both axes, redirecting any running simulation.
+  set spring(SpringDescription s) {
+    _x.spring = s;
+    _y.spring = s;
+  }
+
+  @override
+  void dispose() {
+    _x.removeListener(notifyListeners);
+    _y.removeListener(notifyListeners);
+    _x.dispose();
+    _y.dispose();
+    super.dispose();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SpringBuilder  (replaces SingleMotionBuilder / MotionBuilder without velocity)
+// ─────────────────────────────────────────────────────────────────────────────
+
+typedef SpringWidgetBuilder = Widget Function(
+  BuildContext context,
+  double value,
+  Widget? child,
+);
+
+/// Animates a [double] [value] to new targets using a spring, calling
+/// [builder] on every frame.
+///
+/// Equivalent to motor's `SingleMotionBuilder`.
+///
+/// When [value] changes, the spring is redirected to the new target while
+/// preserving the current velocity (identical to motor's behaviour).
+/// When [spring] changes, the running simulation is redirected too.
+class SpringBuilder extends StatefulWidget {
+  const SpringBuilder({
+    required this.value,
+    required this.spring,
+    required this.builder,
+    this.child,
+    super.key,
+  });
+
+  final double value;
+  final SpringDescription spring;
+  final SpringWidgetBuilder builder;
+  final Widget? child;
+
+  @override
+  State<SpringBuilder> createState() => _SpringBuilderState();
+}
+
+class _SpringBuilderState extends State<SpringBuilder>
+    with SingleTickerProviderStateMixin {
+  late final SingleSpringController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = SingleSpringController(
+      vsync: this,
+      spring: widget.spring,
+      initialValue: widget.value,
+    );
+  }
+
+  @override
+  void didUpdateWidget(SpringBuilder oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.spring != oldWidget.spring) {
+      _ctrl.spring = widget.spring;
+    }
+    if (widget.value != oldWidget.value) {
+      // IP1: When Reduce Motion is active, snap instantly instead of animating.
+      // GlassAccessibilityData.of reads MediaQuery directly when no
+      // GlassAccessibilityScope is present, so this always respects the system
+      // setting with no developer setup required.
+      final reduceMotion = GlassAccessibilityData.of(context).reduceMotion;
+      if (reduceMotion) {
+        _ctrl.setValue(widget.value);
+      } else {
+        _ctrl.animateTo(widget.value);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: _ctrl,
+      builder: (context, child) => widget.builder(context, _ctrl.value, child),
+      child: widget.child,
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// VelocitySpringBuilder  (replaces VelocityMotionBuilder<double> /
+//                         SingleVelocityMotionBuilder)
+// ─────────────────────────────────────────────────────────────────────────────
+
+typedef VelocitySpringWidgetBuilder = Widget Function(
+  BuildContext context,
+  double value,
+  double velocity,
+  Widget? child,
+);
+
+/// Like [SpringBuilder] but also provides the current spring [velocity] to
+/// the builder.  Equivalent to motor's `VelocityMotionBuilder` /
+/// `SingleVelocityMotionBuilder`.
+///
+/// [springWhenActive] is used while the user is interacting (dragging).
+/// [springWhenReleased] is used after the user lifts their finger.
+/// Switching between them mid-animation redirects the simulation smoothly.
+class VelocitySpringBuilder extends StatefulWidget {
+  const VelocitySpringBuilder({
+    required this.value,
+    required this.springWhenActive,
+    required this.springWhenReleased,
+    required this.builder,
+    this.active = true,
+    this.child,
+    super.key,
+  });
+
+  /// Current target value.
+  final double value;
+
+  /// Spring used while [active] is true (following a pointer).
+  final SpringDescription springWhenActive;
+
+  /// Spring used while [active] is false (settling to rest).
+  final SpringDescription springWhenReleased;
+
+  /// Whether the user is currently dragging (selects [springWhenActive]).
+  final bool active;
+
+  final VelocitySpringWidgetBuilder builder;
+  final Widget? child;
+
+  @override
+  State<VelocitySpringBuilder> createState() => _VelocitySpringBuilderState();
+}
+
+class _VelocitySpringBuilderState extends State<VelocitySpringBuilder>
+    with SingleTickerProviderStateMixin {
+  late final SingleSpringController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = SingleSpringController(
+      vsync: this,
+      spring: _currentSpring,
+      initialValue: widget.value,
+    );
+  }
+
+  SpringDescription get _currentSpring =>
+      widget.active ? widget.springWhenActive : widget.springWhenReleased;
+
+  @override
+  void didUpdateWidget(VelocitySpringBuilder oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    // Spring selection changes when drag state or spring params change.
+    // Note: active here only controls WHICH spring is used, never stops the
+    // animation — motor's VelocityMotionBuilder had no snap-on-inactive path.
+    final springChanged = widget.active != oldWidget.active ||
+        widget.springWhenActive != oldWidget.springWhenActive ||
+        widget.springWhenReleased != oldWidget.springWhenReleased;
+    if (springChanged) {
+      _ctrl.spring = _currentSpring;
+    }
+    if (widget.value != oldWidget.value) {
+      // IP1: When Reduce Motion is active, snap instantly instead of animating.
+      final reduceMotion = GlassAccessibilityData.of(context).reduceMotion;
+      if (reduceMotion) {
+        _ctrl.setValue(widget.value);
+      } else {
+        _ctrl.animateTo(widget.value);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: _ctrl,
+      builder: (context, child) =>
+          widget.builder(context, _ctrl.value, _ctrl.velocity, child),
+      child: widget.child,
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OffsetSpringBuilder  (replaces MotionBuilder<Offset> with OffsetMotionConverter)
+// ─────────────────────────────────────────────────────────────────────────────
+
+typedef OffsetSpringWidgetBuilder = Widget Function(
+  BuildContext context,
+  Offset value,
+  Widget? child,
+);
+
+/// Like [SpringBuilder] but for [Offset] values.
+/// Equivalent to motor's `MotionBuilder<Offset>` with `OffsetMotionConverter`.
+class OffsetSpringBuilder extends StatefulWidget {
+  const OffsetSpringBuilder({
+    required this.value,
+    required this.spring,
+    required this.builder,
+    this.child,
+    super.key,
+  });
+
+  final Offset value;
+  final SpringDescription spring;
+  final OffsetSpringWidgetBuilder builder;
+  final Widget? child;
+
+  @override
+  State<OffsetSpringBuilder> createState() => _OffsetSpringBuilderState();
+}
+
+class _OffsetSpringBuilderState extends State<OffsetSpringBuilder>
+    with TickerProviderStateMixin {
+  late final OffsetSpringController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = OffsetSpringController(
+      vsync: this,
+      spring: widget.spring,
+      initialValue: widget.value,
+    );
+  }
+
+  @override
+  void didUpdateWidget(OffsetSpringBuilder oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.spring != oldWidget.spring) {
+      _ctrl.spring = widget.spring;
+    }
+    if (widget.value != oldWidget.value) {
+      _ctrl.animateTo(widget.value);
+    }
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: _ctrl,
+      builder: (context, child) => widget.builder(context, _ctrl.value, child),
+      child: widget.child,
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/utils/liquid_morph_physics.dart
+++ b/packages/liquid_glass_widgets/lib/utils/liquid_morph_physics.dart
@@ -1,0 +1,327 @@
+// ignore_for_file: comment_references
+
+import 'package:flutter/animation.dart';
+
+/// Semantic phase of the liquid glass morph lifecycle.
+///
+/// Consuming widgets can use this to react to *where* in the animation
+/// lifecycle the morph currently is — without re-deriving it from raw
+/// animation values.
+///
+/// State machine (open direction):
+/// ```
+/// idle → detaching → travelling → arriving → settled
+/// ```
+/// State machine (close direction, spring bounces back):
+/// ```
+/// settled → arriving → travelling → detaching → [bounce] → idle
+/// ```
+enum MorphPhase {
+  /// The morph has not started or has fully settled at its origin.
+  idle,
+
+  /// The anchor blob is shrinking and Blob B is just beginning to pull away.
+  /// In practice this covers animation values [0.0 – 0.4].
+  detaching,
+
+  /// Blob B is in mid-travel — the teardrop neck is at maximum stretch.
+  /// Animation values [0.4 – 0.8].
+  travelling,
+
+  /// Blob B is approaching its destination and the neck is retracting.
+  /// Animation values [0.8 – 1.0).
+  arriving,
+
+  /// Blob B has fully settled at its target position.
+  /// Animation value ≥ 1.0.
+  settled,
+}
+
+/// The fully computed render state for one frame of a liquid morph animation.
+///
+/// All values are pre-calculated and ready to be applied directly to widget
+/// geometry. Consumers must not re-derive values from the raw animation value.
+class LiquidMorphState {
+  const LiquidMorphState({
+    required this.pathT,
+    required this.sizeT,
+    required this.currentDx,
+    required this.currentDy,
+    required this.pushDx,
+    required this.pushDy,
+    required this.anchorScale,
+    required this.blend,
+    required this.containerScale,
+    required this.phase,
+  });
+
+  /// Position interpolation value — drives the J-curve overshoot.
+  ///
+  /// Computed by [_BackOutCurve]. Can legitimately exceed `[0, 1]` during the
+  /// close undershoot phase. Use this to position Blob B.
+  final double pathT;
+
+  /// Size interpolation value — drives the teardrop size expansion.
+  ///
+  /// Computed by [Curves.linearToEaseOut]. Stays within `[0, 1]` during
+  /// normal operation (any close undershoot is added additively).
+  final double sizeT;
+
+  /// Absolute horizontal displacement of the menu body (Blob B) from the
+  /// trigger center, in logical pixels.
+  final double currentDx;
+
+  /// Absolute vertical displacement of the menu body (Blob B) from the
+  /// trigger center, in logical pixels.
+  final double currentDy;
+
+  /// Horizontal displacement applied to the anchor blob (Blob A) during the
+  /// underdamped closing bounce. Zero during the opening animation.
+  final double pushDx;
+
+  /// Vertical displacement applied to the anchor blob (Blob A) during the
+  /// underdamped closing bounce. Zero during the opening animation.
+  final double pushDy;
+
+  /// Scale factor for the anchor (ghost trigger) blob in `[0.0 – 1.0]`.
+  ///
+  /// Shrinks to `0.0` over the first 40 % of the opening animation so the
+  /// liquid bridge detaches cleanly. Grows back during closing so the real
+  /// trigger button is ready to "catch" the returning menu.
+  final double anchorScale;
+
+  /// Metaball merge intensity in SDF blur units, clamped to `[0.0 – 28.0]`.
+  ///
+  /// Derived from the separation between [pathT] and [sizeT]: zero when the
+  /// blobs perfectly overlap (no swell needed), and maximum when the teardrop
+  /// bridge is at peak stretch.
+  final double blend;
+
+  /// Scale pulse applied to the menu container (Blob B) during the spring
+  /// overshoot phases.
+  ///
+  /// - `1.0` during normal travel.
+  /// - Slightly above `1.0` on open overshoot (negligible — overdamped).
+  /// - Drops below `1.0` on close undershoot to produce the visible squeeze.
+  final double containerScale;
+
+  /// Semantic lifecycle phase of the morph for this frame.
+  final MorphPhase phase;
+}
+
+/// Pure, stateless math engine for liquid glass morphing animations.
+///
+/// This class implements the J-curve back-out position curve and
+/// [Curves.linearToEaseOut] size curve that together create the
+/// iOS 26 liquid teardrop morphing effect.
+///
+/// It is **intentionally stateless** — feed it the raw animation value plus
+/// the source/destination geometry and it returns a fully computed
+/// [LiquidMorphState] for that frame. No `BuildContext`, no `State`, no
+/// `ChangeNotifier` dependencies.
+///
+/// ## Design
+///
+/// Two conceptual blobs drive the morph:
+///
+/// - **Blob A** (anchor / ghost trigger) stays at the trigger position and
+///   shrinks away over the first 40 % of the animation to cleanly break the
+///   liquid bridge.
+/// - **Blob B** (menu body) travels from the trigger center to the menu
+///   center along a J-curve overshoot trajectory, expanding from trigger size
+///   to menu size.
+///
+/// The metaball SDF shader automatically creates the teardrop neck between the
+/// two blobs — there is no explicit neck geometry.
+///
+/// ## Usage
+///
+/// ```dart
+/// // Typically called from an AnimatedBuilder or addListener callback.
+/// final state = LiquidMorphPhysics.compute(
+///   rawValue: controller.value,
+///   finalDx: finalDx,
+///   finalDy: finalDy,
+///   horizontalOffset: _horizontalOffset,
+///   verticalOffset: _verticalOffset,
+/// );
+///
+/// // Apply to the UI:
+/// Positioned(
+///   left: triggerX + state.pushDx,
+///   top:  triggerY + state.pushDy,
+///   child: Transform.scale(scale: state.anchorScale, child: blobA),
+/// )
+/// ```
+class LiquidMorphPhysics {
+  // Pure utility class — no instances.
+  const LiquidMorphPhysics._();
+
+  // ─── iOS 26 Spring Constants ───────────────────────────────────────────────
+  //
+  // Both open and close use the same underdamped spring profile:
+  //   mass: 1.0, stiffness: 120.0, damping: 16.0
+  //   ω₀ = √(120/1) ≈ 11 rad/s,  ζ = 16/(2×11) ≈ 0.73 — slightly underdamped.
+  //
+  // The underdamping is intentional: it lets the spring overshoot past 0.0 on
+  // close, which drives the physical "bump" on the trigger icon. The J-curve
+  // position curve and the [closeVelocityHint] amplify this into the satisfying
+  // iOS-native rubber-band momentum feel.
+
+  /// Spring profile for the iOS 26 liquid morph **opening** animation.
+  static const SpringDescription openSpring = SpringDescription(
+    mass: 1.0,
+    stiffness: 120.0,
+    damping: 16.0,
+  );
+
+  /// Spring profile for the iOS 26 liquid morph **closing** animation.
+  ///
+  /// Identical constants to [openSpring]. The closing "bump" is produced by
+  /// injecting [closeVelocityHint] at the moment of close — not by different
+  /// spring physics.
+  static const SpringDescription closeSpring = SpringDescription(
+    mass: 1.0,
+    stiffness: 120.0,
+    damping: 16.0,
+  );
+
+  /// Initial velocity hint injected when the close animation starts.
+  ///
+  /// A negative value immediately drives the spring toward zero with
+  /// momentum, maximising the visible rubber-band bounce amplitude.
+  static const double closeVelocityHint = -2.5;
+
+  // ─── Tuning constants (intentionally not public) ───────────────────────────
+  //
+  // These constants are calibrated for iOS 26 native parity. Exposing them
+  // as public parameters would allow developers to produce physically broken
+  // animations. Use [GlassMorphController.speed] for safe speed control.
+
+  /// Amplitude of the J-curve back-out overshoot for position interpolation.
+  static const double _backOutAmplitude = 2.5;
+
+  /// Fraction of the animation over which the anchor blob shrinks to zero.
+  static const double _anchorEaseDuration = 0.4;
+
+  /// Multiplier from path/size separation to SDF blur units.
+  static const double _blendMultiplier = 150.0;
+
+  /// Maximum SDF blend value to prevent excessive merging on small movements.
+  static const double _maxBlend = 28.0;
+
+  // ─── Core computation ──────────────────────────────────────────────────────
+
+  /// Computes the full [LiquidMorphState] for a single animation frame.
+  ///
+  /// ### Parameters
+  ///
+  /// - [rawValue] — the raw, unclamped value from `AnimationController.unbounded`.
+  ///   Legitimately exceeds `[0, 1]` during spring overshoot phases.
+  /// - [finalDx] — target horizontal displacement from the trigger center to
+  ///   the menu center, in logical pixels.
+  /// - [finalDy] — target vertical displacement from the trigger center to
+  ///   the menu center, in logical pixels.
+  /// - [horizontalOffset] — screen-edge clamping correction for horizontal
+  ///   overflow, accumulated by the menu positioning logic.
+  /// - [verticalOffset] — screen-edge clamping correction for vertical overflow.
+  static LiquidMorphState compute({
+    required double rawValue,
+    required double finalDx,
+    required double finalDy,
+    double horizontalOffset = 0.0,
+    double verticalOffset = 0.0,
+  }) {
+    final clampedValue = rawValue.clamp(0.0, 1.0);
+
+    // Inject the close undershoot so Blob B bounces past the anchor on close.
+    // The open-side overshoot (rawValue > 1) is intentionally excluded because
+    // it causes an unwanted size wobble during the initial expansion.
+    final closeUndershoot = rawValue < 0.0 ? rawValue : 0.0;
+
+    // ── J-Curve Position ──────────────────────────────────────────────────────
+    // The back-out curve overshoots far past 1.0 before snapping back,
+    // creating the "string pull" teardrop neck at maximum separation.
+    final pathT = _BackOutCurve(_backOutAmplitude).transform(clampedValue) +
+        closeUndershoot;
+
+    // ── Size ─────────────────────────────────────────────────────────────────
+    // Size grows steadily then decelerates so the teardrop bulge is clearly
+    // visible before the container reaches its final dimensions.
+    final sizeT =
+        Curves.linearToEaseOut.transform(clampedValue) + closeUndershoot;
+
+    // ── Closing Momentum Push (Blob A displacement) ───────────────────────────
+    // When the spring overshoots past 0 (rawValue < 0), Blob A is displaced
+    // proportionally to mirror the closing momentum.
+    final pushDx =
+        rawValue < 0.0 ? (finalDx + horizontalOffset) * rawValue : 0.0;
+    final pushDy = rawValue < 0.0 ? (finalDy + verticalOffset) * rawValue : 0.0;
+
+    // ── Blob B Displacement ───────────────────────────────────────────────────
+    final currentDx = finalDx * pathT;
+    final currentDy = finalDy * pathT;
+
+    // ── Anchor Scale ─────────────────────────────────────────────────────────
+    // Shrinks the ghost trigger (Blob A) to 0 over the first 40 % of the
+    // animation. Grows back during close so the real trigger "catches" the menu.
+    final anchorScale =
+        (1.0 - (clampedValue / _anchorEaseDuration)).clamp(0.0, 1.0);
+
+    // ── Metaball Blend ────────────────────────────────────────────────────────
+    // Separation between pathT (position) and sizeT (size) represents how far
+    // Blob B has pulled away from its anchor. Blend naturally scales with this.
+    final separation = (pathT - sizeT).abs();
+    final blend = (separation * _blendMultiplier).clamp(0.0, _maxBlend);
+
+    // ── Container Scale Pulse ─────────────────────────────────────────────────
+    // Subtle squeeze/swell during spring overshoot phases.
+    final containerScale = rawValue > 1.0
+        ? 1.0 + (rawValue - 1.0) * 0.10 // open overshoot (negligible)
+        : rawValue < 0.0
+            ? 1.0 + rawValue * 0.55 // close undershoot → visible squeeze
+            : 1.0;
+
+    // ── Phase ─────────────────────────────────────────────────────────────────
+    final phase = _derivePhase(rawValue, clampedValue);
+
+    return LiquidMorphState(
+      pathT: pathT,
+      sizeT: sizeT,
+      currentDx: currentDx,
+      currentDy: currentDy,
+      pushDx: pushDx,
+      pushDy: pushDy,
+      anchorScale: anchorScale,
+      blend: blend,
+      containerScale: containerScale,
+      phase: phase,
+    );
+  }
+
+  static MorphPhase _derivePhase(double rawValue, double clampedValue) {
+    if (rawValue < 0.0) return MorphPhase.detaching; // close bounce
+    if (clampedValue < 0.001) return MorphPhase.idle;
+    if (clampedValue < 0.4) return MorphPhase.detaching;
+    if (clampedValue < 0.8) return MorphPhase.travelling;
+    if (clampedValue < 0.999) return MorphPhase.arriving;
+    return MorphPhase.settled;
+  }
+}
+
+/// Back-out easing curve for the J-curve position overshoot.
+///
+/// Creates a pronounced overshoot past `1.0` before snapping back to `1.0`,
+/// which manifests as the teardrop "string pull" effect during the liquid morph.
+///
+/// - [amplitude] controls how far past `1.0` the curve overshoots.
+///   The default value of `2.5` is calibrated for iOS 26 native parity.
+class _BackOutCurve extends Curve {
+  const _BackOutCurve(this.amplitude);
+  final double amplitude;
+
+  @override
+  double transformInternal(double t) {
+    return (t -= 1.0) * t * ((amplitude + 1.0) * t + amplitude) + 1.0;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/containers/glass_card.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/containers/glass_card.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/material.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../types/glass_quality.dart';
+import 'glass_container.dart';
+
+/// A glass card widget following Apple's card design patterns.
+///
+/// [GlassCard] builds upon [GlassContainer] with opinionated defaults for
+/// card-like content containers, matching iOS design guidelines.
+///
+/// This widget provides standard card styling:
+/// - Default padding of 16px (matching iOS card insets)
+/// - Rounded superellipse corners with 12px radius
+/// - Suitable for displaying grouped content
+///
+/// ## Usage Modes
+///
+/// ### Grouped Mode (default)
+/// Uses [LiquidGlass.grouped] and inherits settings from parent
+/// [LiquidGlassLayer]:
+/// ```dart
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(...),
+///   child: ListView(
+///     children: [
+///       GlassCard(
+///         child: ListTile(
+///           title: Text('Item 1'),
+///           subtitle: Text('Description'),
+///         ),
+///       ),
+///       GlassCard(
+///         child: ListTile(
+///           title: Text('Item 2'),
+///           subtitle: Text('Description'),
+///         ),
+///       ),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ### Standalone Mode
+/// Creates its own layer with [LiquidGlass.withOwnLayer]:
+/// ```dart
+/// GlassCard(
+///   useOwnLayer: true,
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 10,
+///   ),
+///   child: Column(
+///     children: [
+///       Text('Title'),
+///       Text('Content'),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ## Customization Examples
+///
+/// ### No padding (full-width content):
+/// ```dart
+/// GlassCard(
+///   padding: EdgeInsets.zero,
+///   child: Image.network('...'),
+/// )
+/// ```
+///
+/// ### Custom shape and padding:
+/// ```dart
+/// GlassCard(
+///   padding: EdgeInsets.all(24),
+///   shape: LiquidRoundedSuperellipse(borderRadius: 20),
+///   child: Text('Custom card'),
+/// )
+/// ```
+///
+/// ### With margin between cards:
+/// ```dart
+/// GlassCard(
+///   margin: EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+///   child: Text('Card with margin'),
+/// )
+/// ```
+///
+/// ## ⚠️ Anti-Pattern: Do Not Place Glass Controls Inside a GlassCard
+///
+/// [GlassCard] inherits the same glass-in-glass restrictions as [GlassContainer].
+/// Do not place interactive glass controls (`GlassSegmentedControl`,
+/// `GlassSlider`, `GlassSwitch`, `GlassButton`) inside a [GlassCard] — see
+/// [GlassContainer] for the full explanation and correct alternatives.
+
+class GlassCard extends StatelessWidget {
+  /// Creates a glass card.
+  const GlassCard({
+    super.key,
+    this.child,
+    this.padding = const EdgeInsets.all(16),
+    this.margin,
+    this.shape = _defaultShape,
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    this.clipBehavior = Clip.none,
+    this.width,
+    this.height,
+  });
+
+  // ===========================================================================
+  // Content Properties
+  // ===========================================================================
+
+  /// The widget below this widget in the tree.
+  ///
+  /// This is the content that will be displayed inside the card.
+  final Widget? child;
+
+  // ===========================================================================
+  // Sizing Properties
+  // ===========================================================================
+
+  /// Width of the card in logical pixels.
+  ///
+  /// If null, the card will size itself to fit its child.
+  final double? width;
+
+  /// Height of the card in logical pixels.
+  ///
+  /// If null, the card will size itself to fit its child.
+  final double? height;
+
+  /// Empty space to inscribe inside the card.
+  ///
+  /// The child is placed inside this padding.
+  ///
+  /// Defaults to 16px on all sides (matching iOS card insets).
+  final EdgeInsetsGeometry padding;
+
+  /// Empty space to surround the card.
+  ///
+  /// The glass effect is not applied to the margin area.
+  ///
+  /// Defaults to null (no margin).
+  final EdgeInsetsGeometry? margin;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Shape of the card.
+  ///
+  /// Can be [LiquidOval], [LiquidRoundedRectangle], or
+  /// [LiquidRoundedSuperellipse].
+  ///
+  /// Defaults to [LiquidRoundedSuperellipse] with 12px border radius, matching
+  /// Apple's standard card corner radius.
+  final LiquidShape shape;
+
+  static const _defaultShape = LiquidRoundedSuperellipse(borderRadius: 12);
+
+  /// Glass effect settings for this card.
+  ///
+  /// Controls the visual appearance of the glass effect including thickness,
+  /// blur radius, color tint, lighting, and more.
+  ///
+  /// **Important:** In grouped mode (default), per-widget settings are
+  /// ignored — the parent layer's settings are used instead. To apply
+  /// per-widget settings, set `useOwnLayer: true`.
+  ///
+  /// For the best of both worlds, set `settings` on [GlassPage] or
+  /// [AdaptiveLiquidGlassLayer] — all grouped children inherit them
+  /// without the performance cost of separate layers.
+  ///
+  /// If null, inherits settings from the nearest parent layer or theme.
+  final LiquidGlassSettings? settings;
+
+  /// Whether to create its own layer or use grouped glass within an existing
+  /// layer.
+  ///
+  /// - `false` (default): Uses [LiquidGlass.grouped], must be inside a
+  ///   [LiquidGlassLayer]. More performant when multiple glass elements share
+  ///   a rendering context. Per-widget [settings] are ignored in this mode.
+  ///
+  /// - `true`: Uses [LiquidGlass.withOwnLayer], can be used anywhere.
+  ///   Creates an independent glass rendering context. Per-widget [settings]
+  ///   are applied in this mode.
+  ///
+  /// Defaults to false.
+  final bool useOwnLayer;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// If null, inherits from parent [InheritedLiquidGlass] or defaults to
+  /// [GlassQuality.standard], which uses the lightweight fragment shader.
+  /// This works reliably in all contexts, including scrollable lists.
+  ///
+  /// Use [GlassQuality.premium] for full-pipeline shader with texture capture
+  /// and chromatic aberration (Impeller only) in static layouts.
+  final GlassQuality? quality;
+
+  /// The clipping behavior for the card.
+  ///
+  /// Controls how content is clipped at the card's bounds:
+  /// - [Clip.none]: No clipping (default, best performance)
+  /// - [Clip.antiAlias]: Smooth anti-aliased clipping
+  /// - [Clip.hardEdge]: Sharp clipping without anti-aliasing
+  ///
+  /// Use [Clip.antiAlias] or [Clip.hardEdge] when the child extends beyond
+  /// the card's bounds (e.g., images, overflowing content).
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
+
+  @override
+  Widget build(BuildContext context) {
+    // Build upon GlassContainer with card-specific defaults
+    return GlassContainer(
+      width: width,
+      height: height,
+      padding: padding,
+      margin: margin,
+      shape: shape,
+      settings: settings,
+      useOwnLayer: useOwnLayer,
+      quality: quality,
+      clipBehavior: clipBehavior,
+      child: child,
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/containers/glass_container.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/containers/glass_container.dart
@@ -1,0 +1,350 @@
+import 'package:flutter/material.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../types/glass_quality.dart';
+import '../shared/adaptive_glass.dart';
+import '../shared/inherited_liquid_glass.dart';
+import '../../theme/glass_theme_helpers.dart';
+
+/// A foundational glass container widget following Apple's liquid glass design.
+///
+/// This is the base primitive for all container-based glass widgets. It
+/// provides a simple glass surface with configurable dimensions, padding,
+/// and shape.
+///
+/// ## Usage Modes
+///
+/// ### Grouped Mode (default)
+/// Uses [LiquidGlass.grouped] and inherits settings from parent
+/// [LiquidGlassLayer]:
+/// ```dart
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(...),
+///   child: Column(
+///     children: [
+///       GlassContainer(
+///         child: Text('Hello'),
+///       ),
+///       GlassContainer(
+///         child: Text('World'),
+///       ),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ### Standalone Mode
+/// Creates its own layer with [LiquidGlass.withOwnLayer]:
+/// ```dart
+/// GlassContainer(
+///   useOwnLayer: true,
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 10,
+///   ),
+///   child: Text('Standalone'),
+/// )
+/// ```
+///
+/// ## Customization Examples
+///
+/// ### Custom padding and shape:
+/// ```dart
+/// GlassContainer(
+///   padding: EdgeInsets.all(20),
+///   shape: LiquidRoundedSuperellipse(borderRadius: 16),
+///   child: Text('Padded content'),
+/// )
+/// ```
+///
+/// ### With constraints:
+/// ```dart
+/// GlassContainer(
+///   width: 200,
+///   height: 100,
+///   child: Center(child: Text('Fixed size')),
+/// )
+/// ```
+///
+/// ### With clipping:
+/// ```dart
+/// GlassContainer(
+///   clipBehavior: Clip.antiAlias,
+///   child: Image.network('...'),
+/// )
+/// ```
+///
+/// ## ⚠️ Anti-Pattern: Do Not Place Glass Controls Inside a GlassContainer
+///
+/// [GlassContainer] is a **foundational surface**, not a generic wrapper.
+/// Placing interactive glass controls inside it causes two problems:
+///
+/// 1. **Visual degradation** — [GlassContainer] sets
+///    [InheritedLiquidGlass.avoidsRefraction] to `true` for its entire child
+///    subtree. Any [GlassEffect] descendant falls back to a non-refracting
+///    path — the inner glass effect is degraded by design.
+///
+/// 2. **Jelly-physics clipping** — With [useOwnLayer] `= true` on Impeller,
+///    the container routes through `LiquidGlass.withOwnLayer` which applies
+///    its own internal shape clip. Interactive indicator widgets overshoot
+///    their bounds during spring animations — that overshoot gets cut.
+///
+/// Interactive glass controls already manage their own surface appearance via
+/// `backgroundColor` and `indicatorColor` — no outer container is needed.
+///
+/// ```dart
+/// // ✅ Correct — control manages its own surface
+/// GlassSegmentedControl(
+///   segments: [...],
+///   selectedIndex: _index,
+///   onSegmentSelected: (i) => setState(() => _index = i),
+/// )
+///
+/// // ❌ Anti-pattern — degrades refraction, clips jelly animation
+/// GlassContainer(
+///   child: GlassSegmentedControl(...),
+/// )
+/// ```
+class GlassContainer extends StatelessWidget {
+  /// Creates a glass container.
+  const GlassContainer({
+    super.key,
+    this.child,
+    this.width,
+    this.height,
+    this.padding,
+    this.margin,
+    this.shape = const LiquidRoundedSuperellipse(borderRadius: 16),
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    this.clipBehavior = Clip.none,
+    this.alignment,
+    this.allowElevation = false,
+    this.glowIntensity = 0.0,
+    this.platformViewBackdrop = false,
+  });
+
+  // ===========================================================================
+  // Content Properties
+  // ===========================================================================
+
+  /// The widget below this widget in the tree.
+  ///
+  /// This is the content that will be displayed inside the glass container.
+  final Widget? child;
+
+  /// The alignment of the [child] within the container.
+  ///
+  /// If null, the child is positioned according to its natural size.
+  final AlignmentGeometry? alignment;
+
+  // ===========================================================================
+  // Sizing Properties
+  // ===========================================================================
+
+  /// Width of the container in logical pixels.
+  ///
+  /// If null, the container will size itself to fit its child.
+  final double? width;
+
+  /// Height of the container in logical pixels.
+  ///
+  /// If null, the container will size itself to fit its child.
+  final double? height;
+
+  /// Empty space to inscribe inside the glass container.
+  ///
+  /// The child is placed inside this padding.
+  final EdgeInsetsGeometry? padding;
+
+  /// Empty space to surround the glass container.
+  ///
+  /// The glass effect is not applied to the margin area.
+  final EdgeInsetsGeometry? margin;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Shape of the glass container.
+  ///
+  /// Can be [LiquidOval], [LiquidRoundedRectangle], or
+  /// [LiquidRoundedSuperellipse].
+  ///
+  /// Defaults to [LiquidRoundedSuperellipse] with 16px border radius, matching
+  /// Apple's standard corner radius for cards and containers.
+  final LiquidShape shape;
+
+  /// Glass effect settings for this container.
+  ///
+  /// Controls the visual appearance of the glass effect including thickness,
+  /// blur radius, color tint, lighting, and more.
+  ///
+  /// **Important:** In grouped mode (default), per-widget settings are
+  /// ignored — the parent layer's settings are used instead. To apply
+  /// per-widget settings, set `useOwnLayer: true`.
+  ///
+  /// For the best of both worlds, set `settings` on [GlassPage] or
+  /// [AdaptiveLiquidGlassLayer] — all grouped children inherit them
+  /// without the performance cost of separate layers.
+  ///
+  /// If null, inherits settings from the nearest parent layer or theme.
+  final LiquidGlassSettings? settings;
+
+  /// Whether to create its own layer or use grouped glass within an existing
+  /// layer.
+  ///
+  /// - `false` (default): Uses [LiquidGlass.grouped], must be inside a
+  /// [LiquidGlassLayer]. This is more performant when you have multiple glass
+  /// elements that can share the same rendering context. Per-widget [settings]
+  /// are ignored in this mode.
+  ///
+  /// - `true`: Uses [LiquidGlass.withOwnLayer], can be used anywhere.
+  ///   Creates an independent glass rendering context. Per-widget [settings]
+  ///   are applied in this mode.
+  ///
+  /// Defaults to false.
+  final bool useOwnLayer;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// If null, inherits from parent [InheritedLiquidGlass] or defaults to
+  /// [GlassQuality.standard], which uses the lightweight fragment shader.
+  /// This is 5-10x faster than BackdropFilter and works reliably in all
+  /// contexts, including scrollable lists.
+  ///
+  /// Use [GlassQuality.premium] for full-pipeline shader with texture capture
+  /// and chromatic aberration (Impeller only) in static layouts.
+  final GlassQuality? quality;
+
+  /// The clipping behavior for the container.
+  ///
+  /// Controls how content is clipped at the container's bounds:
+  /// - [Clip.none]: No clipping (default, best performance)
+  /// - [Clip.antiAlias]: Smooth anti-aliased clipping
+  /// - [Clip.hardEdge]: Sharp clipping without anti-aliasing
+  ///
+  /// Use [Clip.antiAlias] or [Clip.hardEdge] when the child extends beyond
+  /// the container's bounds (e.g., images, overflowing content).
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
+
+  /// Whether to allow elevation effects when in a grouped context.
+  ///
+  /// When false (default), the container won't darken or add rim effects
+  /// when inside another glass container. This is correct for most containers
+  /// as they are surfaces, not interactive elements.
+  ///
+  /// Set to true only for special cases where elevation is needed.
+  ///
+  /// Defaults to false.
+  final bool allowElevation;
+
+  /// Interactive glow intensity for Skia/Web (0.0–1.0).
+  ///
+  /// On Impeller, [GlassGlow] is the preferred mechanism. On Skia/Web this
+  /// drives a shader-based highlight layer. Defaults to 0.0 (no glow).
+  final double glowIntensity;
+
+  /// When true (typically for iOS PlatformViews), forces the BackdropFilter
+  /// fallback render path instead of the Impeller-native shader. Forwarded to
+  /// the underlying [AdaptiveGlass].
+  final bool platformViewBackdrop;
+
+  @override
+  Widget build(BuildContext context) {
+    // Inherit quality from parent layer if not explicitly set
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: quality,
+    );
+
+    // 1. Start with the child content
+    var content = child ?? const SizedBox.shrink();
+
+    // 2. Apply padding inside the container (before glass effect)
+    if (padding != null) {
+      content = Padding(
+        padding: padding!,
+        child: content,
+      );
+    }
+
+    // 3. Apply alignment if provided
+    if (alignment != null) {
+      content = Align(
+        alignment: alignment!,
+        child: content,
+      );
+    }
+
+    // 4. Apply glass effect with adaptive fallback
+    // Premium quality uses Impeller on iOS/macOS, falls back to lightweight shader on web
+    // Standard quality always uses lightweight shader
+
+    // Debug-only: warn when per-widget settings differ from the parent layer's
+    // settings in grouped mode. This catches the common mistake of passing
+    // custom settings to a grouped container and expecting them to apply.
+    // Internal widgets that pass through resolved settings won't trigger this.
+    assert(() {
+      if (settings != null && !useOwnLayer) {
+        final inherited = InheritedLiquidGlass.of(context);
+        if (inherited != null && inherited != settings) {
+          debugPrint(
+            'GlassContainer: `settings` provided without `useOwnLayer: true`. '
+            'In grouped mode, per-widget settings are ignored — the parent '
+            'layer\'s settings are used instead.\n'
+            '  → To apply these settings, add `useOwnLayer: true` (creates a '
+            'separate rendering layer).\n'
+            '  → For better performance, set `settings` on GlassPage or '
+            'AdaptiveLiquidGlassLayer so all grouped children inherit them.',
+          );
+        }
+      }
+      return true;
+    }());
+
+    final effectiveSettings = GlassThemeHelpers.resolveSettings(
+      context,
+      explicit: settings,
+    );
+    Widget glassWidget = AdaptiveGlass(
+      shape: shape,
+      settings: effectiveSettings,
+      quality: effectiveQuality,
+      useOwnLayer: useOwnLayer,
+      clipBehavior: clipBehavior,
+      allowElevation: allowElevation, // Configurable elevation behavior
+      glowIntensity: glowIntensity,
+      platformViewBackdrop: platformViewBackdrop,
+      child: InheritedLiquidGlass(
+        settings: effectiveSettings,
+        quality: effectiveQuality,
+        avoidsRefraction:
+            true, // Containers block children from refracting background
+        child: content,
+      ),
+    );
+
+    // 5. Apply width/height constraints
+    if (width != null || height != null) {
+      glassWidget = SizedBox(
+        width: width,
+        height: height,
+        child: glassWidget,
+      );
+    }
+
+    // 6. Apply margin outside the glass effect
+    if (margin != null) {
+      glassWidget = Padding(
+        padding: margin!,
+        child: glassWidget,
+      );
+    }
+
+    return glassWidget;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/containers/glass_divider.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/containers/glass_divider.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import '../../theme/glass_theme.dart';
+
+/// A glass-aesthetic separator for use between glass content sections.
+///
+/// [GlassDivider] renders a thin frosted hairline that matches iOS 26 separator
+/// styling. It is functionally similar to [Divider] but visually cohesive with
+/// the liquid glass design system.
+///
+/// ## Usage
+///
+/// ### Horizontal divider (default):
+/// ```dart
+/// GlassCard(
+///   child: Column(
+///     children: [
+///       Text('Section A'),
+///       GlassDivider(),
+///       Text('Section B'),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ### Vertical divider:
+/// ```dart
+/// Row(
+///   children: [
+///     Text('Left'),
+///     GlassDivider.vertical(),
+///     Text('Right'),
+///   ],
+/// )
+/// ```
+///
+/// ### Custom thickness and indent:
+/// ```dart
+/// GlassDivider(
+///   thickness: 0.5,
+///   indent: 16,
+///   endIndent: 16,
+///   color: CupertinoColors.white.withOpacity(0.38),
+/// )
+/// ```
+class GlassDivider extends StatelessWidget {
+  /// Creates a horizontal glass divider.
+  const GlassDivider({
+    super.key,
+    this.thickness = 0.5,
+    this.indent = 0.0,
+    this.endIndent = 0.0,
+    this.color,
+    this.height,
+    this.axis = Axis.horizontal,
+  });
+
+  /// Creates a vertical glass divider.
+  ///
+  /// Equivalent to `GlassDivider(axis: Axis.vertical)`.
+  const GlassDivider.vertical({
+    super.key,
+    this.thickness = 0.5,
+    this.indent = 0.0,
+    this.endIndent = 0.0,
+    this.color,
+    this.height,
+  }) : axis = Axis.vertical;
+
+  // ===========================================================================
+  // Appearance Properties
+  // ===========================================================================
+
+  /// The thickness of the divider line.
+  ///
+  /// Defaults to 0.5 logical pixels — matching iOS 26's hairline separator.
+  final double thickness;
+
+  /// Empty space leading the divider on the left/top.
+  ///
+  /// Defaults to 0.
+  final double indent;
+
+  /// Empty space trailing the divider on the right/bottom.
+  ///
+  /// Defaults to 0.
+  final double endIndent;
+
+  /// The color of the divider.
+  ///
+  /// Defaults to `CupertinoColors.white.withValues(alpha: 0.25)` in dark contexts and
+  /// `CupertinoColors.black.withValues(alpha: 0.12)` in light contexts — matching iOS
+  /// separator colours.
+  final Color? color;
+
+  /// The total space occupied in the cross-axis direction.
+  ///
+  /// For a horizontal divider this is the height; for vertical, the width.
+  /// Defaults to 1.0 (slightly more than [thickness] for touch-target padding).
+  final double? height;
+
+  /// The axis along which the divider runs.
+  ///
+  /// [Axis.horizontal] (default) — a full-width horizontal line.
+  /// [Axis.vertical] — a full-height vertical line.
+  final Axis axis;
+
+  @override
+  Widget build(BuildContext context) {
+    // Resolve colour: prefer explicit, fall back to theme-adaptive default.
+    final brightness = GlassTheme.brightnessOf(context);
+    final effectiveColor = color ??
+        (brightness == Brightness.dark
+            ? CupertinoColors.white.withValues(alpha: 0.20)
+            : CupertinoColors.black.withValues(alpha: 0.10));
+
+    final effectiveHeight = height ?? 1.0;
+
+    // Decorative separators should be invisible to VoiceOver/TalkBack,
+    // matching iOS behaviour where UITableView separators are not accessible.
+    if (axis == Axis.vertical) {
+      return ExcludeSemantics(
+        child: SizedBox(
+          width: effectiveHeight,
+          child: Padding(
+            padding: EdgeInsets.only(top: indent, bottom: endIndent),
+            child: VerticalDivider(
+              width: effectiveHeight,
+              thickness: thickness,
+              color: effectiveColor,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return ExcludeSemantics(
+      child: Padding(
+        padding: EdgeInsets.only(left: indent, right: endIndent),
+        child: Divider(
+          height: effectiveHeight,
+          thickness: thickness,
+          color: effectiveColor,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/containers/glass_grouped_section.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/containers/glass_grouped_section.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/cupertino.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../types/glass_quality.dart';
+import 'glass_card.dart';
+import 'glass_divider.dart';
+import 'glass_list_tile.dart';
+
+/// A convenience wrapper that groups [GlassListTile]s inside a [GlassCard].
+///
+/// [GlassGroupedSection] automatically injects [GlassDivider]s between tiles,
+/// with smart leading-indent detection — 56px when the preceding tile has a
+/// [GlassListTile.leading] widget, 16px otherwise.
+///
+/// ## iOS 26 pattern
+///
+/// In iOS 26, Settings-style screens group related rows inside
+/// `UITableView` grouped sections. [GlassGroupedSection] provides the
+/// glass equivalent of that pattern.
+///
+/// ## Usage
+///
+/// ```dart
+/// GlassGroupedSection(
+///   header: const Text('NETWORK'),
+///   children: [
+///     GlassListTile(
+///       leading: Icon(CupertinoIcons.wifi, color: CupertinoColors.white),
+///       title: Text('Wi-Fi'),
+///       trailing: GlassListTile.chevron,
+///     ),
+///     GlassListTile(
+///       leading: Icon(CupertinoIcons.bluetooth, color: CupertinoColors.white),
+///       title: Text('Bluetooth'),
+///       trailing: GlassListTile.chevron,
+///     ),
+///     GlassListTile(
+///       leading: Icon(CupertinoIcons.antenna_radiowaves_left_right,
+///           color: CupertinoColors.white),
+///       title: Text('VPN'),
+///       trailing: GlassListTile.chevron,
+///     ),
+///   ],
+/// )
+/// ```
+///
+/// ## Children
+///
+/// [GlassGroupedSection] is designed to contain [GlassListTile] rows and
+/// standard Flutter content. Do not place interactive glass controls
+/// (`GlassSegmentedControl`, `GlassSlider`, `GlassSwitch`, `GlassButton`)
+/// as direct children — this is a glass-in-glass anti-pattern that degrades
+/// refraction and can clip indicator animations. See [GlassContainer] for
+/// the full explanation.
+
+class GlassGroupedSection extends StatelessWidget {
+  /// Creates a grouped section of glass list tiles.
+  const GlassGroupedSection({
+    super.key,
+    required this.children,
+    this.header,
+    this.footer,
+    this.margin,
+    this.shape,
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+  });
+
+  /// The list tiles to display inside the section.
+  ///
+  /// Typically [GlassListTile] widgets. [GlassGroupedSection] automatically
+  /// injects [GlassDivider]s between adjacent tiles — no manual divider or
+  /// position tracking needed.
+  final List<Widget> children;
+
+  /// Optional header displayed above the glass card.
+  ///
+  /// Typically a [Text] widget with section title styling (uppercase, small
+  /// font, muted colour) matching iOS grouped table section headers.
+  final Widget? header;
+
+  /// Optional footer displayed below the glass card.
+  ///
+  /// Typically a [Text] widget with explanatory text matching iOS grouped
+  /// table section footers.
+  final Widget? footer;
+
+  /// Empty space to surround the section card.
+  ///
+  /// Defaults to `EdgeInsets.symmetric(horizontal: 16, vertical: 6)` matching
+  /// iOS grouped table section insets.
+  final EdgeInsetsGeometry? margin;
+
+  /// Shape of the glass card.
+  ///
+  /// If null, uses [GlassCard]'s default shape.
+  final LiquidShape? shape;
+
+  /// Glass effect settings.
+  ///
+  /// If null, inherits from the parent layer or theme.
+  final LiquidGlassSettings? settings;
+
+  /// Whether to create its own glass layer.
+  ///
+  /// Defaults to false (grouped mode).
+  final bool useOwnLayer;
+
+  /// Rendering quality.
+  final GlassQuality? quality;
+
+  Widget _buildHeader(BuildContext context) {
+    if (header == null) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(left: 16.0, right: 16.0, bottom: 6.0),
+      child: DefaultTextStyle(
+        style: TextStyle(
+          color: CupertinoColors.secondaryLabel.resolveFrom(context),
+          fontSize: 13,
+          fontWeight: FontWeight.w400,
+          letterSpacing: 0.2,
+        ),
+        child: header!,
+      ),
+    );
+  }
+
+  Widget _buildFooter(BuildContext context) {
+    if (footer == null) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(left: 16.0, right: 16.0, top: 6.0),
+      child: DefaultTextStyle(
+        style: TextStyle(
+          color: CupertinoColors.secondaryLabel.resolveFrom(context),
+          fontSize: 13,
+          fontWeight: FontWeight.w400,
+        ),
+        child: footer!,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveMargin =
+        margin ?? const EdgeInsets.symmetric(horizontal: 16, vertical: 6);
+
+    // Interleave GlassDividers between adjacent children. The divider indent
+    // is derived from the preceding tile's leading widget — 56px with a leading
+    // icon (32px icon + 12px gap + 12px content start inset) or 16px otherwise.
+    // If the user manually placed a GlassDivider in children, we don't insert
+    // automatic dividers around it to prevent double-dividers.
+    final processedChildren = <Widget>[];
+    for (var i = 0; i < children.length; i++) {
+      processedChildren.add(children[i]);
+
+      final isLastChild = i == children.length - 1;
+      if (!isLastChild) {
+        final currentChild = children[i];
+        final nextChild = children[i + 1];
+
+        // Skip auto-divider if the current child is a divider, or if the next
+        // child is a divider. This prevents doubling them up.
+        if (currentChild is GlassDivider || nextChild is GlassDivider) continue;
+
+        // Compute indent based on whether the current tile has a leading widget.
+        final double indent =
+            (currentChild is GlassListTile && currentChild.leading != null)
+                ? 56.0
+                : 16.0;
+        processedChildren.add(GlassDivider(indent: indent));
+      }
+    }
+
+    final card = GlassCard(
+      padding: EdgeInsets.zero,
+      margin: EdgeInsets.zero,
+      shape: shape ?? const LiquidRoundedSuperellipse(borderRadius: 12),
+      settings: settings,
+      useOwnLayer: useOwnLayer,
+      quality: quality,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: processedChildren,
+      ),
+    );
+
+    Widget section = Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _buildHeader(context),
+        card,
+        _buildFooter(context),
+      ],
+    );
+
+    if (effectiveMargin != EdgeInsets.zero) {
+      section = Padding(
+        padding: effectiveMargin,
+        child: section,
+      );
+    }
+
+    return section;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/containers/glass_list_tile.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/containers/glass_list_tile.dart
@@ -1,0 +1,284 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../theme/glass_theme.dart';
+import '../../types/glass_quality.dart';
+import 'glass_container.dart';
+
+/// A glass-aesthetic list tile following iOS 26 grouped row design.
+///
+/// [GlassListTile] is the glass design system's equivalent of Flutter's
+/// [ListTile] — a clean, stateless item with no knowledge of its position.
+///
+/// Divider rendering is the responsibility of the parent container:
+/// [GlassGroupedSection] automatically injects [GlassDivider]s between tiles.
+/// For standalone column layouts, compose [GlassDivider] explicitly, as you
+/// would with Flutter's built-in [ListTile] + [Divider] pattern.
+///
+/// ## Usage inside [GlassGroupedSection] (recommended):
+///
+/// ```dart
+/// GlassGroupedSection(
+///   header: const Text('NETWORK'),
+///   children: [
+///     GlassListTile(
+///       leading: Icon(CupertinoIcons.wifi, color: CupertinoColors.white),
+///       title: Text('Wi-Fi'),
+///       trailing: GlassListTile.chevron,
+///     ),
+///     GlassListTile(
+///       leading: Icon(CupertinoIcons.bluetooth, color: CupertinoColors.white),
+///       title: Text('Bluetooth'),
+///       trailing: GlassListTile.chevron,
+///     ),
+///   ],
+/// )
+/// ```
+///
+/// ## Standalone tile (own glass layer):
+///
+/// ```dart
+/// GlassListTile.standalone(
+///   leading: Icon(CupertinoIcons.star_fill, color: Colors.yellow),
+///   title: Text('Featured'),
+///   onTap: () { },
+/// )
+/// ```
+class GlassListTile extends StatefulWidget {
+  /// Creates a glass list tile for use inside a [GlassCard],
+  /// [GlassGroupedSection], or other glass container.
+  /// Does not create its own glass layer.
+  const GlassListTile({
+    super.key,
+    this.leading,
+    required this.title,
+    this.subtitle,
+    this.trailing,
+    this.onTap,
+    this.onLongPress,
+    this.contentPadding = const EdgeInsets.symmetric(
+      horizontal: 16,
+      vertical: 12,
+    ),
+    this.leadingIconColor,
+    this.titleStyle,
+    this.subtitleStyle,
+  })  : _useOwnLayer = false,
+        _settings = null,
+        _quality = null;
+
+  /// Creates a standalone glass list tile that manages its own glass layer.
+  ///
+  /// Use when the tile is not inside a [GlassCard] or [GlassContainer].
+  const GlassListTile.standalone({
+    super.key,
+    this.leading,
+    required this.title,
+    this.subtitle,
+    this.trailing,
+    this.onTap,
+    this.onLongPress,
+    this.contentPadding = const EdgeInsets.symmetric(
+      horizontal: 16,
+      vertical: 12,
+    ),
+    this.leadingIconColor,
+    this.titleStyle,
+    this.subtitleStyle,
+    LiquidGlassSettings? settings,
+    GlassQuality? quality,
+  })  : _useOwnLayer = true,
+        _settings = settings,
+        _quality = quality;
+
+  // ===========================================================================
+  // Content Properties
+  // ===========================================================================
+
+  /// Widget displayed at the start (left) of the tile.
+  ///
+  /// Typically an [Icon] or [CircleAvatar]. Constrained to 24×24 by default.
+  final Widget? leading;
+
+  /// Primary content. Typically a [Text] widget.
+  final Widget title;
+
+  /// Optional secondary content displayed under [title].
+  final Widget? subtitle;
+
+  /// Widget displayed at the end (right) of the tile.
+  ///
+  /// Use [GlassListTile.chevron] for iOS-style navigation disclosure arrows.
+  final Widget? trailing;
+
+  // ===========================================================================
+  // Interaction Properties
+  // ===========================================================================
+
+  /// Called when the user taps the tile.
+  final VoidCallback? onTap;
+
+  /// Called when the user long-presses the tile.
+  final VoidCallback? onLongPress;
+
+  // ===========================================================================
+  // Styling Properties
+  // ===========================================================================
+
+  /// Padding inside the tile around the content row.
+  ///
+  /// Defaults to 16px horizontal, 12px vertical — matching iOS table row insets.
+  final EdgeInsetsGeometry contentPadding;
+
+  /// Tint applied to [leading] icon colour.
+  ///
+  /// If null, the icon uses its own colour or the theme's icon colour.
+  final Color? leadingIconColor;
+
+  /// Text style for [title].
+  ///
+  /// Defaults to white bold text matching glass surfaces.
+  final TextStyle? titleStyle;
+
+  /// Text style for [subtitle].
+  ///
+  /// Defaults to white with reduced opacity.
+  final TextStyle? subtitleStyle;
+
+  // ===========================================================================
+  // Glass Layer Properties (standalone only)
+  // ===========================================================================
+
+  final bool _useOwnLayer;
+  final LiquidGlassSettings? _settings;
+  final GlassQuality? _quality;
+
+  // ===========================================================================
+  // Convenience Constants
+  // ===========================================================================
+
+  /// A standard iOS-style disclosure chevron for use as [trailing].
+  static Widget get chevron => const Icon(
+        CupertinoIcons.chevron_forward,
+        color: CupertinoColors.systemGrey,
+        size: 20,
+      );
+
+  /// A standard iOS-style detail disclosure (circle with 'i') for [trailing].
+  static Widget get infoButton => const Icon(
+        CupertinoIcons.info,
+        color: CupertinoColors.systemGrey,
+        size: 20,
+      );
+
+  @override
+  State<GlassListTile> createState() => _GlassListTileState();
+}
+
+class _GlassListTileState extends State<GlassListTile> {
+  bool _isPressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final content = _buildContent(context);
+
+    if (widget._useOwnLayer) {
+      return GlassContainer(
+        shape: const LiquidRoundedSuperellipse(borderRadius: 12),
+        settings: widget._settings,
+        quality: widget._quality,
+        padding: EdgeInsets.zero,
+        child: content,
+      );
+    }
+
+    return content;
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final dynamicLabelColor =
+        CupertinoTheme.of(context).textTheme.textStyle.color ??
+            CupertinoColors.label;
+
+    final effectiveTitleStyle = widget.titleStyle ??
+        TextStyle(
+          color: dynamicLabelColor,
+          fontSize: 16,
+          fontWeight: FontWeight.w500,
+        );
+    final effectiveSubtitleStyle = widget.subtitleStyle ??
+        TextStyle(
+          color: dynamicLabelColor.withValues(alpha: 0.65),
+          fontSize: 13,
+        );
+
+    Widget row = Row(
+      children: [
+        if (widget.leading != null) ...[
+          IconTheme(
+            data: IconThemeData(
+              color: widget.leadingIconColor ?? dynamicLabelColor,
+              size: 22,
+            ),
+            child: SizedBox(width: 32, child: widget.leading),
+          ),
+          const SizedBox(width: 12),
+        ],
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              DefaultTextStyle(style: effectiveTitleStyle, child: widget.title),
+              if (widget.subtitle != null) ...[
+                const SizedBox(height: 2),
+                DefaultTextStyle(
+                  style: effectiveSubtitleStyle,
+                  child: widget.subtitle!,
+                ),
+              ],
+            ],
+          ),
+        ),
+        if (widget.trailing != null) ...[
+          const SizedBox(width: 8),
+          IconTheme(
+            data: IconThemeData(
+                color: dynamicLabelColor.withValues(alpha: 0.54), size: 20),
+            child: widget.trailing!,
+          ),
+        ],
+      ],
+    );
+
+    Widget tile = Padding(padding: widget.contentPadding, child: row);
+
+    if (widget.onTap != null || widget.onLongPress != null) {
+      tile = Semantics(
+        button: true,
+        child: GestureDetector(
+          onTap: widget.onTap,
+          onLongPress: widget.onLongPress,
+          onTapDown: (_) => setState(() => _isPressed = true),
+          onTapUp: (_) => setState(() => _isPressed = false),
+          onTapCancel: () => setState(() => _isPressed = false),
+          behavior: HitTestBehavior.opaque,
+          child: AnimatedContainer(
+            duration:
+                _isPressed ? Duration.zero : const Duration(milliseconds: 150),
+            curve: Curves.easeOutCubic,
+            color: _isPressed
+                ? (GlassTheme.brightnessOf(context) == Brightness.light
+                    ? CupertinoColors.black.withValues(alpha: 0.08)
+                    : CupertinoColors.white.withValues(alpha: 0.08))
+                : Colors.transparent,
+            child: tile,
+          ),
+        ),
+      );
+    }
+
+    return tile;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/containers/glass_stepper.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/containers/glass_stepper.dart
@@ -1,0 +1,369 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
+
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../theme/glass_theme.dart';
+import '../../types/glass_quality.dart';
+import '../shared/adaptive_glass.dart';
+
+/// A glass-aesthetic numeric stepper matching iOS 26's `UIStepper` control.
+///
+/// [GlassStepper] is the Flutter equivalent of iOS 26's `UIStepper`. It
+/// renders a compact horizontal pill with a decrement (`−`) button on the
+/// left, an increment (`+`) button on the right, and a thin vertical divider
+/// between them — all wrapped in a liquid glass material.
+///
+/// ## Behaviour
+///
+/// - Tapping `−` or `+` calls [onChanged] with the updated value and fires
+///   [HapticFeedback.lightImpact].
+/// - Holding either button triggers **auto-repeat** after [autoRepeatDelay],
+///   firing every [autoRepeatInterval] until released (matching iOS behaviour).
+/// - At [min] the `−` button is visually disabled; at [max] the `+` button is
+///   disabled (unless [wraps] is true, in which case the value cycles).
+/// - Button sides animate to a slightly pressed scale on touch-down.
+///
+/// ## Value display
+///
+/// iOS 26's native `UIStepper` does **not** show the value inside the control
+/// — the value is always displayed in a separate label by the app. [GlassStepper]
+/// follows this convention. To show the value, place a [Text] widget next to it:
+///
+/// ```dart
+/// Row(
+///   mainAxisAlignment: MainAxisAlignment.center,
+///   children: [
+///     Text(
+///       '$_quantity',
+///       style: TextStyle(fontSize: 22, color: CupertinoColors.white, fontWeight: FontWeight.w600),
+///     ),
+///     const SizedBox(width: 16),
+///     GlassStepper(
+///       value: _quantity.toDouble(),
+///       min: 1,
+///       max: 99,
+///       onChanged: (v) => setState(() => _quantity = v.toInt()),
+///     ),
+///   ],
+/// )
+/// ```
+///
+/// ## Properties
+///
+/// | Property | iOS equivalent | Default |
+/// |---|---|---|
+/// | [value] | `value` | — |
+/// | [min] | `minimumValue` | `0` |
+/// | [max] | `maximumValue` | `100` |
+/// | [step] | `stepValue` | `1` |
+/// | [wraps] | `wraps` | `false` |
+/// | [autoRepeat] | `autorepeat` | `true` |
+class GlassStepper extends StatefulWidget {
+  /// Creates an iOS 26-style glass stepper.
+  const GlassStepper({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.min = 0.0,
+    this.max = 100.0,
+    this.step = 1.0,
+    this.wraps = false,
+    this.autoRepeat = true,
+    this.autoRepeatDelay = const Duration(milliseconds: 500),
+    this.autoRepeatInterval = const Duration(milliseconds: 100),
+    this.height = 34.0,
+    this.width = 94.0,
+    this.dividerWidth = 0.5,
+    this.settings,
+    this.quality,
+  });
+
+  // ===========================================================================
+  // Value / Range
+  // ===========================================================================
+
+  /// The current numeric value.
+  final double value;
+
+  /// Called when the value changes via tap or auto-repeat.
+  ///
+  /// The supplied value is already clamped (or wrapped) within [min]..[max].
+  final ValueChanged<double>? onChanged;
+
+  /// The minimum value. Defaults to `0`.
+  final double min;
+
+  /// The maximum value. Defaults to `100`.
+  final double max;
+
+  /// The amount added/subtracted on each tap. Defaults to `1`.
+  final double step;
+
+  /// When `true`, stepping past [max] wraps back to [min] and vice-versa.
+  ///
+  /// Defaults to `false`.
+  final bool wraps;
+
+  // ===========================================================================
+  // Auto-repeat (hold behaviour)
+  // ===========================================================================
+
+  /// When `true`, holding a button fires repeated events like iOS.
+  ///
+  /// Defaults to `true`.
+  final bool autoRepeat;
+
+  /// How long to wait after the first tap before auto-repeat begins.
+  ///
+  /// Defaults to 500 ms.
+  final Duration autoRepeatDelay;
+
+  /// Interval between auto-repeat firings once they begin.
+  ///
+  /// Defaults to 100 ms.
+  final Duration autoRepeatInterval;
+
+  // ===========================================================================
+  // Sizing
+  // ===========================================================================
+
+  /// Height of the control. Defaults to 34 logical pixels (matches iOS 26 pt).
+  final double height;
+
+  /// Width of the control. Defaults to 94 logical pixels (matches iOS 26 pt).
+  final double width;
+
+  /// Thickness of the vertical divider between the two buttons.
+  ///
+  /// Defaults to 0.5.
+  final double dividerWidth;
+
+  // ===========================================================================
+  // Glass
+  // ===========================================================================
+
+  /// Glass effect settings for the pill background.
+  ///
+  /// If null, inherits from the nearest [LiquidGlassLayer] or uses defaults.
+  final LiquidGlassSettings? settings;
+
+  /// Rendering quality. Defaults to [GlassQuality.standard].
+  final GlassQuality? quality;
+
+  @override
+  State<GlassStepper> createState() => _GlassStepperState();
+}
+
+class _GlassStepperState extends State<GlassStepper> {
+  // Press-state scale for each side
+  bool _decrementPressed = false;
+  bool _incrementPressed = false;
+
+  // Auto-repeat timers
+  Timer? _repeatTimer;
+  Timer? _delayTimer;
+
+  @override
+  void dispose() {
+    _cancelRepeat();
+    super.dispose();
+  }
+
+  // ===========================================================================
+  // Value logic
+  // ===========================================================================
+
+  bool get _canDecrement => widget.wraps || widget.value > widget.min + 1e-10;
+
+  bool get _canIncrement => widget.wraps || widget.value < widget.max - 1e-10;
+
+  void _decrement() {
+    if (!_canDecrement) return;
+    HapticFeedback.lightImpact();
+    double next = widget.value - widget.step;
+    if (widget.wraps && next < widget.min) {
+      next = widget.max - ((widget.min - next) % (widget.max - widget.min));
+    }
+    widget.onChanged?.call(next.clamp(widget.min, widget.max));
+  }
+
+  void _increment() {
+    if (!_canIncrement) return;
+    HapticFeedback.lightImpact();
+    double next = widget.value + widget.step;
+    if (widget.wraps && next > widget.max) {
+      next = widget.min + ((next - widget.max) % (widget.max - widget.min));
+    }
+    widget.onChanged?.call(next.clamp(widget.min, widget.max));
+  }
+
+  // ===========================================================================
+  // Auto-repeat
+  // ===========================================================================
+
+  void _startRepeat(VoidCallback action) {
+    if (!widget.autoRepeat) return;
+    _delayTimer = Timer(widget.autoRepeatDelay, () {
+      _repeatTimer = Timer.periodic(widget.autoRepeatInterval, (_) => action());
+    });
+  }
+
+  void _cancelRepeat() {
+    _delayTimer?.cancel();
+    _repeatTimer?.cancel();
+    _delayTimer = null;
+    _repeatTimer = null;
+  }
+
+  // ===========================================================================
+  // Build
+  // ===========================================================================
+
+  @override
+  Widget build(BuildContext context) {
+    final borderRadius = BorderRadius.circular(widget.height / 2);
+
+    // Format current value for VoiceOver — show integer if whole, else decimal.
+    final valueStr = widget.value == widget.value.truncateToDouble()
+        ? widget.value.toInt().toString()
+        : widget.value.toStringAsFixed(1);
+
+    return Semantics(
+      // iOS UIStepper VoiceOver: announces value and supports swipe-up/down
+      // gestures to increment/decrement, matching native UIAccessibility.
+      label: 'Stepper',
+      value: valueStr,
+      increasedValue: _canIncrement
+          ? '${(widget.value + widget.step).clamp(widget.min, widget.max)}'
+          : null,
+      decreasedValue: _canDecrement
+          ? '${(widget.value - widget.step).clamp(widget.min, widget.max)}'
+          : null,
+      onIncrease: _canIncrement ? _increment : null,
+      onDecrease: _canDecrement ? _decrement : null,
+      child: SizedBox(
+        width: widget.width,
+        height: widget.height,
+        child: AdaptiveGlass(
+          shape: LiquidRoundedRectangle(
+            borderRadius: widget.height / 2,
+          ),
+          settings: widget.settings ?? const LiquidGlassSettings(),
+          quality: widget.quality ?? GlassQuality.standard,
+          child: ClipRRect(
+            borderRadius: borderRadius,
+            child: Row(
+              children: [
+                // ── Decrement side ──────────────────────────────────────────────
+                Expanded(
+                  child: _StepperSide(
+                    icon: CupertinoIcons.minus,
+                    isPressed: _decrementPressed,
+                    isEnabled: _canDecrement,
+                    onTapDown: () {
+                      setState(() => _decrementPressed = true);
+                      _decrement();
+                      _startRepeat(_decrement);
+                    },
+                    onTapUp: () {
+                      setState(() => _decrementPressed = false);
+                      _cancelRepeat();
+                    },
+                    onTapCancel: () {
+                      setState(() => _decrementPressed = false);
+                      _cancelRepeat();
+                    },
+                  ),
+                ),
+
+                // ── Vertical divider ────────────────────────────────────────────
+                SizedBox(
+                  width: widget.dividerWidth,
+                  height: widget.height,
+                  child: ColoredBox(
+                    color: GlassTheme.brightnessOf(context) == Brightness.light
+                        ? CupertinoColors.black.withValues(alpha: 0.25)
+                        : CupertinoColors.white.withValues(alpha: 0.25),
+                  ),
+                ),
+
+                // ── Increment side ──────────────────────────────────────────────
+                Expanded(
+                  child: _StepperSide(
+                    icon: CupertinoIcons.plus,
+                    isPressed: _incrementPressed,
+                    isEnabled: _canIncrement,
+                    onTapDown: () {
+                      setState(() => _incrementPressed = true);
+                      _increment();
+                      _startRepeat(_increment);
+                    },
+                    onTapUp: () {
+                      setState(() => _incrementPressed = false);
+                      _cancelRepeat();
+                    },
+                    onTapCancel: () {
+                      setState(() => _incrementPressed = false);
+                      _cancelRepeat();
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// Private: one side (− or +)
+// =============================================================================
+
+class _StepperSide extends StatelessWidget {
+  const _StepperSide({
+    required this.icon,
+    required this.isPressed,
+    required this.isEnabled,
+    required this.onTapDown,
+    required this.onTapUp,
+    required this.onTapCancel,
+  });
+
+  final IconData icon;
+  final bool isPressed;
+  final bool isEnabled;
+  final VoidCallback onTapDown;
+  final VoidCallback onTapUp;
+  final VoidCallback onTapCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTapDown: isEnabled ? (_) => onTapDown() : null,
+      onTapUp: (_) => onTapUp(),
+      onTapCancel: onTapCancel,
+      child: AnimatedScale(
+        scale: (isPressed && isEnabled) ? 0.88 : 1.0,
+        duration: const Duration(milliseconds: 80),
+        curve: Curves.easeOut,
+        child: Center(
+          child: AnimatedOpacity(
+            duration: const Duration(milliseconds: 150),
+            opacity: isEnabled ? 1.0 : 0.3,
+            child: Icon(
+              icon,
+              color: CupertinoTheme.of(context).textTheme.textStyle.color ??
+                  CupertinoColors.label,
+              size: 20,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/feedback/glass_progress_indicator.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/feedback/glass_progress_indicator.dart
@@ -1,0 +1,523 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../theme/glass_theme_data.dart';
+import '../../types/glass_quality.dart';
+import '../shared/adaptive_liquid_glass_layer.dart';
+
+/// A glass morphism progress indicator following Apple's iOS 26 Liquid Glass
+/// design patterns.
+///
+/// [GlassProgressIndicator] provides both circular and linear progress indicators
+/// with glass effect, matching iOS's ProgressView appearance with liquid glass
+/// aesthetics.
+///
+/// ## iOS 26 Specifications
+///
+/// This widget implements the exact iOS 26 Liquid Glass progress indicators:
+/// - **Circular**: 20pt diameter (default), 2.5pt stroke width
+/// - **Linear**: Full width, 4pt height (default)
+/// - **Animation**: 1.0 second rotation for indeterminate
+/// - **Glass Effect**: Translucent with specular highlights
+/// - **Tint Color**: Adaptive based on theme (blue default)
+///
+/// ## Usage
+///
+/// ### Circular Indeterminate (Loading Spinner)
+/// ```dart
+/// GlassProgressIndicator.circular()
+/// ```
+///
+/// ### Circular Determinate (Progress Ring)
+/// ```dart
+/// GlassProgressIndicator.circular(
+///   value: 0.7, // 70% complete
+/// )
+/// ```
+///
+/// ### Linear Indeterminate (Loading Bar)
+/// ```dart
+/// GlassProgressIndicator.linear()
+/// ```
+///
+/// ### Linear Determinate (Progress Bar)
+/// ```dart
+/// GlassProgressIndicator.linear(
+///   value: 0.5, // 50% complete
+/// )
+/// ```
+///
+/// ### Custom Size and Color
+/// ```dart
+/// GlassProgressIndicator.circular(
+///   value: 0.3,
+///   size: 40.0,
+///   strokeWidth: 4.0,
+///   color: Colors.green,
+/// )
+/// ```
+///
+/// ### Standalone Mode
+/// ```dart
+/// GlassProgressIndicator.circular(
+///   useOwnLayer: true,
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 12,
+///   ),
+/// )
+/// ```
+///
+/// ### Within LiquidGlassLayer
+/// ```dart
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 12,
+///   ),
+///   child: Column(
+///     children: [
+///       GlassProgressIndicator.circular(),
+///       SizedBox(height: 20),
+///       GlassProgressIndicator.linear(value: 0.6),
+///     ],
+///   ),
+/// )
+/// ```
+class GlassProgressIndicator extends StatefulWidget {
+  /// Creates a circular glass progress indicator.
+  ///
+  /// If [value] is null, the indicator is indeterminate (infinite animation).
+  /// If [value] is non-null (0.0 to 1.0), the indicator shows determinate progress.
+  const GlassProgressIndicator.circular({
+    super.key,
+    this.value,
+    this.size = 20.0,
+    this.strokeWidth = 2.5,
+    this.color,
+    this.backgroundColor,
+    this.useOwnLayer = false,
+    this.settings,
+    this.quality,
+  })  : _type = _ProgressIndicatorType.circular,
+        height = null,
+        minWidth = null;
+
+  /// Creates a linear glass progress indicator.
+  ///
+  /// If [value] is null, the indicator is indeterminate (infinite animation).
+  /// If [value] is non-null (0.0 to 1.0), the indicator shows determinate progress.
+  const GlassProgressIndicator.linear({
+    super.key,
+    this.value,
+    this.height = 4.0,
+    this.minWidth = 200.0,
+    this.color,
+    this.backgroundColor,
+    this.useOwnLayer = false,
+    this.settings,
+    this.quality,
+  })  : _type = _ProgressIndicatorType.linear,
+        size = null,
+        strokeWidth = null;
+
+  // ===========================================================================
+  // Progress Properties
+  // ===========================================================================
+
+  /// The current progress value (0.0 to 1.0).
+  ///
+  /// If null, the indicator is indeterminate (infinite animation).
+  /// If non-null, the indicator shows determinate progress.
+  ///
+  /// - `0.0` = 0% complete (no progress)
+  /// - `0.5` = 50% complete (half progress)
+  /// - `1.0` = 100% complete (full progress)
+  final double? value;
+
+  /// The color of the progress indicator.
+  ///
+  /// If null, uses theme's primary glow color or iOS blue (#007AFF).
+  final Color? color;
+
+  /// The background color (track color).
+  ///
+  /// If null, uses semi-transparent white (#26FFFFFF - 15% opacity).
+  final Color? backgroundColor;
+
+  // ===========================================================================
+  // Size Properties
+  // ===========================================================================
+
+  /// Size of the circular progress indicator (diameter).
+  ///
+  /// **iOS 26 Standard Sizes**:
+  /// - `20.0` - Default (matches UIActivityIndicator medium)
+  /// - `14.0` - Small
+  /// - `28.0` - Large
+  ///
+  /// Only applies to circular indicators. Ignored for linear.
+  final double? size;
+
+  /// Stroke width of the circular progress indicator.
+  ///
+  /// **iOS 26 Standard**: `2.5pt` (default)
+  ///
+  /// Only applies to circular indicators. Ignored for linear.
+  final double? strokeWidth;
+
+  /// Height of the linear progress indicator.
+  ///
+  /// **iOS 26 Standard**: `4.0pt` (default)
+  ///
+  /// Only applies to linear indicators. Ignored for circular.
+  final double? height;
+
+  /// Minimum width of the linear progress indicator.
+  ///
+  /// Defaults to `200.0` to ensure visibility.
+  ///
+  /// Only applies to linear indicators. Ignored for circular.
+  final double? minWidth;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Whether to create its own [AdaptiveLiquidGlassLayer].
+  ///
+  /// If false (default), the indicator must be inside a [AdaptiveLiquidGlassLayer].
+  /// If true, creates an independent glass layer with [settings].
+  final bool useOwnLayer;
+
+  /// Glass effect settings for standalone mode.
+  ///
+  /// Only used when [useOwnLayer] is true.
+  /// If null, uses [LiquidGlassSettings] defaults.
+  final LiquidGlassSettings? settings;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// If null, inherits from parent or theme, or defaults to [GlassQuality.standard].
+  final GlassQuality? quality;
+
+  // ===========================================================================
+  // Private Properties
+  // ===========================================================================
+
+  final _ProgressIndicatorType _type;
+
+  @override
+  State<GlassProgressIndicator> createState() => _GlassProgressIndicatorState();
+}
+
+class _GlassProgressIndicatorState extends State<GlassProgressIndicator>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1000), // iOS 26: 1.0s rotation
+      vsync: this,
+    );
+
+    // Start animation only if indeterminate
+    if (widget.value == null) {
+      _controller.repeat();
+    }
+  }
+
+  @override
+  void didUpdateWidget(GlassProgressIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    // Handle indeterminate ↔ determinate transitions
+    if (widget.value == null && oldWidget.value != null) {
+      // Switched to indeterminate
+      _controller.repeat();
+    } else if (widget.value != null && oldWidget.value == null) {
+      // Switched to determinate
+      _controller.stop();
+      _controller.value = 0.0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Resolve colors from theme if not explicitly provided
+    final themeData = GlassThemeData.of(context);
+    final effectiveColor = widget.color ??
+        themeData.glowColorsFor(context).primary ??
+        const Color(0xFF007AFF); // iOS blue
+    final effectiveBackgroundColor =
+        widget.backgroundColor ?? const Color(0x26FFFFFF); // 15% white
+
+    final indicator = widget._type == _ProgressIndicatorType.circular
+        ? _buildCircular(effectiveColor, effectiveBackgroundColor)
+        : _buildLinear(effectiveColor, effectiveBackgroundColor);
+
+    // Semantics: determinate → percentage value; indeterminate → "Loading"
+    // Matches iOS ProgressView VoiceOver behaviour.
+    final valueStr = widget.value != null
+        ? '${(widget.value!.clamp(0.0, 1.0) * 100).round()}%'
+        : null;
+    final semanticWidget = Semantics(
+      label: 'Progress',
+      value: valueStr,
+      // liveRegion so dynamic changes are announced without needing focus
+      liveRegion: widget.value != null,
+      child: indicator,
+    );
+
+    // Wrap in glass layer if standalone
+    if (widget.useOwnLayer) {
+      return AdaptiveLiquidGlassLayer(
+        settings: widget.settings ?? const LiquidGlassSettings(),
+        quality: widget.quality,
+        child: semanticWidget,
+      );
+    }
+
+    return semanticWidget;
+  }
+
+  Widget _buildCircular(Color color, Color backgroundColor) {
+    final size = widget.size ?? 20.0;
+    final strokeWidth = widget.strokeWidth ?? 2.5;
+
+    return SizedBox(
+      width: size,
+      height: size,
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, child) {
+          return CustomPaint(
+            painter: _CircularProgressPainter(
+              value: widget.value,
+              color: color,
+              backgroundColor: backgroundColor,
+              strokeWidth: strokeWidth,
+              rotation: _controller.value * 2 * math.pi,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildLinear(Color color, Color backgroundColor) {
+    final height = widget.height ?? 4.0;
+    final minWidth = widget.minWidth ?? 200.0;
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        minWidth: minWidth,
+        minHeight: height,
+        maxHeight: height,
+      ),
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, child) {
+          return CustomPaint(
+            painter: _LinearProgressPainter(
+              value: widget.value,
+              color: color,
+              backgroundColor: backgroundColor,
+              animation: _controller.value,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// Circular Progress Painter
+// =============================================================================
+
+class _CircularProgressPainter extends CustomPainter {
+  _CircularProgressPainter({
+    required this.value,
+    required this.color,
+    required this.backgroundColor,
+    required this.strokeWidth,
+    required this.rotation,
+  });
+
+  final double? value;
+  final Color color;
+  final Color backgroundColor;
+  final double strokeWidth;
+  final double rotation;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = (size.width - strokeWidth) / 2;
+    final rect = Rect.fromCircle(center: center, radius: radius);
+
+    // Draw background track (glass)
+    final backgroundPaint = Paint()
+      ..color = backgroundColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawArc(
+      rect,
+      0,
+      2 * math.pi,
+      false,
+      backgroundPaint,
+    );
+
+    // Draw progress arc with glow
+    final progressPaint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    // Add glass glow effect
+    final glowPaint = Paint()
+      ..color = color.withValues(alpha: 0.3)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth + 2
+      ..strokeCap = StrokeCap.round
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 4);
+
+    if (value == null) {
+      // Indeterminate: rotating arc (90 degrees)
+      final startAngle = rotation - math.pi / 2; // Start at top
+      final sweepAngle = math.pi / 2; // 90 degrees (iOS standard)
+
+      canvas.drawArc(rect, startAngle, sweepAngle, false, glowPaint);
+      canvas.drawArc(rect, startAngle, sweepAngle, false, progressPaint);
+    } else {
+      // Determinate: progress ring
+      final startAngle = -math.pi / 2; // Start at top
+      final sweepAngle = 2 * math.pi * value!.clamp(0.0, 1.0);
+
+      if (sweepAngle > 0) {
+        canvas.drawArc(rect, startAngle, sweepAngle, false, glowPaint);
+        canvas.drawArc(rect, startAngle, sweepAngle, false, progressPaint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_CircularProgressPainter oldDelegate) {
+    return value != oldDelegate.value ||
+        color != oldDelegate.color ||
+        backgroundColor != oldDelegate.backgroundColor ||
+        strokeWidth != oldDelegate.strokeWidth ||
+        rotation != oldDelegate.rotation;
+  }
+}
+
+// =============================================================================
+// Linear Progress Painter
+// =============================================================================
+
+class _LinearProgressPainter extends CustomPainter {
+  _LinearProgressPainter({
+    required this.value,
+    required this.color,
+    required this.backgroundColor,
+    required this.animation,
+  });
+
+  final double? value;
+  final Color color;
+  final Color backgroundColor;
+  final double animation;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final height = size.height;
+    final width = size.width;
+    final borderRadius = height / 2; // Fully rounded ends
+
+    // Draw background track (glass)
+    final backgroundPaint = Paint()
+      ..color = backgroundColor
+      ..style = PaintingStyle.fill;
+
+    final backgroundRect = RRect.fromRectAndRadius(
+      Rect.fromLTWH(0, 0, width, height),
+      Radius.circular(borderRadius),
+    );
+    canvas.drawRRect(backgroundRect, backgroundPaint);
+
+    // Draw progress bar with glow
+    double progressWidth;
+    double progressX;
+
+    if (value == null) {
+      // Indeterminate: moving bar (iOS standard)
+      // Bar moves from -30% to 130% (160% total range)
+      // Bar width is 30% of track width
+      final barWidth = width * 0.3;
+      final position = animation * (width + barWidth) - barWidth;
+      progressX = position;
+      progressWidth = barWidth;
+    } else {
+      // Determinate: fill from left
+      progressX = 0;
+      progressWidth = width * value!.clamp(0.0, 1.0);
+    }
+
+    if (progressWidth > 0) {
+      // Add glow
+      final glowPaint = Paint()
+        ..color = color.withValues(alpha: 0.3)
+        ..style = PaintingStyle.fill
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 4);
+
+      final glowRect = RRect.fromRectAndRadius(
+        Rect.fromLTWH(progressX, 0, progressWidth, height),
+        Radius.circular(borderRadius),
+      );
+      canvas.drawRRect(glowRect, glowPaint);
+
+      // Draw solid progress
+      final progressPaint = Paint()
+        ..color = color
+        ..style = PaintingStyle.fill;
+
+      final progressRect = RRect.fromRectAndRadius(
+        Rect.fromLTWH(progressX, 0, progressWidth, height),
+        Radius.circular(borderRadius),
+      );
+      canvas.drawRRect(progressRect, progressPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_LinearProgressPainter oldDelegate) {
+    return value != oldDelegate.value ||
+        color != oldDelegate.color ||
+        backgroundColor != oldDelegate.backgroundColor ||
+        animation != oldDelegate.animation;
+  }
+}
+
+// =============================================================================
+// Internal Types
+// =============================================================================
+
+enum _ProgressIndicatorType {
+  circular,
+  linear,
+}

--- a/packages/liquid_glass_widgets/lib/widgets/input/glass_form_field.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/input/glass_form_field.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/cupertino.dart';
+
+/// A standard form field wrapper for glass inputs following iOS design patterns.
+///
+/// [GlassFormField] wraps input widgets (like [GlassTextField], [GlassPicker],
+/// etc.) with a standard label, error text, and helper text layout. It ensures
+/// consistent spacing and typography across all form inputs in an application.
+///
+/// ## Key Features
+///
+/// - **Consistent Typography**: Uses standard iOS-style weights and colors for labels
+/// - **Validation Support**: Displays error text in red when provided
+/// - **Helper Text**: Optional secondary text for hints or instructions
+/// - **Flexible Layout**: Works with any child widget
+///
+/// ## Usage
+///
+/// ### Basic Usage
+/// ```dart
+/// GlassFormField(
+///   label: 'Email Address',
+///   child: GlassTextField(
+///     placeholder: 'name@example.com',
+///   ),
+/// )
+/// ```
+///
+/// ### With Validation Error
+/// ```dart
+/// GlassFormField(
+///   label: 'Password',
+///   errorText: isPasswordValid ? null : 'Password must be at least 8 chars',
+///   child: GlassPasswordField(),
+/// )
+/// ```
+///
+/// ### With Helper Text
+/// ```dart
+/// GlassFormField(
+///   label: 'Username',
+///   helperText: 'This will be visible to other users',
+///   child: GlassTextField(),
+/// )
+/// ```
+class GlassFormField extends StatelessWidget {
+  /// Creates a form field wrapper.
+  const GlassFormField({
+    required this.child,
+    super.key,
+    this.label,
+    this.helperText,
+    this.errorText,
+    this.crossAxisAlignment = CrossAxisAlignment.start,
+  });
+
+  /// The input widget (e.g., GlassTextField).
+  final Widget child;
+
+  /// Label displayed above the input.
+  final String? label;
+
+  /// Helper text displayed below the input.
+  final String? helperText;
+
+  /// Error text displayed below the input (replaces helperText).
+  final String? errorText;
+
+  /// Cross alignment of the column.
+  final CrossAxisAlignment crossAxisAlignment;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: crossAxisAlignment,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (label != null) ...[
+          Text(
+            label!,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: CupertinoColors.label.resolveFrom(context),
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+
+        // Wrap child in Theme or similar if we wanted to cascade error state,
+        // but for now we just render it.
+        child,
+
+        if (errorText != null) ...[
+          const SizedBox(height: 6),
+          Text(
+            errorText!,
+            style: TextStyle(
+              fontSize: 12,
+              color: CupertinoColors.systemRed,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ] else if (helperText != null) ...[
+          const SizedBox(height: 6),
+          Text(
+            helperText!,
+            style: TextStyle(
+              fontSize: 12,
+              color: CupertinoColors.secondaryLabel.resolveFrom(context),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/input/glass_password_field.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/input/glass_password_field.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../src/types/glass_interaction_behavior.dart';
+import '../../types/glass_quality.dart';
+import 'glass_text_field.dart';
+
+/// A secure glass text field for password entry.
+///
+/// [GlassPasswordField] wraps [GlassTextField] with a built-in visibility toggle.
+/// It exposes all standard text field and glass configuration options.
+class GlassPasswordField extends StatefulWidget {
+  /// Creates a glass password field.
+  const GlassPasswordField({
+    super.key,
+    this.controller,
+    this.focusNode,
+    this.placeholder = 'Password',
+    this.onChanged,
+    this.onSubmitted,
+    this.enabled = true,
+    this.readOnly = false,
+    this.autofocus = false,
+    this.textInputAction,
+    this.inputFormatters,
+    this.textStyle,
+    this.placeholderStyle,
+    this.padding = const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+    this.width,
+    // Glass properties
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality = GlassQuality.standard,
+    this.shape = const LiquidRoundedSuperellipse(borderRadius: 10),
+    // ── iOS 26 interaction ────────────────────────────────────────────────
+    this.interactionBehavior = GlassInteractionBehavior.full,
+    this.pressScale = 1.03,
+    this.glowColor,
+    this.glowRadius = 1.5,
+    this.onTapOutside,
+  });
+
+  /// Controls the text being edited.
+  final TextEditingController? controller;
+
+  /// Controls the focus state.
+  final FocusNode? focusNode;
+
+  /// Placeholder text.
+  final String placeholder;
+
+  /// Called when text changes.
+  final ValueChanged<String>? onChanged;
+
+  /// Called when submitted.
+  final ValueChanged<String>? onSubmitted;
+
+  /// Whether the field is enabled.
+  final bool enabled;
+
+  /// Whether the field is read-only.
+  final bool readOnly;
+
+  /// Whether to autofocus.
+  final bool autofocus;
+
+  /// Action button on keyboard.
+  final TextInputAction? textInputAction;
+
+  /// Input formatters.
+  final List<TextInputFormatter>? inputFormatters;
+
+  /// Style for the text.
+  final TextStyle? textStyle;
+
+  /// Style for the placeholder.
+  final TextStyle? placeholderStyle;
+
+  /// Padding inside the field.
+  final EdgeInsetsGeometry padding;
+
+  /// Optional fixed width.
+  final double? width;
+
+  /// Glass settings.
+  final LiquidGlassSettings? settings;
+
+  /// Whether to use its own layer (true) or grouped (false).
+  final bool useOwnLayer;
+
+  /// Rendering quality.
+  final GlassQuality quality;
+
+  /// Shape of the field.
+  final LiquidShape shape;
+
+  /// Controls which press-interaction effects are active.
+  ///
+  /// Mirrors [GlassTextField.interactionBehavior] — see that field for details.
+  /// Defaults to [GlassInteractionBehavior.full].
+  final GlassInteractionBehavior interactionBehavior;
+
+  /// Scale factor applied when the field is pressed.
+  ///
+  /// Mirrors [GlassTextField.pressScale]. Defaults to `1.03`.
+  final double pressScale;
+
+  /// Colour of the directional glow. Mirrors [GlassTextField.glowColor].
+  final Color? glowColor;
+
+  /// Spread radius of the glow. Mirrors [GlassTextField.glowRadius].
+  final double glowRadius;
+
+  /// Called when user taps outside. Mirrors [GlassTextField.onTapOutside].
+  final TapRegionCallback? onTapOutside;
+
+  @override
+  State<GlassPasswordField> createState() => _GlassPasswordFieldState();
+}
+
+class _GlassPasswordFieldState extends State<GlassPasswordField> {
+  bool _obscureText = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassTextField(
+      controller: widget.controller,
+      focusNode: widget.focusNode,
+      placeholder: widget.placeholder,
+      obscureText: _obscureText,
+      maxLines: 1,
+      keyboardType: TextInputType.visiblePassword,
+      textInputAction: widget.textInputAction,
+      enabled: widget.enabled,
+      readOnly: widget.readOnly,
+      autofocus: widget.autofocus,
+      inputFormatters: widget.inputFormatters,
+      textStyle: widget.textStyle,
+      placeholderStyle: widget.placeholderStyle,
+      padding: widget.padding,
+      settings: widget.settings,
+      useOwnLayer: widget.useOwnLayer,
+      quality: widget.quality,
+      shape: widget.shape,
+      prefixIcon: Icon(
+        CupertinoIcons.lock_fill,
+        size: 20,
+        color: CupertinoColors.secondaryLabel.resolveFrom(context),
+      ),
+      suffixIcon: Icon(
+        _obscureText ? CupertinoIcons.eye_slash_fill : CupertinoIcons.eye_fill,
+        size: 20,
+        color: CupertinoColors.secondaryLabel.resolveFrom(context),
+      ),
+      onSuffixTap: () {
+        setState(() {
+          _obscureText = !_obscureText;
+        });
+      },
+      onChanged: widget.onChanged,
+      onSubmitted: widget.onSubmitted,
+      interactionBehavior: widget.interactionBehavior,
+      pressScale: widget.pressScale,
+      glowColor: widget.glowColor,
+      glowRadius: widget.glowRadius,
+      onTapOutside: widget.onTapOutside,
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/input/glass_picker.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/input/glass_picker.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/cupertino.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../types/glass_quality.dart';
+import '../shared/adaptive_glass.dart';
+import '../../theme/glass_theme_helpers.dart';
+
+/// A glass picker widget following iOS design patterns.
+///
+/// [GlassPicker] displays a selected value in a glass container. Tapping it
+/// opens a standard Cupertino picker in a modal bottom sheet.
+class GlassPicker extends StatelessWidget {
+  /// Creates a glass picker.
+  const GlassPicker({
+    required this.value,
+    this.onTap,
+    super.key,
+    this.placeholder = 'Select',
+    this.icon,
+    this.height = 48.0,
+    this.width,
+    this.padding = const EdgeInsets.symmetric(horizontal: 16),
+    this.textStyle,
+    this.placeholderStyle,
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    this.shape = const LiquidRoundedSuperellipse(borderRadius: 10),
+  });
+
+  /// The currently selected text value.
+  final String? value;
+
+  /// Placeholder when value is null.
+  final String placeholder;
+
+  /// Icon widget to display at the end (defaults to chevron down).
+  final Widget? icon;
+
+  /// Called when tapped.
+  final VoidCallback? onTap;
+
+  /// Height of the picker field.
+  final double height;
+
+  /// Optional width.
+  final double? width;
+
+  /// Padding.
+  final EdgeInsetsGeometry padding;
+
+  /// Style for the value text.
+  final TextStyle? textStyle;
+
+  /// Style for the placeholder text.
+  final TextStyle? placeholderStyle;
+
+  /// Glass settings.
+  final LiquidGlassSettings? settings;
+
+  /// Whether to use its own layer (true) or grouped (false).
+  final bool useOwnLayer;
+
+  /// Quality.
+  final GlassQuality? quality;
+
+  /// Shape of the container.
+  final LiquidShape shape;
+
+  @override
+  Widget build(BuildContext context) {
+    // Inherit quality from parent layer if not explicitly set
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: quality,
+    );
+
+    final labelColor = CupertinoColors.label.resolveFrom(context);
+    final secondaryColor = CupertinoColors.secondaryLabel.resolveFrom(context);
+
+    final effectiveTextStyle =
+        TextStyle(fontSize: 16, color: labelColor).merge(textStyle);
+
+    final effectivePlaceholderStyle =
+        TextStyle(fontSize: 16, color: secondaryColor).merge(placeholderStyle);
+
+    final child = Container(
+      height: height,
+      width: width,
+      padding: padding,
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              value ?? placeholder,
+              style: value != null
+                  ? effectiveTextStyle
+                  : effectivePlaceholderStyle,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          IconTheme(
+            data: IconThemeData(size: 16, color: secondaryColor),
+            child: icon ?? const Icon(CupertinoIcons.chevron_up_chevron_down),
+          ),
+        ],
+      ),
+    );
+
+    final glassWidget = AdaptiveGlass(
+      shape: shape,
+      settings: settings ?? const LiquidGlassSettings(blur: 8),
+      quality: effectiveQuality,
+      useOwnLayer: useOwnLayer,
+      child: child,
+    );
+
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: glassWidget,
+    );
+  }
+
+  /// Helper to show a bottom sheet picker.
+  static Future<T?> showSheet<T>({
+    required BuildContext context,
+    required List<T> items,
+    required Widget Function(T item) itemBuilder,
+    String? title,
+  }) {
+    return showCupertinoModalPopup<T>(
+      context: context,
+      builder: (context) => Container(
+        height: 300,
+        decoration: BoxDecoration(
+          color: CupertinoColors.systemBackground.resolveFrom(context),
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        child: Column(
+          children: [
+            if (title != null)
+              Container(
+                height: 50,
+                alignment: Alignment.center,
+                child: Text(title,
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
+              ),
+            Expanded(
+              child: CupertinoPicker.builder(
+                itemExtent: 40,
+                onSelectedItemChanged: (index) {
+                  // Handle live update if needed
+                },
+                itemBuilder: (context, index) {
+                  if (index < 0 || index >= items.length) return null;
+                  return itemBuilder(items[index]);
+                },
+                childCount: items.length,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/input/glass_search_bar.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/input/glass_search_bar.dart
@@ -1,0 +1,420 @@
+import 'package:flutter/cupertino.dart';
+import '../../theme/glass_theme.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../types/glass_quality.dart';
+import '../interactive/glass_button.dart';
+import 'glass_text_field.dart';
+
+/// A glass morphism search bar following Apple's iOS 26 design patterns.
+///
+/// [GlassSearchBar] provides a sophisticated search field with pill shape,
+/// animated clear button, and optional cancel button that slides in from the
+/// right. It matches iOS's UISearchBar appearance and behavior with glass
+/// morphism effects.
+///
+/// ## Key Features
+///
+/// - **Pill-Shaped Glass**: Rounded search field with glass effect
+/// - **Animated Clear Button**: Appears/fades when text is entered
+/// - **Cancel Button**: Optional slide-in cancel button (iOS pattern)
+/// - **Search Icon**: Leading search icon with customizable color
+/// - **Auto-focus Support**: Can auto-focus on appearance
+/// - **Dual Mode**: Grouped or standalone rendering
+///
+/// ## Usage
+///
+/// ### Basic Usage
+/// ```dart
+/// String query = '';
+///
+/// GlassSearchBar(
+///   placeholder: 'Search',
+///   onChanged: (value) {
+///     setState(() => query = value);
+///   },
+/// )
+/// ```
+///
+/// ### With Cancel Button
+/// ```dart
+/// GlassSearchBar(
+///   placeholder: 'Search messages',
+///   showsCancelButton: true,
+///   onCancel: () {
+///     // Clear search and dismiss keyboard
+///   },
+/// )
+/// ```
+///
+/// ### Within LiquidGlassLayer (Grouped Mode)
+/// ```dart
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 8,
+///     refractiveIndex: 1.59,
+///   ),
+///   child: Column(
+///     children: [
+///       GlassSearchBar(
+///         placeholder: 'Search',
+///         onChanged: (value) => _performSearch(value),
+///       ),
+///       // Search results...
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ### Standalone Mode
+/// ```dart
+/// GlassSearchBar(
+///   placeholder: 'Search',
+///   useOwnLayer: true,
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 8,
+///   ),
+///   onChanged: (value) => _performSearch(value),
+/// )
+/// ```
+///
+/// ### Custom Styling
+/// ```dart
+/// GlassSearchBar(
+///   placeholder: 'Search products...',
+///   searchIconColor: Colors.blue,
+///   clearIconColor: Colors.blue,
+///   cancelButtonColor: Colors.blue,
+///   textStyle: TextStyle(fontSize: 18, color: Colors.white),
+///   height: 48,
+/// )
+/// ```
+class GlassSearchBar extends StatefulWidget {
+  /// Creates a glass search bar.
+  const GlassSearchBar({
+    super.key,
+    this.controller,
+    this.focusNode,
+    this.placeholder = 'Search',
+    this.onChanged,
+    this.onSubmitted,
+    this.onCancel,
+    this.showsCancelButton = false,
+    this.autofocus = false,
+    this.enabled = true,
+    this.searchIconColor,
+    this.clearIconColor,
+    this.cancelButtonColor,
+    this.cancelIcon,
+    this.cancelIconSize = 24,
+    this.textStyle,
+    this.placeholderStyle,
+    this.height = 44.0,
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+  });
+
+  // ===========================================================================
+  // Search Bar Properties
+  // ===========================================================================
+
+  /// Controls the text being edited.
+  ///
+  /// If null, a controller will be created internally.
+  final TextEditingController? controller;
+
+  /// Optional focus node for the search field.
+  ///
+  /// Providing a [FocusNode] gives you programmatic control over keyboard
+  /// focus independently of [autofocus]:
+  ///
+  /// - `focusNode.requestFocus()` — open keyboard at any moment.
+  /// - `focusNode.unfocus()` — dismiss keyboard without clearing text.
+  /// - `focusNode.addListener(...)` — react to focus changes in your own code.
+  ///
+  /// **Lifecycle:** the caller is responsible for disposing the node.
+  /// The widget will never dispose a caller-provided [FocusNode].
+  ///
+  /// If null, an internal node is created and disposed automatically.
+  final FocusNode? focusNode;
+
+  /// Placeholder text shown when the field is empty.
+  ///
+  /// Defaults to 'Search'.
+  final String placeholder;
+
+  /// Called when the search text changes.
+  final ValueChanged<String>? onChanged;
+
+  /// Called when the user submits the search.
+  final ValueChanged<String>? onSubmitted;
+
+  /// Called when the cancel button is tapped.
+  ///
+  /// If [showsCancelButton] is true and this callback is provided,
+  /// the cancel button will be shown.
+  final VoidCallback? onCancel;
+
+  /// Whether to show the cancel button.
+  ///
+  /// When true, the cancel button slides in from the right when the search
+  /// bar is focused, matching iOS behavior.
+  ///
+  /// Defaults to false.
+  final bool showsCancelButton;
+
+  /// Whether the search field should auto-focus.
+  ///
+  /// Defaults to false.
+  final bool autofocus;
+
+  /// Whether the search field is enabled.
+  ///
+  /// Defaults to true.
+  final bool enabled;
+
+  // ===========================================================================
+  // Style Properties
+  // ===========================================================================
+
+  /// Color of the search icon.
+  ///
+  /// Defaults to white with 60% opacity.
+  final Color? searchIconColor;
+
+  /// Color of the clear button icon.
+  ///
+  /// Defaults to white with 60% opacity.
+  final Color? clearIconColor;
+
+  /// Color of the cancel (×) icon.
+  ///
+  /// Defaults to white with 90% opacity.
+  final Color? cancelButtonColor;
+
+  /// Custom icon widget for the cancel button.
+  ///
+  /// When non-null, replaces the default [CupertinoIcons.xmark] glyph inside
+  /// the glass dismiss pill. The widget is rendered as-is, so it should carry
+  /// its own color and size. When null, [cancelButtonColor] and
+  /// [cancelIconSize] apply to the default × icon.
+  final Widget? cancelIcon;
+
+  /// Size of the cancel (×) icon in logical pixels.
+  ///
+  /// Defaults to `24`, matching the visual weight of the search and clear icons.
+  final double cancelIconSize;
+
+  /// The style of the search text.
+  final TextStyle? textStyle;
+
+  /// The style of the placeholder text.
+  final TextStyle? placeholderStyle;
+
+  /// Height of the search bar.
+  ///
+  /// Defaults to 44 (iOS standard).
+  final double height;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Glass effect settings (only used when [useOwnLayer] is true).
+  final LiquidGlassSettings? settings;
+
+  /// Whether to create its own layer or use grouped glass.
+  ///
+  /// Defaults to false (grouped mode).
+  final bool useOwnLayer;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// Defaults to [GlassQuality.standard], which uses the lightweight fragment
+  /// shader. This works reliably in all contexts, including scrollable lists.
+  ///
+  /// Use [GlassQuality.premium] for full-pipeline shader with texture capture
+  /// and chromatic aberration (Impeller only) in static layouts.
+  final GlassQuality? quality;
+
+  @override
+  State<GlassSearchBar> createState() => _GlassSearchBarState();
+}
+
+class _GlassSearchBarState extends State<GlassSearchBar> {
+  late TextEditingController _controller;
+  late FocusNode _focusNode;
+  bool _ownsController = false;
+  bool _ownsFocusNode = false;
+  bool _hasText = false;
+  bool _showCancelButton = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.controller != null) {
+      _controller = widget.controller!;
+    } else {
+      _controller = TextEditingController();
+      _ownsController = true;
+    }
+    if (widget.focusNode != null) {
+      _focusNode = widget.focusNode!;
+    } else {
+      _focusNode = FocusNode();
+      _ownsFocusNode = true;
+    }
+
+    _hasText = _controller.text.isNotEmpty;
+    _controller.addListener(_onTextChanged);
+    _focusNode.addListener(_onFocusChanged);
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onTextChanged);
+    _focusNode.removeListener(_onFocusChanged);
+    if (_ownsFocusNode) _focusNode.dispose();
+    if (_ownsController) _controller.dispose();
+    super.dispose();
+  }
+
+  void _onTextChanged() {
+    final hasText = _controller.text.isNotEmpty;
+    if (hasText != _hasText) setState(() => _hasText = hasText);
+  }
+
+  void _onFocusChanged() {
+    if (widget.showsCancelButton) {
+      final hasFocus = _focusNode.hasFocus;
+      if (hasFocus != _showCancelButton) {
+        setState(() => _showCancelButton = hasFocus);
+      }
+    }
+  }
+
+  void _handleTapOutside(PointerDownEvent event) {
+    final RenderBox? renderBox = context.findRenderObject() as RenderBox?;
+    if (renderBox != null) {
+      final Offset localPosition = renderBox.globalToLocal(event.position);
+      if (renderBox.paintBounds.contains(localPosition)) {
+        // Tap was inside the search bar row (e.g., on the cancel button), do nothing.
+        return;
+      }
+    }
+    _focusNode.unfocus();
+  }
+
+  void _handleClear() {
+    _controller.clear();
+    widget.onChanged?.call('');
+  }
+
+  void _handleCancel() {
+    _controller.clear();
+    _focusNode.unfocus();
+    widget.onCancel?.call();
+    widget.onChanged?.call('');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+
+    final searchIconColor = widget.searchIconColor ??
+        (isDark ? const Color(0x99FFFFFF) : const Color(0x99000000));
+    final clearIconColor = widget.clearIconColor ??
+        (isDark ? const Color(0x99FFFFFF) : const Color(0x99000000));
+    final cancelButtonColor = widget.cancelButtonColor ??
+        (isDark ? const Color(0xE6FFFFFF) : const Color(0xE6000000));
+
+    return Row(
+      children: [
+        // Search field
+        Expanded(
+          child: GlassTextField.search(
+            controller: _controller,
+            focusNode: _focusNode,
+            placeholder: widget.placeholder,
+            prefixIcon: Icon(
+              CupertinoIcons.search,
+              size: 20,
+              color: searchIconColor,
+            ),
+            // AnimatedSwitcher cross-fades and scales the × in/out as the
+            // user types — identical mechanism to _SearchPill for consistency.
+            // No AnimationController needed; the bool setState drives it.
+            suffixIcon: RepaintBoundary(
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 180),
+                transitionBuilder: (child, animation) => FadeTransition(
+                  opacity: animation,
+                  child: ScaleTransition(scale: animation, child: child),
+                ),
+                child: _hasText
+                    ? Icon(
+                        CupertinoIcons.clear_circled_solid,
+                        key: const ValueKey('clear'),
+                        size: 18,
+                        color: clearIconColor,
+                      )
+                    : const SizedBox.shrink(key: ValueKey('empty')),
+              ),
+            ),
+            onSuffixTap: _hasText ? _handleClear : null,
+            onChanged: widget.onChanged,
+            onSubmitted: widget.onSubmitted,
+            autofocus: widget.autofocus,
+            enabled: widget.enabled,
+            onTapOutside: _handleTapOutside,
+            textStyle: widget.textStyle,
+            placeholderStyle: widget.placeholderStyle,
+            height: widget.height,
+            shape: LiquidRoundedSuperellipse(
+              borderRadius: widget.height / 2,
+            ),
+            settings: widget.settings,
+            useOwnLayer: widget.useOwnLayer,
+            quality: widget.quality,
+          ),
+        ),
+
+        // Cancel button — text style (iOS Spotlight / Messages pattern).
+        // Note: GlassSearchableBottomBar uses a glass ×‑icon button instead;
+        // the two patterns are intentionally different — each matches the iOS
+        // convention for its context (standalone screen vs. bottom bar).
+        AnimatedSize(
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeInOutCubic,
+          child: AnimatedOpacity(
+            opacity: _showCancelButton ? 1.0 : 0.0,
+            duration: const Duration(milliseconds: 180),
+            child: _showCancelButton
+                ? Padding(
+                    padding: const EdgeInsets.only(left: 10),
+                    child: GlassButton(
+                      onTap: _handleCancel,
+                      width: widget.height,
+                      height: widget.height,
+                      shape: const LiquidOval(),
+                      settings: widget.settings,
+                      useOwnLayer: widget.useOwnLayer,
+                      quality: widget.quality,
+                      icon: widget.cancelIcon ??
+                          Icon(
+                            CupertinoIcons.xmark,
+                            color: cancelButtonColor,
+                            size: widget.cancelIconSize,
+                          ),
+                    ),
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/input/glass_text_area.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/input/glass_text_area.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../src/types/glass_interaction_behavior.dart';
+import '../../types/glass_quality.dart';
+import 'glass_text_field.dart';
+
+/// A multi-line glass text area.
+///
+/// [GlassTextArea] optimizes [GlassTextField] for multi-line input.
+/// It exposes all standard text field and glass configuration options.
+class GlassTextArea extends StatelessWidget {
+  /// Creates a glass text area.
+  const GlassTextArea({
+    super.key,
+    this.controller,
+    this.focusNode,
+    this.placeholder,
+    this.minLines = 3,
+    this.maxLines = 5,
+    this.onChanged,
+    this.onSubmitted,
+    this.onLineCountChanged,
+    this.enabled = true,
+    this.readOnly = false,
+    this.autofocus = false,
+    this.textInputAction = TextInputAction.newline,
+    this.inputFormatters,
+    this.textStyle,
+    this.placeholderStyle,
+    this.padding = const EdgeInsets.all(16),
+    this.iconAlignment = CrossAxisAlignment.center,
+    this.height,
+    this.minHeight,
+    this.maxHeight,
+    this.bottom,
+    // Glass properties
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    this.shape = const LiquidRoundedSuperellipse(borderRadius: 10),
+    // ── iOS 26 interaction ────────────────────────────────────────────────────────────
+    this.interactionBehavior = GlassInteractionBehavior.full,
+    this.pressScale = 1.03,
+    this.glowColor,
+    this.glowRadius = 1.5,
+    this.onTapOutside,
+  });
+
+  /// Controls the text.
+  final TextEditingController? controller;
+
+  /// Controls focus.
+  final FocusNode? focusNode;
+
+  /// Placeholder text.
+  final String? placeholder;
+
+  /// Minimum lines.
+  final int minLines;
+
+  /// Maximum lines.
+  final int maxLines;
+
+  /// Text change callback.
+  final ValueChanged<String>? onChanged;
+
+  /// Submit callback.
+  final ValueChanged<String>? onSubmitted;
+
+  /// Enabled state.
+  final bool enabled;
+
+  /// Read-only state.
+  final bool readOnly;
+
+  /// Autofocus state.
+  final bool autofocus;
+
+  /// Action button.
+  final TextInputAction? textInputAction;
+
+  /// Input formatters.
+  final List<TextInputFormatter>? inputFormatters;
+
+  /// Text style.
+  final TextStyle? textStyle;
+
+  /// Placeholder style.
+  final TextStyle? placeholderStyle;
+
+  /// Padding. Defaults to EdgeInsets.all(16).
+  final EdgeInsetsGeometry padding;
+
+  /// Glass settings.
+  final LiquidGlassSettings? settings;
+
+  /// Own layer toggle.
+  final bool useOwnLayer;
+
+  /// Quality setting.
+  final GlassQuality? quality;
+
+  /// Shape setting.
+  final LiquidShape shape;
+
+  /// Controls which press-interaction effects are active.
+  ///
+  /// Mirrors [GlassTextField.interactionBehavior] — see that field for details.
+  /// Defaults to [GlassInteractionBehavior.full].
+  final GlassInteractionBehavior interactionBehavior;
+
+  /// Scale factor applied when the field is pressed.
+  ///
+  /// Mirrors [GlassTextField.pressScale]. Defaults to `1.03`.
+  final double pressScale;
+
+  /// Colour of the directional glow. Mirrors [GlassTextField.glowColor].
+  final Color? glowColor;
+
+  /// Spread radius of the glow. Mirrors [GlassTextField.glowRadius].
+  final double glowRadius;
+
+  /// Called when user taps outside. Mirrors [GlassTextField.onTapOutside].
+  final TapRegionCallback? onTapOutside;
+
+  /// Called when rendered line count changes. Mirrors [GlassTextField.onLineCountChanged].
+  final ValueChanged<int>? onLineCountChanged;
+
+  /// Vertical alignment of prefix/suffix icons. Mirrors [GlassTextField.iconAlignment].
+  final CrossAxisAlignment iconAlignment;
+
+  /// Fixed height. Mirrors [GlassTextField.height].
+  final double? height;
+
+  /// Minimum height constraint. Mirrors [GlassTextField.minHeight].
+  final double? minHeight;
+
+  /// Maximum height constraint. Mirrors [GlassTextField.maxHeight].
+  final double? maxHeight;
+
+  /// Optional bottom panel. Mirrors [GlassTextField.bottom].
+  final Widget? bottom;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassTextField(
+      controller: controller,
+      focusNode: focusNode,
+      placeholder: placeholder,
+      minLines: minLines,
+      maxLines: maxLines,
+      keyboardType: TextInputType.multiline,
+      textInputAction: textInputAction,
+      onChanged: onChanged,
+      onSubmitted: onSubmitted,
+      enabled: enabled,
+      readOnly: readOnly,
+      autofocus: autofocus,
+      inputFormatters: inputFormatters,
+      textStyle: textStyle,
+      placeholderStyle: placeholderStyle,
+      padding: padding,
+      settings: settings,
+      useOwnLayer: useOwnLayer,
+      quality: quality,
+      shape: shape,
+      iconAlignment: iconAlignment,
+      height: height,
+      minHeight: minHeight,
+      maxHeight: maxHeight,
+      onLineCountChanged: onLineCountChanged,
+      bottom: bottom,
+      interactionBehavior: interactionBehavior,
+      pressScale: pressScale,
+      glowColor: glowColor,
+      glowRadius: glowRadius,
+      onTapOutside: onTapOutside,
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/input/glass_text_field.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/input/glass_text_field.dart
@@ -1,0 +1,783 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../src/types/glass_interaction_behavior.dart';
+import '../../types/glass_quality.dart';
+import '../shared/adaptive_glass.dart';
+import '../../theme/glass_theme_helpers.dart';
+import '../../theme/glass_theme.dart';
+
+/// A glass text field widget following Apple's input field design.
+///
+/// [GlassTextField] provides a text input field with glass morphism effect,
+/// matching iOS design patterns with customizable styling.
+///
+/// ## Usage Modes
+///
+/// ### Grouped Mode (default)
+/// ```dart
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(...),
+///   child: Column(
+///     children: [
+///       GlassTextField(
+///         placeholder: 'Email',
+///         keyboardType: TextInputType.emailAddress,
+///       ),
+///       GlassTextField(
+///         placeholder: 'Password',
+///         obscureText: true,
+///       ),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ### Standalone Mode
+/// ```dart
+/// GlassTextField(
+///   useOwnLayer: true,
+///   settings: LiquidGlassSettings(...),
+///   placeholder: 'Search...',
+///   prefixIcon: Icon(Icons.search, size: 20, color: Colors.white70),
+/// )
+/// ```
+///
+/// ## Customization Examples
+///
+/// ### With prefix and suffix icons:
+/// ```dart
+/// GlassTextField(
+///   placeholder: 'Search',
+///   prefixIcon: Icon(Icons.search, size: 20, color: Colors.white70),
+///   suffixIcon: Icon(Icons.clear, size: 20, color: Colors.white70),
+///   onSuffixTap: () => controller.clear(),
+/// )
+/// ```
+///
+/// ### Multiline text area:
+/// ```dart
+/// GlassTextField(
+///   placeholder: 'Enter your message...',
+///   maxLines: 5,
+///   minLines: 3,
+/// )
+/// ```
+class GlassTextField extends StatefulWidget {
+  /// Creates a glass text field.
+  const GlassTextField({
+    super.key,
+    this.controller,
+    this.focusNode,
+    this.placeholder,
+    this.prefixIcon,
+    this.suffixIcon,
+    this.onSuffixTap,
+    this.obscureText = false,
+    this.keyboardType,
+    this.textInputAction,
+    this.maxLines = 1,
+    this.minLines,
+    this.maxLength,
+    this.enabled = true,
+    this.readOnly = false,
+    this.autofocus = false,
+    this.onChanged,
+    this.onSubmitted,
+    this.onLineCountChanged,
+    this.inputFormatters,
+    this.textStyle,
+    this.placeholderStyle,
+    this.padding = const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+    this.iconSpacing = 12.0,
+    this.iconAlignment = CrossAxisAlignment.center,
+    this.height,
+    this.minHeight,
+    this.maxHeight,
+    this.bottom,
+    this.shape = const LiquidRoundedSuperellipse(borderRadius: 10),
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    // ── iOS 26 interaction ────────────────────────────────────────────────────────────
+    this.interactionBehavior = GlassInteractionBehavior.full,
+    this.pressScale = 1.03,
+    this.glowColor,
+    this.glowRadius = 1.5,
+    this.onTapOutside,
+  }) : assert(
+          height == null || (minHeight == null && maxHeight == null),
+          'height is mutually exclusive with minHeight / maxHeight. '
+          'Use either height for a fixed size, or minHeight/maxHeight for '
+          'a constrained range.',
+        );
+
+  /// Creates a glass text field styled specifically for search, matching
+  /// the compact layout and visuals of [GlassSearchBar].
+  const GlassTextField.search({
+    super.key,
+    this.controller,
+    this.focusNode,
+    this.placeholder,
+    this.prefixIcon,
+    this.suffixIcon,
+    this.onSuffixTap,
+    this.enabled = true,
+    this.readOnly = false,
+    this.autofocus = false,
+    this.onChanged,
+    this.onSubmitted,
+    this.inputFormatters,
+    this.textStyle,
+    this.placeholderStyle,
+    this.padding = const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    this.iconSpacing = 8.0,
+    this.height = 44.0,
+    this.shape = const LiquidRoundedSuperellipse(borderRadius: 22),
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    this.interactionBehavior = GlassInteractionBehavior.full,
+    this.pressScale = 1.03,
+    this.glowColor,
+    this.glowRadius = 1.5,
+    this.onTapOutside,
+  })  : obscureText = false,
+        keyboardType = TextInputType.text,
+        textInputAction = TextInputAction.search,
+        maxLines = 1,
+        minLines = 1,
+        maxLength = null,
+        onLineCountChanged = null,
+        iconAlignment = CrossAxisAlignment.center,
+        minHeight = null,
+        maxHeight = null,
+        bottom = null;
+
+  // ===========================================================================
+  // Text Field Properties
+  // ===========================================================================
+
+  /// Controls the text being edited.
+  ///
+  /// If null, a controller will be created internally.
+  final TextEditingController? controller;
+
+  /// Controls the focus state of the text field.
+  ///
+  /// If null, a focus node will be created internally.
+  final FocusNode? focusNode;
+
+  /// Placeholder text shown when the field is empty.
+  final String? placeholder;
+
+  /// Widget displayed at the start of the field.
+  final Widget? prefixIcon;
+
+  /// Widget displayed at the end of the field.
+  final Widget? suffixIcon;
+
+  /// Callback when suffix icon is tapped.
+  final VoidCallback? onSuffixTap;
+
+  /// Whether to obscure the text (for passwords).
+  final bool obscureText;
+
+  /// The type of keyboard to display.
+  final TextInputType? keyboardType;
+
+  /// The action button on the keyboard.
+  final TextInputAction? textInputAction;
+
+  /// Maximum number of lines for the text field.
+  ///
+  /// Defaults to 1 for single-line input.
+  final int maxLines;
+
+  /// Minimum number of lines for the text field.
+  final int? minLines;
+
+  /// Maximum number of characters allowed.
+  final int? maxLength;
+
+  /// Whether the text field is enabled.
+  final bool enabled;
+
+  /// Whether the text field is read-only.
+  final bool readOnly;
+
+  /// Whether the text field should auto-focus.
+  final bool autofocus;
+
+  /// Called when the text changes.
+  final ValueChanged<String>? onChanged;
+
+  /// Called when the user submits the text.
+  final ValueChanged<String>? onSubmitted;
+
+  /// Input formatters for the text field.
+  final List<TextInputFormatter>? inputFormatters;
+
+  /// Called when the user taps outside the text field.
+  ///
+  /// Defaults to unfocusing the field, which dismisses the keyboard.
+  final TapRegionCallback? onTapOutside;
+
+  /// Called when the number of rendered text lines changes.
+  ///
+  /// The callback receives the current line count after layout. This is
+  /// the **rendered** line count (accounting for text wrapping), not the
+  /// number of `\n` characters in the text.
+  ///
+  /// Fires on initial build and on every subsequent change. Does NOT fire
+  /// when the line count stays the same.
+  ///
+  /// Useful for animating the surrounding container’s height or shape
+  /// (e.g. reducing `borderRadius` as lines increase):
+  ///
+  /// ```dart
+  /// GlassTextField(
+  ///   maxLines: 6,
+  ///   onLineCountChanged: (lines) {
+  ///     setState(() => _lines = lines);
+  ///   },
+  /// )
+  /// ```
+  final ValueChanged<int>? onLineCountChanged;
+
+  // ===========================================================================
+  // Style Properties
+  // ===========================================================================
+
+  /// The style of the text being edited.
+  final TextStyle? textStyle;
+
+  /// The style of the placeholder text.
+  final TextStyle? placeholderStyle;
+
+  /// Padding inside the text field.
+  ///
+  /// Defaults to 16px horizontal, 12px vertical.
+  final EdgeInsetsGeometry padding;
+
+  /// Spacing between the icons and the text field.
+  ///
+  /// Defaults to 12.
+  final double iconSpacing;
+
+  /// Shape of the text field.
+  ///
+  /// Defaults to [LiquidRoundedSuperellipse] with 10px border radius.
+  final LiquidShape shape;
+
+  /// Vertical alignment of prefix and suffix icons.
+  ///
+  /// Controls where icons are positioned when the field spans multiple lines:
+  ///
+  /// - [CrossAxisAlignment.center] — icons centered vertically (default)
+  /// - [CrossAxisAlignment.start] — icons pinned to top
+  /// - [CrossAxisAlignment.end] — icons pinned to bottom
+  ///
+  /// For single-line fields this has no visible effect.
+  /// Defaults to [CrossAxisAlignment.center] (preserves existing behaviour).
+  ///
+  /// ```dart
+  /// // Pin icons to bottom — common in chat message composers:
+  /// GlassTextField(
+  ///   maxLines: 6,
+  ///   iconAlignment: CrossAxisAlignment.end,
+  ///   suffixIcon: Icon(Icons.send),
+  /// )
+  /// ```
+  final CrossAxisAlignment iconAlignment;
+
+  // ===========================================================================
+  // Size Properties
+  // ===========================================================================
+
+  /// Fixed height of the text field.
+  ///
+  /// If non-null, the field is wrapped in a `SizedBox` with this height.
+  /// Mutually exclusive with [minHeight] / [maxHeight].
+  ///
+  /// Set to `44` to match [GlassSearchBar.height] for visual parity in
+  /// single-line mode.
+  final double? height;
+
+  /// Minimum height constraint.
+  ///
+  /// When set alongside [maxHeight], wraps the field in a `ConstrainedBox`.
+  /// The field grows from [minHeight] up to [maxHeight] as lines are added.
+  final double? minHeight;
+
+  /// Maximum height constraint.
+  ///
+  /// When set, the field will not grow beyond this height and will scroll
+  /// internally once the content exceeds the available space.
+  final double? maxHeight;
+
+  /// Optional widget displayed below the text area, inside the same glass card.
+  ///
+  /// Use this to build a "rich composer" layout — a text input on top with an
+  /// action bar, attachment strip, or formatting toolbar below, all sharing one
+  /// glass surface.
+  ///
+  /// The panel inherits the frosted-well darkening of the surrounding glass
+  /// card. Callers can add a [Divider] between the text area and the panel if
+  /// a visual separator is desired.
+  ///
+  /// ```dart
+  /// GlassTextField(
+  ///   maxLines: 5,
+  ///   bottom: Padding(
+  ///     padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+  ///     child: Row(
+  ///       children: [
+  ///         IconButton(icon: Icon(Icons.attach_file), onPressed: _attach),
+  ///         const Spacer(),
+  ///         IconButton(icon: Icon(Icons.send), onPressed: _send),
+  ///       ],
+  ///     ),
+  ///   ),
+  /// )
+  /// ```
+  ///
+  /// Not available on [GlassTextField.search] (single-line; `bottom` is
+  /// always `null` there).
+  final Widget? bottom;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Glass effect settings (only used when [useOwnLayer] is true).
+  final LiquidGlassSettings? settings;
+
+  /// Whether to create its own layer or use grouped glass.
+  final bool useOwnLayer;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// Defaults to [GlassQuality.standard], which uses backdrop filter rendering.
+  /// This works reliably in all contexts, including scrollable lists.
+  ///
+  /// Use [GlassQuality.premium] for shader-based glass in static layouts only.
+  final GlassQuality? quality;
+
+  // ── iOS 26 interaction ────────────────────────────────────────────────────
+
+  /// Controls which press-interaction effects are active on this field.
+  ///
+  /// Mirrors the API on [GlassBottomBar] and [GlassSearchableBottomBar] for
+  /// a consistent developer experience across all glass surfaces:
+  ///
+  /// | Value | Glow | Scale-on-focus |
+  /// |---|---|---|
+  /// | `none` | ✗ | ✗ |
+  /// | `glowOnly` | ✓ | ✗ |
+  /// | `scaleOnly` | ✗ | ✓ |
+  /// | `full` *(default)* | ✓ | ✓ |
+  ///
+  /// **Glow** — the iOS 26-style directional spotlight that tracks the touch
+  /// position across the glass surface.
+  ///
+  /// **Scale** — the subtle press-bounce animation (`pressScale`) that fires
+  /// when the user presses down on the field, then springs back on release,
+  /// matching iOS 26 touch feedback.
+  ///
+  /// Defaults to [GlassInteractionBehavior.full], preserving the existing
+  /// visual behaviour.
+  final GlassInteractionBehavior interactionBehavior;
+
+  /// Scale factor applied when the field is pressed.
+  ///
+  /// Only active when [interactionBehavior] includes scale
+  /// ([GlassInteractionBehavior.scaleOnly] or [GlassInteractionBehavior.full]).
+  ///
+  /// A value of `1.03` means the field grows 3% when pressed.
+  /// Defaults to `1.03`.
+  final double pressScale;
+
+  /// Colour of the directional glow.
+  ///
+  /// Only active when [interactionBehavior] includes glow. If null, falls back
+  /// to a soft `Colors.white` at ~12% opacity — visibly lighter than
+  /// [GlassButton]'s `white24` to match the iOS 26 input look.
+  final Color? glowColor;
+
+  /// Spread radius of the directional glow relative to the field's dimensions.
+  ///
+  /// A value of `1.5` means the glow spreads 150% of the field's shorter
+  /// dimension, creating a wide, diffuse ambient highlight across the surface.
+  ///
+  /// Defaults to `1.5`.
+  final double glowRadius;
+
+  @override
+  State<GlassTextField> createState() => _GlassTextFieldState();
+}
+
+class _GlassTextFieldState extends State<GlassTextField> {
+  late FocusNode _focusNode;
+  // Tracks whether _focusNode was created by us (true) or provided externally.
+  bool _ownsNode = false;
+  bool _isFocused = false;
+  bool _isPressed = false;
+  int _currentLineCount = 0;
+  TextEditingController? _effectiveController;
+
+  /// Current rendered line count.
+  ///
+  /// Access via a `GlobalKey<_GlassTextFieldState>`.
+  int get lineCount => _currentLineCount;
+
+  final GlobalKey _textFieldKey = GlobalKey();
+
+  /// Wraps [child] in a [GlassGlow] sensor only when [interactionBehavior]
+  /// includes glow. Skips the widget entirely otherwise — zero allocation cost.
+  Widget _wrapWithGlow(Widget child, bool isDark) {
+    if (!widget.interactionBehavior.hasGlow) return child;
+    return GlassGlow(
+      glowColor: widget.glowColor ??
+          (isDark ? const Color(0x1FFFFFFF) : const Color(0x1F000000)),
+      glowRadius: widget.glowRadius,
+      child: child,
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.focusNode != null) {
+      _focusNode = widget.focusNode!;
+      _ownsNode = false;
+    } else {
+      _focusNode = FocusNode();
+      _ownsNode = true;
+    }
+    _isFocused = _focusNode.hasFocus;
+    _focusNode.addListener(_onFocusChange);
+
+    _initController();
+
+    // Schedule initial line count measurement after first layout.
+    if (widget.onLineCountChanged != null) {
+      _scheduleLineCountCheck();
+    }
+  }
+
+  void _initController() {
+    _effectiveController = widget.controller;
+    _effectiveController?.addListener(_onControllerChange);
+  }
+
+  void _onControllerChange() {
+    if (widget.onLineCountChanged != null) {
+      _scheduleLineCountCheck();
+    }
+  }
+
+  void _onFocusChange() {
+    if (_isFocused != _focusNode.hasFocus) {
+      setState(() => _isFocused = _focusNode.hasFocus);
+    }
+  }
+
+  @override
+  void didUpdateWidget(GlassTextField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // If the external focusNode reference changed, rewire the listener.
+    if (oldWidget.focusNode != widget.focusNode) {
+      _focusNode.removeListener(_onFocusChange);
+
+      // Dispose the old node only if we owned it.
+      if (_ownsNode) _focusNode.dispose();
+
+      if (widget.focusNode != null) {
+        // Caller is providing an external node — adopt it.
+        _focusNode = widget.focusNode!;
+        _ownsNode = false;
+      } else {
+        // Caller removed the external node — create a fresh internal one.
+        _focusNode = FocusNode();
+        _ownsNode = true;
+      }
+
+      _focusNode.addListener(_onFocusChange);
+      _isFocused = _focusNode.hasFocus;
+    }
+    // If the external controller reference changed, rewire the listener.
+    if (oldWidget.controller != widget.controller) {
+      _effectiveController?.removeListener(_onControllerChange);
+      _initController();
+    }
+    // If disabled, cancel any in-flight press so the spring always returns.
+    if (!widget.enabled && _isPressed) {
+      setState(() => _isPressed = false);
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_onFocusChange);
+    if (_ownsNode) _focusNode.dispose();
+    _effectiveController?.removeListener(_onControllerChange);
+    super.dispose();
+  }
+
+  // ── Line count tracking ──────────────────────────────────────────────────
+
+  // Guard state: track (text, width) rather than size.
+  // Tracking only `size` was the bug: when the outer container has a fixed
+  // `height` (e.g. `SizedBox(height: 46)`), the inner TextField RenderBox
+  // size stays constant even as lines change — the size guard exited early
+  // and `onLineCountChanged` silently stopped firing after the first call.
+  // Tracking text + width is the minimal correct guard: size.width changing
+  // means available wrapping space changed; text changing means content
+  // changed. Either is enough to warrant a re-measurement.
+  String _lastMeasuredText = '';
+  double _lastMeasuredWidth = 0.0;
+  bool _lineCheckScheduled = false;
+
+  /// Schedules a line count measurement for the next frame.
+  ///
+  /// Debounced: both `onChanged` and the controller listener call this on
+  /// every keystroke — the flag ensures only one callback is queued per frame.
+  void _scheduleLineCountCheck() {
+    if (_lineCheckScheduled) return;
+    _lineCheckScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _lineCheckScheduled = false;
+      if (!mounted) return;
+      _measureLineCount();
+    });
+  }
+
+  /// Measures the TextField's rendered height and infers line count.
+  /// Fires [onLineCountChanged] only when the count actually changes.
+  void _measureLineCount() {
+    final renderBox =
+        _textFieldKey.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox == null || !renderBox.hasSize) return;
+
+    final size = renderBox.size;
+    if (size.width <= 0) return;
+
+    final currentText = _effectiveController?.text ?? '';
+
+    // Guard: skip only when both text AND available width are unchanged.
+    // We intentionally do NOT guard on size.height — a fixed outer height
+    // (e.g. height: 46) keeps the RenderBox height constant while the number
+    // of rendered lines may still change as the user types.
+    if (currentText == _lastMeasuredText && size.width == _lastMeasuredWidth) {
+      return;
+    }
+    _lastMeasuredText = currentText;
+    _lastMeasuredWidth = size.width;
+
+    // Use MediaQuery textScaler for accurate line height calculation.
+    final textScaler = MediaQuery.textScalerOf(context);
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+
+    final defaultTextStyle = TextStyle(
+      color: isDark
+          ? const Color.fromRGBO(255, 255, 255, 0.9)
+          : const Color.fromRGBO(0, 0, 0, 0.9),
+      fontSize: 16,
+      height: 1.2,
+    );
+    final effectiveStyle = defaultTextStyle.merge(widget.textStyle);
+    final fontSize = effectiveStyle.fontSize ?? 16.0;
+    final effectiveLineHeight =
+        textScaler.scale(fontSize) * (effectiveStyle.height ?? 1.2);
+
+    final lineCount =
+        (size.height / effectiveLineHeight).round().clamp(1, 9999);
+
+    if (lineCount != _currentLineCount) {
+      _currentLineCount = lineCount;
+      widget.onLineCountChanged?.call(lineCount);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+
+    final defaultTextStyle = TextStyle(
+      color: isDark
+          ? const Color.fromRGBO(255, 255, 255, 0.9)
+          : const Color.fromRGBO(0, 0, 0, 0.9),
+      fontSize: 16,
+      height: 1.2,
+    );
+
+    final defaultPlaceholderStyle = TextStyle(
+      color: isDark
+          ? const Color.fromRGBO(255, 255, 255, 0.5)
+          : const Color.fromRGBO(0, 0, 0, 0.5),
+      fontSize: 16,
+    );
+
+    // In fixed-height mode, force CrossAxisAlignment.center so that icon
+    // position is immune to system text scaling. With .center inside
+    // Align(center), the icon position simplifies to (container − icon) / 2
+    // which is independent of the Row's intrinsic height. The .end/.start
+    // alignments depend on Row height and therefore drift when text scales.
+    // In dynamic-height mode, respect the caller's iconAlignment as-is.
+    final effectiveIconAlignment = widget.height != null
+        ? CrossAxisAlignment.center
+        : widget.iconAlignment;
+
+    // Build the icon + text row.
+    final rowContent = Row(
+      crossAxisAlignment: effectiveIconAlignment,
+      children: [
+        // Prefix icon
+        if (widget.prefixIcon != null) ...[
+          widget.prefixIcon!,
+          SizedBox(width: widget.iconSpacing),
+        ],
+
+        // Text field
+        Expanded(
+          child: CupertinoTextField(
+            key: _textFieldKey,
+            controller: widget.controller,
+            focusNode: _focusNode,
+            obscureText: widget.obscureText,
+            keyboardType: widget.keyboardType,
+            textInputAction: widget.textInputAction,
+            maxLines: widget.maxLines,
+            minLines: widget.minLines,
+            maxLength: widget.maxLength,
+            enabled: widget.enabled,
+            readOnly: widget.readOnly,
+            autofocus: widget.autofocus,
+            onChanged: (value) {
+              widget.onChanged?.call(value);
+              _scheduleLineCountCheck();
+            },
+            onSubmitted: widget.onSubmitted,
+            onTapOutside: widget.onTapOutside ??
+                (event) => FocusManager.instance.primaryFocus?.unfocus(),
+            inputFormatters: widget.inputFormatters,
+            style: defaultTextStyle.merge(widget.textStyle),
+            placeholder: widget.placeholder,
+            placeholderStyle:
+                defaultPlaceholderStyle.merge(widget.placeholderStyle),
+            padding: EdgeInsets.zero,
+            decoration: null,
+          ),
+        ),
+
+        // Suffix icon
+        if (widget.suffixIcon != null) ...[
+          SizedBox(width: widget.iconSpacing),
+          GestureDetector(
+            onTap: widget.onSuffixTap,
+            child: widget.suffixIcon,
+          ),
+        ],
+      ],
+    );
+
+    // Fixed-height mode: strip vertical padding and center the row so that
+    // placeholder text stays vertically centred regardless of system font
+    // scale. Dynamic/constrained-height modes use the full padding as before.
+    final resolvedPadding = widget.padding.resolve(Directionality.of(context));
+    Widget textFieldContent = widget.height != null
+        ? Padding(
+            padding: EdgeInsets.only(
+              left: resolvedPadding.left,
+              right: resolvedPadding.right,
+            ),
+            child: Align(alignment: Alignment.center, child: rowContent),
+          )
+        : Padding(padding: widget.padding, child: rowContent);
+
+    // Bottom panel: wrap in a Column when caller provides an action bar,
+    // attachment strip, etc. — all sharing the same glass surface.
+    //
+    // The text area is Flexible so the bottom panel always gets its natural
+    // height first. The text area takes whatever space remains within the
+    // height / maxHeight constraint. Without Flexible the Column has no flex
+    // children and overflows when (text area + bottom) > maxHeight.
+    if (widget.bottom != null) {
+      textFieldContent = Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Flexible(child: textFieldContent),
+          widget.bottom!,
+        ],
+      );
+    }
+
+    // Inherit quality from parent layer if not explicitly set
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+    );
+
+    // Apply glass effect
+    // iOS 26: wrap in GlassGlow only when interactionBehavior includes glow.
+    // _wrapWithGlow skips the widget entirely when glow is suppressed,
+    // saving 3 widget/render-object allocations — same pattern as GlassBottomBar.
+    Widget glassWidget = AdaptiveGlass(
+      shape: widget.shape,
+      settings: GlassThemeHelpers.resolveSettings(
+        context,
+        explicit: widget.settings,
+      ),
+      quality: effectiveQuality,
+      useOwnLayer: widget.useOwnLayer,
+      child: _wrapWithGlow(textFieldContent, isDark),
+    );
+
+    // GlassGlowLayer is now automatically provided by GlassGlow internally.
+
+    // iOS 26: animate scale on press — field squishes/inflates on tap, springs back on release.
+    // Only active when interactionBehavior includes scale.
+    if (widget.interactionBehavior.hasScale) {
+      glassWidget = AnimatedScale(
+        scale: _isPressed ? widget.pressScale : 1.0,
+        duration: const Duration(milliseconds: 220),
+        curve: Curves.easeOutCubic,
+        child: glassWidget,
+      );
+
+      // Wrap with Listener to capture pointer down/up state for the bounce animation
+      glassWidget = Listener(
+        onPointerDown: (_) => setState(() => _isPressed = true),
+        onPointerUp: (_) => setState(() => _isPressed = false),
+        onPointerCancel: (_) => setState(() => _isPressed = false),
+        child: glassWidget,
+      );
+    }
+
+    return Opacity(
+      opacity: widget.enabled ? 1.0 : 0.5,
+      child: _wrapWithConstraints(glassWidget),
+    );
+  }
+
+  /// Wraps [child] in height constraints when [height], [minHeight], or
+  /// [maxHeight] is specified. Returns [child] unchanged otherwise.
+  Widget _wrapWithConstraints(Widget child) {
+    if (widget.height != null) {
+      return SizedBox(height: widget.height, child: child);
+    }
+    if (widget.minHeight != null || widget.maxHeight != null) {
+      return ConstrainedBox(
+        constraints: BoxConstraints(
+          minHeight: widget.minHeight ?? 0,
+          maxHeight: widget.maxHeight ?? double.infinity,
+        ),
+        child: child,
+      );
+    }
+    return child;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/glass_badge.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/glass_badge.dart
@@ -1,0 +1,361 @@
+import 'package:flutter/cupertino.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../theme/glass_theme_data.dart';
+import '../../types/glass_quality.dart';
+import '../shared/adaptive_liquid_glass_layer.dart';
+
+/// Position of the badge relative to the child widget.
+enum BadgePosition {
+  /// Top right corner (default for notification counts)
+  topRight,
+
+  /// Top left corner
+  topLeft,
+
+  /// Bottom right corner
+  bottomRight,
+
+  /// Bottom left corner
+  bottomLeft,
+}
+
+/// A glass morphism badge following iOS 26 liquid glass design.
+///
+/// [GlassBadge] provides notification count or status dot indicators with:
+/// - iOS 26 liquid glass backdrop effect
+/// - Count badge with automatic sizing (1-2 digits small, 3+ wider)
+/// - Dot badge for status indicators (online, active, etc.)
+/// - Four position variants (topRight, topLeft, bottomRight, bottomLeft)
+/// - Auto-hide when count is 0
+/// - Theme-aware colors
+/// - Customizable size and colors
+///
+/// ## Usage
+///
+/// ### Count Badge (Notification)
+/// ```dart
+/// GlassBadge(
+///   count: 5,
+///   child: GlassIconButton(
+///     icon: CupertinoIcons.bell,
+///     onTap: () => showNotifications(),
+///   ),
+/// )
+/// ```
+///
+/// ### Dot Badge (Status Indicator)
+/// ```dart
+/// GlassBadge.dot(
+///   color: Colors.green, // Online status
+///   child: CircleAvatar(
+///     backgroundImage: NetworkImage('https://...'),
+///   ),
+/// )
+/// ```
+///
+/// ### Custom Position
+/// ```dart
+/// GlassBadge(
+///   count: 12,
+///   position: BadgePosition.topLeft,
+///   child: Icon(Icons.mail),
+/// )
+/// ```
+///
+/// ### Custom Colors
+/// ```dart
+/// GlassBadge(
+///   count: 3,
+///   backgroundColor: Colors.blue,
+///   textColor: CupertinoColors.white,
+///   child: Icon(Icons.message),
+/// )
+/// ```
+///
+/// ### Auto-hide when Zero
+/// ```dart
+/// GlassBadge(
+///   count: unreadCount, // Hides when 0
+///   child: Icon(Icons.inbox),
+/// )
+/// ```
+///
+/// ## iOS 26 Design Principles
+///
+/// - **Circular morphology**: Perfect circle for dots, pill for counts
+/// - **Liquid glass backdrop**: Subtle glass effect on badge
+/// - **Semantic colors**: Red for notifications, custom for status
+/// - **Smart positioning**: Overlays child without obscuring content
+/// - **Adaptive sizing**: Badge grows with digit count
+/// - **Visibility**: Only shows when count > 0 or explicitly shown
+class GlassBadge extends StatelessWidget {
+  /// Creates a badge with a count number.
+  const GlassBadge({
+    required this.child,
+    super.key,
+    this.count = 0,
+    this.position = BadgePosition.topRight,
+    this.backgroundColor,
+    this.textColor,
+    this.settings,
+    this.quality,
+    this.showZero = false,
+    this.maxCount = 99,
+  })  : isDot = false,
+        dotColor = null;
+
+  /// Creates a dot badge (status indicator).
+  ///
+  /// Use for online/offline status, active state indicators, etc.
+  ///
+  /// Example:
+  /// ```dart
+  /// GlassBadge.dot(
+  ///   color: Colors.green,
+  ///   position: BadgePosition.bottomRight,
+  ///   child: Avatar(...),
+  /// )
+  /// ```
+  const GlassBadge.dot({
+    required this.child,
+    super.key,
+    this.dotColor = CupertinoColors.systemGreen,
+    this.position = BadgePosition.topRight,
+    this.settings,
+    this.quality,
+  })  : isDot = true,
+        count = 0,
+        backgroundColor = null,
+        textColor = null,
+        showZero = false,
+        maxCount = 99;
+
+  /// The widget to display the badge on top of
+  final Widget child;
+
+  /// Whether this is a dot badge (status indicator)
+  final bool isDot;
+
+  /// The count to display in the badge
+  ///
+  /// If 0 and [showZero] is false, the badge is hidden.
+  final int count;
+
+  /// Position of the badge relative to the child
+  final BadgePosition position;
+
+  /// Background color of the badge
+  ///
+  /// Defaults to red for count badges (iOS notification style).
+  final Color? backgroundColor;
+
+  /// Text color for the count
+  ///
+  /// Defaults to white.
+  final Color? textColor;
+
+  /// Color of the dot badge
+  ///
+  /// Only used for [GlassBadge.dot].
+  final Color? dotColor;
+
+  /// Whether to show the badge when count is 0
+  ///
+  /// Defaults to false (badge hidden when count is 0).
+  final bool showZero;
+
+  /// Maximum count to display
+  ///
+  /// If count exceeds this, displays "99+" (or maxCount+).
+  /// Defaults to 99.
+  final int maxCount;
+
+  /// Custom glass settings (overrides theme)
+  final LiquidGlassSettings? settings;
+
+  /// Rendering quality (overrides theme)
+  final GlassQuality? quality;
+
+  @override
+  Widget build(BuildContext context) {
+    // Don't show count badge if count is 0 and showZero is false
+    if (!isDot && count == 0 && !showZero) {
+      return child;
+    }
+
+    // Build the semantic label for the badge overlay.
+    // - Count badges: "5 notifications" (matches iOS badge VoiceOver)
+    // - Dot badges: "Active" (status indicator)
+    final String badgeLabel = isDot
+        ? 'Active'
+        : (count > maxCount
+            ? '$maxCount+ notifications'
+            : '$count notifications');
+
+    return Semantics(
+      label: badgeLabel,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          child,
+          Positioned(
+            top: _getTopPosition(),
+            right: _getRightPosition(),
+            bottom: _getBottomPosition(),
+            left: _getLeftPosition(),
+            // Badge visual is decorative — the parent Semantics node above
+            // carries the label, so exclude the badge widget itself.
+            child: ExcludeSemantics(
+              child:
+                  isDot ? _buildDotBadge(context) : _buildCountBadge(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCountBadge(BuildContext context) {
+    final themeData = GlassThemeData.of(context);
+    final glowColors = themeData.glowColorsFor(context);
+
+    final bgColor =
+        backgroundColor ?? glowColors.danger ?? const Color(0xFFFF3B30);
+    final fgColor = textColor ?? CupertinoColors.white;
+
+    // Format count display
+    final String displayText =
+        count > maxCount ? '$maxCount+' : count.toString();
+
+    // Determine size based on digit count
+    final bool isWide = count > 9 || count > maxCount;
+    final double minWidth = isWide ? 20.0 : 18.0;
+    final double horizontalPadding = isWide ? 6.0 : 0.0;
+
+    return AdaptiveLiquidGlassLayer(
+      settings: settings ??
+          const LiquidGlassSettings(
+            thickness: 20.0,
+            blur: 4.0,
+            refractiveIndex: 1.1,
+            saturation: 1.2,
+          ),
+      quality: quality,
+      child: Container(
+        constraints: BoxConstraints(
+          minWidth: minWidth,
+          minHeight: 18.0,
+        ),
+        padding: EdgeInsets.symmetric(
+          horizontal: horizontalPadding,
+          vertical: 2.0,
+        ),
+        decoration: BoxDecoration(
+          color: bgColor,
+          borderRadius: BorderRadius.circular(9),
+          border: Border.all(
+            color: CupertinoColors.white.withValues(alpha: 0.3),
+            width: 1.5,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: bgColor.withValues(alpha: 0.4),
+              blurRadius: 8,
+              spreadRadius: 1,
+            ),
+          ],
+        ),
+        child: Text(
+          displayText,
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: fgColor,
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            height: 1.2,
+            letterSpacing: -0.2,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDotBadge(BuildContext context) {
+    final color = dotColor ?? CupertinoColors.systemGreen;
+
+    return AdaptiveLiquidGlassLayer(
+      settings: settings ??
+          const LiquidGlassSettings(
+            thickness: 15.0,
+            blur: 3.0,
+            refractiveIndex: 1.1,
+            saturation: 1.2,
+          ),
+      quality: quality,
+      child: Container(
+        width: 12,
+        height: 12,
+        decoration: BoxDecoration(
+          color: color,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: CupertinoColors.white,
+            width: 2,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: color.withValues(alpha: 0.5),
+              blurRadius: 6,
+              spreadRadius: 1,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  double? _getTopPosition() {
+    switch (position) {
+      case BadgePosition.topRight:
+      case BadgePosition.topLeft:
+        return isDot ? -2 : -6;
+      case BadgePosition.bottomRight:
+      case BadgePosition.bottomLeft:
+        return null;
+    }
+  }
+
+  double? _getRightPosition() {
+    switch (position) {
+      case BadgePosition.topRight:
+      case BadgePosition.bottomRight:
+        return isDot ? -2 : -6;
+      case BadgePosition.topLeft:
+      case BadgePosition.bottomLeft:
+        return null;
+    }
+  }
+
+  double? _getBottomPosition() {
+    switch (position) {
+      case BadgePosition.topRight:
+      case BadgePosition.topLeft:
+        return null;
+      case BadgePosition.bottomRight:
+      case BadgePosition.bottomLeft:
+        return isDot ? -2 : -6;
+    }
+  }
+
+  double? _getLeftPosition() {
+    switch (position) {
+      case BadgePosition.topRight:
+      case BadgePosition.bottomRight:
+        return null;
+      case BadgePosition.topLeft:
+      case BadgePosition.bottomLeft:
+        return isDot ? -2 : -6;
+    }
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/glass_button.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/glass_button.dart
@@ -1,0 +1,888 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../theme/glass_theme_data.dart';
+import '../../types/glass_quality.dart';
+import '../../types/glass_button_style.dart';
+import '../shared/adaptive_glass.dart';
+import '../../theme/glass_theme_helpers.dart';
+import '../surfaces/glass_app_bar.dart';
+
+/// Glass morphism button with scale animation and glow effects.
+///
+/// This button provides a complete liquid glass experience with:
+/// - Liquid glass visual effect with customizable settings
+/// - Scale animation (squash & stretch) when pressed
+/// - Touch-responsive glow effect on interaction (Impeller) or shader-based
+///   glow (Skia)
+/// - Full control over all animation and visual properties
+/// - Accessibility support with semantic labels
+/// - Flexible content support (icon or custom child)
+///
+/// ## Platform Rendering
+///
+/// The glow effect adapts to the platform:
+/// - **Impeller**: Uses advanced compositing via [GlassGlow]
+/// - **Skia/Web**: Animates shader saturation parameter for frosted glow
+///
+/// ## Usage Modes
+///
+/// ### Grouped Mode (default)
+/// Uses [LiquidGlass.grouped] and inherits settings from parent
+/// [LiquidGlassLayer]:
+/// ```dart
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(...),
+///   child: Column(
+///     children: [
+///       GlassButton(
+///         icon: Icon(CupertinoIcons.heart),
+///         onTap: () => print('Favorite'),
+///       ),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ### Standalone Mode
+/// Creates its own layer with [LiquidGlass.withOwnLayer]:
+/// ```dart
+/// GlassButton(
+///   icon: Icon(CupertinoIcons.play),
+///   onTap: () => print('Play'),
+///   useOwnLayer: true,
+///   settings: LiquidGlassSettings(
+///     thickness: 0.3,
+///     blurRadius: 20,
+///   ),
+/// )
+/// ```
+///
+/// ## Customization Examples
+///
+/// ### Custom stretch behavior:
+/// ```dart
+/// GlassButton(
+///   icon: Icon(CupertinoIcons.star),
+///   onTap: () {},
+///   interactionScale: 1.1,  // Grow 10% when pressed
+///   stretch: 0.8,           // More dramatic stretch
+///   resistance: 0.15,       // Higher drag resistance
+/// )
+/// ```
+///
+/// ### Custom glow effect:
+/// ```dart
+/// GlassButton(
+///   icon: Icon(CupertinoIcons.bolt),
+///   onTap: () {},
+///   glowColor: Colors.blue.withOpacity(0.4),
+///   glowRadius: 1.5,  // Larger glow
+/// )
+/// ```
+///
+/// ### Custom content:
+/// ```dart
+/// GlassButton.custom(
+///   onTap: () {},
+///   width: 120,
+///   height: 48,
+///   child: Text('Click Me', style: TextStyle(color: Colors.white)),
+/// )
+/// ```
+///
+/// ## Navigation bar / toolbar usage
+///
+/// When multiple buttons share a [LiquidGlassBlendGroup] (e.g. inside an
+/// [AdaptiveLiquidGlassLayer]), the drag-follow animation physically moves each
+/// button's glass shape in the shader's coordinate space. Because the blend
+/// group treats all shapes as a connected liquid surface, dragging one button
+/// causes neighboring buttons to visually respond — this is intentional for
+/// isolated floating buttons, but can feel jarring in a nav bar.
+///
+/// Reduce [stretch] for tightly-grouped buttons to keep the tactile press feel
+/// without excessive cross-button coupling:
+///
+/// ```dart
+/// // Nav bar / toolbar — subtle liquid feel, minimal coupling
+/// GlassButton(
+///   stretch: 0.15,
+///   icon: Icon(CupertinoIcons.home),
+///   onTap: () {},
+/// )
+///
+/// // Standalone FAB — full liquid feel (default)
+/// GlassButton(
+///   icon: Icon(CupertinoIcons.add),
+///   onTap: () {},
+/// )
+/// ```
+///
+/// Setting [stretch] to `0.0` disables drag-following entirely while keeping
+/// the press-scale effect ([interactionScale]).
+class GlassButton extends StatefulWidget {
+  /// Creates a glass button with an icon.
+  const GlassButton({
+    required this.icon,
+    required this.onTap,
+    super.key,
+    this.label = '',
+    this.width = 56,
+    this.height = 56,
+    this.iconSize = 24.0,
+    this.iconColor,
+    this.shape = const LiquidOval(),
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    // LiquidStretch properties
+    this.interactionScale = 1.05,
+    this.stretch = 0.5,
+    this.resistance = 0.01,
+    this.stretchHitTestBehavior = HitTestBehavior.opaque,
+    // GlassGlow properties
+    this.glowColor,
+    this.glowRadius = 1.0,
+    this.glowBlurRadius,
+    this.glowSpreadRadius,
+    this.glowOpacity,
+    this.glowHitTestBehavior = HitTestBehavior.opaque,
+    this.enabled = true,
+    this.style = GlassButtonStyle.filled,
+    this.persistPressOnDrag = true,
+    this.anchorStretch = true,
+    this.anchorStretchSettings = const AnchorStretchSettings(),
+    this.alignment = Alignment.center,
+    this.ambientBaseLight = 0.08,
+    this.platformViewBackdrop = false,
+  }) : child = null;
+
+  /// Creates a glass button with custom content.
+  ///
+  /// This allows you to use any widget as the button's content instead of
+  /// just an icon. Useful for text buttons, composite content, etc.
+  ///
+  /// Example:
+  /// ```dart
+  /// GlassButton.custom(
+  ///   onTap: () {},
+  ///   width: 120,
+  ///   height: 48,
+  ///   child: Row(
+  ///     mainAxisAlignment: MainAxisAlignment.center,
+  ///     children: [
+  ///       Icon(CupertinoIcons.play, size: 16),
+  ///       SizedBox(width: 8),
+  ///       Text('Play'),
+  ///     ],
+  ///   ),
+  /// )
+  /// ```
+  const GlassButton.custom({
+    required this.child,
+    required this.onTap,
+    super.key,
+    this.label = '',
+    this.width,
+    this.height,
+    this.shape = const LiquidOval(),
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    // LiquidStretch properties
+    this.interactionScale = 1.05,
+    this.stretch = 0.5,
+    this.resistance = 0.01,
+    this.stretchHitTestBehavior = HitTestBehavior.opaque,
+    // GlassGlow properties
+    this.glowColor,
+    this.glowRadius = 1.0,
+    this.glowBlurRadius,
+    this.glowSpreadRadius,
+    this.glowOpacity,
+    this.glowHitTestBehavior = HitTestBehavior.opaque,
+    this.enabled = true,
+    this.style = GlassButtonStyle.filled,
+    this.persistPressOnDrag = true,
+    this.anchorStretch = true,
+    this.anchorStretchSettings = const AnchorStretchSettings(),
+    this.alignment = Alignment.center,
+    this.ambientBaseLight = 0.08,
+    this.platformViewBackdrop = false,
+  })  : icon = null,
+        iconSize = 24.0,
+        iconColor = null;
+
+  // ===========================================================================
+  // Content Properties
+  // ===========================================================================
+
+  /// The widget to display in the button.
+  ///
+  /// Mutually exclusive with [child]. Pass any widget — standard [Icon]
+  /// widgets will inherit color and size from [iconColor] and [iconSize]
+  /// via [IconTheme]. Custom widgets handle their own styling.
+  final Widget? icon;
+
+  /// Custom widget to display in the button.
+  ///
+  /// Mutually exclusive with [icon]. Use [GlassButton.custom] constructor
+  /// to provide custom content.
+  final Widget? child;
+
+  /// Size of the icon (only used when [icon] is provided).
+  ///
+  /// Defaults to 24.0.
+  final double iconSize;
+
+  /// Color of the icon (only used when [icon] is provided).
+  ///
+  /// Defaults to [CupertinoColors.white] for prominent buttons, and [CupertinoColors.label] otherwise.
+  final Color? iconColor;
+
+  // ===========================================================================
+  // Button Properties
+  // ===========================================================================
+
+  /// Callback when the button is tapped.
+  ///
+  /// If [enabled] is false, this callback will not be invoked.
+  final VoidCallback onTap;
+
+  /// Whether the button is enabled.
+  ///
+  /// When false, the button will be visually disabled and [onTap] will not
+  /// be invoked. The button will render with reduced opacity.
+  ///
+  /// Defaults to true.
+  final bool enabled;
+
+  /// Semantic label for accessibility.
+  ///
+  /// This label is announced by screen readers to describe the button's
+  /// purpose. If empty, the button's visual content is used instead.
+  ///
+  /// Defaults to an empty string.
+  final String label;
+
+  /// Width of the button in logical pixels.
+  ///
+  /// When `null`, the button will size itself based on parent constraints
+  /// (e.g. expanding to fill an [Expanded] widget).
+  ///
+  /// The default [GlassButton] constructor sets this to 56.0 for icon buttons.
+  /// The [GlassButton.custom] constructor defaults to `null` so the button
+  /// respects flexible parent layouts.
+  final double? width;
+
+  /// Height of the button in logical pixels.
+  ///
+  /// Defaults to 56.0.
+  final double? height;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Shape of the glass button.
+  ///
+  /// Can be [LiquidOval], [LiquidRoundedRectangle], or
+  /// [LiquidRoundedSuperellipse].
+  ///
+  /// Defaults to [LiquidOval].
+  final LiquidShape shape;
+
+  /// Glass effect settings for the button.
+  ///
+  /// Controls the visual appearance of the glass effect including thickness,
+  /// blur radius, color tint, lighting, and more.
+  ///
+  /// If null, settings are inherited from [DefaultButtonSettings] (set via
+  /// [GlassAppBar.buttonSettings]), then from the page-level glass layer,
+  /// then from the app-level [GlassTheme].
+  final LiquidGlassSettings? settings;
+
+  /// Whether to create its own layer or use grouped glass within an existing
+  /// layer.
+  ///
+  /// - `false` (default): Uses [LiquidGlass.grouped], must be inside a
+  /// [LiquidGlassLayer].
+  ///   This is more performant when you have multiple glass elements that
+  ///   can share the same rendering context.
+  ///
+  /// - `true`: Uses [LiquidGlass.withOwnLayer], can be used anywhere.
+  ///   Creates an independent glass rendering context for this button.
+  ///
+  /// Defaults to false.
+  final bool useOwnLayer;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// Defaults to [GlassQuality.standard], which uses backdrop filter rendering.
+  /// This works reliably in all contexts, including scrollable lists.
+  ///
+  /// Use [GlassQuality.premium] for the full Impeller shader pipeline. When using
+  /// premium quality on a standalone button (outside of an [AdaptiveLiquidGlassLayer]
+  /// or [LiquidGlassLayer]), you **must** also set [useOwnLayer] to `true`.
+  /// Without it, the button has no ancestor layer to render against and will show
+  /// an assertion error in debug mode (graceful pass-through in release).
+  ///
+  /// ```dart
+  /// // ✓ Correct — standalone premium button
+  /// GlassButton(
+  ///   quality: GlassQuality.premium,
+  ///   useOwnLayer: true,
+  ///   icon: Icon(CupertinoIcons.play),
+  ///   onTap: () {},
+  /// )
+  ///
+  /// // ✓ Also correct — inside an AdaptiveLiquidGlassLayer (no useOwnLayer needed)
+  /// AdaptiveLiquidGlassLayer(
+  ///   quality: GlassQuality.premium,
+  ///   child: GlassButton(
+  ///     icon: Icon(CupertinoIcons.play),
+  ///     onTap: () {},
+  ///   ),
+  /// )
+  /// ```
+  final GlassQuality? quality;
+
+  /// The visual style of the button.
+  ///
+  /// Use [GlassButtonStyle.transparent] when grouping buttons to avoid
+  /// double-drawing glass backgrounds.
+  final GlassButtonStyle style;
+
+  // ===========================================================================
+  // LiquidStretch Properties (Animation & Interaction)
+  // ===========================================================================
+
+  /// The scale factor to apply when the user is interacting with the button.
+  ///
+  /// - 1.0 means no scaling
+  /// - Greater than 1.0 means the button will grow (e.g., 1.05 = 5% larger)
+  /// - Less than 1.0 means the button will shrink
+  ///
+  /// This creates a satisfying "press down" effect when the button is touched.
+  ///
+  /// Defaults to 1.05.
+  final double interactionScale;
+
+  /// The factor to multiply the drag offset by to determine the stretch amount.
+  ///
+  /// Controls how much the button stretches in response to drag gestures:
+  /// - 0.0 means no stretch
+  /// - 1.0 means the stretch matches the drag offset exactly (usually too much)
+  /// - 0.5 (default) provides a balanced, natural stretch effect
+  ///
+  /// Higher values create more dramatic squash and stretch animations.
+  ///
+  /// Defaults to 0.5.
+  final double stretch;
+
+  /// The resistance factor to apply to the drag offset.
+  ///
+  /// Controls how "sticky" the drag feels. Higher values create more
+  /// resistance, making the button feel heavier and more sluggish. Lower
+  /// values make it feel lighter and more responsive.
+  ///
+  /// Uses non-linear damping that increases with distance from the rest
+  /// position.
+  ///
+  /// Defaults to 0.01.
+  final double resistance;
+
+  /// The hit test behavior for the stretch gesture listener.
+  ///
+  /// Controls how the stretch effect responds to touches:
+  /// - [HitTestBehavior.opaque]: Consumes all touches (default)
+  /// - [HitTestBehavior.translucent]: Allows touches to pass through
+  /// - [HitTestBehavior.deferToChild]: Only responds when touching the child
+  ///
+  /// Defaults to [HitTestBehavior.opaque].
+  final HitTestBehavior stretchHitTestBehavior;
+
+  // ===========================================================================
+  // GlassGlow Properties (Touch Effects)
+  // ===========================================================================
+
+  /// The color of the glow effect.
+  ///
+  /// The glow will have this color's opacity at the center and fade to fully
+  /// transparent at the edge. Use semi-transparent colors for best results.
+  ///
+  /// If null, uses the primary glow color from [GlassTheme].
+  ///
+  /// Common values:
+  /// - [Colors.white24]: Subtle white glow
+  /// - [Colors.blue.withOpacity(0.3)]: Blue glow
+  /// - [Colors.transparent]: Disables glow effect
+  ///
+  /// Defaults to null (uses theme).
+  final Color? glowColor;
+
+  /// The radius of the glow effect relative to the layer's shortest side.
+  ///
+  /// - 1.0 (default): Glow radius equals the shortest dimension of the button
+  /// - 0.5: Glow radius is half the shortest dimension
+  /// - 2.0: Glow radius is twice the shortest dimension
+  ///
+  /// Larger values create a more diffuse, spread-out glow.
+  ///
+  /// Defaults to 1.0.
+  final double glowRadius;
+
+  /// Additional Gaussian blur sigma applied to the glow halo.
+  ///
+  /// If null, the value from [GlassThemeData.glowColorsFor] is used.
+  /// Pass 0 to disable blur. Values of 4–16 create a diffuse halo.
+  final double? glowBlurRadius;
+
+  /// Extra glow circle spread as a fraction of the layer's shortest side.
+  ///
+  /// If null, the value from [GlassThemeData.glowColorsFor] is used.
+  final double? glowSpreadRadius;
+
+  /// Master opacity multiplier (0–1) applied on top of [glowColor]'s alpha.
+  ///
+  /// If null, the value from [GlassThemeData.glowColorsFor] is used.
+  final double? glowOpacity;
+
+  /// The hit test behavior for the glow gesture listener.
+  ///
+  /// Controls how the glow effect responds to touches:
+  /// - [HitTestBehavior.opaque]: Consumes all touches (default)
+  /// - [HitTestBehavior.translucent]: Allows touches to pass through
+  /// - [HitTestBehavior.deferToChild]: Only responds when touching the child
+  ///
+  /// Defaults to [HitTestBehavior.opaque].
+  final HitTestBehavior glowHitTestBehavior;
+
+  /// Whether the pressed glass distortion persists while the finger is held
+  /// down, even if dragged far away from the button.
+  ///
+  /// - `true` (default): The distortion and glow stay active for the entire
+  ///   duration the finger is on screen, matching iOS 26 toolbar/navigation
+  ///   buttons (Weather app, Maps, etc.). The button stretches with a jelly
+  ///   feel and maintains its pressed visual state until the finger lifts.
+  ///
+  /// - `false`: The distortion cancels when the finger moves beyond the tap
+  ///   tolerance (~18 logical pixels), matching iOS 26 lock screen buttons
+  ///   (camera, torch) that snap back if you drag away.
+  ///
+  /// Defaults to true.
+  final bool persistPressOnDrag;
+
+  /// Whether the stretch anchors the button in place.
+  ///
+  /// When `true` (default), the button stays fixed and elongates toward
+  /// the finger — matching iOS 26 button behaviour.
+  /// When `false`, the button follows the finger (jelly-follow mode).
+  ///
+  /// Defaults to `true`.
+  ///
+  /// See [LiquidStretch.anchorStretch].
+  final bool anchorStretch;
+
+  /// Fine-tuning for the anchor stretch effect.
+  ///
+  /// Controls intensity, squash, translation damping, and bounciness.
+  /// Most developers won’t need to change these — the defaults match
+  /// iOS 26 button behaviour.
+  ///
+  /// See [AnchorStretchSettings] for details.
+  final AnchorStretchSettings anchorStretchSettings;
+
+  /// How to align the child content within the button bounds.
+  ///
+  /// Defaults to [Alignment.center], which is correct for icon buttons.
+  /// Use [Alignment.topLeft] or similar for custom card-style layouts.
+  final AlignmentGeometry alignment;
+
+  /// Opacity of the ambient base light when the button is pressed.
+  ///
+  /// iOS 26 buttons maintain a subtle overall surface brightness when active,
+  /// in addition to the directional glow that follows the finger. This
+  /// prevents the button from going dark when the finger drags the directional
+  /// highlight off-edge.
+  ///
+  /// - 0.0: No ambient base light (button goes dark off-edge)
+  /// - 0.08 (default): Subtle surface luminosity matching iOS 26
+  /// - 0.15: Noticeably brighter surface
+  ///
+  /// Set to 0.0 to disable.
+  final double ambientBaseLight;
+
+  /// When true (typically for iOS PlatformViews), forces the BackdropFilter
+  /// fallback render path instead of the Impeller-native shader. Forwarded to
+  /// the underlying [AdaptiveGlass].
+  final bool platformViewBackdrop;
+
+  @override
+  State<GlassButton> createState() => _GlassButtonState();
+}
+
+class _GlassButtonState extends State<GlassButton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _saturationController;
+  late final Animation<double> _saturationAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _saturationController = AnimationController(
+      duration: const Duration(milliseconds: 50), // Fast, instant response
+      vsync: this,
+    );
+    _saturationAnimation = CurvedAnimation(
+      parent: _saturationController,
+      curve: Curves.easeOut,
+    );
+  }
+
+  @override
+  void dispose() {
+    _saturationController.dispose();
+    super.dispose();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tap-based pressed state (persistPressOnDrag: false)
+  // Used by lock screen camera/torch buttons — cancels on drag.
+  //
+  // All press handlers below guard on `mounted` before touching
+  // [_saturationController]: a button can be DISPOSED mid-press — e.g. a
+  // collapsing nav mini-bar removed by the very tap that expands it — after which
+  // a queued pointerUp / pointerCancel still dispatches here and would call
+  // `.reverse()` on the disposed controller, throwing
+  // `AnimationController.reverse() called after dispose()` (assert `_ticker != null`).
+  // ---------------------------------------------------------------------------
+
+  void _handleTapDown(TapDownDetails details) {
+    if (!mounted || !widget.enabled) return;
+    _saturationController.forward();
+  }
+
+  void _handleTapUp(TapUpDetails details) {
+    if (!mounted || !widget.enabled) return;
+    _saturationController.reverse();
+  }
+
+  void _handleTapCancel() {
+    if (!mounted || !widget.enabled) return;
+    _saturationController.reverse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pointer-based pressed state (persistPressOnDrag: true)
+  // Used by toolbar/nav buttons — distortion persists while finger is down.
+  // Raw Listener tracks the pointer until pointerUp/Cancel regardless of
+  // distance, matching iOS 26 Weather/Maps button behaviour.
+  // ---------------------------------------------------------------------------
+
+  void _handlePointerDown(PointerDownEvent event) {
+    if (!mounted || !widget.enabled) return;
+    _saturationController.forward();
+  }
+
+  void _handlePointerUp(PointerUpEvent event) {
+    if (!mounted || !widget.enabled) return;
+    _saturationController.reverse();
+  }
+
+  void _handlePointerCancel(PointerCancelEvent event) {
+    if (!mounted || !widget.enabled) return;
+    _saturationController.reverse();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Resolve quality and theme — hoisted here so stretchWidget can branch on quality
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+    );
+
+    final resolvedGlowColors =
+        GlassThemeData.of(context).glowColorsFor(context);
+    final effectiveGlowColor = widget.glowColor ??
+        resolvedGlowColors.primary ??
+        CupertinoTheme.of(context)
+            .textTheme
+            .textStyle
+            .color
+            ?.withValues(alpha: 0.24) ??
+        CupertinoColors.white.withValues(alpha: 0.24);
+    final effectiveGlowBlurRadius =
+        widget.glowBlurRadius ?? resolvedGlowColors.glowBlurRadius;
+    final effectiveGlowSpreadRadius =
+        widget.glowSpreadRadius ?? resolvedGlowColors.glowSpreadRadius;
+    final effectiveGlowOpacity =
+        widget.glowOpacity ?? resolvedGlowColors.glowOpacity;
+
+    // Build the content widget (either icon or custom child)
+    final contentWidget = SizedBox(
+      height: widget.height,
+      width: widget.width,
+      child: Align(
+        alignment: widget.alignment,
+        widthFactor: widget.width == null ? 1.0 : null,
+        heightFactor: widget.height == null ? 1.0 : null,
+        child: widget.child ??
+            IconTheme(
+              data: IconThemeData(
+                color: widget.iconColor ??
+                    (widget.style == GlassButtonStyle.prominent
+                        ? CupertinoColors.white
+                        : (CupertinoTheme.of(context)
+                                .textTheme
+                                .textStyle
+                                .color ??
+                            CupertinoColors.label)),
+                size: widget.iconSize,
+              ),
+              child: widget.icon ?? const SizedBox.shrink(),
+            ),
+      ),
+    );
+
+    // 2. Build the inner content (Ambient base + Glow + Icon/Child)
+    //
+    // The ambient base light provides a subtle surface brightness when pressed,
+    // matching iOS 26 where active buttons never go completely dark even when
+    // the directional glow follows the finger off-edge.
+    final ambientOverlay = widget.ambientBaseLight > 0
+        ? AnimatedBuilder(
+            animation: _saturationAnimation,
+            builder: (context, _) {
+              final opacity =
+                  _saturationAnimation.value * widget.ambientBaseLight;
+              if (opacity <= 0) return const SizedBox.shrink();
+              return Positioned.fill(
+                child: IgnorePointer(
+                  child: ColoredBox(
+                    color: CupertinoColors.white.withValues(alpha: opacity),
+                  ),
+                ),
+              );
+            },
+          )
+        : null;
+
+    final contentWithAmbient = ambientOverlay != null
+        ? Stack(
+            alignment: widget.alignment,
+            children: [
+              contentWidget,
+              ambientOverlay,
+            ],
+          )
+        : contentWidget;
+
+    // This part is static relative to the glass saturation pulse
+    final glowContent = GlassGlow(
+      glowColor: effectiveGlowColor,
+      glowRadius: widget.glowRadius,
+      glowBlurRadius: effectiveGlowBlurRadius,
+      glowSpreadRadius: effectiveGlowSpreadRadius,
+      glowOpacity: effectiveGlowOpacity,
+      hitTestBehavior: widget.glowHitTestBehavior,
+      child: contentWithAmbient,
+    );
+
+    // 3. Animate ONLY the glass settings that change during interaction
+    final glassWidget = AnimatedBuilder(
+      animation: _saturationAnimation,
+      child: glowContent,
+      builder: (context, child) {
+        if (widget.style == GlassButtonStyle.transparent) {
+          // Clip interaction glow to the button's shape so it doesn't
+          // bleed into a rectangle.
+          return ClipPath(
+            clipper: _ExpandedShapeClipper(shape: widget.shape, expansion: 0),
+            clipBehavior: Clip.antiAlias,
+            child: child!,
+          );
+        }
+
+        // Resolve settings: widget explicit → app bar default → inherited.
+        final effectiveExplicit =
+            widget.settings ?? DefaultButtonSettings.of(context);
+        var baseSettings = GlassThemeHelpers.resolveSettings(
+          context,
+          explicit: effectiveExplicit,
+        );
+
+        // Prominent style: thicker, more opaque, brighter glass for primary CTAs.
+        // iOS 26's `.glassProminent` is visibly more frosted than `.glass`.
+        if (widget.style == GlassButtonStyle.prominent) {
+          baseSettings = baseSettings.copyWith(
+            thickness: (baseSettings.effectiveThickness * 2.5).clamp(30, 100),
+            glassColor: baseSettings.glassColor.withValues(
+                alpha: (baseSettings.glassColor.a * 2.5).clamp(0.4, 0.9)),
+            lightIntensity:
+                (baseSettings.effectiveLightIntensity * 1.5).clamp(0.3, 1.0),
+          );
+        }
+
+        // useOwnLayer is passed through to AdaptiveGlass, which automatically
+        // promotes interactive elements to own-layer in premium mode (via
+        // isInteractive: true). No need to auto-promote here.
+
+        // Pass glow intensity directly to AdaptiveGlass for Skia shader feedback.
+        // On Impeller, GlassGlow widget is used instead (separate from glass effect).
+        // On Skia/Web, glowIntensity controls shader-based additive brightness.
+        return AdaptiveGlass(
+          shape: widget.shape,
+          settings: baseSettings, // Preserve user's saturation setting!
+          quality: effectiveQuality,
+          useOwnLayer: widget.useOwnLayer,
+          glowIntensity: _saturationAnimation.value, // 0.0-1.0 animation
+          isInteractive: true, // Buttons manage their own RepaintBoundary
+          platformViewBackdrop: widget.platformViewBackdrop,
+          child: child!,
+        );
+      },
+    );
+
+    // 4. Wrap with stretch animation and interaction containers
+    // These remain outside the AnimatedBuilder to prevent redundant rebuilds.
+    //
+    // We skip RepaintBoundary when the button can be stretched. The stretch
+    // animation applies a Transform.scale that scales the cached texture:
+    //
+    // - Minimal: always skipped (vector ClipPath — no bitmap to distort).
+    // - Premium + stretch: skipped. Impeller's LiquidGlassLayer compositing
+    //   bakes shape edges into the cached texture; scaling that texture causes
+    //   bilinear interpolation artefacts. This is a known Impeller limitation
+    //   — the fix belongs at the shader/compositing level, not as a per-button
+    //   ClipPath workaround. Standard's 2D shader re-executes within the
+    //   boundary so it stays sharp.
+    // - Premium + no stretch (stretch == 0): kept. No scaling means no
+    //   artefacts, and the boundary gives a pure performance win for the
+    //   expensive Impeller pipeline.
+    // - Standard: always kept. The lightweight shader re-executes at the
+    //   correct resolution even inside a RepaintBoundary.
+
+    final bool hasStretch = widget.stretch > 0;
+    final bool skipBoundary = effectiveQuality == GlassQuality.minimal ||
+        (effectiveQuality == GlassQuality.premium && hasStretch);
+
+    // Resolve interaction settings: explicit widget param > theme > default
+    final themeInteraction = GlassThemeData.of(context).interaction;
+
+    final stretchContent = LiquidStretch(
+      interactionScale: widget.interactionScale != 1.05
+          ? widget.interactionScale
+          : themeInteraction.interactionScale ?? widget.interactionScale,
+      stretch: widget.stretch != 0.5
+          ? widget.stretch
+          : themeInteraction.stretch ?? widget.stretch,
+      resistance: widget.resistance != 0.01
+          ? widget.resistance
+          : themeInteraction.resistance ?? widget.resistance,
+      hitTestBehavior: widget.stretchHitTestBehavior,
+      anchorStretch: widget.anchorStretch != true
+          ? widget.anchorStretch
+          : themeInteraction.anchorStretch ?? widget.anchorStretch,
+      anchorStretchSettings: !identical(
+              widget.anchorStretchSettings, const AnchorStretchSettings())
+          ? widget.anchorStretchSettings
+          : themeInteraction.anchorStretchSettings ??
+              widget.anchorStretchSettings,
+      child: Semantics(
+        button: true,
+        label: widget.label.isNotEmpty ? widget.label : null,
+        enabled: widget.enabled,
+        child: glassWidget,
+      ),
+    );
+
+    final stretchWidget =
+        skipBoundary ? stretchContent : RepaintBoundary(child: stretchContent);
+
+    // Apply opacity when disabled
+    final finalWidget = widget.enabled
+        ? stretchWidget
+        : Opacity(
+            opacity: 0.5,
+            child: stretchWidget,
+          );
+
+    // ---------------------------------------------------------------------------
+    // Interaction wrapper: choose between tap-based and pointer-based press
+    // tracking depending on persistPressOnDrag.
+    //
+    // persistPressOnDrag: true  → raw Listener wraps GestureDetector.
+    //   The Listener tracks the pointer globally (pointerDown/Up/Cancel)
+    //   so the pressed visual persists while the finger is down. The inner
+    //   GestureDetector still handles onTap for the callback.
+    //
+    // persistPressOnDrag: false → GestureDetector handles everything.
+    //   onTapDown/Up/Cancel drive the saturation controller, so dragging
+    //   away cancels the pressed state (iOS lock screen behavior).
+    // ---------------------------------------------------------------------------
+    if (widget.persistPressOnDrag) {
+      return Listener(
+        onPointerDown: _handlePointerDown,
+        onPointerUp: _handlePointerUp,
+        onPointerCancel: _handlePointerCancel,
+        behavior: HitTestBehavior.opaque,
+        child: GestureDetector(
+          onTap: widget.enabled ? widget.onTap : null,
+          behavior: HitTestBehavior.opaque,
+          child: finalWidget,
+        ),
+      );
+    }
+
+    // Tap-based path (lock screen buttons)
+    return GestureDetector(
+      onTap: widget.enabled ? widget.onTap : null,
+      onTapDown: _handleTapDown,
+      onTapUp: _handleTapUp,
+      onTapCancel: _handleTapCancel,
+      behavior: HitTestBehavior.opaque,
+      child: finalWidget,
+    );
+  }
+}
+
+/// Clips to a [ShapeBorder]'s outer path, optionally expanded by [expansion]
+/// pixels on all sides.
+///
+/// At rest ([expansion] > 0), the clip is slightly larger than the shape,
+/// allowing the glass shader's rim/refraction to extend beyond the strict
+/// shape boundary. During stretch interaction ([expansion] → 0), the clip
+/// tightens to the exact shape boundary, hiding rasterization artifacts.
+class _ExpandedShapeClipper extends CustomClipper<Path> {
+  _ExpandedShapeClipper({
+    required this.shape,
+    this.expansion = 0.0,
+  });
+
+  final ShapeBorder shape;
+  final double expansion;
+
+  @override
+  Path getClip(Size size) {
+    if (expansion <= 0) {
+      // Tight clip — exact shape boundary.
+      return shape.getOuterPath(Offset.zero & size);
+    }
+    // Expanded clip — inflate the rect so the shape path extends beyond
+    // the widget's layout bounds, giving the shader's rim room to render.
+    final expandedRect = Rect.fromLTWH(
+      -expansion,
+      -expansion,
+      size.width + expansion * 2,
+      size.height + expansion * 2,
+    );
+    return shape.getOuterPath(expandedRect);
+  }
+
+  @override
+  bool shouldReclip(_ExpandedShapeClipper oldClipper) =>
+      shape != oldClipper.shape || expansion != oldClipper.expansion;
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/glass_button_group.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/glass_button_group.dart
@@ -1,0 +1,484 @@
+import 'package:flutter/cupertino.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../theme/glass_theme.dart';
+import '../../types/glass_button_style.dart';
+import '../../types/glass_quality.dart';
+import '../containers/glass_container.dart';
+import '../overlays/glass_menu.dart';
+import 'glass_button.dart';
+import '../../theme/glass_theme_helpers.dart';
+
+// =============================================================================
+// GlassButtonGroupItem — lightweight data model
+// =============================================================================
+
+/// A lightweight data class representing a single item in a [GlassButtonGroup].
+///
+/// Unlike [GlassButton], a [GlassButtonGroupItem] carries no widget state — no
+/// animation controllers, no stretch physics, no glow overlays. The parent
+/// [GlassButtonGroup] provides the glass surface and renders each item as a
+/// simple icon with a press-dim highlight.
+///
+/// ## Basic tap item
+///
+/// ```dart
+/// GlassButtonGroup.icons(
+///   items: [
+///     GlassButtonGroupItem(icon: Icon(CupertinoIcons.bold), onTap: () {}),
+///     GlassButtonGroupItem(icon: Icon(CupertinoIcons.italic), onTap: () {}),
+///     GlassButtonGroupItem(icon: Icon(CupertinoIcons.underline), onTap: () {}),
+///   ],
+/// )
+/// ```
+///
+/// ## Menu item (iOS 26 UIBarButtonItem.menu equivalent)
+///
+/// Use [GlassButtonGroupItem.menu] to make an item open a [GlassMenu] pull-down
+/// when tapped. This mirrors `UIBarButtonItem.menu` within a `UIBarButtonItemGroup`.
+///
+/// ```dart
+/// GlassButtonGroup.icons(
+///   items: [
+///     GlassButtonGroupItem(icon: Icon(CupertinoIcons.chart_bar), onTap: () {}),
+///     GlassButtonGroupItem.menu(
+///       icon: Icon(CupertinoIcons.ellipsis),
+///       menuItems: [
+///         GlassMenuItem(title: 'Copy', onTap: () {}),
+///         GlassMenuDivider(),
+///         GlassMenuItem(title: 'Delete', isDestructive: true, onTap: () {}),
+///       ],
+///     ),
+///   ],
+/// )
+/// ```
+class GlassButtonGroupItem {
+  // No-op used by GlassButtonGroupItem.menu so onTap is always non-null.
+  static void _noOp() {}
+
+  /// Creates a group item with an icon and tap callback.
+  const GlassButtonGroupItem({
+    required this.icon,
+    required this.onTap,
+    this.label,
+    this.enabled = true,
+  })  : menuItems = null,
+        menuAlignment = null,
+        menuWidth = 200;
+
+  /// Creates a group item that opens a [GlassMenu] pull-down when tapped.
+  ///
+  /// This is the Flutter equivalent of `UIBarButtonItem.menu` inside a
+  /// `UIBarButtonItemGroup` — the standard iOS 26 pattern for toolbar
+  /// buttons that reveal a list of actions.
+  ///
+  /// [menuItems] accepts both [GlassMenuItem] and [GlassMenuDivider] widgets,
+  /// matching the [GlassMenu.items] contract directly.
+  ///
+  /// [menuAlignment] controls where the menu expands relative to the trigger.
+  /// Defaults to auto-detection based on screen position.
+  ///
+  /// [menuWidth] is the width of the expanded menu panel. Defaults to 200.
+  const GlassButtonGroupItem.menu({
+    required this.icon,
+    required List<Widget> this.menuItems,
+    this.menuAlignment,
+    this.menuWidth = 200,
+    this.label,
+  })  : onTap = _noOp,
+        enabled = true;
+
+  /// The icon widget to display.
+  ///
+  /// Typically a [CupertinoIcon] or [Icon]. The parent [GlassButtonGroup]
+  /// wraps this in an [IconTheme] that sets size and color based on the
+  /// current brightness.
+  final Widget icon;
+
+  /// Called when the item is tapped.
+  ///
+  /// Not used when [menuItems] is non-null — the tap opens the menu instead.
+  final VoidCallback onTap;
+
+  /// Optional semantic label for accessibility.
+  ///
+  /// If provided, wraps the item in [Semantics] with `button: true`.
+  final String? label;
+
+  /// Whether the item is interactive.
+  ///
+  /// When false, the item renders at 50% opacity and ignores taps.
+  final bool enabled;
+
+  /// When non-null, tapping this item opens a [GlassMenu] pull-down.
+  ///
+  /// Accepts [GlassMenuItem] and [GlassMenuDivider] widgets. Set via
+  /// [GlassButtonGroupItem.menu].
+  final List<Widget>? menuItems;
+
+  /// Controls where the menu expands relative to the trigger button.
+  ///
+  /// Defaults to auto-detection. Set via [GlassButtonGroupItem.menu].
+  final GlassMenuAlignment? menuAlignment;
+
+  /// Width of the expanded menu panel in logical pixels.
+  ///
+  /// Defaults to 200. Set via [GlassButtonGroupItem.menu].
+  final double menuWidth;
+}
+
+// =============================================================================
+// GlassButtonGroup
+// =============================================================================
+
+/// A container that groups multiple buttons in a single glass pill.
+///
+/// ## Two usage modes
+///
+/// ### 1. Lightweight items (recommended)
+///
+/// Use [GlassButtonGroup.icons] with [GlassButtonGroupItem] data objects. Each item
+/// is rendered as a minimal icon with tap handling — no animation controllers
+/// or glass shaders per item. The group provides the glass surface.
+///
+/// ```dart
+/// GlassButtonGroup.icons(
+///   items: [
+///     GlassButtonGroupItem(icon: Icon(CupertinoIcons.text_alignleft), onTap: () {}),
+///     GlassButtonGroupItem(icon: Icon(CupertinoIcons.trash), onTap: () {}),
+///     GlassButtonGroupItem(icon: Icon(CupertinoIcons.add), onTap: () {}),
+///   ],
+/// )
+/// ```
+///
+/// ### 2. Full widget children
+///
+/// Use the default constructor with [GlassButton] children for full control
+/// over each button's style, stretch, and glow.
+///
+/// ```dart
+/// GlassButtonGroup(
+///   children: [
+///     GlassButton(icon: Icon(CupertinoIcons.bold), style: GlassButtonStyle.transparent, onTap: () {}),
+///     GlassButton(icon: Icon(CupertinoIcons.italic), style: GlassButtonStyle.transparent, onTap: () {}),
+///   ],
+/// )
+/// ```
+class GlassButtonGroup extends StatelessWidget {
+  /// Creates a group of glass buttons from widget children.
+  ///
+  /// Children should be [GlassButton]s with [GlassButtonStyle.transparent].
+  /// For a lighter-weight alternative, use [GlassButtonGroup.icons].
+  const GlassButtonGroup({
+    required this.children,
+    super.key,
+    this.direction = Axis.horizontal,
+    this.settings,
+    this.quality,
+    this.borderRadius = 16.0,
+    this.borderColor,
+    this.useOwnLayer = false,
+    this.showDividers = true,
+    this.iconSize = 22.0,
+    this.itemPadding = const EdgeInsets.all(12),
+    this.platformViewBackdrop = false,
+  }) : items = null;
+
+  /// Creates a group of glass buttons from lightweight [GlassButtonGroupItem]s.
+  ///
+  /// Each item is rendered as a simple icon with press-dim feedback — no
+  /// animation controllers, stretch physics, or glow overlays. The group
+  /// provides the glass surface.
+  ///
+  /// Defaults to `showDividers: false` and `borderRadius: 22.0` for the
+  /// unified pill look shown in iOS 26 toolbar groups.
+  const GlassButtonGroup.icons({
+    required List<GlassButtonGroupItem> this.items,
+    super.key,
+    this.direction = Axis.horizontal,
+    this.settings,
+    this.quality,
+    this.borderRadius = 22.0,
+    this.borderColor,
+    this.useOwnLayer = false,
+    this.showDividers = false,
+    this.iconSize = 22.0,
+    this.itemPadding = const EdgeInsets.all(12),
+    this.platformViewBackdrop = false,
+  }) : children = const [];
+
+  /// The buttons to display in the group (widget children mode).
+  ///
+  /// Ideally, these should be [GlassButton]s with [GlassButtonStyle.transparent].
+  /// Empty when using [GlassButtonGroup.icons].
+  final List<Widget> children;
+
+  /// Lightweight item data for icon-based groups.
+  ///
+  /// When non-null, [children] is ignored and items are rendered internally
+  /// as lightweight icons with press-dim feedback.
+  final List<GlassButtonGroupItem>? items;
+
+  /// Direction to arrange buttons (horizontal or vertical).
+  final Axis direction;
+
+  /// Custom glass settings.
+  final LiquidGlassSettings? settings;
+
+  /// Quality of glass effect.
+  final GlassQuality? quality;
+
+  /// Border radius of the group container.
+  final double borderRadius;
+
+  /// Color of the dividers between buttons.
+  ///
+  /// Defaults to a semi-transparent black or white depending on brightness.
+  final Color? borderColor;
+
+  /// Whether to create its own glass layer.
+  final bool useOwnLayer;
+
+  /// Whether to show dividers between buttons.
+  ///
+  /// Defaults to `true` for the [GlassButtonGroup] constructor,
+  /// `false` for [GlassButtonGroup.icons].
+  final bool showDividers;
+
+  /// The icon size used for items in [GlassButtonGroup.icons] mode.
+  ///
+  /// Defaults to 22.0.
+  final double iconSize;
+
+  /// Padding around each item in [GlassButtonGroup.icons] mode.
+  ///
+  /// Defaults to `EdgeInsets.all(12)`.
+  final EdgeInsetsGeometry itemPadding;
+
+  /// Forces the BackdropFilter fallback render path so premium glass
+  /// renders cleanly over an iOS PlatformView.
+  ///
+  /// The premium shader pipeline cannot sample PlatformView pixels (e.g.
+  /// a Mapbox `MapWidget`), so over one it would render the group as a
+  /// solid slab. When true, the group falls back to Flutter's
+  /// BackdropFilter — which *can* sample PlatformViews on Impeller — so
+  /// `quality: GlassQuality.premium` can be used over a PlatformView
+  /// without the slab artifact. Forwarded to the underlying
+  /// [GlassButton.custom] (items mode) / [GlassContainer] (children mode).
+  /// Defaults to false.
+  final bool platformViewBackdrop;
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: quality,
+    );
+
+    // Resolve icon color from brightness.
+    final iconColor = CupertinoColors.label.resolveFrom(context);
+
+    // ---------------------------------------------------------------------------
+    // Items mode: use a GlassButton.custom as the parent shell.
+    //
+    // This gives the whole pill stretch, glow, saturation, and shadow for free
+    // via existing GlassButton infrastructure — one AnimationController for the
+    // entire group instead of one per icon. Individual items handle their own
+    // tap targets with lightweight GestureDetectors.
+    //
+    // When any item has menuItems, the ENTIRE pill becomes the GlassMenu trigger
+    // so the whole shape morphs into the menu on tap — matching the iOS 26
+    // GlassEffectContainer morph pattern. Only the first menu item is used as
+    // the menu trigger; subsequent menu items are treated as plain tap items.
+    // ---------------------------------------------------------------------------
+    if (items != null) {
+      final shape = LiquidRoundedSuperellipse(borderRadius: borderRadius);
+      final menuItemIndex = items!.indexWhere((item) => item.menuItems != null);
+
+      // Helper that builds the pill shell — reused in both branches.
+      Widget buildPill({
+        VoidCallback? menuToggle,
+      }) {
+        return GlassButton.custom(
+          onTap: () {}, // Items handle their own taps
+          shape: shape,
+          settings: settings,
+          useOwnLayer: useOwnLayer,
+          quality: effectiveQuality,
+          platformViewBackdrop: platformViewBackdrop,
+          width: null, // Size to content
+          height: null, // Size to content
+          // Reduce stretch for grouped buttons — full stretch looks too dramatic
+          // on a wide pill. This matches iOS 26 toolbar feel.
+          stretch: 0.15,
+          child: IntrinsicHeight(
+            child: Flex(
+              direction: direction,
+              mainAxisSize: MainAxisSize.min,
+              children: _buildItemWidgets(
+                iconColor,
+                menuToggle: menuToggle,
+                menuItemIndex: menuItemIndex,
+              ),
+            ),
+          ),
+        );
+      }
+
+      if (menuItemIndex >= 0) {
+        final menuItem = items![menuItemIndex];
+        // Wrap the ENTIRE pill in GlassMenu so the whole shape morphs.
+        return GlassMenu(
+          menuAlignment: menuItem.menuAlignment,
+          menuWidth: menuItem.menuWidth,
+          items: menuItem.menuItems!,
+          triggerBuilder: (context, toggleMenu) =>
+              buildPill(menuToggle: toggleMenu),
+        );
+      }
+
+      return buildPill();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Children mode: use GlassContainer for full widget flexibility.
+    // ---------------------------------------------------------------------------
+    final effectiveBorderColor = borderColor ??
+        (GlassTheme.brightnessOf(context) == Brightness.light
+            ? CupertinoColors.black.withValues(alpha: 0.12)
+            : CupertinoColors.white.withValues(alpha: 0.12));
+
+    return GlassContainer(
+      useOwnLayer: useOwnLayer,
+      quality: effectiveQuality,
+      settings: settings,
+      platformViewBackdrop: platformViewBackdrop,
+      shape: LiquidRoundedSuperellipse(borderRadius: borderRadius),
+      padding: EdgeInsets.zero,
+      clipBehavior: Clip.antiAlias,
+      child: IntrinsicHeight(
+        child: Flex(
+          direction: direction,
+          mainAxisSize: MainAxisSize.min,
+          children: _buildChildrenWithDividers(effectiveBorderColor),
+        ),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Items mode — lightweight icons with press-dim highlight
+  // ---------------------------------------------------------------------------
+
+  List<Widget> _buildItemWidgets(
+    Color iconColor, {
+    VoidCallback? menuToggle,
+    int? menuItemIndex,
+  }) {
+    final itemList = items!;
+    final List<Widget> widgets = [];
+
+    for (int i = 0; i < itemList.length; i++) {
+      if (showDividers && i > 0) {
+        widgets.add(
+          direction == Axis.horizontal
+              ? Container(width: 1, color: iconColor.withValues(alpha: 0.12))
+              : Container(height: 1, color: iconColor.withValues(alpha: 0.12)),
+        );
+      }
+
+      final item = itemList[i];
+      // Menu item slot: route its tap to toggleMenu so the whole pill morphs.
+      final isMenuTrigger = menuToggle != null && i == menuItemIndex;
+      widgets.add(
+        _GlassGroupItemWidget(
+          item: item,
+          iconColor: iconColor,
+          iconSize: iconSize,
+          padding: itemPadding,
+          onTapOverride: isMenuTrigger ? menuToggle : null,
+        ),
+      );
+    }
+    return widgets;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Children mode — full widget children with optional dividers
+  // ---------------------------------------------------------------------------
+
+  List<Widget> _buildChildrenWithDividers(Color resolvedBorderColor) {
+    if (!showDividers) {
+      return children;
+    }
+
+    final List<Widget> result = [];
+    for (int i = 0; i < children.length; i++) {
+      if (i > 0) {
+        result.add(
+          direction == Axis.horizontal
+              ? Container(width: 1, color: resolvedBorderColor)
+              : Container(height: 1, color: resolvedBorderColor),
+        );
+      }
+      result.add(children[i]);
+    }
+    return result;
+  }
+}
+
+// =============================================================================
+// _GlassGroupItemWidget — lightweight per-item tap target
+// =============================================================================
+
+/// Renders a single [GlassButtonGroupItem] as a minimal tap target.
+///
+/// The parent [GlassButton.custom] provides all visual press feedback
+/// (stretch, glow, saturation). This widget only handles individual tap
+/// routing and accessibility semantics.
+class _GlassGroupItemWidget extends StatelessWidget {
+  const _GlassGroupItemWidget({
+    required this.item,
+    required this.iconColor,
+    required this.iconSize,
+    required this.padding,
+    this.onTapOverride,
+  });
+
+  final GlassButtonGroupItem item;
+  final Color iconColor;
+  final double iconSize;
+  final EdgeInsetsGeometry padding;
+
+  /// When non-null, replaces [GlassButtonGroupItem.onTap] as the tap handler.
+  ///
+  /// Used for menu-trigger items to call the enclosing [GlassMenu]'s
+  /// toggleMenu callback so the whole pill morphs rather than the slot.
+  final VoidCallback? onTapOverride;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: item.enabled ? (onTapOverride ?? item.onTap) : null,
+      behavior: HitTestBehavior.opaque,
+      child: Semantics(
+        button: true,
+        label: item.label,
+        enabled: item.enabled,
+        child: Opacity(
+          opacity: item.enabled ? 1.0 : 0.5,
+          child: Padding(
+            padding: padding,
+            child: IconTheme(
+              data: IconThemeData(
+                color: iconColor,
+                size: iconSize,
+              ),
+              child: item.icon,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/glass_chip.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/glass_chip.dart
@@ -1,0 +1,359 @@
+import 'package:flutter/cupertino.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../theme/glass_theme.dart';
+import '../../theme/glass_theme_data.dart';
+import '../../types/glass_quality.dart';
+import 'glass_button.dart';
+
+/// A glass morphism chip following Apple's iOS 26 design patterns.
+///
+/// [GlassChip] provides a compact, pill-shaped chip with glass effect, perfect
+/// for tags, filters, selections, and dismissible elements. It composes
+/// [GlassButton] internally for consistent interaction behavior.
+///
+/// ## Key Features
+///
+/// - **Pill-Shaped Glass**: Rounded chip with glass morphism effect
+/// - **Optional Leading Icon**: Icon before the label
+/// - **Optional Delete Button**: Dismissible variant with X button
+/// - **Selected State**: Highlight state for filter chips
+/// - **Press Effects**: Inherits squash/stretch and glow from GlassButton
+/// - **Flexible Sizing**: Automatically sizes to content
+///
+/// ## Usage
+///
+/// ### Basic Chip
+/// ```dart
+/// GlassChip(
+///   label: 'Technology',
+///   onTap: () => print('Tapped'),
+/// )
+/// ```
+///
+/// ### With Leading Icon
+/// ```dart
+/// GlassChip(
+///   label: 'Favorite',
+///   icon: Icon(CupertinoIcons.heart_fill),
+///   onTap: () => toggleFavorite(),
+/// )
+/// ```
+///
+/// ### Dismissible Chip
+/// ```dart
+/// GlassChip(
+///   label: 'Selected Tag',
+///   onDeleted: () => removeTag(),
+/// )
+/// ```
+///
+/// ### Selected State (Filter Chips)
+/// ```dart
+/// GlassChip(
+///   label: 'Active',
+///   selected: true,
+///   selectedColor: Colors.blue,
+///   onTap: () => toggleFilter(),
+/// )
+/// ```
+///
+/// ### Within LiquidGlassLayer (Grouped Mode)
+/// ```dart
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 3,
+///   ),
+///   child: Wrap(
+///     spacing: 8,
+///     children: [
+///       GlassChip(label: 'Flutter', onTap: () {}),
+///       GlassChip(label: 'Dart', onTap: () {}),
+///       GlassChip(label: 'iOS', onTap: () {}),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ### Standalone Mode
+/// ```dart
+/// GlassChip(
+///   label: 'Technology',
+///   useOwnLayer: true,
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 8,
+///   ),
+/// )
+/// ```
+class GlassChip extends StatelessWidget {
+  /// Creates a glass chip.
+  const GlassChip({
+    required this.label,
+    super.key,
+    this.icon,
+    this.onTap,
+    this.onDeleted,
+    this.selected = false,
+    this.selectedColor,
+    Widget? deleteIcon,
+    this.deleteIconSize = 16.0,
+    this.iconSize = 16.0,
+    this.iconColor,
+    this.labelStyle,
+    this.padding = const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    this.spacing = 6.0,
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    // GlassButton properties
+    this.interactionScale = 1.03,
+    this.stretch = 0.3,
+    this.glowRadius = 0.8,
+    this.anchorStretch = true,
+    this.anchorStretchSettings = const AnchorStretchSettings(),
+  }) : deleteIcon = deleteIcon ?? const Icon(CupertinoIcons.xmark_circle_fill);
+
+  // ===========================================================================
+  // Chip Properties
+  // ===========================================================================
+
+  /// The label text displayed in the chip.
+  final String label;
+
+  /// Optional leading icon widget.
+  final Widget? icon;
+
+  /// Called when the chip is tapped.
+  ///
+  /// If both [onTap] and [onDeleted] are null, the chip will be
+  /// non-interactive.
+  final VoidCallback? onTap;
+
+  /// Called when the delete button is tapped.
+  ///
+  /// When provided, a delete button (X icon) will be shown on the right side.
+  /// The chip becomes dismissible.
+  final VoidCallback? onDeleted;
+
+  /// Whether the chip is in selected state.
+  ///
+  /// When true, the chip will be highlighted with [selectedColor].
+  /// Useful for filter chips.
+  ///
+  /// Defaults to false.
+  final bool selected;
+
+  /// Color used when the chip is selected.
+  ///
+  /// If null and [selected] is true, defaults to white with 30% opacity.
+  final Color? selectedColor;
+
+  /// Widget used for the delete button.
+  ///
+  /// Defaults to [Icon(CupertinoIcons.xmark_circle_fill)].
+  final Widget deleteIcon;
+
+  /// Size of the delete icon.
+  ///
+  /// Defaults to 16.0.
+  final double deleteIconSize;
+
+  // ===========================================================================
+  // Style Properties
+  // ===========================================================================
+
+  /// Size of the leading icon.
+  ///
+  /// Defaults to 16.0.
+  final double iconSize;
+
+  /// Color of the leading icon.
+  ///
+  /// If null, defaults to white with 90% opacity.
+  final Color? iconColor;
+
+  /// Style for the label text.
+  ///
+  /// If null, defaults to 14px white text with 90% opacity.
+  final TextStyle? labelStyle;
+
+  /// Padding inside the chip.
+  ///
+  /// Defaults to 12px horizontal, 8px vertical.
+  final EdgeInsetsGeometry padding;
+
+  /// Spacing between icon and label, and label and delete button.
+  ///
+  /// Defaults to 6.0.
+  final double spacing;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Glass effect settings (only used when [useOwnLayer] is true).
+  final LiquidGlassSettings? settings;
+
+  /// Whether to create its own layer or use grouped glass.
+  ///
+  /// Defaults to false (grouped mode).
+  final bool useOwnLayer;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// If null, inherits from parent [InheritedLiquidGlass] or defaults to
+  /// [GlassQuality.standard], which uses backdrop filter rendering.
+  /// This works reliably in all contexts, including scrollable lists.
+  ///
+  /// Use [GlassQuality.premium] for shader-based glass in static layouts only.
+  final GlassQuality? quality;
+
+  // ===========================================================================
+  // Interaction Properties (from GlassButton)
+  // ===========================================================================
+
+  /// Scale factor when pressed.
+  ///
+  /// Values > 1.0 grow the chip, < 1.0 shrink it.
+  /// Defaults to 1.03 (3% growth, subtle for chips).
+  final double interactionScale;
+
+  /// Stretch intensity during animation (0-1).
+  ///
+  /// Defaults to 0.3 (subtle stretch for chips).
+  final double stretch;
+
+  /// Glow radius multiplier.
+  ///
+  /// Defaults to 0.8 (subtle glow for chips).
+  final double glowRadius;
+
+  /// Whether to anchor the chip in place while stretching toward the finger.
+  ///
+  /// Defaults to `true`. See [GlassButton.anchorStretch].
+  final bool anchorStretch;
+
+  /// Fine-tuning for the anchor stretch effect.
+  ///
+  /// See [AnchorStretchSettings] for details.
+  final AnchorStretchSettings anchorStretchSettings;
+
+  static const _chipShape = LiquidRoundedSuperellipse(borderRadius: 100);
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    final baseColor = isDark ? CupertinoColors.white : CupertinoColors.black;
+    final defaultContentColor = baseColor.withValues(alpha: 0.9);
+    final defaultSelectedColor =
+        baseColor.withValues(alpha: isDark ? 0.3 : 0.1);
+    final defaultGlowUnselected =
+        baseColor.withValues(alpha: isDark ? 0.2 : 0.05);
+
+    final effectiveIconColor = iconColor ?? defaultContentColor;
+    final effectiveLabelStyle = labelStyle ??
+        TextStyle(
+          fontSize: 14,
+          color: defaultContentColor,
+          fontWeight: FontWeight.w500,
+        );
+
+    // Build chip content
+    final chipContent = Padding(
+      padding: padding,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Leading icon
+          if (icon != null) ...[
+            IconTheme(
+              data: IconThemeData(
+                color: effectiveIconColor,
+                size: iconSize,
+              ),
+              child: icon!,
+            ),
+            SizedBox(width: spacing),
+          ],
+
+          // Label
+          Text(
+            label,
+            style: effectiveLabelStyle,
+          ),
+
+          // Delete button
+          if (onDeleted != null) ...[
+            SizedBox(width: spacing),
+            GestureDetector(
+              onTap: onDeleted,
+              child: IconTheme(
+                data: IconThemeData(
+                  color: effectiveIconColor,
+                  size: deleteIconSize,
+                ),
+                child: deleteIcon,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+
+    // Determine if chip should be interactive
+    final isInteractive = onTap != null || onDeleted != null;
+
+    // Apply selected state color overlay
+    final contentWithSelection = selected
+        ? Container(
+            decoration: BoxDecoration(
+              color: selectedColor ?? defaultSelectedColor,
+              borderRadius: BorderRadius.circular(100),
+            ),
+            child: chipContent,
+          )
+        : chipContent;
+
+    // Resolve interaction settings: explicit widget param > theme > chip default
+    final themeInteraction = GlassThemeData.of(context).interaction;
+
+    final effectiveInteractionScale = interactionScale != 1.03
+        ? interactionScale
+        : themeInteraction.interactionScale ?? interactionScale;
+    final effectiveStretch =
+        stretch != 0.3 ? stretch : themeInteraction.stretch ?? stretch;
+    final effectiveAnchorStretch = anchorStretch != true
+        ? anchorStretch
+        : themeInteraction.anchorStretch ?? anchorStretch;
+    final effectiveAnchorStretchSettings =
+        !identical(anchorStretchSettings, const AnchorStretchSettings())
+            ? anchorStretchSettings
+            : themeInteraction.anchorStretchSettings ?? anchorStretchSettings;
+
+    return IntrinsicWidth(
+      child: IntrinsicHeight(
+        child: GlassButton.custom(
+          onTap: onTap ?? (onDeleted != null ? () {} : () {}),
+          shape: _chipShape,
+          settings: settings,
+          useOwnLayer: useOwnLayer,
+          quality: quality ?? GlassQuality.standard,
+          interactionScale: effectiveInteractionScale,
+          stretch: effectiveStretch,
+          glowRadius: glowRadius,
+          glowColor: selected
+              ? (selectedColor ?? defaultSelectedColor)
+              : defaultGlowUnselected,
+          enabled: isInteractive,
+          anchorStretch: effectiveAnchorStretch,
+          anchorStretchSettings: effectiveAnchorStretchSettings,
+          width: double.infinity, // Expand to intrinsic width
+          height: double.infinity, // Expand to intrinsic height
+          child: contentWithSelection,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/glass_icon_button.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/glass_icon_button.dart
@@ -1,0 +1,288 @@
+import 'package:flutter/cupertino.dart' show CupertinoColors;
+import 'package:flutter/material.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../types/glass_quality.dart';
+import 'glass_button.dart';
+
+/// A glass morphism icon button following Apple's iOS 26 design patterns.
+///
+/// [GlassIconButton] provides an icon-only button with liquid glass effect,
+/// optimized for toolbars, app bars, and navigation elements.
+///
+/// ## Key Features
+///
+/// - Icon-only button (no text/labels)
+/// - Liquid glass effect with interactive glow
+/// - Squash and stretch animation on tap
+/// - Two rendering modes (grouped/standalone)
+/// - Circular or rounded square shapes
+/// - Disabled state support
+///
+/// ## Usage
+///
+/// ### Basic Icon Button
+/// ```dart
+/// GlassIconButton(
+///   icon: Icon(Icons.favorite),
+///   onPressed: () => print('Tapped'),
+/// )
+/// ```
+///
+/// ### Custom Size and Shape
+/// ```dart
+/// GlassIconButton(
+///   icon: Icon(Icons.settings),
+///   onPressed: () {},
+///   size: 48,
+///   shape: GlassIconButtonShape.roundedSquare,
+///   borderRadius: 12,
+/// )
+/// ```
+///
+/// ### With Custom Glow
+/// ```dart
+/// GlassIconButton(
+///   icon: Icon(Icons.star),
+///   onPressed: () {},
+///   glowColor: Colors.yellow,
+///   glowRadius: 30,
+/// )
+/// ```
+///
+/// ### Standalone Mode
+/// ```dart
+/// GlassIconButton(
+///   icon: Icon(Icons.add),
+///   onPressed: () {},
+///   useOwnLayer: true,
+///   settings: LiquidGlassSettings(
+///     thickness: 40,
+///     blur: 15,
+///   ),
+/// )
+/// ```
+///
+/// ### In a Toolbar (Grouped Mode)
+/// ```dart
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(...),
+///   child: Row(
+///     children: [
+///       GlassIconButton(icon: Icon(Icons.menu), onPressed: () {}),
+///       Spacer(),
+///       GlassIconButton(icon: Icon(Icons.search), onPressed: () {}),
+///       GlassIconButton(icon: Icon(Icons.more_vert), onPressed: () {}),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ### Disabled State
+/// ```dart
+/// GlassIconButton(
+///   icon: Icon(Icons.delete),
+///   onPressed: null,  // null = disabled
+/// )
+/// ```
+class GlassIconButton extends StatelessWidget {
+  /// Creates a glass icon button.
+  const GlassIconButton({
+    required this.icon,
+    required this.onPressed,
+    super.key,
+    this.size = 44,
+    this.iconSize,
+    this.shape = GlassIconButtonShape.circle,
+    this.borderRadius = 12,
+    this.glowColor,
+    this.glowRadius = 20,
+    this.interactionScale = 0.95,
+    this.useOwnLayer = false,
+    this.settings,
+    this.quality,
+    this.persistPressOnDrag = true,
+    this.anchorStretch = true,
+    this.anchorStretchSettings = const AnchorStretchSettings(),
+    this.platformViewBackdrop = false,
+  });
+
+  // Default icon colors are resolved at build time from CupertinoColors.label
+  // so they adapt to light/dark mode. Disabled state uses secondaryLabel
+  // for natural dimming across both appearances.
+
+  // ===========================================================================
+  // Content Properties
+  // ===========================================================================
+
+  /// The icon widget to display.
+  ///
+  /// Pass any widget — standard [Icon] widgets will inherit color and size
+  /// from [IconTheme]. Custom widgets (SVG, PNG, etc.) handle their own styling.
+  final Widget icon;
+
+  /// Size of the icon within the button.
+  ///
+  /// If null, defaults to `size * 0.5` (half of button size).
+  final double? iconSize;
+
+  // ===========================================================================
+  // Interaction Properties
+  // ===========================================================================
+
+  /// Callback when the button is pressed.
+  ///
+  /// If null, the button is disabled and interaction effects are disabled.
+  final VoidCallback? onPressed;
+
+  /// Scale factor when pressed.
+  ///
+  /// Values less than 1.0 create a "squash" effect on tap.
+  /// Defaults to 0.95 (95% of original size).
+  final double interactionScale;
+
+  // ===========================================================================
+  // Size and Shape Properties
+  // ===========================================================================
+
+  /// Size of the button (width and height).
+  ///
+  /// Defaults to 44 (iOS standard touch target).
+  final double size;
+
+  /// Shape of the button.
+  ///
+  /// Defaults to [GlassIconButtonShape.circle].
+  final GlassIconButtonShape shape;
+
+  /// Border radius for rounded square shape.
+  ///
+  /// Only used when [shape] is [GlassIconButtonShape.roundedSquare].
+  /// Defaults to 12.
+  final double borderRadius;
+
+  // ===========================================================================
+  // Glow Effect Properties
+  // ===========================================================================
+
+  /// Color of the glow effect.
+  ///
+  /// If null, uses white with low opacity.
+  final Color? glowColor;
+
+  /// Radius of the glow effect in logical pixels.
+  ///
+  /// Defaults to 20.
+  final double glowRadius;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Whether to create its own [LiquidGlassLayer].
+  ///
+  /// If false (default), the button must be inside a [LiquidGlassLayer].
+  /// If true, creates an independent glass layer with [settings].
+  ///
+  /// Defaults to false (grouped mode).
+  final bool useOwnLayer;
+
+  /// Glass effect settings for standalone mode.
+  ///
+  /// Only used when [useOwnLayer] is true.
+  /// If null, uses [LiquidGlassSettings] defaults.
+  final LiquidGlassSettings? settings;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// If null, resolved via [GlassThemeHelpers.resolveQuality] — inherits from
+  /// the nearest ancestor layer, then the theme, then the [GlassButton]
+  /// widget-class default ([GlassQuality.standard]).
+  final GlassQuality? quality;
+
+  /// Whether the pressed glass distortion persists while the finger is held
+  /// down, even if dragged far away from the button.
+  ///
+  /// Forwarded to the underlying [GlassButton.persistPressOnDrag].
+  /// See [GlassButton.persistPressOnDrag] for full documentation.
+  ///
+  /// Defaults to true.
+  final bool persistPressOnDrag;
+
+  /// Whether to anchor the button in place while stretching toward the finger.
+  ///
+  /// Defaults to `true`. See [GlassButton.anchorStretch].
+  final bool anchorStretch;
+
+  /// Fine-tuning for the anchor stretch effect.
+  ///
+  /// See [AnchorStretchSettings] for details.
+  final AnchorStretchSettings anchorStretchSettings;
+
+  /// When true (typically for iOS PlatformViews), forces the BackdropFilter
+  /// fallback render path instead of the Impeller-native shader. Forwarded to
+  /// the underlying [GlassButton] (and on to its [AdaptiveGlass]).
+  final bool platformViewBackdrop;
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveIconSize = iconSize ?? (size * 0.5);
+    final isEnabled = onPressed != null;
+
+    // Build icon content wrapped in IconTheme so standard Icon widgets
+    // inherit the correct size and color automatically.
+    final iconColor = isEnabled
+        ? CupertinoColors.label.resolveFrom(context)
+        : CupertinoColors.tertiaryLabel.resolveFrom(context);
+    final iconWidget = IconTheme(
+      data: IconThemeData(
+        color: iconColor,
+        size: effectiveIconSize,
+      ),
+      child: icon,
+    );
+
+    final glassShape = _buildShape();
+
+    return GlassButton.custom(
+      onTap: onPressed ?? () {},
+      enabled: isEnabled,
+      width: size,
+      height: size,
+      shape: glassShape,
+      settings: settings,
+      useOwnLayer: useOwnLayer,
+      quality: quality,
+      interactionScale: interactionScale,
+      glowColor: glowColor, // Let GlassButton use theme if null
+      glowRadius: glowRadius,
+      persistPressOnDrag: persistPressOnDrag,
+      anchorStretch: anchorStretch,
+      anchorStretchSettings: anchorStretchSettings,
+      platformViewBackdrop: platformViewBackdrop,
+      child: iconWidget,
+    );
+  }
+
+  static const _defaultOval = LiquidOval();
+
+  LiquidShape _buildShape() {
+    switch (shape) {
+      case GlassIconButtonShape.circle:
+        return _defaultOval;
+      case GlassIconButtonShape.roundedSquare:
+        return LiquidRoundedSuperellipse(
+          borderRadius: borderRadius,
+        );
+    }
+  }
+}
+
+/// Shape options for [GlassIconButton].
+enum GlassIconButtonShape {
+  /// Circular button (iOS standard for icon buttons).
+  circle,
+
+  /// Rounded square button.
+  roundedSquare,
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/glass_page_control.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/glass_page_control.dart
@@ -1,0 +1,328 @@
+import 'package:flutter/cupertino.dart' show CupertinoColors;
+import 'package:flutter/widgets.dart';
+
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../types/glass_quality.dart';
+import 'glass_button.dart';
+
+/// A glass morphism page control following iOS 26's `UIPageControl` design.
+///
+/// [GlassPageControl] renders a **glass capsule** (same height as
+/// [GlassButton]) with dot indicators inside — matching the iOS 26 Weather,
+/// Home, and Lock Screen page controls. Tapping the capsule triggers the same
+/// glow-and-grow interaction as [GlassButton], with no drag/anchor-stretch.
+///
+/// ## Usage
+///
+/// ### Basic Page Control
+/// ```dart
+/// GlassPageControl(
+///   count: 5,
+///   currentPage: _currentPage,
+///   onPageChanged: (page) => setState(() => _currentPage = page),
+/// )
+/// ```
+///
+/// ### With PageView
+/// ```dart
+/// Column(
+///   children: [
+///     Expanded(
+///       child: PageView(
+///         controller: _pageController,
+///         onPageChanged: (page) => setState(() => _currentPage = page),
+///         children: pages,
+///       ),
+///     ),
+///     GlassPageControl(
+///       count: pages.length,
+///       currentPage: _currentPage,
+///       onPageChanged: (page) {
+///         _pageController.animateToPage(page,
+///           duration: Duration(milliseconds: 300),
+///           curve: Curves.easeInOut,
+///         );
+///       },
+///     ),
+///   ],
+/// )
+/// ```
+///
+/// ### With Leading Icon (like iOS Weather location arrow)
+/// ```dart
+/// GlassPageControl(
+///   count: 5,
+///   currentPage: _currentPage,
+///   leadingIcon: Icon(CupertinoIcons.location_fill, size: 12),
+/// )
+/// ```
+class GlassPageControl extends StatefulWidget {
+  /// Creates a glass page control.
+  const GlassPageControl({
+    required this.count,
+    required this.currentPage,
+    super.key,
+    this.onPageChanged,
+    this.dotSize = 7.0,
+    this.spacing = 7.0,
+    this.activeColor,
+    this.inactiveColor,
+    this.leadingIcon,
+    this.settings,
+    this.quality,
+    this.useOwnLayer = false,
+    this.height = 56,
+    this.animationDuration = const Duration(milliseconds: 250),
+    this.animationCurve = Curves.easeOutCubic,
+  });
+
+  // ===========================================================================
+  // Data Properties
+  // ===========================================================================
+
+  /// Total number of pages.
+  final int count;
+
+  /// The currently active page (0-indexed).
+  final int currentPage;
+
+  /// Called when a dot is tapped.
+  ///
+  /// If null, the capsule still responds to press (glow + scale) but
+  /// does not navigate.
+  final ValueChanged<int>? onPageChanged;
+
+  // ===========================================================================
+  // Appearance Properties
+  // ===========================================================================
+
+  /// Diameter of each dot.
+  ///
+  /// Defaults to 7.0 (matching iOS 26).
+  final double dotSize;
+
+  /// Spacing between dots.
+  ///
+  /// Defaults to 7.0.
+  final double spacing;
+
+  /// Color of the active dot.
+  ///
+  /// If null, defaults to white.
+  final Color? activeColor;
+
+  /// Color of inactive dots.
+  ///
+  /// If null, defaults to white at 35% opacity.
+  final Color? inactiveColor;
+
+  /// Optional leading icon displayed before the dots.
+  ///
+  /// iOS Weather uses a location arrow icon to indicate the current
+  /// location page. The icon is sized to match [dotSize].
+  final Widget? leadingIcon;
+
+  /// Height of the glass capsule.
+  ///
+  /// Defaults to 56 to match [GlassButton] height.
+  final double height;
+
+  // ===========================================================================
+  // Glass Properties
+  // ===========================================================================
+
+  /// Glass effect settings for the capsule.
+  ///
+  /// If null, uses the same defaults as [GlassButton].
+  final LiquidGlassSettings? settings;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// If null, inherits from parent or defaults to [GlassQuality.standard].
+  final GlassQuality? quality;
+
+  /// Whether the glass capsule creates its own layer.
+  ///
+  /// Defaults to false (grouped mode — same as [GlassButton]).
+  final bool useOwnLayer;
+
+  // ===========================================================================
+  // Animation Properties
+  // ===========================================================================
+
+  /// Duration of the dot transition animation.
+  ///
+  /// Defaults to 250ms.
+  final Duration animationDuration;
+
+  /// Curve for the dot transition animation.
+  ///
+  /// Defaults to [Curves.easeOutCubic].
+  final Curve animationCurve;
+
+  @override
+  State<GlassPageControl> createState() => _GlassPageControlState();
+}
+
+class _GlassPageControlState extends State<GlassPageControl>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _animation;
+  int _previousPage = 0;
+
+  // Active/inactive dot colors are resolved at build time from
+  // CupertinoColors.label / .tertiaryLabel so they adapt to light/dark mode.
+
+  @override
+  void initState() {
+    super.initState();
+    _previousPage = widget.currentPage;
+    _controller = AnimationController(
+      duration: widget.animationDuration,
+      vsync: this,
+    );
+    _animation = CurvedAnimation(
+      parent: _controller,
+      curve: widget.animationCurve,
+    );
+    _controller.value = 1.0; // Start fully settled
+  }
+
+  @override
+  void didUpdateWidget(covariant GlassPageControl oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.currentPage != widget.currentPage) {
+      _previousPage = oldWidget.currentPage;
+      _controller.forward(from: 0.0);
+    }
+    if (oldWidget.animationDuration != widget.animationDuration) {
+      _controller.duration = widget.animationDuration;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.count <= 0) return const SizedBox.shrink();
+
+    final effectiveActiveColor =
+        widget.activeColor ?? CupertinoColors.label.resolveFrom(context);
+    final effectiveInactiveColor = widget.inactiveColor ??
+        CupertinoColors.tertiaryLabel.resolveFrom(context);
+
+    // Build the dot row content
+    final dotsContent = AnimatedBuilder(
+      animation: _animation,
+      builder: (context, child) {
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // Leading icon (e.g. location arrow)
+            if (widget.leadingIcon != null) ...[
+              SizedBox(
+                width: widget.dotSize,
+                height: widget.dotSize,
+                child: FittedBox(child: widget.leadingIcon!),
+              ),
+              SizedBox(width: widget.spacing),
+            ],
+            // Dots
+            ...List.generate(widget.count, (index) {
+              final isActive = index == widget.currentPage;
+              final wasPrevious = index == _previousPage;
+              final t = _animation.value;
+
+              // Animate dot scale
+              double scale;
+              if (isActive && wasPrevious) {
+                scale = 1.0;
+              } else if (isActive) {
+                scale = _lerpDouble(0.7, 1.0, t);
+              } else if (wasPrevious) {
+                scale = _lerpDouble(1.0, 0.7, t);
+              } else {
+                scale = 0.7;
+              }
+
+              // Animate colour
+              Color dotColor;
+              if (isActive && wasPrevious) {
+                dotColor = effectiveActiveColor;
+              } else if (isActive) {
+                dotColor = Color.lerp(
+                      effectiveInactiveColor,
+                      effectiveActiveColor,
+                      t,
+                    ) ??
+                    effectiveActiveColor;
+              } else if (wasPrevious) {
+                dotColor = Color.lerp(
+                      effectiveActiveColor,
+                      effectiveInactiveColor,
+                      t,
+                    ) ??
+                    effectiveInactiveColor;
+              } else {
+                dotColor = effectiveInactiveColor;
+              }
+
+              return Padding(
+                padding: EdgeInsets.symmetric(horizontal: widget.spacing / 2),
+                child: SizedBox(
+                  width: widget.dotSize,
+                  height: widget.dotSize,
+                  child: Center(
+                    child: Container(
+                      width: widget.dotSize * scale,
+                      height: widget.dotSize * scale,
+                      decoration: BoxDecoration(
+                        color: dotColor,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            }),
+          ],
+        );
+      },
+    );
+
+    // Use GlassButton.custom for the glass capsule — gives us the same
+    // press glow + scale interaction as regular buttons, with no drag.
+    return GlassButton.custom(
+      onTap: () {
+        // On tap, advance to next page (cycling)
+        if (widget.onPageChanged != null) {
+          final nextPage = (widget.currentPage + 1) % widget.count;
+          widget.onPageChanged!(nextPage);
+        }
+      },
+      height: widget.height,
+      shape: const LiquidRoundedSuperellipse(borderRadius: 100),
+      settings: widget.settings,
+      quality: widget.quality,
+      useOwnLayer: widget.useOwnLayer,
+      // Same press effect as buttons, but no drag/anchor stretch
+      interactionScale: 1.05,
+      stretch: 0.0,
+      anchorStretch: false,
+      persistPressOnDrag: true,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: dotsContent,
+      ),
+    );
+  }
+
+  static double _lerpDouble(double a, double b, double t) {
+    return a + (b - a) * t;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/glass_pull_down_button.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/glass_pull_down_button.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/cupertino.dart';
+
+import '../../types/glass_quality.dart';
+import '../overlays/glass_menu.dart';
+import '../overlays/glass_menu_item.dart';
+import 'glass_button.dart';
+import '../../theme/glass_theme_helpers.dart';
+import '../../src/renderer/liquid_shape.dart';
+
+/// A toolbar button that opens a liquid glass pull-down menu.
+///
+/// This widget combines [GlassButton] and [GlassMenu] to create a standard
+/// "pull-down" interaction pattern commonly used in toolbars and navigation bars.
+class GlassPullDownButton extends StatelessWidget {
+  /// Creates a glass pull-down button.
+  const GlassPullDownButton({
+    required this.items,
+    Widget? icon,
+    this.label,
+    super.key,
+    this.buttonWidth = 44,
+    this.buttonHeight = 44,
+    this.buttonShape,
+    this.menuWidth = 200,
+    this.menuAlignment,
+    this.quality,
+    this.onSelected,
+  }) : icon = icon ?? const Icon(CupertinoIcons.ellipsis_circle);
+
+  /// The shape of the trigger button.
+  ///
+  /// If null, defaults to [LiquidOval].
+  final LiquidShape? buttonShape;
+
+  /// The icon widget to display on the button.
+  final Widget icon;
+
+  /// Optional label to display next to the icon.
+  final String? label;
+
+  /// The list of items to display in the menu.
+  ///
+  /// Accepts [GlassMenuItem] and [GlassMenuDivider] widgets, matching the
+  /// [GlassMenu.items] contract directly. [GlassMenuDivider] items are passed
+  /// through as-is; only [GlassMenuItem] instances are wrapped by [onSelected].
+  final List<Widget> items;
+
+  /// Width of the trigger button.
+  final double buttonWidth;
+
+  /// Height of the trigger button.
+  final double buttonHeight;
+
+  /// Width of the expanded menu.
+  final double menuWidth;
+
+  /// Controls where the menu expands relative to the trigger button.
+  ///
+  /// Defaults to [GlassMenuAlignment.none], which auto-detects the best
+  /// alignment based on the trigger's position on screen.
+  final GlassMenuAlignment? menuAlignment;
+
+  /// Quality of the glass effect.
+  final GlassQuality? quality;
+
+  /// Callback when a menu item is selected.
+  ///
+  /// This is called in addition to the individual [GlassMenuItem.onTap] callback.
+  final ValueChanged<String>? onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    // Inherit quality from parent layer if not explicitly set
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: quality,
+    );
+
+    final effectiveTextColor =
+        CupertinoTheme.of(context).textTheme.textStyle.color ??
+            CupertinoColors.label;
+
+    return GlassMenu(
+      menuWidth: menuWidth,
+      menuAlignment: menuAlignment,
+      quality: effectiveQuality,
+      triggerBuilder: (context, toggleMenu) {
+        if (label != null && label!.isNotEmpty) {
+          return GlassButton.custom(
+            onTap: toggleMenu,
+            width: buttonWidth,
+            height: buttonHeight,
+            shape: buttonShape ?? const LiquidOval(),
+            quality: effectiveQuality,
+            useOwnLayer: effectiveQuality == GlassQuality.premium,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconTheme(
+                  data: IconThemeData(size: 20, color: effectiveTextColor),
+                  child: icon,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  label!,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                    color: effectiveTextColor,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }
+
+        return GlassButton(
+          onTap: toggleMenu,
+          icon: icon,
+          label: label ?? '',
+          width: buttonWidth,
+          height: buttonHeight,
+          shape: buttonShape ?? const LiquidOval(),
+          quality: effectiveQuality,
+          useOwnLayer: effectiveQuality == GlassQuality.premium,
+        );
+      },
+      items: items.map((item) {
+        // Wrap GlassMenuItem taps to fire the onSelected callback.
+        // GlassMenuDivider and other non-GlassMenuItem widgets are passed through.
+        if (onSelected != null && item is GlassMenuItem) {
+          return GlassMenuItem(
+            title: item.title,
+            icon: item.icon,
+            isDestructive: item.isDestructive,
+            subtitle: item.subtitle,
+            enabled: item.enabled,
+            onTap: () {
+              item.onTap.call();
+              onSelected!(item.title);
+            },
+            trailing: item.trailing,
+          );
+        }
+        return item;
+      }).toList(),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/glass_segmented_control.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/glass_segmented_control.dart
@@ -1,0 +1,593 @@
+import 'package:flutter/cupertino.dart';
+
+import '../../constants/glass_defaults.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../src/types/glass_interaction_behavior.dart';
+import '../../theme/glass_theme.dart';
+import '../../theme/glass_theme_helpers.dart';
+import '../../types/glass_quality.dart';
+import '../shared/adaptive_liquid_glass_layer.dart';
+import '../surfaces/glass_bottom_bar.dart' show MaskingQuality;
+import '../surfaces/glass_tab_bar.dart' show DividerSettings, GlassSegment;
+import 'shared/scrollable_segment_content.dart';
+import 'shared/segmented_control_internal.dart';
+
+/// A glass morphism segmented control following Apple's design patterns.
+///
+/// [GlassSegmentedControl] provides a sophisticated segmented control with
+/// an animated glass indicator, jelly physics, and smooth transitions between
+/// segments. It matches iOS's UISegmentedControl appearance and behavior.
+///
+/// ## Key Features
+///
+/// - **Animated Glass Indicator**: Smoothly animates between segments
+/// - **Jelly Physics**: Organic squash and stretch effects during movement
+/// - **Drag Support**: Swipe between segments with velocity-based snapping
+/// - **Sharp Text**: Selected text stays sharp above the glass
+/// - **Flexible Sizing**: Automatically sizes segments evenly
+/// - **Customizable Appearance**: Full control over colors, sizes, and effects
+///
+/// ## ⚠️ Do Not Wrap in GlassContainer or GlassCard
+///
+/// Placing this widget inside a [GlassContainer] or [GlassCard] is an
+/// anti-pattern that causes two problems:
+///
+/// 1. **Visual degradation** — the container sets `avoidsRefraction: true`
+///    on its children, causing the indicator's glass refraction to fall back
+///    to a non-refracting path.
+/// 2. **Jelly-physics clipping** — with `useOwnLayer: true` on the container,
+///    the container's own-layer clip cuts the indicator's jelly overshoot
+///    during drag animations.
+///
+/// The track background is already handled by [backgroundColor] — no outer
+/// container is needed. For a standalone glass layer, use [useOwnLayer] on
+/// this widget directly.
+///
+
+/// ## Usage
+///
+/// ### Basic Usage
+/// ```dart
+/// int selectedIndex = 0;
+///
+/// GlassSegmentedControl(
+///   segments: const [
+///     GlassSegment(label: 'Daily'),
+///     GlassSegment(label: 'Weekly'),
+///     GlassSegment(label: 'Monthly'),
+///   ],
+///   selectedIndex: selectedIndex,
+///   onSegmentSelected: (index) {
+///     setState(() => selectedIndex = index);
+///   },
+/// )
+/// ```
+///
+/// ### Within LiquidGlassLayer (Grouped Mode)
+/// ```dart
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 3,
+///     refractiveIndex: 1.59,
+///   ),
+///   child: Column(
+///     children: [
+///       GlassSegmentedControl(
+///         segments: const [
+///           GlassSegment(label: 'One'),
+///           GlassSegment(label: 'Two'),
+///           GlassSegment(label: 'Three'),
+///         ],
+///         selectedIndex: _selectedIndex,
+///         onSegmentSelected: (index) {
+///           setState(() => _selectedIndex = index);
+///         },
+///       ),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ### Standalone Mode
+/// ```dart
+/// GlassSegmentedControl(
+///   segments: const [
+///     GlassSegment(label: 'Option A'),
+///     GlassSegment(label: 'Option B'),
+///   ],
+///   selectedIndex: _selectedIndex,
+///   onSegmentSelected: (index) {
+///     setState(() => _selectedIndex = index);
+///   },
+///   useOwnLayer: true,
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 3,
+///   ),
+/// )
+/// ```
+///
+/// ### Icons and labels
+/// ```dart
+/// GlassSegmentedControl(
+///   segments: const [
+///     GlassSegment(icon: Icon(Icons.photo),     label: 'Photos'),
+///     GlassSegment(icon: Icon(Icons.videocam),  label: 'Videos'),
+///     GlassSegment(icon: Icon(Icons.music_note),label: 'Music'),
+///   ],
+///   selectedIndex: _selectedIndex,
+///   onSegmentSelected: (index) =>
+///       setState(() => _selectedIndex = index),
+///   height: 56,
+/// )
+/// ```
+///
+/// ### Custom Styling
+/// ```dart
+/// GlassSegmentedControl(
+///   segments: const [
+///     GlassSegment(label: 'Small'),
+///     GlassSegment(label: 'Medium'),
+///     GlassSegment(label: 'Large'),
+///   ],
+///   selectedIndex: _selectedIndex,
+///   onSegmentSelected: (index) =>
+///       setState(() => _selectedIndex = index),
+///   height: 36,
+///   borderRadius: 18,
+///   selectedTextStyle: TextStyle(
+///     fontSize: 14,
+///     fontWeight: FontWeight.w600,
+///     color: CupertinoColors.white,
+///   ),
+///   unselectedTextStyle: TextStyle(
+///     fontSize: 14,
+///     fontWeight: FontWeight.w500,
+///     color: CupertinoColors.white.withOpacity(0.6),
+///   ),
+/// )
+/// ```
+class GlassSegmentedControl extends StatefulWidget {
+  /// Creates a fixed-width glass segmented control (iOS UISegmentedControl).
+  ///
+  /// All segments are equal-width. For a scrollable variant that mimics
+  /// [GlassTabBar]`(isScrollable: true)`, use [GlassSegmentedControl.scrollable].
+  const GlassSegmentedControl({
+    required this.segments,
+    required this.selectedIndex,
+    required this.onSegmentSelected,
+    super.key,
+    this.height = GlassDefaults.heightControl,
+    this.borderRadius = GlassDefaults.borderRadius,
+    this.padding = const EdgeInsets.all(2),
+    this.selectedTextStyle,
+    this.unselectedTextStyle,
+    this.backgroundColor,
+    this.indicatorColor,
+    this.indicatorSettings,
+    this.indicatorPinchStrength = 0.4,
+    this.indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    this.backgroundKey,
+    // ── iOS 26 interaction ──────────────────────────────────────────────────
+    this.interactionBehavior = GlassInteractionBehavior.full,
+    this.glowColor,
+    this.glowRadius = 1.5,
+    // Scrollable-mode fields — unused in fixed mode.
+    this.isScrollable = false,
+    this.iconSize = 24.0,
+    this.labelPadding = const EdgeInsets.symmetric(horizontal: 16),
+    this.selectedIconColor,
+    this.unselectedIconColor,
+    this.maskingQuality = MaskingQuality.high,
+    this.dividerSettings,
+    this.indicatorShadow,
+  })  : assert(
+          segments.length >= 2,
+          'GlassSegmentedControl requires at least 2 segments',
+        ),
+        assert(
+          segments.length <= 6,
+          'GlassSegmentedControl works best with 2–5 segments. '
+          'For 6+ items use GlassSegmentedControl.scrollable().',
+        ),
+        assert(
+          selectedIndex >= 0 && selectedIndex < segments.length,
+          'selectedIndex must be within bounds of segments list',
+        );
+
+  /// Creates a scrollable glass segmented control that 100% mimics
+  /// [GlassTabBar]`(isScrollable: true)` from the original API.
+  ///
+  /// Use this when you have many segments (typically 6+) that won’t fit in
+  /// the available width. Segments have natural widths and scroll horizontally.
+  ///
+  /// ```dart
+  /// GlassSegmentedControl.scrollable(
+  ///   segments: [
+  ///     GlassSegment(label: 'All'),
+  ///     GlassSegment(label: 'Photos', icon: Icon(Icons.photo)),
+  ///     GlassSegment(label: 'Videos'),
+  ///     GlassSegment(label: 'Music'),
+  ///     GlassSegment(label: 'Files'),
+  ///   ],
+  ///   selectedIndex: _selectedIndex,
+  ///   onSegmentSelected: (i) => setState(() => _selectedIndex = i),
+  /// )
+  /// ```
+  const GlassSegmentedControl.scrollable({
+    required this.segments,
+    required this.selectedIndex,
+    required this.onSegmentSelected,
+    super.key,
+    this.height = 44.0,
+    this.borderRadius = GlassDefaults.borderRadius,
+    this.padding = const EdgeInsets.all(2),
+    this.selectedTextStyle,
+    this.unselectedTextStyle,
+    this.backgroundColor,
+    this.indicatorColor,
+    this.indicatorSettings,
+    this.indicatorPinchStrength = 0.4,
+    this.indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    this.backgroundKey,
+    // Scrollable-specific params
+    this.iconSize = 24.0,
+    this.labelPadding = const EdgeInsets.symmetric(horizontal: 16),
+    this.selectedIconColor,
+    this.unselectedIconColor,
+    this.maskingQuality = MaskingQuality.high,
+    this.dividerSettings,
+    this.indicatorShadow,
+  })  : isScrollable = true,
+        interactionBehavior = GlassInteractionBehavior.full,
+        glowColor = null,
+        glowRadius = 1.5,
+        assert(segments.length >= 1,
+            'GlassSegmentedControl.scrollable requires at least 1 segment'),
+        assert(
+          selectedIndex >= 0 && selectedIndex < segments.length,
+          'selectedIndex must be within bounds of segments list',
+        );
+
+  // ===========================================================================
+  // Segment Configuration
+  // ===========================================================================
+
+  /// List of segments to display.
+  ///
+  /// Each [GlassSegment] may have a [GlassSegment.label], a [GlassSegment.icon], or both.
+  /// In fixed mode (default), all segments are equal-width. In scrollable mode
+  /// segments have natural widths and scroll horizontally.
+  ///
+  /// Minimum 2 segments required (fixed mode), 1 segment (scrollable mode).
+  final List<GlassSegment> segments;
+
+  /// Whether this control scrolls horizontally.
+  ///
+  /// When `false` (default), uses equal-width segments with [SegmentedControlContent].
+  /// When `true`, uses [ScrollableSegmentContent] with natural widths — identical to
+  /// [GlassTabBar]`(isScrollable: true)` from the original API.
+  final bool isScrollable;
+
+  /// Index of the currently selected segment.
+  ///
+  /// Must be between 0 and segments.length - 1.
+  final int selectedIndex;
+
+  /// Called when a segment is selected.
+  ///
+  /// Provides the index of the newly selected segment.
+  ///
+  /// > **Note (iOS-style behaviour):** This callback may fire during a
+  /// > *cancelled* gesture if the drag indicator travelled far enough to
+  /// > snap to a different segment before the cancel arrived. This matches
+  /// > `UISegmentedControl` semantics. If you need strict tap-only selection,
+  /// > compare the received index against `selectedIndex` before acting.
+  final ValueChanged<int> onSegmentSelected;
+
+  // ===========================================================================
+  // Layout Properties
+  // ===========================================================================
+
+  /// Height of the segmented control.
+  ///
+  /// Defaults to 32 (matching iOS UISegmentedControl).
+  final double height;
+
+  /// Border radius of the segmented control.
+  ///
+  /// Defaults to 16 (height / 2) for a pill shape.
+  final double borderRadius;
+
+  /// Padding around the indicator inside the background.
+  ///
+  /// Defaults to 2 pixels on all sides.
+  final EdgeInsetsGeometry padding;
+
+  // ===========================================================================
+  // Style Properties
+  // ===========================================================================
+
+  /// Text style for the selected segment.
+  ///
+  /// If null, uses default style with fontSize 13, fontWeight w600,
+  /// and white color.
+  final TextStyle? selectedTextStyle;
+
+  /// Text style for unselected segments.
+  ///
+  /// If null, uses default style with fontSize 13, fontWeight w500,
+  /// and white color at 60% opacity.
+  final TextStyle? unselectedTextStyle;
+
+  /// Background color of the segmented control.
+  ///
+  /// If null, uses a semi-transparent fill depending on brightness.
+  final Color? backgroundColor;
+
+  /// Color of the indicator when not being dragged.
+  ///
+  /// If null, uses a semi-transparent color from the theme.
+  final Color? indicatorColor;
+
+  /// Glass settings for the draggable indicator.
+  ///
+  /// If null, uses optimized defaults for the indicator:
+  /// - glassColor: Color.from(alpha: 0.1, red: 1, green: 1, blue: 1)
+  /// - saturation: 1.5
+  /// - refractiveIndex: 1.15
+  /// - thickness: 20
+  /// - lightIntensity: 2
+  /// - chromaticAberration: 0.5
+  /// - blur: 0
+  final LiquidGlassSettings? indicatorSettings;
+
+  /// Maximum concave lens pinch strength for the sliding indicator pill.
+  ///
+  /// - `1.0` (default) — full Apple-calibrated pinch
+  /// - `0.0` — pinch fully disabled
+  /// Maximum concave lens pinch strength. Forwarded to [AnimatedGlassIndicator].
+  ///
+  /// Defaults to `0.4` — the iOS 26-calibrated gentle concave lens warp, matching
+  /// [GlassBottomBar] and [GlassTabBar] for a consistent feel across all
+  /// interactive indicator widgets. Set to `0.0` to disable, `1.0` to restore
+  /// the original full-strength warp.
+  final double indicatorPinchStrength;
+
+  /// Expansion padding applied to the active indicator pill during interaction.
+  ///
+  /// The pill grows by this amount beyond its segment boundary as the user drags,
+  /// creating the iOS 26 "jelly" overshoot. Defaults to
+  /// `EdgeInsets.symmetric(horizontal: 12, vertical: 8)` matching [GlassBottomBar]
+  /// and [GlassTabBar].
+  final EdgeInsetsGeometry indicatorExpansion;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Glass effect settings (only used when [useOwnLayer] is true).
+  ///
+  /// If null when [useOwnLayer] is true, uses optimized defaults:
+  /// - thickness: 30
+  /// - blur: 3
+  /// - chromaticAberration: 0.5
+  /// - lightIntensity: 2
+  /// - refractiveIndex: 1.15
+  final LiquidGlassSettings? settings;
+
+  /// Whether to create its own layer or use grouped glass.
+  ///
+  /// - `false` (default): Uses grouped glass, must be inside [LiquidGlassLayer]
+  /// - `true`: Creates own layer with [LiquidGlass.withOwnLayer]
+  ///
+  /// Defaults to false.
+  final bool useOwnLayer;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// Defaults to [GlassQuality.standard] (backdrop filter).
+  final GlassQuality? quality;
+
+  /// Optional background key for Skia/Web refraction.
+  final GlobalKey? backgroundKey;
+
+  // ── iOS 26 interaction ────────────────────────────────────────────────────
+
+  /// Controls which iOS 26 interaction effects are active on the indicator.
+  ///
+  /// | Value | Glow on press/drag |
+  /// |---|---|
+  /// | `none` | ✗ |
+  /// | `glowOnly` | ✓ |
+  /// | `scaleOnly` | ✗ |
+  /// | `full` *(default)* | ✓ |
+  ///
+  /// Set to [GlassInteractionBehavior.none] to suppress the glow entirely.
+  final GlassInteractionBehavior interactionBehavior;
+
+  /// Colour of the press/drag glow on the indicator pill.
+  ///
+  /// Only active when [interactionBehavior] includes glow. Defaults to a
+  /// soft white (~12% opacity) — same as [GlassTextField].
+  final Color? glowColor;
+
+  /// Spread radius of the glow relative to the indicator's shorter dimension.
+  ///
+  /// Defaults to `1.5` (150%), matching [GlassTextField].
+  final double glowRadius;
+
+  // ===========================================================================
+  // Scrollable-mode params (used only when isScrollable: true)
+  // ===========================================================================
+
+  /// Icon size in logical pixels. Used in scrollable mode only.
+  /// Defaults to 24.0 — matching [GlassTabBar].
+  final double iconSize;
+
+  /// Horizontal padding inside each tab label cell. Scrollable mode only.
+  final EdgeInsetsGeometry labelPadding;
+
+  /// Icon color for the selected segment. Scrollable mode only.
+  /// Defaults to the primary label color.
+  final Color? selectedIconColor;
+
+  /// Icon color for unselected segments. Scrollable mode only.
+  /// Defaults to the secondary label color.
+  final Color? unselectedIconColor;
+
+  /// Masking quality for the dual-layer icon rendering. Scrollable mode only.
+  final MaskingQuality maskingQuality;
+
+  /// Optional divider settings between segments. Scrollable mode only.
+  final DividerSettings? dividerSettings;
+
+  /// Optional box shadows on the pill indicator. Scrollable mode only.
+  final List<BoxShadow>? indicatorShadow;
+
+  @override
+  State<GlassSegmentedControl> createState() => _GlassSegmentedControlState();
+}
+
+class _GlassSegmentedControlState extends State<GlassSegmentedControl> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  // Default background colors — match GlassTabBar._buildInline() exactly.
+  static const _defaultLightBg = Color(0x1F000000); // black12
+  static const _defaultDarkBg = Color(0x1FFFFFFF); // white12
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+    );
+
+    final effectiveSettings = widget.settings ??
+        const LiquidGlassSettings(
+          thickness: GlassDefaults.thickness,
+          blur: GlassDefaults.blur,
+          chromaticAberration: GlassDefaults.chromaticAberration,
+          lightIntensity: GlassDefaults.lightIntensity,
+          refractiveIndex: GlassDefaults.refractiveIndex,
+          lightAngle: GlassDefaults.lightAngle,
+        );
+
+    // ── Scrollable mode: 100% mirrors GlassTabBar(isScrollable: true) ────────
+    if (widget.isScrollable) {
+      final isLight = GlassTheme.brightnessOf(context) == Brightness.light;
+      final bg = widget.backgroundColor ??
+          (isLight ? _defaultLightBg : _defaultDarkBg);
+      final borderRadius = BorderRadius.circular(widget.borderRadius);
+
+      final content = Container(
+        height: widget.height,
+        // No clipBehavior: glass pill expansion must not be clipped.
+        // SingleChildScrollView's own Clip.hardEdge clips scroll content.
+        decoration: BoxDecoration(color: bg, borderRadius: borderRadius),
+        padding: widget.padding,
+        child: ScrollableSegmentContent(
+          tabs: widget.segments,
+          selectedIndex: widget.selectedIndex,
+          onTabSelected: widget.onSegmentSelected,
+          isScrollable: true,
+          scrollController: _scrollController,
+          indicatorColor: widget.indicatorColor,
+          selectedLabelStyle: widget.selectedTextStyle,
+          unselectedLabelStyle: widget.unselectedTextStyle,
+          selectedIconColor: widget.selectedIconColor,
+          unselectedIconColor: widget.unselectedIconColor,
+          iconSize: widget.iconSize,
+          labelPadding: widget.labelPadding,
+          quality: effectiveQuality,
+          indicatorBorderRadius: null, // derived from tabBarBorderRadius
+          indicatorSettings: widget.indicatorSettings,
+          indicatorPinchStrength: widget.indicatorPinchStrength,
+          indicatorExpansion: widget.indicatorExpansion,
+          backgroundKey: widget.backgroundKey,
+          maskingQuality: widget.maskingQuality,
+          dividerSettings: widget.dividerSettings,
+          indicatorShadow: widget.indicatorShadow,
+          tabBarBorderRadius: borderRadius,
+        ),
+      );
+
+      if (widget.useOwnLayer) {
+        return AdaptiveLiquidGlassLayer(
+          settings: effectiveSettings,
+          quality: effectiveQuality,
+          child: content,
+        );
+      }
+      return content;
+    }
+
+    // ── Fixed mode: equal-width SegmentedControlContent ───────────────────────
+    final backgroundColor = widget.backgroundColor ??
+        (GlassTheme.brightnessOf(context) == Brightness.light
+            ? CupertinoColors.black.withValues(alpha: 0.08)
+            : CupertinoColors.white.withValues(alpha: 0.12));
+
+    // SizedBox sets the height without clipping. DecoratedBox paints the
+    // background without enforcing a clip — jelly expansion can overflow freely.
+    final control = SizedBox(
+      height: widget.height,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(widget.borderRadius),
+        ),
+        child: Padding(
+          padding: widget.padding,
+          child: SegmentedControlContent(
+            segments: widget.segments,
+            selectedIndex: widget.selectedIndex,
+            onSegmentSelected: widget.onSegmentSelected,
+            selectedTextStyle: widget.selectedTextStyle,
+            unselectedTextStyle: widget.unselectedTextStyle,
+            indicatorColor: widget.indicatorColor,
+            indicatorSettings: widget.indicatorSettings,
+            indicatorPinchStrength: widget.indicatorPinchStrength,
+            indicatorExpansion: widget.indicatorExpansion,
+            borderRadius: widget.borderRadius,
+            quality: effectiveQuality,
+            backgroundKey: widget.backgroundKey,
+            interactionBehavior: widget.interactionBehavior,
+            glowColor: widget.glowColor,
+            glowRadius: widget.glowRadius,
+          ),
+        ),
+      ),
+    );
+
+    if (widget.useOwnLayer) {
+      return AdaptiveLiquidGlassLayer(
+        settings: effectiveSettings,
+        quality: effectiveQuality,
+        child: control,
+      );
+    }
+    return control;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/glass_slider.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/glass_slider.dart
@@ -1,0 +1,718 @@
+import 'dart:async';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../constants/glass_defaults.dart';
+import '../../src/types/glass_interaction_behavior.dart';
+import '../../types/glass_quality.dart';
+import '../../utils/draggable_indicator_physics.dart';
+import '../../utils/glass_spring.dart';
+import '../shared/glass_effect.dart';
+import '../../theme/glass_theme.dart';
+import '../../theme/glass_theme_helpers.dart';
+
+/// A glass morphism slider following Apple's iOS 26 design patterns.
+///
+/// [GlassSlider] provides a sophisticated slider with glass track, draggable
+/// thumb with jelly physics, and smooth animations. It matches iOS's UISlider
+/// appearance and behavior with glass morphism effects.
+///
+/// ## Key Features
+///
+/// - **Glass Track**: Background track with glass effect
+/// - **Active Track**: Colored portion showing current value
+/// - **Jelly Thumb**: Draggable thumb with organic squash/stretch physics
+/// - **Haptic Feedback**: Subtle feedback when reaching discrete values
+/// - **Continuous or Discrete**: Support for continuous values or divisions
+/// - **Customizable**: Full control over colors, sizes, and shapes
+///
+/// ## Usage
+///
+/// ### Basic Usage (Continuous)
+/// ```dart
+/// double volume = 0.5;
+///
+/// GlassSlider(
+///   value: volume,
+///   onChanged: (value) {
+///     setState(() => volume = value);
+///   },
+/// )
+/// ```
+///
+/// ### Discrete Values
+/// ```dart
+/// double brightness = 3.0;
+///
+/// GlassSlider(
+///   value: brightness,
+///   min: 0.0,
+///   max: 5.0,
+///   divisions: 5,
+///   onChanged: (value) {
+///     setState(() => brightness = value);
+///   },
+/// )
+/// ```
+///
+/// ### Within LiquidGlassLayer (Grouped Mode)
+/// ```dart
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 3,
+///     refractiveIndex: 1.59,
+///   ),
+///   child: Column(
+///     children: [
+///       GlassSlider(
+///         value: volume,
+///         onChanged: (value) => setVolume(value),
+///         label: 'Volume',
+///       ),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ### Standalone Mode
+/// ```dart
+/// GlassSlider(
+///   value: brightness,
+///   onChanged: (value) => setBrightness(value),
+///   useOwnLayer: true,
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 3,
+///   ),
+/// )
+/// ```
+///
+/// ### Custom Styling
+/// ```dart
+/// GlassSlider(
+///   value: temperature,
+///   min: 0,
+///   max: 100,
+///   onChanged: (value) => setTemperature(value),
+///   activeColor: Colors.red,
+///   thumbColor: Colors.red,
+///   trackHeight: 6,
+///   thumbRadius: 16,
+/// )
+/// ```
+class GlassSlider extends StatefulWidget {
+  /// Creates a glass slider.
+  const GlassSlider({
+    required this.value,
+    required this.onChanged,
+    super.key,
+    this.onChangeStart,
+    this.onChangeEnd,
+    this.min = 0.0,
+    this.max = 1.0,
+    this.divisions,
+    this.label,
+    this.activeColor,
+    this.inactiveColor,
+    this.thumbColor = CupertinoColors.white,
+    this.trackHeight = 4.0,
+    this.thumbRadius = 15.0,
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    // ── iOS 26 interaction ──────────────────────────────────────────────────────
+    this.interactionBehavior = GlassInteractionBehavior.full,
+    this.glowColor,
+    this.glowRadius = 1.5,
+  });
+
+  // ===========================================================================
+  // Slider Properties
+  // ===========================================================================
+
+  /// The current value of the slider.
+  ///
+  /// Must be between [min] and [max].
+  final double value;
+
+  /// Called when the user is selecting a new value.
+  final ValueChanged<double>? onChanged;
+
+  /// Called when the user starts dragging the slider.
+  final ValueChanged<double>? onChangeStart;
+
+  /// Called when the user finishes dragging the slider.
+  final ValueChanged<double>? onChangeEnd;
+
+  /// The minimum value of the slider.
+  ///
+  /// Defaults to 0.0.
+  final double min;
+
+  /// The maximum value of the slider.
+  ///
+  /// Defaults to 1.0.
+  final double max;
+
+  /// The number of discrete divisions.
+  ///
+  /// If null, the slider is continuous. If provided, the slider will snap
+  /// to discrete values.
+  final int? divisions;
+
+  /// Optional label shown above the thumb.
+  final String? label;
+
+  // ===========================================================================
+  // Style Properties
+  // ===========================================================================
+
+  /// Color of the active track (left of thumb).
+  ///
+  /// If null, defaults to white with 80% opacity.
+  final Color? activeColor;
+
+  /// Color of the inactive track (right of thumb).
+  ///
+  /// If null, defaults to white with 20% opacity.
+  final Color? inactiveColor;
+
+  /// Color of the thumb.
+  ///
+  /// Defaults to white.
+  final Color thumbColor;
+
+  /// Height of the track.
+  ///
+  /// Defaults to 4.0.
+  final double trackHeight;
+
+  /// Radius of the thumb.
+  ///
+  /// Defaults to 14.0 (iOS standard).
+  final double thumbRadius;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Glass effect settings (only used when [useOwnLayer] is true).
+  final LiquidGlassSettings? settings;
+
+  /// Whether to create its own layer or use grouped glass.
+  ///
+  /// Defaults to false (grouped mode).
+  final bool useOwnLayer;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// Defaults to [GlassQuality.standard], which uses the lightweight fragment
+  /// shader. This works reliably in all contexts, including scrollable lists.
+  ///
+  /// Use [GlassQuality.premium] for full-pipeline shader with texture capture
+  /// and chromatic aberration (Impeller only) in static layouts.
+  /// Defaults to [GlassQuality.standard].
+  final GlassQuality? quality;
+
+  // ── iOS 26 interaction ────────────────────────────────────────────────────
+
+  /// Controls which iOS 26 interaction effects are active on the thumb.
+  ///
+  /// | Value | Glow on drag |
+  /// |---|---|
+  /// | `none` | ✗ |
+  /// | `glowOnly` | ✓ |
+  /// | `scaleOnly` | ✗ |
+  /// | `full` *(default)* | ✓ |
+  ///
+  /// Set to [GlassInteractionBehavior.none] to suppress the drag glow entirely.
+  final GlassInteractionBehavior interactionBehavior;
+
+  /// Colour of the drag glow on the thumb.
+  ///
+  /// Only active when [interactionBehavior] includes glow. Defaults to a
+  /// soft white (~12% opacity) — same as [GlassTextField].
+  final Color? glowColor;
+
+  /// Spread radius of the drag glow relative to the thumb’s shorter dimension.
+  ///
+  /// Defaults to `1.5` (150% of thumb height), matching [GlassTextField].
+  final double glowRadius;
+
+  @override
+  State<GlassSlider> createState() => _GlassSliderState();
+}
+
+class _GlassSliderState extends State<GlassSlider>
+    with TickerProviderStateMixin {
+  // Cache default colors to avoid allocations
+  static const _defaultThumbShadowColor =
+      Color(0x40000000); // black.withValues(alpha: 0.25)
+
+  double? _dragValue;
+  bool _isDragging = false;
+  late AnimationController _scaleController;
+  late AnimationController _thicknessController;
+  late Animation<double> _scaleAnimation;
+  late Animation<double> _thicknessAnimation;
+
+  // Spring-based jelly velocity controller.
+  // Produces smooth, high-magnitude velocity values with natural deceleration
+  // and elastic bounce-back — matching the tab bar / bottom bar pill feel.
+  late final SingleSpringController _jellyController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Scale controller for thumb size change when dragging
+    _scaleController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 150),
+    );
+
+    // iOS 26: Thumb "balloons in size" when dragging (1.25x = 25% larger)
+    _scaleAnimation = Tween<double>(
+      begin: 1.0,
+      end: 1.35, // More dramatic balloon effect
+    ).animate(
+      CurvedAnimation(
+        parent: _scaleController,
+        curve: Curves.easeOutBack, // Slight overshoot for organic feel
+        reverseCurve: Curves.easeInBack,
+      ),
+    );
+
+    // Simple 0→1 hold: fades the white pill out on press-down and
+    // keeps it clear for the entire drag. Reverses back on release.
+    _thicknessController = AnimationController(
+      duration: const Duration(milliseconds: 300),
+      vsync: this,
+    );
+
+    _thicknessAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(
+      CurvedAnimation(
+        parent: _thicknessController,
+        curve: Curves.easeOut,
+        reverseCurve: Curves.easeIn,
+      ),
+    );
+
+    // Jelly spring: snappy with slight bounce for organic squash/stretch.
+    // The controller drives a normalised position; its VELOCITY is what
+    // feeds buildJellyTransform for the squash/stretch matrix.
+    _jellyController = SingleSpringController(
+      vsync: this,
+      spring: GlassSpring.snappy(
+        duration: const Duration(milliseconds: 350),
+      ),
+      initialValue: 0.0,
+    );
+  }
+
+  @override
+  void dispose() {
+    _scaleController.dispose();
+    _thicknessController.dispose();
+    _jellyController.dispose();
+    super.dispose();
+  }
+
+  double _normalizedToValue(double normalized) {
+    return widget.min + (normalized * (widget.max - widget.min));
+  }
+
+  void _handleDragDown(DragDownDetails details) {
+    // Instant visual response on touch down (iOS 26)
+    if (_isDragging) return;
+
+    setState(() {
+      _isDragging = true;
+    });
+    unawaited(_scaleController.forward());
+    // Fade the white pill out; stays clear for the whole drag
+    unawaited(_thicknessController.forward());
+  }
+
+  void _handleDragStart(DragStartDetails details) {
+    // Only call onChangeStart once per interaction
+    widget.onChangeStart?.call(widget.value);
+  }
+
+  void _handleDragUpdate(
+      DragUpdateDetails details, BoxConstraints constraints) {
+    final box = context.findRenderObject()! as RenderBox;
+    final localPosition = box.globalToLocal(details.globalPosition);
+
+    // Calculate normalized position (0-1)
+    final trackWidth = constraints.maxWidth - (widget.thumbRadius * 2);
+    final normalizedX =
+        ((localPosition.dx - widget.thumbRadius) / trackWidth).clamp(0.0, 1.0);
+
+    // Feed the spring controller with the new normalised position.
+    // Its velocity property produces smooth, spring-based values that
+    // buildJellyTransform can use for organic squash/stretch.
+    _jellyController.animateTo(normalizedX);
+
+    // Convert to value
+    var newValue = _normalizedToValue(normalizedX);
+
+    // Snap to divisions if provided
+    if (widget.divisions != null) {
+      final stepSize = (widget.max - widget.min) / widget.divisions!;
+      newValue = (newValue / stepSize).round() * stepSize + widget.min;
+      newValue = newValue.clamp(widget.min, widget.max);
+
+      // Haptic feedback on division change
+      if (_dragValue != null && newValue != _dragValue) {
+        unawaited(HapticFeedback.selectionClick());
+      }
+    }
+
+    setState(() {
+      _dragValue = newValue;
+    });
+
+    widget.onChanged?.call(newValue);
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    _cleanupDrag();
+    widget.onChangeEnd?.call(widget.value);
+  }
+
+  void _handleDragCancel() {
+    _cleanupDrag();
+  }
+
+  void _cleanupDrag() {
+    if (!_isDragging) return;
+
+    setState(() {
+      _isDragging = false;
+      _dragValue = null;
+    });
+
+    // Scale down thumb when ending drag
+    unawaited(_scaleController.reverse());
+
+    // Fade the white pill back in on release
+    unawaited(_thicknessController.reverse());
+
+    // Let the spring settle — this produces the elastic bounce-back jelly
+    // animation as the velocity decays through the spring curve.
+    // (No need to reset; the spring naturally settles to its current target.)
+  }
+
+  // Cache effectiveQuality at state level to make it accessible in _buildThumbGlass
+  GlassQuality? _effectiveQuality;
+
+  @override
+  Widget build(BuildContext context) {
+    // Inherit quality from parent layer or theme if not explicitly set
+    _effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+    );
+
+    final effectiveValue = _dragValue ?? widget.value;
+    final normalizedValue =
+        ((effectiveValue - widget.min) / (widget.max - widget.min))
+            .clamp(0.0, 1.0);
+
+    // Performance: Cache color calculations - these allocate on every build
+    final brightness = GlassTheme.brightnessOf(context);
+    final isDark = brightness == Brightness.dark;
+    final activeColor = widget.activeColor ??
+        (brightness == Brightness.light
+            ? CupertinoColors.black.withValues(alpha: 0.8)
+            : CupertinoColors.white.withValues(alpha: 0.8));
+    final inactiveColor = widget.inactiveColor ??
+        (brightness == Brightness.light
+            ? CupertinoColors.black.withValues(alpha: 0.2)
+            : CupertinoColors.white.withValues(alpha: 0.2));
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final trackWidth = constraints.maxWidth - (widget.thumbRadius * 2);
+        final thumbPosition =
+            widget.thumbRadius + (trackWidth * normalizedValue);
+
+        final step = (widget.max - widget.min) / (widget.divisions ?? 10);
+        final increasedValue =
+            (widget.value + step).clamp(widget.min, widget.max);
+        final decreasedValue =
+            (widget.value - step).clamp(widget.min, widget.max);
+
+        final normalizedIncreased =
+            ((increasedValue - widget.min) / (widget.max - widget.min))
+                .clamp(0.0, 1.0);
+        final normalizedDecreased =
+            ((decreasedValue - widget.min) / (widget.max - widget.min))
+                .clamp(0.0, 1.0);
+
+        final thumbHeight = widget.thumbRadius * 1.6;
+
+        return Semantics(
+          label: widget.label ?? 'Slider',
+          value: '${(normalizedValue * 100).round()}%',
+          increasedValue: '${(normalizedIncreased * 100).round()}%',
+          decreasedValue: '${(normalizedDecreased * 100).round()}%',
+          onIncrease: widget.onChanged != null
+              ? () {
+                  widget.onChanged!(increasedValue);
+                }
+              : null,
+          onDecrease: widget.onChanged != null
+              ? () {
+                  widget.onChanged!(decreasedValue);
+                }
+              : null,
+          child: RepaintBoundary(
+            child: GestureDetector(
+              onHorizontalDragDown: _handleDragDown,
+              onHorizontalDragStart: _handleDragStart,
+              onHorizontalDragUpdate: (details) =>
+                  _handleDragUpdate(details, constraints),
+              onHorizontalDragEnd: _handleDragEnd,
+              onHorizontalDragCancel: _handleDragCancel,
+              child: SizedBox(
+                height: widget.thumbRadius * 2 + 16,
+                width: constraints.maxWidth,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    // Track (centered vertically)
+                    Positioned.fill(
+                      child: Center(
+                        child: SizedBox(
+                          height: widget.trackHeight,
+                          child: Stack(
+                            children: [
+                              // Full inactive track (iOS 26 style)
+                              // Plain semi-transparent bar — no rim, no shader.
+                              // Matches the real iOS 26 slider exactly.
+                              Positioned.fill(
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    color: inactiveColor,
+                                    borderRadius: BorderRadius.circular(
+                                      widget.trackHeight / 2,
+                                    ),
+                                  ),
+                                ),
+                              ),
+
+                              // Active track
+                              if (normalizedValue > 0)
+                                Positioned(
+                                  left: 0,
+                                  right: constraints.maxWidth *
+                                      (1 - normalizedValue),
+                                  top: 0,
+                                  bottom: 0,
+                                  child: Container(
+                                    decoration: BoxDecoration(
+                                      color: activeColor,
+                                      borderRadius: BorderRadius.horizontal(
+                                        left: Radius.circular(
+                                          widget.trackHeight / 2,
+                                        ),
+                                        right: normalizedValue >= 1.0
+                                            ? Radius.circular(
+                                                widget.trackHeight / 2,
+                                              )
+                                            : Radius.zero,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+
+                    // Thumb (iOS 26: premium hardware aligned + jelly physics)
+                    AnimatedBuilder(
+                      animation: Listenable.merge([
+                        _scaleController,
+                        _thicknessController,
+                        _jellyController,
+                      ]),
+                      builder: (context, child) {
+                        final scale = _scaleAnimation.value;
+
+                        // Calculate actual thumb size after scaling for centering
+                        final scaledThumbHeight = thumbHeight * scale;
+                        // Adjust top position to keep thumb centered as it grows
+                        final topPosition =
+                            (widget.thumbRadius * 2 + 16 - scaledThumbHeight) /
+                                2;
+
+                        // Spring-based jelly: velocity from the spring controller
+                        // produces smooth squash/stretch with natural deceleration
+                        // and elastic bounce-back — matching tab bar/bottom bar.
+                        final jellyVelocity = _jellyController.velocity;
+                        final jellyTransform =
+                            DraggableIndicatorPhysics.buildJellyTransform(
+                          velocity: Offset(jellyVelocity, 0),
+                          maxDistortion: 0.6,
+                          // Slider spring tracks 0→1 normalised position,
+                          // producing velocities of ~1-3 units/sec (vs tab bar's
+                          // 10-20+). Scale down so these smaller velocities
+                          // produce visible squash/stretch.
+                          velocityScale: 2,
+                        );
+
+                        return Positioned(
+                          left: thumbPosition - widget.thumbRadius,
+                          top: topPosition,
+                          child: Transform(
+                            alignment: Alignment.center,
+                            transform: jellyTransform,
+                            child: Stack(
+                              clipBehavior: Clip.none,
+                              children: [
+                                _buildThumbGlass(scale, isDark),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildThumbGlass(double scale, bool isDark) {
+    final thumbWidth = widget.thumbRadius * 2.6;
+    final thumbHeight = widget.thumbRadius * 1.6;
+    final borderRadius = thumbHeight / 2;
+
+    // Calculate transition value (0 = at rest, 1 = fully dragging)
+    final transition = _thicknessAnimation.value;
+
+    // Standard: same rim/light math as AnimatedGlassIndicator pill.
+    //   Dampeners in GlassEffect.build(): rimThickness×0.35, lightIntensity×0.6.
+    // Premium: original values preserved exactly — no change to Premium rendering.
+    final isStdPath =
+        (_effectiveQuality ?? GlassQuality.standard) == GlassQuality.standard;
+
+    // iOS 26: Dynamic size matching GlassSwitch pattern
+    // The glass shell grows with the scale animation
+    final totalWidth = thumbWidth * scale;
+    final totalHeight = thumbHeight * scale;
+
+    // iOS 26: Material content wrapped in Opacity (matches GlassSwitch pattern).
+    // Using Opacity widget (not color alpha) is critical for Impeller: it
+    // properly removes the child from the compositing tree, allowing the
+    // native LiquidGlass refraction to show through when the material fades.
+    final materialContent = Opacity(
+      opacity: (1.0 - transition * 1.2).clamp(0.0, 1.0),
+      child: Container(
+        width: thumbWidth,
+        height: thumbHeight,
+        decoration: BoxDecoration(
+          color: widget.thumbColor.withValues(alpha: 1.0),
+          borderRadius: BorderRadius.circular(borderRadius),
+          boxShadow: [
+            BoxShadow(
+              color: _defaultThumbShadowColor.withValues(
+                alpha: 0.25 * (1.0 - transition),
+              ),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    // Use liquid glass with clean superellipse shape
+    // Border radius scales with the total height
+    final thumbShape = LiquidRoundedSuperellipse(
+      borderRadius: totalHeight / 2,
+    );
+
+    // CRITICAL: Outer SizedBox with dynamic size ensures proper premium rendering
+    return SizedBox(
+      width: totalWidth,
+      height: totalHeight,
+      child: GlassEffect(
+        shape: thumbShape,
+        // Light mode: clear refractive glass with thicker body — visibility comes
+        // from optical distortion and edge highlights.
+        settings: LiquidGlassSettings(
+          glassColor: isDark
+              ? const Color.from(alpha: 0.08, red: 1, green: 1, blue: 1)
+              : const Color.from(
+                  alpha: 0.12, red: 0.88, green: 0.88, blue: 0.90),
+          refractiveIndex: isDark ? 1.3 : 1.4,
+          thickness: isDark ? 13 : 17,
+          lightIntensity: isStdPath
+              ? 0.0
+              : 1.8, // no specular on synthetic path; premium unchanged
+          blur: 0,
+          lightAngle: GlassDefaults.lightAngle,
+        ),
+        rimThickness: isStdPath
+            ? (isDark ? 0.5 : 0.7)
+            : 0.5, // slightly thicker rim in light mode
+        ambientRim: isStdPath
+            ? (isDark ? 0.08 : 0.15)
+            : 0.1, // stronger ambient ring in light mode
+        baseAlphaMultiplier: isStdPath
+            ? (isDark ? 0.08 : 0.12)
+            : 0.08, // near-clear body — refraction provides visibility
+        edgeAlphaMultiplier: isStdPath
+            ? (isDark ? 0.15 : 0.28)
+            : 0, // stronger edge contrast in light mode
+        quality: _effectiveQuality ?? GlassQuality.standard,
+        interactionIntensity: transition,
+        child: SizedBox(
+          width: totalWidth,
+          height: totalHeight,
+          child: Stack(
+            alignment: Alignment.center,
+            clipBehavior: Clip.none,
+            children: [
+              // Glass shell footprint (crucial for proper shader rendering)
+              Positioned.fill(child: Container(color: Colors.transparent)),
+
+              // Physical material content (centered, original size)
+              materialContent,
+
+              // Glowing element — only when interactionBehavior includes glow.
+              if (transition > 0.05 && widget.interactionBehavior.hasGlow)
+                Opacity(
+                  opacity: transition,
+                  child: GlassGlow(
+                    glowColor:
+                        widget.glowColor ?? Color(0x1FFFFFFF), // white ~12%
+                    glowRadius: widget.glowRadius,
+                    child: SizedBox(
+                      width: thumbWidth,
+                      height: thumbHeight,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/glass_switch.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/glass_switch.dart
@@ -1,0 +1,698 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../constants/glass_defaults.dart';
+import '../../theme/glass_theme.dart';
+import '../../types/glass_quality.dart';
+import '../shared/glass_effect.dart';
+import '../../theme/glass_theme_helpers.dart';
+
+/// A glass toggle switch with Apple's signature jump animation.
+///
+/// [GlassSwitch] provides a toggle switch with glass morphism effect and
+/// smooth spring-based animations, matching iOS toggle behavior with a
+/// satisfying "jump" when switching states.
+///
+/// ## Usage Modes
+///
+/// ### Grouped Mode (default)
+/// ```dart
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(...),
+///   child: Column(
+///     children: [
+///       GlassSwitch(
+///         value: isEnabled,
+///         onChanged: (value) => setState(() => isEnabled = value),
+///       ),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ### Standalone Mode
+/// ```dart
+/// GlassSwitch(
+///   useOwnLayer: true,
+///   settings: LiquidGlassSettings(...),
+///   value: darkMode,
+///   onChanged: (value) => toggleDarkMode(value),
+/// )
+/// ```
+///
+/// ## Customization Examples
+///
+/// ### Custom colors:
+/// ```dart
+/// GlassSwitch(
+///   value: isOn,
+///   onChanged: (value) {},
+///   activeColor: Colors.green,
+///   inactiveColor: Colors.grey,
+/// )
+/// ```
+///
+/// ### Custom size:
+/// ```dart
+/// GlassSwitch(
+///   value: isOn,
+///   onChanged: (value) {},
+///   width: 60,
+///   height: 32,
+/// )
+/// ```
+class GlassSwitch extends StatefulWidget {
+  /// Creates a glass switch.
+  const GlassSwitch({
+    required this.value,
+    required this.onChanged,
+    super.key,
+    this.activeColor,
+    this.inactiveColor,
+    this.thumbColor = CupertinoColors.white,
+    this.width = 58.0,
+    this.height = 26.0,
+    this.settings,
+    this.useOwnLayer = false,
+    this.quality,
+    this.enableHaptics = true,
+  });
+
+  // ===========================================================================
+  // Switch Properties
+  // ===========================================================================
+
+  /// Whether the switch is on or off.
+  final bool value;
+
+  /// Called when the user toggles the switch.
+  final ValueChanged<bool> onChanged;
+
+  /// The color of the track when the switch is on.
+  ///
+  /// If null, defaults to system green (`CupertinoColors.systemGreen`).
+  final Color? activeColor;
+
+  /// The color of the track when the switch is off.
+  ///
+  /// If null, defaults to a semi-transparent white.
+  final Color? inactiveColor;
+
+  /// The color of the thumb (circular knob).
+  ///
+  /// Defaults to white.
+  final Color thumbColor;
+
+  // ===========================================================================
+  // Sizing Properties
+  // ===========================================================================
+
+  /// Width of the switch.
+  ///
+  /// Defaults to 58.0.
+  final double width;
+
+  /// Height of the switch.
+  ///
+  /// Defaults to 26.0.
+  final double height;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Glass effect settings (only used when [useOwnLayer] is true).
+  final LiquidGlassSettings? settings;
+
+  /// Whether to create its own layer or use grouped glass.
+  final bool useOwnLayer;
+
+  /// Defaults to [GlassQuality.standard], which uses backdrop filter rendering.
+  /// This works reliably in all contexts, including scrollable lists.
+  ///
+  /// Use [GlassQuality.premium] for shader-based glass in static layouts only.
+  final GlassQuality? quality;
+
+  /// Whether to emit haptic feedback on toggle.
+  ///
+  /// When `true` (the default), a [HapticFeedback.lightImpact] fires:
+  /// - immediately when the switch is tapped,
+  /// - when the thumb crosses the 50 % midpoint during a drag, and
+  /// - on drag release if the thumb snaps to a new state and the midpoint
+  ///   was never crossed (e.g. a fast flick).
+  ///
+  /// Set to `false` to suppress all haptics — useful when the parent widget
+  /// already manages its own haptic layer.
+  final bool enableHaptics;
+
+  @override
+  State<GlassSwitch> createState() => _GlassSwitchState();
+}
+
+class _GlassSwitchState extends State<GlassSwitch>
+    with TickerProviderStateMixin {
+  // Cache default shadow color to avoid allocations
+  // Shadow color for the thumb material
+  static const _defaultThumbShadowColor = Color(0x33000000);
+
+  late AnimationController _positionController;
+  late AnimationController _thicknessController;
+  late Animation<double> _positionAnimation;
+  late Animation<double> _thicknessAnimation;
+  late bool _isMovingForward; // Track direction of animation
+
+  // ---------------------------------------------------------------------------
+  // Gesture state
+  // ---------------------------------------------------------------------------
+  bool _isDragging = false;
+  double _dragStartX = 0.0;
+  double _dragStartPosition = 0.0;
+  bool _dragAbandonedExternally = false;
+  bool _justEndedDrag = false;
+
+  // ---------------------------------------------------------------------------
+  // Haptic state
+  // ---------------------------------------------------------------------------
+  // Tracks whether the thumb crossed the 50% midpoint during the current drag.
+  // Prevents a double-fire on drag release when the midpoint was already felt.
+  bool _dragMidpointHapticFired = false;
+  // The side of the midpoint the thumb was on at the last _onDragUpdate call.
+  // Used to detect a crossing without comparing raw floats.
+  bool _dragWasAboveMidpoint = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Unified tempo: Position jump and Liquid bloom now move together
+    _positionController = AnimationController(
+        duration: const Duration(milliseconds: 380), vsync: this);
+    _thicknessController = AnimationController(
+        duration: const Duration(milliseconds: 380), vsync: this);
+
+    _positionAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(
+      CurvedAnimation(
+        parent: _positionController,
+        curve: Curves.easeInOutCubic, // Match the growth momentum
+        reverseCurve: Curves.easeInOutCubic,
+      ),
+    );
+
+    // Pulse animation (0 -> 1 -> 0)
+    // Synchronized to grow and settle as the toggle jumps
+    _thicknessAnimation = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween<double>(begin: 0.0, end: 1.0)
+            .chain(CurveTween(curve: Curves.easeInOutCubic)),
+        weight: 45, // Grow up as it gains speed
+      ),
+      TweenSequenceItem(
+        tween: Tween<double>(begin: 1.0, end: 0.0)
+            .chain(CurveTween(curve: Curves.easeInOutQuad)),
+        weight: 55, // Settle down as it lands
+      ),
+    ]).animate(_thicknessController);
+
+    // Set initial state
+    _isMovingForward = widget.value;
+    if (widget.value) {
+      _positionController.value = 1.0;
+    }
+  }
+
+  @override
+  void didUpdateWidget(GlassSwitch oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.value != oldWidget.value) {
+      // If the user is mid-drag, an external value change wins — abandon the
+      // drag cleanly so the animation takes over without a visual jump.
+      if (_isDragging) {
+        _isDragging = false;
+        _dragAbandonedExternally = true;
+      }
+
+      // Track direction: true = moving forward (left to right)
+      _isMovingForward = widget.value;
+
+      // Animate position
+      if (widget.value) {
+        unawaited(_positionController.forward());
+      } else {
+        unawaited(_positionController.reverse());
+      }
+
+      // Trigger the liquid pulse bloom (Grow up and then down)
+      final bool justEndedDrag = _justEndedDrag;
+      _justEndedDrag = false;
+
+      if (!justEndedDrag) {
+        if (_thicknessController.value >= 0.99) {
+          _thicknessController.value = 0.0;
+        }
+
+        // Sync the jump duration exactly to the remaining travel time so that
+        // if the user held the switch (full bloom), it stays bloomed and deflates
+        // cleanly across the entire horizontal movement.
+        final double posDist = widget.value
+            ? (1.0 - _positionController.value)
+            : _positionController.value;
+        final int ms = (380 * posDist).round();
+
+        if (ms > 0) {
+          unawaited(_thicknessController.animateTo(
+            1.0,
+            duration: Duration(milliseconds: ms),
+            // Use an ease-in curve so that if the thumb is fully bloomed (held down),
+            // it maintains its stretched shape for the majority of the travel,
+            // and only deflates back to a circle as it lands on the other side.
+            // This prevents the "jerky" deflation mid-flight.
+            curve: Curves.easeIn,
+          ));
+        } else {
+          _thicknessController.value = 1.0;
+        }
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _positionController.dispose();
+    _thicknessController.dispose();
+    super.dispose();
+  }
+
+  void _handleTap() {
+    widget.onChanged(!widget.value);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Drag-to-toggle handlers
+  // ---------------------------------------------------------------------------
+
+  /// Pixel travel distance from the left edge to right edge of the thumb runway.
+  double get _thumbTravelDistance {
+    final thumbSize = widget.height - 4.0;
+    final thumbWidth = thumbSize * 1.6;
+    return widget.width - thumbWidth - 4.0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Gesture handlers
+  // ---------------------------------------------------------------------------
+
+  void _onTapDown(TapDownDetails details) {
+    // Finger is down: start the bloom immediately for instant feedback.
+    if (_thicknessController.value >= 0.99) {
+      _thicknessController.value = 0.0;
+    }
+    _dragAbandonedExternally = false;
+    unawaited(_thicknessController.animateTo(
+      0.45,
+      duration: const Duration(milliseconds: 120),
+      curve: Curves.easeOut,
+    ));
+  }
+
+  void _onTapUp(TapUpDetails details) {
+    // A tap is confirmed only when no horizontal drag was registered.
+    if (!_isDragging) {
+      // Fire haptic immediately — user feels the click the instant they lift.
+      if (widget.enableHaptics) unawaited(HapticFeedback.lightImpact());
+      // Deflate the bloom — the tap animation in didUpdateWidget will
+      // re-trigger it correctly with the full directional stretch.
+      _handleTap();
+    }
+  }
+
+  void _onTapCancel() {
+    // Finger moved away without a tap or drag completing.
+    if (!_isDragging) {
+      unawaited(_thicknessController.forward(from: _thicknessController.value));
+    }
+  }
+
+  void _onDragStart(DragStartDetails details) {
+    // Flutter has confirmed horizontal movement — commit to drag mode.
+    _positionController.stop();
+    _dragStartX = details.localPosition.dx;
+    _dragStartPosition = _positionController.value;
+    _dragAbandonedExternally = false;
+    setState(() => _isDragging = true);
+
+    // Stop any deflation that onTapCancel might have started
+    _thicknessController.stop();
+
+    // Ensure bloom is at peak.
+    if (_thicknessController.value >= 0.99) {
+      _thicknessController.value = 0.0;
+    }
+
+    // If we're not at perfect plump (e.g., started deflating), animate back to 0.45
+    if ((_thicknessController.value - 0.45).abs() > 0.01) {
+      unawaited(_thicknessController.animateTo(
+        0.45,
+        duration: const Duration(milliseconds: 80),
+      ));
+    } else {
+      _thicknessController.value = 0.45;
+    }
+
+    // Reset midpoint-haptic tracking for this new drag.
+    _dragMidpointHapticFired = false;
+    _dragWasAboveMidpoint = _positionController.value >= 0.5;
+  }
+
+  void _onDragCancel() {
+    setState(() => _isDragging = false);
+    // Deflate bloom smoothly.
+    unawaited(_thicknessController.forward(from: _thicknessController.value));
+  }
+
+  void _onDragUpdate(DragUpdateDetails details) {
+    if (!_isDragging) return;
+    // Map finger position → track position (0.0 – 1.0) and push it directly
+    // into the controller so the AnimatedBuilder redraws this frame.
+    final travel = _thumbTravelDistance;
+    final dragDelta = details.localPosition.dx - _dragStartX;
+    _positionController.value =
+        (_dragStartPosition + dragDelta / travel).clamp(0.0, 1.0);
+
+    // Detect midpoint crossing and fire a single haptic tick.
+    // iOS fires at the 50 % mark regardless of drag direction.
+    if (widget.enableHaptics && !_dragMidpointHapticFired) {
+      final nowAbove = _positionController.value >= 0.5;
+      if (nowAbove != _dragWasAboveMidpoint) {
+        unawaited(HapticFeedback.lightImpact());
+        _dragMidpointHapticFired = true;
+      }
+      _dragWasAboveMidpoint = nowAbove;
+    }
+  }
+
+  void _onDragEnd(DragEndDetails details) {
+    // No-op if an external value change has already taken ownership.
+    if (_dragAbandonedExternally) {
+      _dragAbandonedExternally = false;
+      return;
+    }
+    if (!_isDragging) return;
+    final position = _positionController.value;
+    final velocity = details.primaryVelocity ?? 0.0;
+
+    // A fast flick (> 200 px/s) wins over position; otherwise snap at 50 %.
+    final bool shouldBeOn =
+        velocity.abs() > 200.0 ? velocity > 0 : position >= 0.5;
+
+    _isMovingForward = shouldBeOn;
+    setState(() => _isDragging = false);
+    _justEndedDrag = true;
+
+    // Animate thumb to its resting position.
+    if (shouldBeOn) {
+      unawaited(_positionController.forward());
+    } else {
+      unawaited(_positionController.reverse());
+    }
+
+    // Continue the settle bloom down to 0 so the landing feels weighty.
+    unawaited(_thicknessController.forward(from: _thicknessController.value));
+
+    // Haptic on snap — only if the state is changing AND the midpoint
+    // crossing haptic didn't already fire (avoids a double-tap feel on
+    // slow deliberate drags that naturally crossed the midpoint).
+    if (widget.enableHaptics &&
+        !_dragMidpointHapticFired &&
+        shouldBeOn != widget.value) {
+      unawaited(HapticFeedback.lightImpact());
+    }
+    _dragMidpointHapticFired = false;
+
+    // Notify parent only when the value actually changed.
+    if (shouldBeOn != widget.value) {
+      widget.onChanged(shouldBeOn);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Inherit quality from parent layer or theme if not explicitly set
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+    );
+
+    final thumbSize = widget.height - 4.0;
+    final thumbWidth = thumbSize * 1.6; // Match _buildThumb ratio
+    final trackWidth = widget.width;
+    // Fix: Use actual thumb width for travel distance calculation
+    final thumbTravelDistance = trackWidth - thumbWidth - 4.0;
+
+    // Performance: Cache color calculations as const to avoid allocation
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    // Light mode: solid opaque grey matching native iOS switch track groove.
+    // Dark mode: semi-transparent white overlay for glass aesthetic.
+    final inactiveTrackColor = widget.inactiveColor ??
+        (isDark ? const Color(0x33FFFFFF) : const Color(0xFFC5C5C6));
+    final activeTrackColor = widget.activeColor ?? CupertinoColors.systemGreen;
+
+    return GestureDetector(
+      // NOTE: We do NOT use onTap here. Having both onTap and onHorizontalDrag*
+      // on the same GestureDetector creates a gesture arena conflict — Flutter
+      // must choose one winner per touch, leading to missed interactions.
+      // Instead, we detect taps manually: onTapDown starts the bloom, onTapUp
+      // fires the toggle if no horizontal drag was confirmed.
+      onTapDown: _onTapDown,
+      onTapUp: _onTapUp,
+      onTapCancel: _onTapCancel,
+      onHorizontalDragCancel: _onDragCancel,
+      onHorizontalDragStart: _onDragStart,
+      onHorizontalDragUpdate: _onDragUpdate,
+      onHorizontalDragEnd: _onDragEnd,
+      // Performance: RepaintBoundary isolates switch animation from parent
+      child: RepaintBoundary(
+        child: AnimatedBuilder(
+          animation:
+              Listenable.merge([_positionController, _thicknessController]),
+          builder: (context, child) {
+            final position = _positionAnimation.value;
+            final thickness = _thicknessAnimation.value;
+            // Tie squash directly to thickness so it doesn't fluctuate during drag
+            final scale = 1.0 - (thickness * 0.08);
+
+            // Build the track — plain Container driven entirely by `position`
+            // from the single AnimatedBuilder above. Using AnimatedContainer
+            // here previously caused a 200ms *second* animation to start after
+            // the rebuild, making the track go green late. Now everything is
+            // frame-locked to _positionAnimation.
+            //
+            // Color strategy:
+            //   0.0 = fully inactive (inactiveTrackColor, no glow)
+            //   1.0 = fully active   (activeTrackColor gradient, glow)
+            // We lerp smoothly using `position` as the blend factor.
+            final blendedColor =
+                Color.lerp(inactiveTrackColor, activeTrackColor, position)!;
+            final specularTop =
+                Color.lerp(activeTrackColor, CupertinoColors.white, 0.25)!;
+
+            final track = Container(
+              width: trackWidth,
+              height: widget.height,
+              decoration: BoxDecoration(
+                // Gradient blends in as position → 1: starts as a flat lerped
+                // colour, gains the specular highlight progressively.
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Color.lerp(blendedColor, specularTop, position)!,
+                    blendedColor,
+                  ],
+                ),
+                borderRadius: BorderRadius.circular(widget.height / 2),
+                // Glow fades in smoothly from 0 → max alpha over full travel.
+                // Kept subtle (0.35 max, 6dp blur) to avoid over-illumination.
+                boxShadow: position > 0.01
+                    ? [
+                        BoxShadow(
+                          color: activeTrackColor.withValues(
+                            alpha: 0.35 * position,
+                          ),
+                          blurRadius: 6,
+                          spreadRadius: 0,
+                          offset: const Offset(0, 1),
+                        ),
+                      ]
+                    : null,
+              ),
+            );
+
+            // Growth/Expansion offsets
+            final vExpand = thickness * 10.0;
+            final leadStretch = thickness * 16.0;
+
+            final thumbOffset = 2.0 + (thumbTravelDistance * position);
+
+            // Anchor logic:
+            // Dragging -> Symmetric stretch (anchor center)
+            // Jumping  -> Directional stretch (anchor left or right based on direction)
+            final double anchorOffset = _isDragging
+                ? (leadStretch / 2.0)
+                : (_isMovingForward ? 0.0 : leadStretch);
+
+            final thumbLeft = thumbOffset - anchorOffset;
+
+            final thumb = Positioned(
+              left: thumbLeft,
+              top: 2.0 - vExpand,
+              child: Transform.scale(
+                // Combined scale: Squash for jump + slight Grow for the liquid bloom
+                scale: scale * (1.0 + thickness * 0.1),
+                child: _buildThumb(thumbSize, thickness, scale, vExpand,
+                    leadStretch, anchorOffset, effectiveQuality, isDark),
+              ),
+            );
+
+            return Semantics(
+              label: 'Switch',
+              toggled: widget.value,
+              enabled: true,
+              onTap: _handleTap,
+              child: SizedBox(
+                width: trackWidth,
+                height: widget.height,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    track,
+                    thumb,
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildThumb(
+      double size,
+      double transition,
+      double scale,
+      double vExpand,
+      double leadStretch,
+      double anchorOffset,
+      GlassQuality? effectiveQuality,
+      bool isDark) {
+    // iOS 26: Unified Material Melt with Directional Anchoring
+    final thumbWidth = size * 1.6;
+    final thumbHeight = size;
+    final totalWidth = thumbWidth + leadStretch;
+    final totalHeight = thumbHeight + vExpand * 2;
+
+    // iOS 26: Synchronized Biological Bloom
+    // Restored perfect pill radius (no squareness)
+    final thumbShape = LiquidRoundedSuperellipse(
+      borderRadius: totalHeight / 2,
+    );
+    // Standard path only — Premium values are unchanged.
+    final isStdPath =
+        (effectiveQuality ?? GlassQuality.standard) == GlassQuality.standard;
+
+    final materialContent = Opacity(
+      opacity: (1.0 - transition * 1.2).clamp(0.0, 1.0),
+      child: Container(
+        width: thumbWidth,
+        height: thumbHeight,
+        decoration: BoxDecoration(
+          color: widget.thumbColor.withValues(alpha: 1.0),
+          borderRadius: BorderRadius.circular(thumbHeight / 2),
+          boxShadow: [
+            BoxShadow(
+              color: _defaultThumbShadowColor.withValues(
+                  alpha: 0.2 * (1.0 - transition)),
+              blurRadius: 0,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    return SizedBox(
+      width: totalWidth,
+      height: totalHeight,
+      child: GlassEffect(
+        shape: thumbShape,
+        // Standard: same rim/light math as AnimatedGlassIndicator pill.
+        //   rimThickness×0.35, lightIntensity×0.6 dampeners applied in GlassEffect.build().
+        // Premium: original values preserved exactly — no change to Premium rendering.
+        // Light mode: clear refractive glass with thicker body — visibility comes
+        //   from optical distortion and edge highlights, not body fill colour.
+        settings: LiquidGlassSettings(
+          glassColor: isDark
+              ? const Color.from(alpha: 0.08, red: 1, green: 1, blue: 1)
+              : const Color.from(
+                  alpha: 0.12, red: 0.88, green: 0.88, blue: 0.90),
+          refractiveIndex: isDark ? 1.12 : 1.22,
+          thickness: isDark ? 10 : 14,
+          lightIntensity: isStdPath
+              ? 0.0
+              : 2.0, // no specular on synthetic path (clamped by synthBase); premium unchanged
+          blur: 0,
+          lightAngle: GlassDefaults.lightAngle,
+        ),
+        rimThickness: isStdPath
+            ? (isDark ? 0.5 : 0.7)
+            : 0.5, // slightly thicker rim in light mode
+        ambientRim: isStdPath
+            ? (isDark ? 0.08 : 0.15)
+            : 0.1, // stronger ambient ring in light mode
+        baseAlphaMultiplier: isStdPath
+            ? (isDark ? 0.0 : 0.04)
+            : 0.2, // near-clear body — refraction provides visibility
+        edgeAlphaMultiplier: isStdPath
+            ? (isDark ? 0.15 : 0.28)
+            : 0.4, // stronger edge contrast in light mode
+        quality: effectiveQuality ?? GlassQuality.standard,
+        interactionIntensity: transition,
+        child: Stack(
+          alignment: Alignment.center,
+          clipBehavior: Clip.none,
+          children: [
+            // Glass shell footprint
+            Positioned.fill(child: Container(color: Colors.transparent)),
+
+            // Physical thumb position based on anchor
+            Positioned(
+              left: anchorOffset,
+              child: materialContent,
+            ),
+
+            if (transition > 0.05)
+              Positioned(
+                left: anchorOffset,
+                child: Opacity(
+                  opacity: transition,
+                  child: GlassGlow(
+                    child: SizedBox(
+                      width: thumbWidth,
+                      height: thumbHeight,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/liquid_glass_scope.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/liquid_glass_scope.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/widgets.dart';
+
+/// A scope that provides infrastructure for glass refraction on Skia and Web.
+///
+/// Place [LiquidGlassScope] at the root of a stack or page.
+/// Descendant [GlassEffect] widgets (used by [GlassSegmentedControl],
+/// [GlassTabBar], [GlassBottomBar]) will automatically find and sample the
+/// capture surface marked by [GlassRefractionSource].
+///
+/// On Impeller, [LiquidGlassScope] is not needed — `GlassQuality.premium`
+/// uses the native scene graph for refraction.
+///
+/// Usage:
+/// ```dart
+/// LiquidGlassScope(
+///   child: Stack(
+///     children: [
+///       // 1. Mark the capture surface
+///       GlassRefractionSource(
+///         child: Image.asset('wallpaper.jpg'),
+///       ),
+///
+///       // 2. Glass widgets sample it automatically
+///       Center(child: GlassSegmentedControl(...)),
+///     ],
+///   ),
+/// )
+/// ```
+class LiquidGlassScope extends StatefulWidget {
+  const LiquidGlassScope({
+    required this.child,
+    super.key,
+  });
+
+  /// Convenience constructor for the common pattern of a background behind content.
+  ///
+  /// This eliminates the boilerplate of manually creating a Stack with Positioned.fill
+  /// widgets. It's equivalent to:
+  ///
+  /// ```dart
+  /// LiquidGlassScope(
+  ///   child: Stack(
+  ///     children: [
+  ///       Positioned.fill(
+  ///         child: GlassBackgroundSource(child: background),
+  ///       ),
+  ///       Positioned.fill(child: content),
+  ///     ],
+  ///   ),
+  /// )
+  /// ```
+  ///
+  /// Example:
+  /// ```dart
+  /// LiquidGlassScope.stack(
+  ///   background: Image.asset('wallpaper.jpg', fit: BoxFit.cover),
+  ///   content: Scaffold(
+  ///     body: MyContent(),
+  ///     bottomNavigationBar: GlassBottomBar(...),
+  ///   ),
+  /// )
+  /// ```
+  @Deprecated(
+    'Use GlassPage instead. GlassPage automatically handles Scaffold transparency '
+    'and adaptive quality degradation. This factory will be removed in 1.0.0.',
+  )
+  factory LiquidGlassScope.stack({
+    Key? key,
+    required Widget background,
+    required Widget content,
+  }) {
+    return LiquidGlassScope(
+      key: key,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: GlassBackgroundSource(child: background),
+          ),
+          content, // Don't wrap in Positioned - let it naturally fill
+        ],
+      ),
+    );
+  }
+
+  final Widget child;
+
+  /// Returns the background key from the nearest ancestor scope.
+  static GlobalKey? of(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<_InheritedLiquidGlassScope>()
+        ?.backgroundKey;
+  }
+
+  @override
+  State<LiquidGlassScope> createState() => _LiquidGlassScopeState();
+}
+
+class _LiquidGlassScopeState extends State<LiquidGlassScope> {
+  // Create the key ONCE and keep it stable across rebuilds
+  final GlobalKey _backgroundKey =
+      GlobalKey(debugLabel: 'LiquidGlassBackground');
+
+  @override
+  Widget build(BuildContext context) {
+    return _InheritedLiquidGlassScope(
+      backgroundKey: _backgroundKey,
+      child: widget.child,
+    );
+  }
+}
+
+/// Marks a widget as the texture capture source for the nearest [LiquidGlassScope].
+///
+/// Wraps [child] in a [RepaintBoundary] tagged with the scope's [GlobalKey].
+/// Descendant [GlassEffect] widgets (e.g. [GlassCard], [GlassSegmentedControl])
+/// will sample this boundary every frame to produce real background colour absorption
+/// on Skia and Web paths, simulating true physical glass.
+///
+/// On Impeller with `GlassQuality.premium`, this is not needed — the native
+/// scene graph handles color absorption and refraction without a captured boundary.
+///
+/// If [enabled] is false, the widget will not inject a [RepaintBoundary] and
+/// will simply return its child, allowing [GlassAdaptiveScope] to disable
+/// sampling gracefully during high GPU load.
+///
+/// Typically you do not use this directly. Use [GlassPage] at the root of your route.
+///
+/// ```dart
+/// GlassPage(
+///   background: Image.asset('wallpaper.jpg', fit: BoxFit.cover),
+///   child: Scaffold(...),
+/// )
+/// ```
+///
+/// Or manually, for granular control:
+///
+/// ```dart
+/// GlassBackgroundSource(
+///   enabled: true,
+///   child: Image.asset('wallpaper.jpg'),
+/// )
+/// ```
+class GlassBackgroundSource extends StatelessWidget {
+  const GlassBackgroundSource({
+    required this.child,
+    this.enabled = true,
+    super.key,
+  });
+
+  final Widget child;
+
+  /// Whether the background should be captured into a texture.
+  /// If false, glass surfaces will fall back to a synthetic frosted tint.
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!enabled) return child;
+
+    final key = LiquidGlassScope.of(context);
+
+    assert(() {
+      if (key == null) {
+        debugPrint(
+          'ℹ️ [GlassBackgroundSource] No LiquidGlassScope found in the widget tree.\n'
+          '   The background will render normally but glass will use\n'
+          '   synthetic frost instead of real background colour sampling.\n'
+          '   Use GlassPage or wrap your widget tree with LiquidGlassScope to enable sampling.',
+        );
+      }
+      return true;
+    }());
+
+    // If no scope is found, render the child normally — no silent failures.
+    if (key == null) return child;
+
+    return RepaintBoundary(
+      key: key,
+      child: child,
+    );
+  }
+}
+
+/// Deprecated: use [GlassBackgroundSource] instead.
+///
+/// [GlassRefractionSource] was renamed to [GlassBackgroundSource] in 0.11.0
+/// to better reflect its purpose for absorbing background colors, not just refraction.
+@Deprecated(
+  'Use GlassBackgroundSource instead. '
+  'GlassRefractionSource was renamed in 0.11.0 for clarity. '
+  'This alias will be removed in 1.0.0.',
+)
+typedef GlassRefractionSource = GlassBackgroundSource;
+
+/// Deprecated: use [GlassBackgroundSource] instead.
+@Deprecated(
+  'Use GlassBackgroundSource instead. '
+  'This alias will be removed in 1.0.0.',
+)
+typedef LiquidGlassBackground = GlassBackgroundSource;
+
+class _InheritedLiquidGlassScope extends InheritedWidget {
+  const _InheritedLiquidGlassScope({
+    required this.backgroundKey,
+    required super.child,
+  });
+
+  final GlobalKey backgroundKey;
+
+  @override
+  bool updateShouldNotify(_InheritedLiquidGlassScope oldWidget) {
+    return backgroundKey != oldWidget.backgroundKey;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/shared/scrollable_segment_content.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/shared/scrollable_segment_content.dart
@@ -1,0 +1,936 @@
+// Shared internal widget for GlassSegmentedControl — scrollable mode.
+//
+// NOT part of the public API — do not export from liquid_glass_widgets.dart.
+library;
+
+import 'package:flutter/cupertino.dart' show CupertinoColors, CupertinoTheme;
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import '../../../src/renderer/liquid_glass_renderer.dart';
+import '../../../types/glass_quality.dart';
+import '../../../utils/draggable_indicator_physics.dart';
+import '../../../utils/glass_spring.dart';
+import '../../shared/animated_glass_indicator.dart';
+import '../../surfaces/glass_bottom_bar.dart' show MaskingQuality;
+import '../../surfaces/glass_tab_bar.dart' show GlassSegment, DividerSettings;
+
+// =============================================================================
+// ScrollableSegmentContent — draggable indicator + segment layout
+// =============================================================================
+
+/// Internal stateful widget managing the scrollable pill indicator and segment
+/// items for [GlassSegmentedControl.scrollable].
+///
+/// Extracted from [GlassSegmentedControl] to keep the public widget focused on
+/// configuration and glass-layer wrapping, while this widget owns all gesture,
+/// spring, and rendering logic for the scrollable layout mode.
+class ScrollableSegmentContent extends StatefulWidget {
+  const ScrollableSegmentContent({
+    required this.tabs,
+    required this.selectedIndex,
+    required this.onTabSelected,
+    required this.isScrollable,
+    required this.scrollController,
+    required this.indicatorColor,
+    required this.selectedLabelStyle,
+    required this.unselectedLabelStyle,
+    required this.selectedIconColor,
+    required this.unselectedIconColor,
+    required this.iconSize,
+    required this.labelPadding,
+    required this.quality,
+    this.indicatorBorderRadius,
+    this.indicatorSettings,
+    this.indicatorPinchStrength = 0.4,
+    this.indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    this.backgroundKey,
+    this.maskingQuality = MaskingQuality.high,
+    this.dividerSettings,
+    this.indicatorShadow,
+    this.tabBarBorderRadius,
+    super.key,
+  });
+
+  final List<GlassSegment> tabs;
+  final int selectedIndex;
+  final ValueChanged<int> onTabSelected;
+  final bool isScrollable;
+  final ScrollController scrollController;
+  final Color? indicatorColor;
+  final TextStyle? selectedLabelStyle;
+  final TextStyle? unselectedLabelStyle;
+  final Color? selectedIconColor;
+  final Color? unselectedIconColor;
+  final double iconSize;
+  final EdgeInsetsGeometry labelPadding;
+  final GlassQuality quality;
+  final BorderRadius? indicatorBorderRadius;
+  final LiquidGlassSettings? indicatorSettings;
+
+  /// Maximum concave lens pinch strength. Forwarded to [AnimatedGlassIndicator].
+  final double indicatorPinchStrength;
+
+  /// Expansion padding applied to the pill during drag — mirrors [GlassBottomBar].
+  final EdgeInsetsGeometry indicatorExpansion;
+  final GlobalKey? backgroundKey;
+  final MaskingQuality maskingQuality;
+  final DividerSettings? dividerSettings;
+
+  /// Optional shadows for the active indicator pill. Passed through to
+  /// [AnimatedGlassIndicator] but suppressed while a drag is in progress so
+  /// the shadow does not interact with the live BackdropFilter blur.
+  final List<BoxShadow>? indicatorShadow;
+
+  /// Border radius of the outer tab bar container — used to clip Layer 1
+  /// (tab labels + background pill) to the same rounded shape.
+  final BorderRadius? tabBarBorderRadius;
+
+  @override
+  State<ScrollableSegmentContent> createState() =>
+      ScrollableSegmentContentState();
+}
+
+/// State for [ScrollableSegmentContent]. Public for testing via `@visibleForTesting`.
+@visibleForTesting
+class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
+    with TickerProviderStateMixin {
+  // Cache default indicator color to avoid allocations
+  static const _defaultIndicatorColor =
+      Color(0x33FFFFFF); // white.withValues(alpha: 0.2)
+
+  bool _isDown = false;
+  bool _isDragging = false;
+  late double _xAlign = _computeXAlignmentForTab(widget.selectedIndex);
+
+  /// Specifically tracks if we are dragging the indicator in scrollable mode.
+  bool _isDraggingIndicator = false;
+
+  /// Shadows are suppressed while the indicator is being dragged so they
+  /// do not interact with the live BackdropFilter blur, then restored
+  /// when the pill is idle.
+  List<BoxShadow>? get _effectiveShadow =>
+      _isDraggingIndicator ? null : widget.indicatorShadow;
+
+  // Scrollable-overlay indicator position, animated in content space.
+  // Decoupled from the _xAlign spring so scroll never causes drift.
+  late SingleSpringController _indOffsetSpring;
+  late SingleSpringController _indWidthSpring;
+
+  // D1: hoisted — avoids allocating a new _MergedListenable on every build.
+  // Drives the ListenableBuilder that wraps VelocitySpringBuilder so spring
+  // ticks rebuild only the indicator subtree, not the full State.build().
+  late Listenable _springListenable;
+
+  late List<GlobalKey> _tabKeys;
+  List<double> _tabWidths = [];
+  List<double> _tabOffsets = [];
+
+  // Gesture recognizers for precision control.
+  late HorizontalDragGestureRecognizer _drag;
+  late TapGestureRecognizer _tap;
+
+  @override
+  void initState() {
+    super.initState();
+    _indOffsetSpring = SingleSpringController(
+      vsync: this,
+      spring: GlassSpring.snappy(duration: const Duration(milliseconds: 350)),
+    );
+    _indWidthSpring = SingleSpringController(
+      vsync: this,
+      spring: GlassSpring.snappy(duration: const Duration(milliseconds: 350)),
+    );
+    // D1: create once — controllers never change after initState.
+    // ListenableBuilder in build() listens to this; no setState on spring ticks.
+    _springListenable = Listenable.merge([_indOffsetSpring, _indWidthSpring]);
+    _initKeys();
+    if (widget.isScrollable) {
+      widget.scrollController.addListener(_onScroll);
+    }
+
+    // Setup Gesture Arena Team to allow indicator drag to "steal" focus from ScrollView.
+    final team = GestureArenaTeam();
+    _drag = HorizontalDragGestureRecognizer()
+      ..team = team
+      ..onDown = _handleDragDown
+      ..onUpdate = _handleDragUpdate
+      ..onEnd = _handleDragEnd
+      ..onCancel = _handleDragCancel;
+
+    team.captain = _drag;
+
+    _tap = TapGestureRecognizer()..onTapUp = _handleTapUp;
+  }
+
+  void _onScroll() {
+    // Rebuild to update the screen-relative indicator position during scroll.
+    if (mounted) setState(() {});
+  }
+
+  void _initKeys() {
+    _tabKeys = List.generate(widget.tabs.length, (_) => GlobalKey());
+    WidgetsBinding.instance.addPostFrameCallback((_) => _measureTabs());
+  }
+
+  void _measureTabs() {
+    if (!mounted) return;
+    double offset = 0;
+    List<double> widths = [];
+    List<double> offsets = [];
+    bool allMeasured = true;
+    final dividerWidth = widget.dividerSettings?.thickness ?? 0.0;
+    for (int i = 0; i < _tabKeys.length; i++) {
+      final box = _tabKeys[i].currentContext?.findRenderObject() as RenderBox?;
+      if (box == null || !box.hasSize) {
+        allMeasured = false;
+        break;
+      }
+      final width = box.size.width;
+      offsets.add(offset);
+      widths.add(width);
+      offset += width;
+      if (widget.dividerSettings != null && i != _tabKeys.length - 1) {
+        offset += dividerWidth;
+      }
+    }
+    if (allMeasured) {
+      final selIdx = widget.selectedIndex.clamp(0, widths.length - 1);
+      setState(() {
+        _tabWidths = widths;
+        _tabOffsets = offsets;
+        // Snap indicator to selected tab after first measure (no animation).
+        _indOffsetSpring.setValue(offsets[selIdx]);
+        _indWidthSpring.setValue(widths[selIdx]);
+      });
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _measureTabs());
+    }
+  }
+
+  @override
+  void dispose() {
+    _indOffsetSpring.dispose();
+    _indWidthSpring.dispose();
+    _drag.dispose();
+    _tap.dispose();
+    if (widget.isScrollable) {
+      widget.scrollController.removeListener(_onScroll);
+    }
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(ScrollableSegmentContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    // Handle scrollController swap (e.g., parent provides a new controller).
+    if (widget.isScrollable &&
+        oldWidget.scrollController != widget.scrollController) {
+      oldWidget.scrollController.removeListener(_onScroll);
+      widget.scrollController.addListener(_onScroll);
+    }
+
+    // Handle isScrollable toggling (unlikely in practice, but safe).
+    if (!oldWidget.isScrollable && widget.isScrollable) {
+      widget.scrollController.addListener(_onScroll);
+      // Re-measure in scrollable mode — tab widths may differ.
+      setState(() {
+        _tabWidths = [];
+        _tabOffsets = [];
+      });
+      _indOffsetSpring.setValue(0);
+      _indWidthSpring.setValue(0);
+      _initKeys();
+    } else if (oldWidget.isScrollable && !widget.isScrollable) {
+      oldWidget.scrollController.removeListener(_onScroll);
+      // Re-measure in non-scrollable mode (expanded layout).
+      setState(() {
+        _tabWidths = [];
+        _tabOffsets = [];
+      });
+      _indOffsetSpring.setValue(0);
+      _indWidthSpring.setValue(0);
+      _initKeys();
+    }
+
+    if (oldWidget.selectedIndex != widget.selectedIndex && !_isDragging) {
+      setState(() {
+        _xAlign = _computeXAlignmentForTab(widget.selectedIndex);
+      });
+      // Animate overlay indicator to new tab (scrollable mode).
+      if (widget.isScrollable &&
+          widget.selectedIndex < _tabOffsets.length &&
+          widget.selectedIndex < _tabWidths.length) {
+        _indOffsetSpring.setValue(_tabOffsets[widget.selectedIndex]);
+        _indWidthSpring.animateTo(_tabWidths[widget.selectedIndex]);
+      }
+      // Programmatic selection change — ensure the new tab scrolls into view.
+      if (widget.isScrollable) {
+        WidgetsBinding.instance.addPostFrameCallback(
+          (_) => _scrollToEnsureVisible(widget.selectedIndex),
+        );
+      }
+    }
+    if (oldWidget.tabs.length != widget.tabs.length) {
+      setState(() {
+        _xAlign = _computeXAlignmentForTab(widget.selectedIndex);
+        _tabWidths = [];
+        _tabOffsets = [];
+      });
+      _indOffsetSpring.setValue(0);
+      _indWidthSpring.setValue(0);
+      _initKeys();
+    }
+  }
+
+  double _computeXAlignmentForTab(int tabIndex) {
+    return DraggableIndicatorPhysics.computeAlignment(
+      tabIndex,
+      widget.tabs.length,
+    );
+  }
+
+  // ===========================================================================
+  // GESTURE HANDLERS
+  // ===========================================================================
+
+  void _handleTapUp(TapUpDetails details) {
+    final box = context.findRenderObject() as RenderBox?;
+    if (box == null) return;
+
+    final localX = details.localPosition.dx;
+
+    int targetIndex = -1;
+    if (widget.isScrollable) {
+      final scrollOffset = widget.scrollController.hasClients
+          ? widget.scrollController.offset
+          : 0.0;
+      final absoluteX = localX + scrollOffset;
+      for (int i = 0; i < _tabOffsets.length; i++) {
+        if (absoluteX >= _tabOffsets[i] &&
+            absoluteX <= _tabOffsets[i] + _tabWidths[i]) {
+          targetIndex = i;
+          break;
+        }
+      }
+    } else {
+      targetIndex = (localX / box.size.width * widget.tabs.length).floor();
+    }
+
+    if (targetIndex != -1 && targetIndex < widget.tabs.length) {
+      _onTabTap(targetIndex);
+    }
+  }
+
+  void _handleDragDown(DragDownDetails details) {
+    if (!widget.isScrollable) {
+      setState(() => _isDown = true);
+      return;
+    }
+
+    final scrollOffset = widget.scrollController.hasClients
+        ? widget.scrollController.offset
+        : 0.0;
+    final absoluteX = details.localPosition.dx + scrollOffset;
+
+    final selIdx = widget.selectedIndex;
+    if (selIdx < _tabOffsets.length) {
+      final left = _tabOffsets[selIdx];
+      final right = left + _tabWidths[selIdx];
+
+      // If the press is within the active indicator's bounds, start indicator drag.
+      if (absoluteX >= left && absoluteX <= right) {
+        setState(() {
+          _isDraggingIndicator = true;
+          _isDown = true;
+        });
+      }
+    }
+  }
+
+  void _handleDragUpdate(DragUpdateDetails details) {
+    final box = context.findRenderObject() as RenderBox?;
+    if (box == null || box.size.width <= 0) return;
+    const double rubberBandFactor = 0.5;
+    const double overstepRatio = 0.085;
+    const double fixedModeOverstep = 0.17;
+
+    // --- FIXED MODE ---
+    if (!widget.isScrollable) {
+      setState(() {
+        _isDragging = true;
+
+        // Use absolute pointer position to prevent drift
+        double raw = DraggableIndicatorPhysics.getAlignmentFromGlobalPosition(
+          details.globalPosition,
+          context,
+          widget.tabs.length,
+        );
+        if (raw < -1.0) {
+          raw = -1.0 + (raw + 1.0) * rubberBandFactor;
+        } else if (raw > 1.0) {
+          raw = 1.0 + (raw - 1.0) * rubberBandFactor;
+        }
+        _xAlign = raw.clamp(-1.0 - fixedModeOverstep, 1.0 + fixedModeOverstep);
+      });
+      return;
+    }
+
+    // --- SCROLLABLE MODE ---
+    if (!_isDraggingIndicator || _tabOffsets.isEmpty) return;
+    setState(() {
+      _isDragging = true;
+      final double screenWidth = box.size.width;
+      final double viewMin = widget.scrollController.offset;
+      final double viewMax = viewMin + screenWidth;
+      double delta = details.delta.dx;
+      final double curOffset = _indOffsetSpring.value;
+
+      // Calculate dynamic width based on current position to avoid jumps
+      double targetWidth = _tabWidths[0];
+      if (_tabWidths.length == widget.tabs.length) {
+        int index = 0;
+        for (int i = 0; i < _tabOffsets.length - 1; i++) {
+          if (curOffset >= _tabOffsets[i]) index = i;
+        }
+        final int nextIndex = (index + 1).clamp(0, widget.tabs.length - 1);
+        final double diff = _tabOffsets[nextIndex] - _tabOffsets[index];
+        final double t =
+            (diff != 0 ? (curOffset - _tabOffsets[index]) / diff : 0.0)
+                .clamp(0.0, 1.0);
+        targetWidth =
+            _tabWidths[index] + (_tabWidths[nextIndex] - _tabWidths[index]) * t;
+      }
+
+      // Define physical boundaries
+      final double leftWall = viewMin;
+      final double rightWall = viewMax - targetWidth;
+
+      // Apply rubber-band resistance when hitting boundaries
+      if ((curOffset < leftWall && delta < 0) ||
+          (curOffset > rightWall && delta > 0)) {
+        delta *= rubberBandFactor;
+      }
+
+      // Clamp final position with allowed overstep
+      final double maxOverstep = screenWidth * overstepRatio;
+      final double finalOffset = (curOffset + delta).clamp(
+        leftWall - maxOverstep,
+        rightWall + maxOverstep,
+      );
+
+      // Update springs
+      _indOffsetSpring.setValue(finalOffset);
+      _indWidthSpring.setValue(targetWidth);
+    });
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    if (!_isDragging) {
+      _handleDragCancel();
+      return;
+    }
+    final box = context.findRenderObject() as RenderBox?;
+    final double width = box?.size.width ?? 1.0;
+    final double velocityX = details.velocity.pixelsPerSecond.dx;
+    int targetTabIndex;
+
+    if (widget.isScrollable) {
+      // Scrollable mode: find closest tab by raw pixel offset, then
+      // apply a velocity override if the user flicked hard enough.
+      // (computeTargetIndex works in normalised 0–1 space; pixel-space
+      // nearest-tab search is intentionally kept here.)
+      targetTabIndex = widget.selectedIndex;
+      double minDistance = double.infinity;
+      for (int i = 0; i < _tabOffsets.length; i++) {
+        final double dist = (_indOffsetSpring.value - _tabOffsets[i]).abs();
+        if (dist < minDistance) {
+          minDistance = dist;
+          targetTabIndex = i;
+        }
+      }
+      // Fling override: normalise velocity to 0–1 relative units and
+      // delegate to the shared utility so both branches share the same
+      // at-least-one-tab guarantee.
+      final double relativeVelocity = width > 0 ? velocityX / width : 0.0;
+      if (relativeVelocity.abs() > 0.5) {
+        targetTabIndex =
+            (relativeVelocity > 0 ? targetTabIndex + 1 : targetTabIndex - 1)
+                .clamp(0, widget.tabs.length - 1);
+      }
+    } else {
+      // Fixed mode: delegate entirely to DraggableIndicatorPhysics so this
+      // widget no longer duplicates the snapping math used by the rest of
+      // the package. Velocity is normalised from px/s → 0–1 relative units
+      // to match computeTargetIndex's coordinate contract.
+      final double currentRelativeX = (_xAlign + 1) / 2;
+      final double relativeVelocity = width > 0 ? velocityX / width : 0.0;
+      final double itemWidth = 1.0 / widget.tabs.length;
+      targetTabIndex = DraggableIndicatorPhysics.computeTargetIndex(
+        currentRelativeX: currentRelativeX,
+        velocityX: relativeVelocity,
+        itemWidth: itemWidth,
+        itemCount: widget.tabs.length,
+      );
+    }
+
+    setState(() {
+      _isDragging = false;
+      _isDraggingIndicator = false;
+      _isDown = false;
+      if (!widget.isScrollable) {
+        _xAlign = _computeXAlignmentForTab(targetTabIndex);
+      }
+    });
+
+    if (targetTabIndex != widget.selectedIndex) {
+      widget.onTabSelected(targetTabIndex);
+    } else if (widget.isScrollable) {
+      // Snap scrollable indicator to the precise tab position.
+      _indOffsetSpring.setValue(_tabOffsets[targetTabIndex]);
+      _indWidthSpring.animateTo(_tabWidths[targetTabIndex]);
+    }
+  }
+
+  void _handleDragCancel() {
+    setState(() {
+      _isDragging = false;
+      _isDraggingIndicator = false;
+      _isDown = false;
+      if (!widget.isScrollable) {
+        _xAlign = _computeXAlignmentForTab(widget.selectedIndex);
+      }
+    });
+  }
+
+  void _onTabTap(int index) {
+    if (!widget.tabs[index].enabled) return;
+    if (index != widget.selectedIndex) {
+      widget.onTabSelected(index);
+    }
+    // Scroll the tapped tab fully into view in case it was partially visible.
+    if (widget.isScrollable) {
+      _scrollToEnsureVisible(index);
+    }
+  }
+
+  /// Smoothly scrolls the [SingleChildScrollView] so that [tabIndex] is
+  /// fully visible, with a small breathing-room edge padding.
+  ///
+  /// Called on tap and on programmatic selection changes. Only fires when
+  /// measurements are ready and the controller has an attached position.
+  void _scrollToEnsureVisible(int tabIndex) {
+    if (!widget.scrollController.hasClients) return;
+    if (tabIndex >= _tabOffsets.length || tabIndex >= _tabWidths.length) return;
+
+    final position = widget.scrollController.position;
+    final viewportWidth = position.viewportDimension;
+    final currentOffset = position.pixels;
+    const edgePadding = 12.0; // breathing room from the left/right edge
+
+    final tabLeft = _tabOffsets[tabIndex];
+    final tabRight = tabLeft + _tabWidths[tabIndex];
+
+    double targetOffset = currentOffset;
+
+    if (tabLeft - currentOffset < edgePadding) {
+      // Tab is partially or fully off-screen to the left.
+      targetOffset = tabLeft - edgePadding;
+    } else if (tabRight - currentOffset > viewportWidth - edgePadding) {
+      // Tab is partially or fully off-screen to the right.
+      targetOffset = tabRight - viewportWidth + edgePadding;
+    }
+
+    targetOffset = targetOffset.clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+
+    if ((targetOffset - currentOffset).abs() > 0.5) {
+      widget.scrollController.animateTo(
+        targetOffset,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOutCubic,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final indicatorColor = widget.indicatorColor ?? _defaultIndicatorColor;
+
+    // Resolve label and icon colors from CupertinoTheme — brightness-aware.
+    // Matches the pattern used by GlassBottomBar (glass_bottom_bar.dart L563).
+    final dynamicLabelColor =
+        CupertinoTheme.of(context).textTheme.textStyle.color ??
+            CupertinoColors.label.resolveFrom(context);
+    final dynamicSecondaryColor =
+        CupertinoColors.secondaryLabel.resolveFrom(context);
+
+    final selectedLabelStyle = TextStyle(
+      fontSize: 14,
+      fontWeight: FontWeight.w600,
+      color: dynamicLabelColor,
+    ).merge(widget.selectedLabelStyle);
+
+    final unselectedLabelStyle = TextStyle(
+      fontSize: 14,
+      fontWeight: FontWeight.w500,
+      color: dynamicSecondaryColor,
+    ).merge(widget.unselectedLabelStyle);
+
+    final selectedIconColor = widget.selectedIconColor ?? dynamicLabelColor;
+    final unselectedIconColor =
+        widget.unselectedIconColor ?? dynamicSecondaryColor;
+
+    final Widget tabLabels = _buildTabLabels(
+      selectedLabelStyle,
+      unselectedLabelStyle,
+      selectedIconColor,
+      unselectedIconColor,
+    );
+
+    return RawGestureDetector(
+      gestures: {
+        HorizontalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<
+            HorizontalDragGestureRecognizer>(
+          () => _drag,
+          (instance) {},
+        ),
+        TapGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+          () => _tap,
+          (instance) {},
+        ),
+      },
+      // D1: ListenableBuilder scoped to the indicator subtree.
+      // Spring ticks rebuild only VelocitySpringBuilder and its children;
+      // theme resolution and tabLabels construction happen once per full
+      // setState (discrete: tab change, drag end, isDown toggle).
+      // tabLabels is passed as child so it is built once and reused as a
+      // stable widget reference across all spring ticks.
+      child: ListenableBuilder(
+        listenable: _springListenable,
+        child: tabLabels,
+        builder: (context, stableTabLabels) {
+          // stableTabLabels is always non-null — we always pass tabLabels as child.
+          final safeTabLabels = stableTabLabels!;
+          return VelocitySpringBuilder(
+            value: widget.isScrollable ? _indOffsetSpring.value : _xAlign,
+            springWhenActive: GlassSpring.interactive(),
+            springWhenReleased: GlassSpring.snappy(
+              duration: const Duration(milliseconds: 350),
+            ),
+            active: widget.isScrollable ? _isDraggingIndicator : _isDragging,
+            builder: (context, currentValue, velocity, _) {
+              // Normalizing velocity: pixels-per-frame to a manageable 0.0-2.0 scale for the shader
+              // in scrollable mode. Prevents over-stretching into a vertical line during drag.
+              final double normalizedVelocity =
+                  widget.isScrollable ? velocity / 150.0 : velocity;
+
+              final Alignment alignment = widget.isScrollable
+                  ? Alignment.center
+                  : Alignment(currentValue, 0);
+              final double screenLeft =
+                  widget.isScrollable && widget.scrollController.hasClients
+                      ? currentValue - widget.scrollController.offset
+                      : 0.0;
+
+              // Bloom while the position spring is still in transit — deactivates
+              // naturally as the spring settles (mirrors GlassSegmentedControl).
+              final bool isMoving;
+              final bool canShowIndicator;
+
+              if (widget.isScrollable) {
+                final bool measuredReady =
+                    _tabWidths.length == widget.tabs.length;
+                final double targetOffset =
+                    measuredReady && widget.selectedIndex < _tabOffsets.length
+                        ? _tabOffsets[widget.selectedIndex]
+                        : 0.0;
+                isMoving = (currentValue - targetOffset).abs() > 2.0;
+                canShowIndicator = measuredReady && _indWidthSpring.value > 0;
+              } else {
+                final double targetAlignment =
+                    _computeXAlignmentForTab(widget.selectedIndex);
+                isMoving = (alignment.x - targetAlignment).abs() > 0.05;
+                canShowIndicator = true;
+              }
+
+              return SpringBuilder(
+                spring: GlassSpring.snappy(
+                  duration: const Duration(milliseconds: 300),
+                ),
+                value: _isDown || isMoving ? 1.0 : 0.0,
+                builder: (context, thickness, _) {
+                  // Helper to prevent indicator parameter duplication
+                  Widget buildIndicator(
+                      {required bool paintBackground,
+                      required bool paintGlass}) {
+                    return AnimatedGlassIndicator(
+                      velocity: normalizedVelocity,
+                      itemCount: widget.tabs.length,
+                      alignment: alignment,
+                      thickness: thickness,
+                      quality: widget.quality,
+                      indicatorColor: indicatorColor,
+                      isBackgroundIndicator: false,
+                      borderRadius: widget.indicatorBorderRadius?.topLeft.x ??
+                          widget.tabBarBorderRadius?.topLeft.x ??
+                          16,
+                      settings: widget.indicatorSettings,
+                      pinchStrength: widget.indicatorPinchStrength,
+                      backgroundKey: widget.backgroundKey,
+                      expansion: widget.maskingQuality == MaskingQuality.off
+                          ? EdgeInsets.zero
+                          : widget.indicatorExpansion,
+                      paintBackground: paintBackground,
+                      paintGlass: paintGlass,
+                      shadows: paintBackground ? _effectiveShadow : null,
+                      exactWidth:
+                          widget.isScrollable ? _indWidthSpring.value : null,
+                      exactOffset: widget.isScrollable ? screenLeft : null,
+                    );
+                  }
+
+                  if (widget.isScrollable) {
+                    // Three-layer architecture:
+                    //  1. ClipRect layer: tab labels + solid background pill — both clip
+                    //     cleanly at the viewport boundary as the user scrolls.
+                    //  2. Glass bloom layer (above ClipRect): only the glass effect renders
+                    //     here, so the jelly bloom can expand freely past the bar edges.
+                    final physics = _isDraggingIndicator
+                        ? const NeverScrollableScrollPhysics()
+                        : const ClampingScrollPhysics();
+
+                    return Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        // ── Layer 1: clipped content ────────────────────────────────────
+                        // ClipRRect clips to the tab bar's rounded corners so the solid
+                        // background pill and tab labels don't overflow the corner radius.
+                        ClipRRect(
+                          borderRadius:
+                              widget.tabBarBorderRadius ?? BorderRadius.zero,
+                          child: Stack(
+                            clipBehavior: Clip.none,
+                            children: [
+                              // Background solid pill — clips with the bar (rendered before
+                              // labels so labels paint above the pill — correct z-order).
+                              if (canShowIndicator)
+                                buildIndicator(
+                                    paintBackground: true, paintGlass: false),
+
+                              // Tab labels (scrollable) — stableTabLabels is the ListenableBuilder
+                              // child: built once per full setState, reused across spring ticks.
+                              NotificationListener<ScrollStartNotification>(
+                                onNotification: (_) {
+                                  if (_isDown) setState(() => _isDown = false);
+                                  return false;
+                                },
+                                child: SingleChildScrollView(
+                                  controller: widget.scrollController,
+                                  scrollDirection: Axis.horizontal,
+                                  physics: physics,
+                                  child: safeTabLabels,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+
+                        // ── Layer 2: glass bloom (above all clips) ──────────────────────
+                        if (canShowIndicator)
+                          buildIndicator(
+                              paintBackground: false, paintGlass: true),
+                      ],
+                    );
+                  } else {
+                    // Non-scrollable mode: stacking background, labels, glass without clipping.
+                    //
+                    // Premium: glass renders ABOVE labels — Impeller's physical refraction
+                    // wraps the icon correctly (it refracts around it, not covers it).
+                    //
+                    // Standard/Minimal: glass renders BELOW labels — the 2D shader is an
+                    // opaque paint pass that would obscure the icon if placed on top.
+                    final bool isPremiumQuality =
+                        widget.quality == GlassQuality.premium;
+                    return Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        if (canShowIndicator)
+                          buildIndicator(
+                              paintBackground: true,
+                              paintGlass: !isPremiumQuality),
+                        safeTabLabels,
+                        if (canShowIndicator && isPremiumQuality)
+                          buildIndicator(
+                              paintBackground: false, paintGlass: true),
+                      ],
+                    );
+                  }
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildTabLabels(
+    TextStyle selectedStyle,
+    TextStyle unselectedStyle,
+    Color selectedIconColor,
+    Color unselectedIconColor,
+  ) {
+    final List<Widget> tabWidgets = List.generate(
+      widget.tabs.length,
+      (index) {
+        final tab = widget.tabs[index];
+        final isSelected = index == widget.selectedIndex;
+        return KeyedSubtree(
+          key: _tabKeys[index],
+          child: RepaintBoundary(
+            child: TabBarItem(
+              tab: tab,
+              isSelected: isSelected,
+              onTap: () => _onTabTap(index),
+              onTapDown: () {},
+              labelStyle: isSelected ? selectedStyle : unselectedStyle,
+              iconColor: isSelected ? selectedIconColor : unselectedIconColor,
+              iconSize: widget.iconSize,
+              padding: widget.labelPadding,
+            ),
+          ),
+        );
+      },
+    );
+
+    if (widget.dividerSettings != null) {
+      final d = widget.dividerSettings!;
+      for (int i = widget.tabs.length - 1; i > 0; i--) {
+        final isVisible = !d.isHideAutomatically ||
+            (i - 1 != widget.selectedIndex && i != widget.selectedIndex);
+
+        tabWidgets.insert(
+          i,
+          AnimatedOpacity(
+            opacity: isVisible ? 1.0 : 0.0,
+            duration: d.duration ?? const Duration(milliseconds: 200),
+            curve: d.curve ?? Curves.easeInOut,
+            child: Container(
+              width: d.thickness,
+              margin: EdgeInsets.only(top: d.indent, bottom: d.endIndent),
+              decoration: d.decoration ??
+                  BoxDecoration(
+                    color: CupertinoColors.separator.resolveFrom(context),
+                  ),
+            ),
+          ),
+        );
+      }
+    }
+
+    if (widget.isScrollable) {
+      return Row(children: tabWidgets);
+    }
+
+    return Row(
+      children: tabWidgets
+          .map((tab) => tab is KeyedSubtree ? Expanded(child: tab) : tab)
+          .toList(),
+    );
+  }
+}
+
+// =============================================================================
+// TabBarItem — single tab label/icon widget
+// =============================================================================
+
+/// Renders a single tab label and/or icon for [GlassTabBar].
+///
+/// Handles tap gestures, semantics, and animated text style transitions.
+class TabBarItem extends StatelessWidget {
+  const TabBarItem({
+    required this.tab,
+    required this.isSelected,
+    required this.onTap,
+    required this.onTapDown,
+    required this.labelStyle,
+    required this.iconColor,
+    required this.iconSize,
+    required this.padding,
+    super.key,
+  });
+
+  final GlassSegment tab;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final VoidCallback onTapDown;
+  final TextStyle labelStyle;
+  final Color iconColor;
+  final double iconSize;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget? iconWidget;
+    if (tab.icon != null) {
+      iconWidget = IconTheme(
+        data: IconThemeData(color: iconColor, size: iconSize),
+        child: tab.icon!,
+      );
+    }
+
+    Widget? labelWidget;
+    if (tab.label != null) {
+      labelWidget = Text(
+        tab.label!,
+        style: labelStyle,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      );
+    }
+
+    Widget content;
+    if (iconWidget != null && labelWidget != null) {
+      content = Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          iconWidget,
+          const SizedBox(height: 4),
+          labelWidget,
+        ],
+      );
+    } else if (iconWidget != null) {
+      content = iconWidget;
+    } else if (labelWidget != null) {
+      content = labelWidget;
+    } else {
+      content = const SizedBox.shrink();
+    }
+
+    return GestureDetector(
+      onTap: onTap,
+      onTapDown: (_) => onTapDown(),
+      behavior: HitTestBehavior.opaque,
+      child: Semantics(
+        button: true,
+        selected: isSelected,
+        label: tab.semanticLabel ?? tab.label,
+        child: Container(
+          padding: padding,
+          alignment: Alignment.center,
+          child: AnimatedDefaultTextStyle(
+            duration: const Duration(milliseconds: 200),
+            style: labelStyle,
+            child: content,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/interactive/shared/segmented_control_internal.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/interactive/shared/segmented_control_internal.dart
@@ -1,0 +1,436 @@
+// Internal state widget for [GlassSegmentedControl].
+//
+// Mirrors the [tab_bar_internal.dart] pattern:
+//   — keeps [GlassSegmentedControl] as a pure public-API widget file
+//   — houses all gesture, animation, and layout state here
+//
+// NOT part of the public API — do not export from liquid_glass_widgets.dart.
+//
+// Architecture note: This widget deliberately does NOT use [TabDragGestureMixin]
+// because its gesture architecture differs in two key ways:
+//   1. Tap handling uses per-segment GestureDetectors (correct for equal-width
+//      segments) rather than a single global-position→index mapping.
+//   2. Drag-end snapping uses DraggableIndicatorPhysics.computeTargetIndex
+//      (floor-based bin selection, consistent with tab_bar_internal.dart),
+//      whereas the mixin uses a round-based formula tuned for GlassBottomBar.
+// Both the tab bar and segmented control already share the right abstractions:
+// DraggableIndicatorPhysics, AnimatedGlassIndicator, and GlassSpring.
+
+import 'package:flutter/cupertino.dart';
+
+import '../../../src/renderer/liquid_glass_renderer.dart';
+import '../../../src/types/glass_interaction_behavior.dart';
+import '../../../theme/glass_theme.dart';
+import '../../../types/glass_quality.dart';
+import '../../../utils/draggable_indicator_physics.dart';
+import '../../../utils/glass_spring.dart';
+import '../../shared/animated_glass_indicator.dart';
+import '../../surfaces/glass_tab_bar.dart' show GlassSegment;
+
+// =============================================================================
+// Widget
+// =============================================================================
+
+/// Internal content widget for [GlassSegmentedControl].
+///
+/// Manages all gesture handling, spring animations, and indicator rendering.
+/// Separated to keep [GlassSegmentedControl] a clean public-API-only file.
+class SegmentedControlContent extends StatefulWidget {
+  const SegmentedControlContent({
+    required this.segments,
+    required this.selectedIndex,
+    required this.onSegmentSelected,
+    required this.selectedTextStyle,
+    required this.unselectedTextStyle,
+    required this.indicatorColor,
+    required this.borderRadius,
+    required this.quality,
+    this.indicatorSettings,
+    this.indicatorPinchStrength = 0.4,
+    this.indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    this.backgroundKey,
+    this.interactionBehavior = GlassInteractionBehavior.full,
+    this.glowColor,
+    this.glowRadius = 1.5,
+    super.key,
+  });
+
+  /// List of segments to display. Each [GlassSegment] may have a label, an icon,
+  /// or both. Minimum 2 segments required.
+  final List<GlassSegment> segments;
+  final int selectedIndex;
+  final ValueChanged<int> onSegmentSelected;
+  final TextStyle? selectedTextStyle;
+  final TextStyle? unselectedTextStyle;
+  final Color? indicatorColor;
+  final LiquidGlassSettings? indicatorSettings;
+
+  /// Maximum concave lens pinch strength. Forwarded to [AnimatedGlassIndicator].
+  final double indicatorPinchStrength;
+
+  /// Expansion padding applied to the pill during drag — mirrors [GlassBottomBar].
+  final EdgeInsetsGeometry indicatorExpansion;
+  final double borderRadius;
+  final GlassQuality quality;
+  final GlobalKey? backgroundKey;
+  final GlassInteractionBehavior interactionBehavior;
+  final Color? glowColor;
+  final double glowRadius;
+
+  @override
+  State<SegmentedControlContent> createState() =>
+      SegmentedControlContentState();
+}
+
+// =============================================================================
+// State
+// =============================================================================
+
+class SegmentedControlContentState extends State<SegmentedControlContent> {
+  // Colours are resolved dynamically in build() based on CupertinoTheme
+
+  // ── Gesture state ─────────────────────────────────────────────────────────
+  bool _isDown = false;
+  bool _isDragging = false;
+
+  /// Current horizontal alignment of the indicator in the range [-1, 1].
+  late double _xAlign = _computeXAlignmentForSegment(widget.selectedIndex);
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  @override
+  void didUpdateWidget(covariant SegmentedControlContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.selectedIndex != widget.selectedIndex ||
+        oldWidget.segments.length != widget.segments.length) {
+      setState(() {
+        _xAlign = _computeXAlignmentForSegment(widget.selectedIndex);
+      });
+    }
+  }
+
+  // ── Coordinate helpers ────────────────────────────────────────────────────
+
+  /// Converts a segment index to horizontal alignment (-1 to 1).
+  double _computeXAlignmentForSegment(int segmentIndex) {
+    return DraggableIndicatorPhysics.computeAlignment(
+      segmentIndex,
+      widget.segments.length,
+    );
+  }
+
+  /// Converts a global drag position to horizontal alignment (-1 to 1).
+  double _getAlignmentFromGlobalPosition(Offset globalPosition) {
+    return DraggableIndicatorPhysics.getAlignmentFromGlobalPosition(
+      globalPosition,
+      context,
+      widget.segments.length,
+    );
+  }
+
+  // ── Gesture handlers ──────────────────────────────────────────────────────
+
+  void _onDragDown(DragDownDetails details) {
+    setState(() => _isDown = true);
+  }
+
+  void _onDragUpdate(DragUpdateDetails details) {
+    setState(() {
+      _isDragging = true;
+      _xAlign = _getAlignmentFromGlobalPosition(details.globalPosition);
+    });
+  }
+
+  void _onDragEnd(DragEndDetails details) {
+    setState(() {
+      _isDragging = false;
+      _isDown = false;
+    });
+
+    final box = context.findRenderObject()! as RenderBox;
+    final currentRelativeX = (_xAlign + 1) / 2;
+    final segmentWidth = 1.0 / widget.segments.length;
+    final indicatorWidth = 1.0 / widget.segments.length;
+    final draggableRange = 1.0 - indicatorWidth;
+    final velocityX =
+        (details.velocity.pixelsPerSecond.dx / box.size.width) / draggableRange;
+
+    final targetSegmentIndex = DraggableIndicatorPhysics.computeTargetIndex(
+      currentRelativeX: currentRelativeX,
+      velocityX: velocityX,
+      itemWidth: segmentWidth,
+      itemCount: widget.segments.length,
+    );
+
+    _xAlign = _computeXAlignmentForSegment(targetSegmentIndex);
+
+    if (targetSegmentIndex != widget.selectedIndex) {
+      widget.onSegmentSelected(targetSegmentIndex);
+    }
+  }
+
+  void _onDragCancel() {
+    if (_isDragging) {
+      final currentRelativeX = (_xAlign + 1) / 2;
+      final targetSegmentIndex = DraggableIndicatorPhysics.computeTargetIndex(
+        currentRelativeX: currentRelativeX,
+        velocityX: 0,
+        itemWidth: 1.0 / widget.segments.length,
+        itemCount: widget.segments.length,
+      );
+      setState(() {
+        _isDragging = false;
+        _isDown = false;
+        _xAlign = _computeXAlignmentForSegment(targetSegmentIndex);
+      });
+      if (targetSegmentIndex != widget.selectedIndex) {
+        widget.onSegmentSelected(targetSegmentIndex);
+      }
+    } else {
+      setState(
+        () => _xAlign = _computeXAlignmentForSegment(widget.selectedIndex),
+      );
+    }
+  }
+
+  void _onSegmentTap(int index) {
+    if (!widget.segments[index].enabled) return;
+    if (index != widget.selectedIndex) {
+      widget.onSegmentSelected(index);
+    }
+  }
+
+  // ── Build ─────────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    final indicatorColor = widget.indicatorColor ??
+        (GlassTheme.brightnessOf(context) == Brightness.light
+            ? CupertinoColors.black.withValues(alpha: 0.08)
+            : CupertinoColors.white.withValues(alpha: 0.2));
+    final targetAlignment = _computeXAlignmentForSegment(widget.selectedIndex);
+
+    // Indicator is slightly less rounded than the container to account for
+    // the inset padding.
+    final indicatorRadius = widget.borderRadius - 3;
+
+    final dynamicLabelColor =
+        CupertinoTheme.of(context).textTheme.textStyle.color ??
+            CupertinoColors.label;
+
+    final selectedTextStyle = TextStyle(
+      fontSize: 13,
+      fontWeight: FontWeight.w600,
+      color: dynamicLabelColor,
+    ).merge(widget.selectedTextStyle);
+
+    final unselectedTextStyle = TextStyle(
+      fontSize: 13,
+      fontWeight: FontWeight.w500,
+      color: dynamicLabelColor.withValues(alpha: 0.6),
+    ).merge(widget.unselectedTextStyle);
+
+    return Listener(
+      // Raw pointer events fire BEFORE gesture recognizers and never compete
+      // in the gesture arena, so _isDown is always set on the very first event.
+      onPointerDown: (_) => setState(() => _isDown = true),
+      // On finger/button lift, clear _isDown if not mid-drag.
+      onPointerUp: (_) {
+        if (!_isDragging) setState(() => _isDown = false);
+      },
+      onPointerCancel: (_) {
+        if (!_isDragging) setState(() => _isDown = false);
+      },
+      child: GestureDetector(
+        onHorizontalDragDown: _onDragDown,
+        onHorizontalDragUpdate: _onDragUpdate,
+        onHorizontalDragEnd: _onDragEnd,
+        onHorizontalDragCancel: _onDragCancel,
+        child: VelocitySpringBuilder(
+          value: _xAlign,
+          springWhenActive: GlassSpring.interactive(),
+          springWhenReleased: GlassSpring.snappy(
+            duration: const Duration(milliseconds: 350),
+          ),
+          active: _isDragging,
+          builder: (context, value, velocity, child) {
+            final alignment = Alignment(value, 0);
+
+            return SpringBuilder(
+              spring: GlassSpring.snappy(
+                duration: const Duration(milliseconds: 300),
+              ),
+              // Show glass bloom when: pressed, dragging, OR indicator is still
+              // settling toward its target. Threshold 0.05 matches
+              // tab_bar_internal.dart for consistent cross-component behaviour.
+              value: _isDown || (alignment.x - targetAlignment).abs() > 0.05
+                  ? 1.0
+                  : 0.0,
+              builder: (context, thickness, child) {
+                final isPremiumQuality = widget.quality == GlassQuality.premium;
+                return Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    // Pass 1 — solid background pill, always below labels.
+                    // For non-premium quality the glass effect is also included
+                    // here (single-pass, cheaper path).
+                    AnimatedGlassIndicator(
+                      velocity: velocity,
+                      itemCount: widget.segments.length,
+                      alignment: alignment,
+                      thickness: thickness,
+                      quality: widget.quality,
+                      indicatorColor: indicatorColor,
+                      isBackgroundIndicator: false,
+                      paintBackground: true,
+                      paintGlass: !isPremiumQuality,
+                      borderRadius: indicatorRadius,
+                      settings: widget.indicatorSettings,
+                      pinchStrength: widget.indicatorPinchStrength,
+                      expansion: widget.indicatorExpansion,
+                      backgroundKey: widget.backgroundKey,
+                    ),
+                    // Segment labels paint between the two indicator passes so
+                    // the premium glass layer above can refract them.
+                    child!,
+                    // Pass 2 (premium only) — glass-only pass rendered ABOVE
+                    // the labels so the shader samples and refracts them,
+                    // matching the iOS 26 refraction seen in GlassTabBar /
+                    // GlassBottomBar.
+                    if (isPremiumQuality)
+                      AnimatedGlassIndicator(
+                        velocity: velocity,
+                        itemCount: widget.segments.length,
+                        alignment: alignment,
+                        thickness: thickness,
+                        quality: widget.quality,
+                        indicatorColor: indicatorColor,
+                        isBackgroundIndicator: false,
+                        paintBackground: false,
+                        paintGlass: true,
+                        borderRadius: indicatorRadius,
+                        settings: widget.indicatorSettings,
+                        pinchStrength: widget.indicatorPinchStrength,
+                        expansion: widget.indicatorExpansion,
+                        backgroundKey: widget.backgroundKey,
+                      ),
+                  ],
+                );
+              },
+              child: Row(
+                children: [
+                  for (var i = 0; i < widget.segments.length; i++)
+                    Expanded(
+                      child: RepaintBoundary(
+                        child: GestureDetector(
+                          onTap: () => _onSegmentTap(i),
+                          onTapDown: (_) {
+                            if (!widget.segments[i].enabled) return;
+                            if (i != widget.selectedIndex) {
+                              widget.onSegmentSelected(i);
+                            }
+                          },
+                          behavior: HitTestBehavior.opaque,
+                          child: Semantics(
+                            button: true,
+                            selected: widget.selectedIndex == i,
+                            label: widget.segments[i].semanticLabel ??
+                                widget.segments[i].label ??
+                                '',
+                            child: Center(
+                              child: IgnorePointer(
+                                ignoring: !widget.segments[i].enabled,
+                                child: Opacity(
+                                  opacity:
+                                      widget.segments[i].enabled ? 1.0 : 0.38,
+                                  child: _buildSegmentContent(
+                                    widget.segments[i],
+                                    isSelected: widget.selectedIndex == i,
+                                    selectedStyle: selectedTextStyle,
+                                    unselectedStyle: unselectedTextStyle,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            );
+          },
+          child: Row(
+            children: [
+              for (var i = 0; i < widget.segments.length; i++)
+                Expanded(
+                  child: Center(
+                    child: widget.segments[i].label != null
+                        ? Text(widget.segments[i].label!)
+                        : (widget.segments[i].icon ?? const SizedBox.shrink()),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ── Segment content builder ───────────────────────────────────────────────
+
+  /// Builds the content for a single segment — label only, icon only, or both.
+  Widget _buildSegmentContent(
+    GlassSegment tab, {
+    required bool isSelected,
+    required TextStyle selectedStyle,
+    required TextStyle unselectedStyle,
+  }) {
+    final style = isSelected ? selectedStyle : unselectedStyle;
+    final hasLabel = tab.label != null && tab.label!.isNotEmpty;
+    final hasIcon = tab.icon != null;
+
+    if (hasIcon && hasLabel) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconTheme(
+            data: IconThemeData(
+              color: style.color,
+              size: 16,
+            ),
+            child: tab.icon!,
+          ),
+          const SizedBox(height: 2),
+          AnimatedDefaultTextStyle(
+            duration: const Duration(milliseconds: 200),
+            style: style,
+            child: Text(
+              tab.label!,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      );
+    }
+
+    if (hasIcon) {
+      return IconTheme(
+        data: IconThemeData(color: style.color, size: 20),
+        child: tab.icon!,
+      );
+    }
+
+    return AnimatedDefaultTextStyle(
+      duration: const Duration(milliseconds: 200),
+      style: style,
+      child: Text(
+        tab.label ?? '',
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/glass_action_sheet.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/glass_action_sheet.dart
@@ -1,0 +1,413 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../theme/glass_theme_data.dart';
+import '../../theme/glass_theme.dart';
+import '../../types/glass_quality.dart';
+import '../shared/adaptive_liquid_glass_layer.dart';
+
+/// Style of action sheet action.
+enum GlassActionSheetStyle {
+  /// Default action style (white text)
+  defaultStyle,
+
+  /// Destructive action style (red text, indicates deletion/removal)
+  destructive,
+
+  /// Cancel action style (bold text, typically for dismissal)
+  cancel,
+}
+
+/// An action that can be taken from a [GlassActionSheet].
+class GlassActionSheetAction {
+  /// Creates an action sheet action.
+  const GlassActionSheetAction({
+    required this.label,
+    required this.onPressed,
+    this.icon,
+    this.style = GlassActionSheetStyle.defaultStyle,
+  });
+
+  /// The label text for the action
+  final String label;
+
+  /// Callback when the action is pressed
+  final VoidCallback onPressed;
+
+  /// Optional icon widget to display before the label
+  final Widget? icon;
+
+  /// Visual style of the action
+  final GlassActionSheetStyle style;
+}
+
+/// A glass morphism action sheet following iOS 26 liquid glass design.
+///
+/// [GlassActionSheet] provides an iOS-style bottom action sheet with:
+/// - iOS 26 liquid glass backdrop effect
+/// - Bottom-anchored action list
+/// - Destructive action styling (red text/icon)
+/// - Cancel button always at bottom with separator
+/// - Tap outside to dismiss
+/// - Slide-up animation
+/// - Optional title and message
+///
+/// ## Usage
+///
+/// ### Basic Action Sheet
+/// ```dart
+/// showGlassActionSheet(
+///   context: context,
+///   title: 'Delete Photo?',
+///   message: 'This action cannot be undone',
+///   actions: [
+///     GlassActionSheetAction(
+///       label: 'Delete',
+///       style: GlassActionSheetStyle.destructive,
+///       onPressed: () {
+///         // Delete logic
+///         Navigator.pop(context);
+///       },
+///     ),
+///   ],
+/// );
+/// ```
+///
+/// ### Multiple Actions
+/// ```dart
+/// showGlassActionSheet(
+///   context: context,
+///   title: 'Choose Action',
+///   actions: [
+///     GlassActionSheetAction(
+///       label: 'Save to Photos',
+///       icon: Icon(CupertinoIcons.photo),
+///       onPressed: () => save(),
+///     ),
+///     GlassActionSheetAction(
+///       label: 'Share',
+///       icon: Icon(CupertinoIcons.share),
+///       onPressed: () => share(),
+///     ),
+///     GlassActionSheetAction(
+///       label: 'Delete',
+///       icon: Icon(CupertinoIcons.delete),
+///       style: GlassActionSheetStyle.destructive,
+///       onPressed: () => delete(),
+///     ),
+///   ],
+/// );
+/// ```
+///
+/// ### Custom Cancel Label
+/// ```dart
+/// showGlassActionSheet(
+///   context: context,
+///   title: 'Select Option',
+///   actions: [...],
+///   cancelLabel: 'Dismiss', // Custom cancel button text
+/// );
+/// ```
+///
+/// ### No Cancel Button
+/// ```dart
+/// showGlassActionSheet(
+///   context: context,
+///   title: 'Select Option',
+///   actions: [...],
+///   showCancelButton: false,
+/// );
+/// ```
+///
+/// ## iOS 26 Design Principles
+///
+/// - **Bottom-anchored**: Always slides up from bottom
+/// - **Grouped layout**: Actions in one card, cancel button separated
+/// - **Destructive styling**: Red text for dangerous actions
+/// - **Glass backdrop**: Liquid glass effect on action cards
+/// - **Modal dismissal**: Tap outside or cancel to dismiss
+/// - **Safe area aware**: Respects bottom safe area
+///
+/// ## Differences from GlassSheet
+///
+/// - **GlassActionSheet**: Predefined action list (like iOS UIAlertController)
+/// - **GlassSheet**: Custom content (like iOS UISheetPresentationController)
+///
+/// Use [GlassActionSheet] when you need a simple action picker.
+/// Use [GlassSheet] when you need custom content or forms.
+Future<T?> showGlassActionSheet<T>({
+  required BuildContext context,
+  String? title,
+  String? message,
+  required List<GlassActionSheetAction> actions,
+  String cancelLabel = 'Cancel',
+  bool showCancelButton = true,
+  bool barrierDismissible = true,
+  LiquidGlassSettings? settings,
+  GlassQuality? quality,
+}) {
+  return showCupertinoModalPopup<T>(
+    context: context,
+    barrierDismissible: barrierDismissible,
+    barrierColor: Colors.black54,
+    builder: (context) => _GlassActionSheetContent(
+      title: title,
+      message: message,
+      actions: actions,
+      cancelLabel: cancelLabel,
+      showCancelButton: showCancelButton,
+      settings: settings,
+      quality: quality,
+    ),
+  );
+}
+
+/// Internal widget for action sheet content.
+class _GlassActionSheetContent extends StatelessWidget {
+  const _GlassActionSheetContent({
+    required this.actions,
+    required this.cancelLabel,
+    required this.showCancelButton,
+    this.title,
+    this.message,
+    this.settings,
+    this.quality,
+  });
+
+  final String? title;
+  final String? message;
+  final List<GlassActionSheetAction> actions;
+  final String cancelLabel;
+  final bool showCancelButton;
+  final LiquidGlassSettings? settings;
+  final GlassQuality? quality;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Main actions card
+              _buildActionsCard(context),
+
+              // Spacing between actions and cancel
+              if (showCancelButton) const SizedBox(height: 8),
+
+              // Cancel button (separated)
+              if (showCancelButton) _buildCancelButton(context),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildActionsCard(BuildContext context) {
+    final themeData = GlassThemeData.of(context);
+    final glowColors = themeData.glowColorsFor(context);
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    final cardColor = isDark
+        ? CupertinoColors.black.withValues(alpha: 0.65)
+        : CupertinoColors.white.withValues(alpha: 0.65);
+    final dividerColor = isDark
+        ? CupertinoColors.white.withValues(alpha: 0.2)
+        : CupertinoColors.black.withValues(alpha: 0.1);
+
+    return AdaptiveLiquidGlassLayer(
+      settings: settings ??
+          const LiquidGlassSettings(
+            thickness: 30.0,
+            blur: 5.0,
+            refractiveIndex: 1.15,
+            saturation: 1.2,
+          ),
+      quality: quality,
+      child: Container(
+        decoration: BoxDecoration(
+          color: cardColor,
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(14),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Title and message
+              if (title != null || message != null) _buildHeader(context),
+
+              // Actions list
+              for (int i = 0; i < actions.length; i++) ...[
+                if (i > 0 || (title != null || message != null))
+                  Divider(
+                    height: 1,
+                    thickness: 0.5,
+                    color: dividerColor,
+                  ),
+                _ActionSheetButton(
+                  action: actions[i],
+                  glowColors: glowColors,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+      child: Column(
+        children: [
+          if (title != null)
+            Text(
+              title!,
+              style: TextStyle(
+                color: CupertinoColors.label.resolveFrom(context),
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          if (title != null && message != null) const SizedBox(height: 4),
+          if (message != null)
+            Text(
+              message!,
+              style: TextStyle(
+                color: CupertinoColors.secondaryLabel.resolveFrom(context),
+                fontSize: 13,
+                fontWeight: FontWeight.w400,
+              ),
+              textAlign: TextAlign.center,
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCancelButton(BuildContext context) {
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    final cardColor = isDark
+        ? CupertinoColors.black.withValues(alpha: 0.65)
+        : CupertinoColors.white.withValues(alpha: 0.65);
+
+    return AdaptiveLiquidGlassLayer(
+      settings: settings ??
+          const LiquidGlassSettings(
+            thickness: 30.0,
+            blur: 5.0,
+            refractiveIndex: 1.15,
+            saturation: 1.2,
+          ),
+      quality: quality,
+      child: Container(
+        decoration: BoxDecoration(
+          color: cardColor,
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(14),
+          child: _ActionSheetButton(
+            action: GlassActionSheetAction(
+              label: cancelLabel,
+              style: GlassActionSheetStyle.cancel,
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            glowColors: null,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A single action button within the action sheet — manages its own pressed
+/// state to provide iOS-style opacity highlight on tap-down.
+class _ActionSheetButton extends StatefulWidget {
+  const _ActionSheetButton({
+    required this.action,
+    required this.glowColors,
+  });
+
+  final GlassActionSheetAction action;
+  final GlassGlowColors? glowColors;
+
+  @override
+  State<_ActionSheetButton> createState() => _ActionSheetButtonState();
+}
+
+class _ActionSheetButtonState extends State<_ActionSheetButton> {
+  bool _isPressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final action = widget.action;
+    final Color textColor = _getTextColor(action.style);
+    final FontWeight fontWeight = action.style == GlassActionSheetStyle.cancel
+        ? FontWeight.w600
+        : FontWeight.w400;
+
+    return GestureDetector(
+      onTap: () {
+        action.onPressed();
+        if (action.style != GlassActionSheetStyle.cancel) {
+          Navigator.of(context).pop();
+        }
+      },
+      onTapDown: (_) => setState(() => _isPressed = true),
+      onTapUp: (_) => setState(() => _isPressed = false),
+      onTapCancel: () => setState(() => _isPressed = false),
+      behavior: HitTestBehavior.opaque,
+      child: AnimatedContainer(
+        duration:
+            _isPressed ? Duration.zero : const Duration(milliseconds: 150),
+        curve: Curves.easeOutCubic,
+        color: _isPressed
+            ? CupertinoColors.label.resolveFrom(context).withValues(alpha: 0.06)
+            : const Color(0x00000000),
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 16,
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (action.icon != null) ...[
+              IconTheme(
+                data: IconThemeData(color: textColor, size: 20),
+                child: action.icon!,
+              ),
+              const SizedBox(width: 12),
+            ],
+            Text(
+              action.label,
+              style: TextStyle(
+                color: textColor,
+                fontSize: 17,
+                fontWeight: fontWeight,
+                letterSpacing: -0.3,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _getTextColor(GlassActionSheetStyle style) {
+    switch (style) {
+      case GlassActionSheetStyle.defaultStyle:
+      case GlassActionSheetStyle.cancel:
+        return CupertinoColors.label.resolveFrom(context);
+      case GlassActionSheetStyle.destructive:
+        return widget.glowColors?.danger ?? CupertinoColors.destructiveRed;
+    }
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/glass_dialog.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/glass_dialog.dart
@@ -1,0 +1,451 @@
+import 'package:flutter/cupertino.dart';
+
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../types/glass_quality.dart';
+import '../containers/glass_card.dart';
+import '../interactive/glass_button.dart';
+import '../shared/adaptive_liquid_glass_layer.dart';
+import '../../theme/glass_theme_helpers.dart';
+
+/// A glass morphism alert dialog following Apple's iOS design patterns.
+///
+/// [GlassDialog] provides a modal dialog with liquid glass effect,
+/// composing [GlassCard] and [GlassButton] as building blocks.
+///
+/// ## Key Features
+///
+/// - Liquid glass backdrop with blur effect
+/// - Composable design using GlassCard + GlassButton
+/// - iOS-style alert layout
+/// - 1-3 action buttons with smart layout
+/// - Customizable glass settings
+/// - Optional custom content
+///
+/// ## Usage
+///
+/// ### Basic Alert
+/// ```dart
+/// GlassDialog.show(
+///   context: context,
+///   title: 'Delete Item?',
+///   message: 'This action cannot be undone.',
+///   actions: [
+///     GlassDialogAction(
+///       label: 'Cancel',
+///       onPressed: () => Navigator.pop(context),
+///     ),
+///     GlassDialogAction(
+///       label: 'Delete',
+///       isDestructive: true,
+///       onPressed: () {
+///         // Delete logic
+///         Navigator.pop(context);
+///       },
+///     ),
+///   ],
+/// );
+/// ```
+///
+/// ### Single Action
+/// ```dart
+/// GlassDialog.show(
+///   context: context,
+///   title: 'Success',
+///   message: 'Your changes have been saved.',
+///   actions: [
+///     GlassDialogAction(
+///       label: 'OK',
+///       onPressed: () => Navigator.pop(context),
+///     ),
+///   ],
+/// );
+/// ```
+///
+/// ### Three Actions
+/// ```dart
+/// GlassDialog.show(
+///   context: context,
+///   title: 'Save Changes?',
+///   message: 'You have unsaved changes.',
+///   actions: [
+///     GlassDialogAction(
+///       label: 'Don\'t Save',
+///       onPressed: () => Navigator.pop(context, false),
+///     ),
+///     GlassDialogAction(
+///       label: 'Cancel',
+///       onPressed: () => Navigator.pop(context),
+///     ),
+///     GlassDialogAction(
+///       label: 'Save',
+///       isPrimary: true,
+///       onPressed: () => Navigator.pop(context, true),
+///     ),
+///   ],
+/// );
+/// ```
+///
+/// ### Custom Content
+/// ```dart
+/// GlassDialog.show(
+///   context: context,
+///   title: 'Enter Name',
+///   content: Padding(
+///     padding: EdgeInsets.symmetric(vertical: 16),
+///     child: TextField(
+///       decoration: InputDecoration(
+///         hintText: 'Name',
+///       ),
+///     ),
+///   ),
+///   actions: [
+///     GlassDialogAction(
+///       label: 'Cancel',
+///       onPressed: () => Navigator.pop(context),
+///     ),
+///     GlassDialogAction(
+///       label: 'OK',
+///       isPrimary: true,
+///       onPressed: () => Navigator.pop(context),
+///     ),
+///   ],
+/// );
+/// ```
+///
+/// ### Custom Glass Settings
+/// ```dart
+/// GlassDialog.show(
+///   context: context,
+///   title: 'Custom Dialog',
+///   message: 'With custom glass effect',
+///   settings: LiquidGlassSettings(
+///     thickness: 40,
+///     blur: 15,
+///     glassColor: Colors.purple,
+///   ),
+///   actions: [
+///     GlassDialogAction(
+///       label: 'OK',
+///       onPressed: () => Navigator.pop(context),
+///     ),
+///   ],
+/// );
+/// ```
+class GlassDialog extends StatelessWidget {
+  /// Creates a glass dialog widget.
+  ///
+  /// Typically not instantiated directly - use [GlassDialog.show] instead.
+  const GlassDialog({
+    required this.actions,
+    super.key,
+    this.title,
+    this.message,
+    this.content,
+    this.settings,
+    this.quality,
+    this.maxWidth = 280,
+  }) : assert(
+          actions.length > 0 && actions.length <= 3,
+          'GlassDialog must have 1-3 actions',
+        );
+
+  static const _actionButtonShape = LiquidRoundedSuperellipse(borderRadius: 12);
+
+  // Cache default colors to avoid allocations
+  static const _defaultGlowColor =
+      Color(0x4DFFFFFF); // white.withValues(alpha: 0.3)
+  static const _destructiveGlowColor =
+      Color(0x4DFF0000); // red.withValues(alpha: 0.3)
+  static const _primaryGlowColor =
+      Color(0x4D0000FF); // blue.withValues(alpha: 0.3)
+
+  // ===========================================================================
+  // Content Properties
+  // ===========================================================================
+
+  /// Title of the dialog.
+  ///
+  /// Displayed in bold at the top of the dialog. If null, no title is shown.
+  final String? title;
+
+  /// Message text of the dialog.
+  ///
+  /// Displayed below the title in a lighter color. If null, no message is
+  /// shown.
+  final String? message;
+
+  /// Custom content widget.
+  ///
+  /// Displayed between the message and actions. Use this for custom content
+  /// like text fields, pickers, or other interactive widgets.
+  ///
+  /// If both [message] and [content] are provided, content is shown below
+  /// the message.
+  final Widget? content;
+
+  /// Maximum width of the dialog in logical pixels.
+  ///
+  /// Defaults to 280 (iOS standard alert width).
+  final double maxWidth;
+
+  // ===========================================================================
+  // Action Properties
+  // ===========================================================================
+
+  /// Action buttons to display at the bottom of the dialog.
+  ///
+  /// Must have 1-3 actions. Layout automatically adjusts:
+  /// - 1-2 actions: Horizontal layout
+  /// - 3 actions: Vertical layout (iOS pattern)
+  final List<GlassDialogAction> actions;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Glass effect settings for the dialog.
+  ///
+  /// Controls the visual appearance of the glass effect including thickness,
+  /// blur radius, color tint, lighting, and more.
+  ///
+  /// If null, uses [LiquidGlassSettings] defaults.
+  final LiquidGlassSettings? settings;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// Defaults to [GlassQuality.standard], which uses backdrop filter rendering.
+  final GlassQuality? quality;
+
+  // ===========================================================================
+  // Static Show Method
+  // ===========================================================================
+
+  /// Shows a glass dialog.
+  ///
+  /// Returns a [Future] that resolves to the value (if any) passed to
+  /// [Navigator.pop] when the dialog is dismissed.
+  ///
+  /// Parameters:
+  /// - [context]: Build context for showing the dialog
+  /// - [title]: Title text (optional)
+  /// - [message]: Message text (optional)
+  /// - [content]: Custom content widget (optional)
+  /// - [actions]: Action buttons (required, 1-3 actions)
+  /// - [settings]: Glass effect settings (null uses defaults)
+  /// - [quality]: Rendering quality (defaults to standard)
+  /// - [barrierDismissible]: Whether tapping outside dismisses (default: false)
+  /// - [barrierColor]: Color of the modal barrier (defaults to black54)
+  /// - [maxWidth]: Maximum width of dialog (default: 280)
+  ///
+  /// Example:
+  /// ```dart
+  /// final result = await GlassDialog.show<bool>(
+  ///   context: context,
+  ///   title: 'Confirm',
+  ///   message: 'Are you sure?',
+  ///   actions: [
+  ///     GlassDialogAction(
+  ///       label: 'Cancel',
+  ///       onPressed: () => Navigator.pop(context, false),
+  ///     ),
+  ///     GlassDialogAction(
+  ///       label: 'Confirm',
+  ///       onPressed: () => Navigator.pop(context, true),
+  ///     ),
+  ///   ],
+  /// );
+  /// ```
+  static Future<T?> show<T>({
+    required BuildContext context,
+    required List<GlassDialogAction> actions,
+    String? title,
+    String? message,
+    Widget? content,
+    LiquidGlassSettings? settings,
+    GlassQuality quality = GlassQuality.standard,
+    bool barrierDismissible = false,
+    Color? barrierColor,
+    double maxWidth = 280,
+  }) {
+    return showCupertinoDialog<T>(
+      context: context,
+      barrierDismissible: barrierDismissible,
+      builder: (context) => GlassDialog(
+        title: title,
+        message: message,
+        content: content,
+        actions: actions,
+        settings: settings,
+        quality: quality,
+        maxWidth: maxWidth,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Inherit quality from parent layer if not explicitly set
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: quality,
+    );
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: maxWidth),
+        child: GlassCard(
+          useOwnLayer: true,
+          settings: settings,
+          quality: effectiveQuality,
+          padding: const EdgeInsets.all(20),
+          child: AdaptiveLiquidGlassLayer(
+            settings: settings ?? const LiquidGlassSettings(),
+            quality: effectiveQuality,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // Title
+                if (title != null) ...[
+                  Text(
+                    title!,
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: CupertinoColors.label.resolveFrom(context),
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 8),
+                ],
+
+                // Message
+                if (message != null) ...[
+                  Text(
+                    message!,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color:
+                          CupertinoColors.secondaryLabel.resolveFrom(context),
+                      height: 1.4,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 8),
+                ],
+
+                // Custom content
+                if (content != null) ...[
+                  content!,
+                  const SizedBox(height: 8),
+                ],
+
+                const SizedBox(height: 12),
+
+                // Actions
+                _buildActions(context),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildActions(BuildContext context) {
+    // 1-2 actions: Horizontal layout
+    if (actions.length <= 2) {
+      return Row(
+        children: actions.asMap().entries.map((entry) {
+          final index = entry.key;
+          final action = entry.value;
+          return Expanded(
+            child: Padding(
+              padding: EdgeInsets.only(
+                left: index > 0 ? 8 : 0,
+              ),
+              child: _buildActionButton(action, context),
+            ),
+          );
+        }).toList(),
+      );
+    }
+
+    // 3 actions: Vertical layout (iOS pattern)
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: actions.asMap().entries.map((entry) {
+        final index = entry.key;
+        final action = entry.value;
+        return Padding(
+          padding: EdgeInsets.only(
+            top: index > 0 ? 8 : 0,
+          ),
+          child: _buildActionButton(action, context),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildActionButton(GlassDialogAction action, BuildContext context) {
+    // Determine button styling based on action type
+    var glowColor = _defaultGlowColor;
+    if (action.isDestructive) {
+      glowColor = _destructiveGlowColor;
+    } else if (action.isPrimary) {
+      glowColor = _primaryGlowColor;
+    }
+
+    return GlassButton.custom(
+      onTap: action.onPressed,
+      height: 44,
+      shape: _actionButtonShape,
+      glowColor: glowColor,
+      child: Text(
+        action.label,
+        style: TextStyle(
+          fontSize: 16,
+          fontWeight: action.isPrimary ? FontWeight.bold : FontWeight.w600,
+          color: action.isDestructive
+              ? CupertinoColors.destructiveRed
+              : CupertinoColors.label.resolveFrom(context),
+        ),
+      ),
+    );
+  }
+}
+
+/// Configuration for a dialog action button.
+///
+/// Used with [GlassDialog] to define action buttons.
+class GlassDialogAction {
+  /// Creates a dialog action configuration.
+  const GlassDialogAction({
+    required this.label,
+    required this.onPressed,
+    this.isPrimary = false,
+    this.isDestructive = false,
+  });
+
+  /// Label text for the button.
+  final String label;
+
+  /// Callback when the button is pressed.
+  final VoidCallback onPressed;
+
+  /// Whether this is the primary (recommended) action.
+  ///
+  /// Primary actions are displayed with bold text and blue glow.
+  /// Typically used for the positive/affirmative action.
+  ///
+  /// Defaults to false.
+  final bool isPrimary;
+
+  /// Whether this is a destructive action.
+  ///
+  /// Destructive actions are displayed with red text and red glow.
+  /// Typically used for delete, remove, or other dangerous actions.
+  ///
+  /// Defaults to false.
+  final bool isDestructive;
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/glass_menu.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/glass_menu.dart
@@ -1,0 +1,308 @@
+import 'dart:math' as math;
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import '../../utils/glass_morph_controller.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../constants/glass_defaults.dart';
+import '../../types/glass_quality.dart';
+import '../containers/glass_container.dart';
+import '../shared/adaptive_liquid_glass_layer.dart';
+import '../shared/inherited_liquid_glass.dart';
+import 'glass_menu_item.dart';
+import '../../theme/glass_theme_helpers.dart';
+import '../../theme/glass_theme.dart';
+
+part 'shared/glass_menu_internal.dart';
+
+/// Controls which edge/corner of the trigger button the menu expands from.
+///
+/// When [GlassMenu.menuAlignment] is set to one of these values, the menu
+/// anchors its opposite edge to that point on the trigger. For example,
+/// [topLeft] anchors the menu's top-left corner to the trigger, so
+/// the body expands downwards and to the right.
+///
+/// Use [none] (the default) to let the menu auto-detect the best alignment
+/// based on the trigger's screen position.
+enum GlassMenuAlignment {
+  /// Auto-detect alignment based on screen position (default behaviour).
+  none,
+  topLeft,
+  topCenter,
+  topRight,
+  centerLeft,
+  center,
+  centerRight,
+  bottomLeft,
+  bottomCenter,
+  bottomRight,
+}
+
+/// A liquid glass context menu that morphs from its trigger button.
+///
+/// [GlassMenu] implements the iOS 26 "liquid glass" morphing pattern where
+/// a button seamlessly transforms into a menu. The same glass container
+/// transitions between button and menu states using spring physics.
+///
+/// ## Features
+/// - **True morphing**: Button transforms into menu (not overlay)
+/// - **Smooth spring physics**: Gentle settle with no harsh bounces (stiffness: 300, damping: 24)
+/// - **Liquid swoop**: Subtle 5px parabolic arc for seamless down-and-up motion
+/// - **Seamless crossfade**: Button only appears at final 5% to preserve morph illusion
+/// - **Dimension interpolation**: Width, height, and border radius morph smoothly
+/// - **Position aware**: Menu expands from button position
+/// - **Settings inheritance**: Inherits parent layer settings like GlassCard (thin rim by default)
+/// - **No button animation**: Trigger button remains static, only shape morphs
+class GlassMenu extends StatefulWidget {
+  /// The widget that triggers the menu.
+  ///
+  /// If provided, this widget will be wrapped in a [GestureDetector] to handle
+  /// taps. Use this for simple, non-interactive triggers like Icons or Text.
+  ///
+  /// If your trigger is interactive (like a [GlassButton]), use [triggerBuilder]
+  /// instead to manually handle the tap event.
+  final Widget? trigger;
+
+  /// A builder for the trigger widget that provides access to the menu toggle callback.
+  ///
+  /// Use this when your trigger widget handles its own interactions (e.g., a [GlassButton]
+  /// or [IconButton]).
+  ///
+  /// Example:
+  /// ```dart
+  /// GlassMenu(
+  ///   triggerBuilder: (context, toggle) => GlassButton(
+  ///     onTap: toggle,
+  ///     child: Text('Open'),
+  ///   ),
+  ///   ...
+  /// )
+  /// ```
+  final Widget Function(BuildContext context, VoidCallback toggleMenu)?
+      triggerBuilder;
+
+  /// The list of items to display in the menu.
+  ///
+  /// Typically contains [GlassMenuItem] and [GlassMenuDivider].
+  final List<Widget> items;
+
+  /// The alignment of the menu relative to the trigger.
+  final GlassMenuAlignment? menuAlignment;
+
+  /// Whether to automatically adjust the menu position to keep it on screen.
+  final bool autoAdjustToScreen;
+
+  /// Width of the expanded menu.
+  final double menuWidth;
+
+  /// Border radius of the expanded menu.
+  ///
+  /// Defaults to 32.0 for a modern rounded look.
+  final double menuBorderRadius;
+
+  /// Border radius of the selection highlight and menu items.
+  ///
+  /// Defaults to 24.0.
+  final double itemBorderRadius;
+
+  /// Custom glass settings for the menu container.
+  final LiquidGlassSettings? settings;
+
+  /// Rendering quality for the glass effect.
+  final GlassQuality? quality;
+
+  /// Liquid stretch factor. Default: 0.5.
+  final double stretch;
+
+  /// Scale factor applied on touch. Default: 1.02.
+  final double interactionScale;
+
+  /// The resistance factor to apply to the drag offset.
+  /// Higher values make the drag feel "stickier". Default: 0.08.
+  final double stretchResistance;
+
+  /// The axis to constrain the stretch to. If null, stretches in both axes.
+  final Axis? stretchAxis;
+
+  /// Whether to allow stretch in the positive X direction (Right).
+  /// If null, automatically determined by menu position.
+  final bool? allowPositiveX;
+
+  /// Whether to allow stretch in the negative X direction (Left).
+  /// If null, automatically determined by menu position.
+  final bool? allowNegativeX;
+
+  /// Whether to allow stretch in the positive Y direction (Down).
+  /// If null, automatically determined by menu position.
+  final bool? allowPositiveY;
+
+  /// Whether to allow stretch in the negative Y direction (Up).
+  /// If null, automatically determined by menu position.
+  final bool? allowNegativeY;
+
+  /// Whether to show glow/glare on touch for tactile feedback. Default: true.
+  final bool enableInteractionGlow;
+
+  /// Whether the glow should act as a momentary tap indicator.
+  ///
+  /// If true, the glow will appear on tap but will automatically fade out
+  /// if the user starts dragging. It will not reappear until a new tap starts.
+  /// Default: true.
+  final bool glowOnTapOnly;
+
+  /// Custom color for the touch interaction glow.
+  final Color? glowColor;
+
+  /// Radius of the touch interaction glow. Default: 0.6.
+  final double glowRadius;
+
+  /// The intensity of the interactive glow.
+  ///
+  /// Defaults to 0.0.
+  final double glowIntensity;
+
+  /// Custom color for the menu selection background.
+  final Color selectionColor;
+
+  /// Optional fixed height for the menu.
+  ///
+  /// If null, the menu will size itself to fit its items.
+  /// If provided, the menu will have a fixed height and internal scrolling.
+  final double? menuHeight;
+
+  /// The minimum distance between the menu and the screen edges.
+  ///
+  /// Only applies when [autoAdjustToScreen] is true.
+  /// Defaults to 0.0 (touches the edge). Set to a value like 12.0 for a safe margin.
+  final EdgeInsets menuPadding;
+
+  /// Called when the menu begins closing.
+  ///
+  /// Fires immediately when a close is triggered — tap outside the barrier,
+  /// re-tapping the trigger button, or selecting a menu item — **before** the
+  /// close animation completes. Use this to synchronise external state (e.g.
+  /// stopping a morph controller) that should react as soon as the close
+  /// gesture is confirmed.
+  ///
+  /// If you need to act only after the animation has fully settled, listen to
+  /// [GlassMorphController] status changes directly.
+  final VoidCallback? onClose;
+
+  /// Optional controller to drive the menu imperatively
+  /// ([GlassMenuController.open] / [GlassMenuController.close]) instead of — or
+  /// in addition to — tapping the trigger.
+  ///
+  /// Tapping the trigger goes through [_GlassMenuState._toggleMenu], which is
+  /// gated on the morph progress (a close that lands while the menu is still
+  /// expanding is ignored). The controller commands [_GlassMenuState._openMenu]
+  /// / [_GlassMenuState._closeMenu] directly, so it is deterministic for any
+  /// timing — useful when an external gesture owner (e.g. a central gesture
+  /// arena) decides when to show and dismiss the menu.
+  final GlassMenuController? controller;
+
+  /// Whether to render the full-screen tap-to-dismiss barrier behind the open
+  /// menu. Defaults to `true` (modal: a tap outside the menu closes it).
+  ///
+  /// Set to `false` when an external gesture owner (e.g. a canvas gesture arena)
+  /// must keep receiving pointer events while the menu is open and will handle
+  /// dismissal itself — the barrier otherwise sits in the root overlay above
+  /// everything and swallows all input. Pairs with [controller]-driven open/close.
+  final bool showDismissBarrier;
+
+  /// Whether the open/close morph blooms from a zero-size point at the trigger
+  /// center instead of from a glass blob the size of the trigger. Defaults to
+  /// `false` (the menu spawns as a small rounded "metaball" matching the trigger
+  /// and morphs outward — the standard iOS-26 liquid-glass behavior).
+  ///
+  /// Set to `true` when the trigger is invisible or zero-sized (e.g. an
+  /// imperatively-driven menu positioned by an external gesture owner via
+  /// [controller]), so there is no button for the spawn blob to grow from. In
+  /// that case the trigger ghost (Blob A) is suppressed entirely and the menu
+  /// body lerps its size from 0 → full while keeping the identical teardrop
+  /// shape morph (radius circle→rounded-rect, J-curve travel, and spring). The
+  /// shape still spawns at — and collapses back to — the trigger center, so a
+  /// zero-sized trigger reads as a point bloom rather than an 8px glass dot.
+  final bool morphFromZero;
+
+  /// When true (typically for iOS PlatformViews), forces the BackdropFilter
+  /// fallback render path instead of the Impeller-native shader. Forwarded to
+  /// the underlying [AdaptiveLiquidGlassLayer].
+  final bool platformViewBackdrop;
+
+  /// Creates a liquid glass menu.
+  const GlassMenu({
+    super.key,
+    this.trigger,
+    this.triggerBuilder,
+    required this.items,
+    this.menuAlignment,
+    this.autoAdjustToScreen = false,
+    this.menuWidth = 200,
+    this.menuBorderRadius = 32.0,
+    this.itemBorderRadius = 24.0,
+    this.settings,
+    this.quality,
+    this.stretch = 0.5,
+    this.interactionScale = 1.02,
+    this.stretchResistance = 0.08,
+    this.stretchAxis,
+    this.allowPositiveX,
+    this.allowNegativeX,
+    this.allowPositiveY,
+    this.allowNegativeY,
+    this.menuHeight,
+    this.menuPadding = EdgeInsets.zero,
+    this.selectionColor = const Color(0x3DFFFFFF),
+    this.enableInteractionGlow = true,
+    this.glowOnTapOnly = true,
+    this.glowColor,
+    this.glowRadius = 0.6,
+    this.glowIntensity = 0.0,
+    this.onClose,
+    this.controller,
+    this.showDismissBarrier = true,
+    this.morphFromZero = false,
+    this.platformViewBackdrop = false,
+  }) : assert(trigger != null || triggerBuilder != null,
+            'Either trigger or triggerBuilder must be provided');
+
+  @override
+  State<GlassMenu> createState() => _GlassMenuState();
+}
+
+/// Drives a [GlassMenu] imperatively, bypassing the trigger tap.
+///
+/// Pass it to [GlassMenu.controller]. Unlike tapping the trigger (which toggles
+/// and is gated on the morph progress), [open] and [close] command the menu's
+/// morph directly, so a [close] that lands mid-open reliably dismisses the menu
+/// instead of re-opening it. Intended for cases where something other than the
+/// menu's own trigger decides when it appears — e.g. a central gesture arena.
+///
+/// One controller drives one mounted [GlassMenu] at a time.
+class GlassMenuController {
+  _GlassMenuState? _state;
+
+  void _attach(_GlassMenuState state) => _state = state;
+
+  void _detach(_GlassMenuState state) {
+    if (identical(_state, state)) _state = null;
+  }
+
+  /// Whether the menu's overlay is currently shown (open, or animating closed).
+  bool get isOpen => _state?._overlayController.isShowing ?? false;
+
+  /// Opens the menu, morphing from the trigger's current position. Safe to call
+  /// while a close is still animating — the spring reverses toward open.
+  void open() => _state?._openMenu();
+
+  /// Closes the menu with the rubber-band morph. Deterministic for any timing:
+  /// unlike a trigger tap, it never re-opens a still-expanding menu.
+  void close() => _state?._closeMenu();
+
+  /// Nudges the open menu to track a moving anchor: [offset] (screen px) is added
+  /// to the menu's captured trigger position every frame until reset. A no-op
+  /// while closed; cleared on the next [open]. Used by external gesture owners
+  /// that move the anchor AFTER opening — e.g. a canvas tile trailing under a
+  /// rubberband, where the menu should stay glued to the tile.
+  void setFollowOffset(Offset offset) => _state?.setFollowOffset(offset);
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/glass_menu_item.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/glass_menu_item.dart
@@ -1,0 +1,326 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// A menu item for use within a [GlassMenu].
+///
+/// [GlassMenuItem] provides a standard layout for menu options, including
+/// support for icons, labels, and "destructive" styling. It handles its own
+/// hover and tap interactions with liquid glass effects.
+class GlassMenuItem extends StatefulWidget {
+  /// Creates a glass menu item.
+  const GlassMenuItem({
+    required this.title,
+    required this.onTap,
+    super.key,
+    this.icon,
+    this.isDestructive = false,
+    this.trailing,
+    this.height = 44.0,
+    this.subtitle,
+    this.isPressed,
+    this.isSelected = false,
+    this.enabled = true,
+    this.titleStyle,
+    this.subtitleStyle,
+    this.iconColor,
+    this.iconSize = 20.0,
+    this.maxLines = 1,
+  });
+
+  /// The primary text of the item.
+  final String title;
+
+  /// The icon widget displayed before the title.
+  final Widget? icon;
+
+  /// Optional subtitle text displayed below the title.
+  final String? subtitle;
+
+  /// Callback when the item is tapped.
+  final VoidCallback onTap;
+
+  /// Whether this is a destructive action (e.g., Delete).
+  ///
+  /// Renders with red text and distinct hover effect.
+  final bool isDestructive;
+
+  /// A widget to display after the title (e.g., shortcut key).
+  final Widget? trailing;
+
+  /// Height of the item.
+  ///
+  /// Defaults to 44.0 (standard iOS touch target).
+  final double height;
+
+  /// External override for the pressed state.
+  final bool? isPressed;
+
+  /// Whether the item is currently selected (e.g. by a sliding pill).
+  final bool isSelected;
+
+  /// Whether the item should handle its own interactions.
+  final bool enabled;
+
+  /// Custom text style for the title.
+  final TextStyle? titleStyle;
+
+  /// Custom text style for the subtitle.
+  final TextStyle? subtitleStyle;
+
+  /// Custom color for the icon.
+  final Color? iconColor;
+
+  /// Custom size for the icon.
+  final double iconSize;
+
+  /// Maximum number of lines for the title text.
+  ///
+  /// Defaults to 1. Set to 2 for longer labels like "Set Up Name & Photo".
+  final int maxLines;
+
+  @override
+  State<GlassMenuItem> createState() => _GlassMenuItemState();
+}
+
+/// A separator line for use within a [GlassMenu].
+class GlassMenuDivider extends StatelessWidget {
+  /// The height of the divider area (line + spacing).
+  final double height;
+
+  /// Custom color for the divider line.
+  final Color? color;
+
+  /// Horizontal padding for the divider line.
+  final double indent;
+
+  /// Creates a glass menu divider.
+  const GlassMenuDivider({
+    super.key,
+    this.height = 12.0,
+    this.color,
+    this.indent = 8.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = CupertinoTheme.of(context);
+    // Resolve from theme's label color, falling back to text color at 15%
+    final defaultLineColor =
+        (theme.textTheme.tabLabelTextStyle.color ?? CupertinoColors.label)
+            .withValues(alpha: 0.15);
+    return SizedBox(
+      height: height,
+      child: Center(
+        child: Container(
+          height: 0.5,
+          margin: EdgeInsets.symmetric(horizontal: indent),
+          color: color ?? defaultLineColor,
+        ),
+      ),
+    );
+  }
+}
+
+/// A non-interactive label or content item for use within a [GlassMenu].
+///
+/// Use this for headers, section labels, or purely decorative content.
+/// It does not respond to hover/press and is ignored by the selection pill.
+class GlassMenuLabel extends StatelessWidget {
+  /// The label text. If provided, renders stylized uppercase text.
+  final String? title;
+
+  /// The custom widget to display. Use this if [title] is null.
+  final Widget? child;
+
+  /// The height of the item.
+  ///
+  /// Defaults to 30.0 (aligned with author's fix to prevent pill-position drift).
+  final double height;
+
+  /// Override for the default caption text style. Only used if [title] is provided.
+  final TextStyle? style;
+
+  /// Horizontal padding for the content. Only used if [child] is provided.
+  final double horizontalPadding;
+
+  /// Creates a glass menu label.
+  const GlassMenuLabel({
+    this.title,
+    this.child,
+    this.style,
+    this.height = 30.0,
+    this.horizontalPadding = 16.0,
+    super.key,
+  }) : assert(title != null || child != null,
+            'Either title or child must be provided');
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = CupertinoTheme.of(context);
+    // Use the theme's secondary label color for muted captions
+    final defaultLabelColor = (theme.textTheme.tabLabelTextStyle.color ??
+            CupertinoColors.secondaryLabel)
+        .withValues(alpha: 0.45);
+    return Container(
+      height: height,
+      padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+      alignment: Alignment.centerLeft,
+      child: child ??
+          Text(
+            title!.toUpperCase(),
+            style: style ??
+                TextStyle(
+                  color: defaultLabelColor,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 0.8,
+                ),
+          ),
+    );
+  }
+}
+
+class _GlassMenuItemState extends State<GlassMenuItem> {
+  bool _isHovered = false;
+  bool _isPressed = false;
+  @override
+  void dispose() {
+    _isHovered = false;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Resolve foreground color from the current CupertinoTheme.
+    // This automatically supports Light Mode, Dark Mode, and custom themes.
+    final theme = CupertinoTheme.of(context);
+    final defaultForeground =
+        theme.textTheme.textStyle.color ?? CupertinoColors.label;
+
+    // Determine the base color of the item (inheritance logic)
+    // Priority: iconColor > titleStyle.color > destructiveRed > theme foreground
+    final Color baseColor = widget.iconColor ??
+        widget.titleStyle?.color ??
+        (widget.isDestructive
+            ? CupertinoColors.destructiveRed
+            : defaultForeground);
+
+    // Apply specific opacities based on original design specs:
+    // Icon: 100% (enabled), 50% (disabled)
+    // Text: 90% (static for enabled/disabled)
+    final Color iconColor = widget.iconColor ??
+        (widget.isDestructive
+            ? CupertinoColors.destructiveRed
+            : baseColor.withValues(alpha: widget.enabled ? 1.0 : 0.5));
+
+    final Color textColor = widget.titleStyle?.color ??
+        (widget.isDestructive
+            ? CupertinoColors.destructiveRed
+            : baseColor.withValues(alpha: 0.9));
+    // Dynamic background for hover/press states
+    // We use a subtle white overlay to "brighten" the glass
+    final bool effectivePressed = (widget.isPressed == true) || _isPressed;
+    final bool effectiveSelected = widget.isSelected;
+
+    final Color backgroundColor = effectiveSelected
+        ? Colors.transparent // Parent renders the sliding pill
+        : effectivePressed
+            ? const Color(0x26FFFFFF) // Standalone press
+            : _isHovered
+                ? const Color(0x1AFFFFFF)
+                : Colors.transparent;
+
+    // Scale effect on press (subtle squash like iOS buttons)
+    final double scale = effectivePressed ? 0.98 : 1.0;
+
+    // Build the item content
+    return GestureDetector(
+      onTapDown:
+          widget.enabled ? (_) => setState(() => _isPressed = true) : null,
+      onTapUp:
+          widget.enabled ? (_) => setState(() => _isPressed = false) : null,
+      onTapCancel:
+          widget.enabled ? () => setState(() => _isPressed = false) : null,
+      onTap: widget.enabled ? widget.onTap : null,
+      child: MouseRegion(
+        onEnter: (_) => setState(() => _isHovered = true),
+        onExit: (_) => setState(() => _isHovered = false),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(minHeight: widget.height),
+          child: AnimatedScale(
+            scale: scale,
+            duration: const Duration(milliseconds: 150),
+            curve: Curves.easeOutCubic,
+            child: AnimatedContainer(
+              duration: (effectiveSelected || effectivePressed)
+                  ? Duration.zero // Instant highlight on tap down
+                  : const Duration(
+                      milliseconds: 150), // Smooth fade out on release
+              curve: Curves.easeOutCubic,
+              constraints: BoxConstraints(minHeight: widget.height),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              decoration: BoxDecoration(
+                color: backgroundColor,
+                borderRadius: BorderRadius.circular(24),
+              ),
+              child: Opacity(
+                opacity: widget.enabled ? 1.0 : 0.4,
+                child: Row(
+                  children: [
+                    // Icon
+                    if (widget.icon != null) ...[
+                      IconTheme(
+                        data: IconThemeData(
+                          color: iconColor,
+                          size: widget.iconSize,
+                        ),
+                        child: widget.icon!,
+                      ),
+                      const SizedBox(width: 12),
+                    ],
+
+                    // Text Content (Title & Subtitle)
+                    Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            widget.title,
+                            maxLines: widget.maxLines,
+                            overflow: TextOverflow.ellipsis,
+                            style: widget.titleStyle ??
+                                TextStyle(
+                                  color: textColor,
+                                  fontSize: 17,
+                                  fontWeight: FontWeight.w400,
+                                ),
+                          ),
+                          if (widget.subtitle != null)
+                            Text(
+                              widget.subtitle!,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: widget.subtitleStyle ??
+                                  TextStyle(
+                                    color: textColor.withValues(alpha: 0.6),
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w400,
+                                  ),
+                            ),
+                        ],
+                      ),
+                    ),
+
+                    // Trailing
+                    if (widget.trailing != null) widget.trailing!,
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/glass_modal_sheet.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/glass_modal_sheet.dart
@@ -1,0 +1,400 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/physics.dart';
+import 'package:flutter/services.dart';
+
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../theme/glass_theme_helpers.dart';
+import '../../theme/glass_theme.dart';
+import '../../types/glass_quality.dart';
+import '../shared/adaptive_glass.dart';
+import '../../src/renderer/internal/interaction_notification.dart';
+import 'shared/glass_sheet_defaults.dart';
+
+part 'shared/glass_modal_sheet_mechanics.dart';
+part 'shared/glass_modal_sheet_internal.dart';
+part 'shared/glass_modal_sheet_state.dart';
+
+/// A high-fidelity, liquid glass modal sheet inspired by iOS 18+ design patterns.
+///
+/// [GlassModalSheet] provides a fluid, multi-state modal experience (peek, half, full)
+/// with advanced glass morphism effects, interactive scaling, and physics-based gestures.
+class GlassModalSheet extends StatefulWidget {
+  // ===========================================================================
+  // Content Properties
+  // ===========================================================================
+
+  /// The primary content widget displayed inside the glass sheet.
+  final Widget child;
+
+  // ===========================================================================
+  // Geometry Properties
+  // ===========================================================================
+
+  /// Height in the 'half' state (0.0 - 1.0 fraction or absolute pixels). Default: 0.45.
+  final double halfSize;
+
+  /// Maximum sheet height in 'full' state.
+  ///
+  /// - If 0.0 < value <= 1.0: Treated as fraction of screen height.
+  /// - If value > 1.0: Treated as absolute pixels.
+  /// - If null: Defaults to screen height minus 90px (iOS Page Sheet style).
+  final double? fullSize;
+
+  /// Height in the 'peek' state. Default: 90.0.
+  final double peekSize;
+
+  /// Internal padding for the sheet content.
+  final EdgeInsetsGeometry? padding;
+
+  /// Initial state when the sheet is first shown.
+  final GlassSheetState initialState;
+
+  // ===========================================================================
+  // Appearance Properties
+  // ===========================================================================
+
+  /// If null, it will be automatically resolved based on the device's
+  /// physical geometry (adaptive radius).
+  final double? topBorderRadius;
+
+  /// If null, it will be automatically resolved based on the device's
+  /// physical geometry (adaptive radius).
+  final double? bottomBorderRadius;
+
+  /// Corner radius of the top edges when fully expanded (full).
+  final double? fullTopBorderRadius;
+
+  /// Corner radius of the bottom edges when fully expanded (full).
+  final double? fullBottomBorderRadius;
+
+  /// Corner radius specifically for the 'peek' state.
+  final double? peekTopBorderRadius;
+
+  /// Corner radius specifically for the 'peek' state.
+  final double? peekBottomRadius;
+
+  /// Horizontal padding between the sheet and the screen edges.
+  final double horizontalMargin;
+
+  /// Horizontal padding specifically for the 'peek' state.
+  /// If null, [horizontalMargin] is used.
+  final double? peekHorizontalMargin;
+
+  /// Bottom padding from the screen edge.
+  final double bottomMargin;
+
+  /// Bottom padding specifically for the 'peek' state.
+  /// If null, [bottomMargin] is used.
+  final double? peekBottomMargin;
+
+  /// Fixed width for the 'peek' state.
+  /// If provided, the sheet will morph from this width to full width.
+  final double? peekWidth;
+
+  /// Color/Saturation transition mode when expanding to full state.
+  final GlassFillTransition fillTransition;
+
+  /// Threshold (0.0 - 1.0) at which the sheet starts turning into a solid color.
+  final double fillThreshold;
+
+  /// Glass morphism effect settings (blur, thickness, lighting).
+  final LiquidGlassSettings? settings;
+
+  /// Background color used when the sheet is fully expanded and opaque.
+  final Color? expandedColor;
+
+  /// Rendering quality (BackdropFilter vs Shader). Defaults to standard.
+  final GlassQuality? quality;
+
+  /// When true (typically over an iOS PlatformView), forces the BackdropFilter
+  /// fallback render path so premium glass renders cleanly over the
+  /// PlatformView instead of as a solid slab. Forwarded to the sheet's
+  /// underlying [AdaptiveGlass]. Defaults to false.
+  final bool platformViewBackdrop;
+
+  // ===========================================================================
+  // Physics & Interaction Properties
+  // ===========================================================================
+
+  /// Scale factor applied during interaction for tactile feedback. Default: 1.01.
+  final double interactionScale;
+
+  /// Whether to show glow/glare on touch for tactile feedback. Default: true.
+  final bool enableInteractionGlow;
+
+  /// Whether to pulse saturation/lighting of the whole sheet on touch. Default: true.
+  final bool enableSaturationGlow;
+
+  /// Optional state-specific settings that override the base [settings].
+  final LiquidGlassSettings? peekSettings;
+  final LiquidGlassSettings? halfSettings;
+  final LiquidGlassSettings? fullSettings;
+
+  /// Liquid stretch multiplier for over-scroll/drag effects. Default: 0.5.
+  final double stretch;
+
+  /// Resistance factor when dragging beyond bounds. Default: 0.08.
+  final double resistance;
+
+  /// Snap progress threshold (0.0 - 1.0). Default: 0.4.
+  final double snapThreshold;
+
+  /// Velocity threshold for flick gestures (pixels/sec). Default: 700.0.
+  final double velocityThreshold;
+
+  /// Custom color for the touch interaction glow.
+  final Color? glowColor;
+
+  /// Radius of the touch interaction glow. Default: 1.5.
+  final double glowRadius;
+
+  /// Whether to prevent sheet scaling when interacting with children. Default: false.
+  final bool suppressInteractionOnChildren;
+
+  /// Controller for programmatic sheet control (snap, animate).
+  final GlassModalSheetController? controller;
+
+  /// Callback triggered when the sheet snaps to a new state.
+  final ValueChanged<GlassSheetState>? onStateChanged;
+
+  /// Interaction mode (dismissible vs persistent).
+  final GlassSheetMode mode;
+
+  /// Whether the 'peek' state is enabled.
+  ///
+  /// If null, it defaults to false for [GlassSheetMode.dismissible] and true for
+  /// [GlassSheetMode.persistent].
+  final bool? enablePeek;
+
+  // ===========================================================================
+  // Drag Indicator Properties
+  // ===========================================================================
+
+  /// Whether to show the iOS-style drag handle at the top. Default: true.
+  final bool showDragIndicator;
+
+  /// Custom color for the drag handle.
+  final Color? dragIndicatorColor;
+
+  /// Width of the drag handle pill in logical pixels. Defaults to 36
+  /// (iOS native). Bump higher (e.g. 64) for sheets where the handle
+  /// reads as the primary affordance and the thinner default feels
+  /// too subtle relative to the rest of the sheet's content.
+  final double dragIndicatorWidth;
+
+  /// Whether to enable a gradient fade effect at the top of the sheet.
+  final bool enableTopFade;
+
+  /// The height of the top fade effect in pixels. Default: 40.0.
+  final double topFadeHeight;
+
+  /// Whether to maintain high glass vibrancy for content even when the sheet is solid (full state).
+  final bool maintainContentGlass;
+
+  /// Custom glass settings for content specifically for the 'full' state.
+  final LiquidGlassSettings? fullStateContentSettings;
+
+  const GlassModalSheet({
+    super.key,
+    required this.child,
+    this.halfSize = 0.45,
+    this.fullSize,
+    this.initialState = GlassSheetState.half,
+    this.topBorderRadius = 56,
+    this.bottomBorderRadius,
+    this.fullTopBorderRadius = 46,
+    this.fullBottomBorderRadius,
+    this.horizontalMargin = 5.0,
+    this.bottomMargin = 6.0,
+    this.fillThreshold = 0.60,
+    this.interactionScale = 1.01,
+    this.enableInteractionGlow = true,
+    this.enableSaturationGlow = true,
+    this.peekSettings,
+    this.halfSettings,
+    this.fullSettings,
+    this.stretch = 0.5,
+    this.resistance = 0.08,
+    this.snapThreshold = 0.4,
+    this.velocityThreshold = 700.0,
+    this.settings,
+    this.quality,
+    this.platformViewBackdrop = false,
+    this.expandedColor,
+    this.controller,
+    this.onStateChanged,
+    this.mode = GlassSheetMode.dismissible,
+    this.peekSize = 90.0,
+    this.fillTransition = GlassFillTransition.instant,
+    this.showDragIndicator = true,
+    this.dragIndicatorColor,
+    this.dragIndicatorWidth = 36,
+    this.glowColor,
+    this.glowRadius = 1.5,
+    this.suppressInteractionOnChildren = false,
+    this.padding,
+    this.enableTopFade = false,
+    this.topFadeHeight = 40.0,
+    this.maintainContentGlass = true,
+    this.fullStateContentSettings,
+    this.enablePeek,
+    this.peekHorizontalMargin,
+    this.peekBottomMargin,
+    this.peekWidth,
+    this.peekTopBorderRadius,
+    this.peekBottomRadius,
+  });
+
+  /// Shows a high-fidelity glass modal sheet.
+  static Future<T?> show<T>({
+    required BuildContext context,
+    required WidgetBuilder builder,
+    double halfSize = 0.45,
+    double? fullSize,
+    GlassSheetState initialState = GlassSheetState.half,
+    double fillThreshold = 0.60,
+    LiquidGlassSettings? settings,
+    Color? expandedColor,
+    ValueChanged<GlassSheetState>? onStateChanged,
+    GlassSheetMode mode = GlassSheetMode.dismissible,
+    double peekSize = 90.0,
+    GlassQuality? quality,
+    bool platformViewBackdrop = false,
+    Color barrierColor = Colors.black54,
+    bool isDismissible = true,
+    bool useRootNavigator = false,
+    double interactionScale = 1.01,
+    bool enableInteractionGlow = true,
+    bool enableSaturationGlow = true,
+    LiquidGlassSettings? peekSettings,
+    LiquidGlassSettings? halfSettings,
+    LiquidGlassSettings? fullSettings,
+    double stretch = 0.5,
+    GlassModalSheetController? controller,
+    GlassFillTransition fillTransition = GlassFillTransition.instant,
+    bool showDragIndicator = true,
+    Color? dragIndicatorColor,
+    double dragIndicatorWidth = 36,
+    double? topBorderRadius = 56,
+    double? bottomBorderRadius,
+    double? fullTopBorderRadius = 46,
+    double? fullBottomBorderRadius,
+    double horizontalMargin = 8.0,
+    double bottomMargin = 8.0,
+    double resistance = 0.08,
+    double snapThreshold = 0.4,
+    double velocityThreshold = 700.0,
+    Color? glowColor,
+    double glowRadius = 1.5,
+    bool suppressInteractionOnChildren = false,
+    EdgeInsetsGeometry? padding,
+    bool enableTopFade = false,
+    double topFadeHeight = 40.0,
+    bool maintainContentGlass = true,
+    LiquidGlassSettings? fullStateContentSettings,
+    bool? enablePeek,
+    double? peekHorizontalMargin,
+    double? peekBottomMargin,
+    double? peekWidth,
+    double? peekTopBorderRadius,
+    double? peekBottomRadius,
+  }) {
+    assert(() {
+      if (mode == GlassSheetMode.persistent &&
+          barrierColor == Colors.transparent) {
+        debugPrint(
+          '[GlassModalSheet] WARNING: show() with persistent mode and '
+          'transparent barrier does NOT provide true hit-through interaction. '
+          'Use GlassModalSheetScaffold directly for maps-style hit-through UI.',
+        );
+      }
+      return true;
+    }());
+
+    final effectiveController = controller ?? GlassModalSheetController();
+    bool isClosing = false;
+
+    return showGeneralDialog<T>(
+      context: context,
+      barrierDismissible: isDismissible,
+      barrierLabel: 'Dismiss',
+      barrierColor: barrierColor,
+      useRootNavigator: useRootNavigator,
+      transitionDuration: const Duration(milliseconds: 500),
+      transitionBuilder: (context, animation, secondaryAnimation, child) {
+        return SlideTransition(
+          position: Tween<Offset>(begin: const Offset(0, 1), end: Offset.zero)
+              .animate(
+            CurvedAnimation(parent: animation, curve: Curves.easeOutQuart),
+          ),
+          child: child,
+        );
+      },
+      pageBuilder: (context, animation, secondaryAnimation) {
+        return GlassModalSheetScaffold(
+          controller: effectiveController,
+          halfSize: halfSize,
+          fullSize: fullSize,
+          initialState: initialState,
+          fillThreshold: fillThreshold,
+          settings: settings,
+          expandedColor: expandedColor,
+          mode: mode,
+          peekSize: peekSize,
+          quality: quality,
+          platformViewBackdrop: platformViewBackdrop,
+          interactionScale: interactionScale,
+          enableInteractionGlow: enableInteractionGlow,
+          enableSaturationGlow: enableSaturationGlow,
+          peekSettings: peekSettings,
+          halfSettings: halfSettings,
+          fullSettings: fullSettings,
+          stretch: stretch,
+          fillTransition: fillTransition,
+          showDragIndicator: showDragIndicator,
+          dragIndicatorColor: dragIndicatorColor,
+          dragIndicatorWidth: dragIndicatorWidth,
+          topBorderRadius: topBorderRadius,
+          bottomBorderRadius: bottomBorderRadius,
+          fullTopBorderRadius: fullTopBorderRadius,
+          fullBottomBorderRadius: fullBottomBorderRadius,
+          horizontalMargin: horizontalMargin,
+          bottomMargin: bottomMargin,
+          resistance: resistance,
+          snapThreshold: snapThreshold,
+          velocityThreshold: velocityThreshold,
+          glowColor: glowColor,
+          glowRadius: glowRadius,
+          suppressInteractionOnChildren: suppressInteractionOnChildren,
+          padding: padding,
+          enableTopFade: enableTopFade,
+          topFadeHeight: topFadeHeight,
+          maintainContentGlass: maintainContentGlass,
+          fullStateContentSettings: fullStateContentSettings,
+          enablePeek: enablePeek,
+          peekHorizontalMargin: peekHorizontalMargin,
+          peekBottomMargin: peekBottomMargin,
+          peekWidth: peekWidth,
+          peekTopBorderRadius: peekTopBorderRadius,
+          peekBottomRadius: peekBottomRadius,
+          onStateChanged: (state) {
+            onStateChanged?.call(state);
+            if (state == GlassSheetState.hidden && !isClosing) {
+              isClosing = true;
+              Navigator.of(context).pop();
+            }
+          },
+          body: const SizedBox.shrink(),
+          sheet: builder(context),
+        );
+      },
+    );
+  }
+
+  @override
+  State<GlassModalSheet> createState() => _GlassModalSheetState();
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/glass_popover.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/glass_popover.dart
@@ -1,0 +1,285 @@
+import 'dart:math' as math;
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import '../../utils/glass_morph_controller.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../constants/glass_defaults.dart';
+import '../../types/glass_quality.dart';
+import '../containers/glass_container.dart';
+import '../shared/inherited_liquid_glass.dart';
+import 'glass_menu.dart' show GlassMenuAlignment;
+import '../../theme/glass_theme_helpers.dart';
+import '../../theme/glass_theme.dart';
+
+part 'shared/glass_popover_internal.dart';
+
+/// A liquid glass popover that morphs from its trigger button.
+///
+/// [GlassPopover] implements the same iOS 26 liquid morph animation as
+/// [GlassMenu], but instead of presenting a list of menu items, it presents
+/// **any custom widget**. Use it for tooltips, mini forms, preview cards,
+/// colour pickers, or any content that should appear in a glass overlay.
+///
+/// The popover morphs from the trigger button using spring physics and the
+/// dual-blob metaball technique, creating a teardrop expansion effect.
+///
+/// ## Features
+/// - **Liquid morph animation**: Same teardrop physics as [GlassMenu]
+/// - **Custom content**: Any widget, not just menu items
+/// - **Self-closing**: Content receives a `close` callback
+/// - **Auto-positioning**: Detects best alignment from trigger position
+/// - **Screen-edge clamping**: Keeps popover within safe area
+/// - **Barrier dismissal**: Tap outside to close (configurable)
+///
+/// ## Usage
+///
+/// ### Basic Usage
+/// ```dart
+/// GlassPopover(
+///   trigger: Icon(CupertinoIcons.info_circle, color: Colors.white),
+///   contentBuilder: (context, close) => Padding(
+///     padding: EdgeInsets.all(16),
+///     child: Text('Hello from the popover!',
+///       style: TextStyle(color: Colors.white)),
+///   ),
+/// )
+/// ```
+///
+/// ### With Interactive Trigger
+/// ```dart
+/// GlassPopover(
+///   triggerBuilder: (context, toggle) => GlassButton(
+///     onTap: toggle,
+///     child: Text('Show Details'),
+///   ),
+///   contentBuilder: (context, close) => Padding(
+///     padding: EdgeInsets.all(16),
+///     child: Column(
+///       mainAxisSize: MainAxisSize.min,
+///       children: [
+///         Text('Profile Details', style: TextStyle(color: Colors.white)),
+///         SizedBox(height: 12),
+///         GlassButton(onTap: close, child: Text('Done')),
+///       ],
+///     ),
+///   ),
+/// )
+/// ```
+///
+/// ### With Fixed Height (Scrollable)
+/// ```dart
+/// GlassPopover(
+///   popoverHeight: 300,
+///   trigger: Icon(CupertinoIcons.list_bullet),
+///   contentBuilder: (context, close) => ListView.builder(
+///     itemCount: 50,
+///     itemBuilder: (context, i) => ListTile(title: Text('Item $i')),
+///   ),
+/// )
+/// ```
+///
+/// ### Custom Alignment
+/// ```dart
+/// GlassPopover(
+///   alignment: GlassMenuAlignment.bottomCenter,
+///   trigger: Icon(CupertinoIcons.arrow_down),
+///   contentBuilder: (context, close) => Text('Below the trigger'),
+/// )
+/// ```
+class GlassPopover extends StatefulWidget {
+  /// Creates a liquid glass popover.
+  const GlassPopover({
+    super.key,
+    this.trigger,
+    this.triggerBuilder,
+    required this.contentBuilder,
+    this.popoverWidth = 280,
+    this.popoverHeight,
+    this.popoverBorderRadius = 24.0,
+    this.alignment,
+    this.autoAdjustToScreen = true,
+    this.screenPadding = const EdgeInsets.all(12),
+    this.settings,
+    this.quality,
+    this.stretch = 0.3,
+    this.interactionScale = 1.02,
+    this.stretchResistance = 0.08,
+    this.stretchAxis,
+    this.allowPositiveX,
+    this.allowNegativeX,
+    this.allowPositiveY,
+    this.allowNegativeY,
+    this.enableInteractionGlow = true,
+    this.glowOnTapOnly = true,
+    this.glowColor,
+    this.glowRadius = 0.6,
+    this.glowIntensity = 0.0,
+    this.onClose,
+    this.onOpen,
+    this.barrierDismissible = true,
+  }) : assert(trigger != null || triggerBuilder != null,
+            'Either trigger or triggerBuilder must be provided');
+
+  /// The widget that triggers the popover.
+  ///
+  /// If provided, this widget will be wrapped in a [GestureDetector] to handle
+  /// taps. Use this for simple, non-interactive triggers like Icons or Text.
+  ///
+  /// If your trigger is interactive (like a [GlassButton]), use
+  /// [triggerBuilder] instead to manually handle the tap event.
+  final Widget? trigger;
+
+  /// A builder for the trigger widget that provides access to the popover
+  /// toggle callback.
+  ///
+  /// Use this when your trigger widget handles its own interactions
+  /// (e.g., a [GlassButton] or [IconButton]).
+  ///
+  /// Example:
+  /// ```dart
+  /// GlassPopover(
+  ///   triggerBuilder: (context, toggle) => GlassButton(
+  ///     onTap: toggle,
+  ///     child: Text('Open'),
+  ///   ),
+  ///   ...,
+  /// )
+  /// ```
+  final Widget Function(BuildContext context, VoidCallback togglePopover)?
+      triggerBuilder;
+
+  /// Builder for the popover content.
+  ///
+  /// Receives a `close` callback so content can dismiss the popover
+  /// programmatically (e.g., a "Done" button).
+  ///
+  /// The content is rendered directly inside the morphing [GlassContainer],
+  /// so it inherits the glass effect. The widget should use
+  /// [MainAxisSize.min] or constrained height to size correctly.
+  final Widget Function(BuildContext context, VoidCallback close)
+      contentBuilder;
+
+  /// Width of the expanded popover.
+  ///
+  /// Defaults to 280.
+  final double popoverWidth;
+
+  /// Fixed height for the popover.
+  ///
+  /// If null, the popover sizes itself to fit its content (intrinsic height).
+  /// If provided, the popover will have a fixed height — the content is
+  /// responsible for its own scrolling.
+  final double? popoverHeight;
+
+  /// Border radius of the expanded popover.
+  ///
+  /// Defaults to 24.0.
+  final double popoverBorderRadius;
+
+  /// The alignment of the popover relative to the trigger.
+  ///
+  /// If null or [GlassMenuAlignment.none], the popover auto-detects the best
+  /// alignment based on the trigger's screen position.
+  final GlassMenuAlignment? alignment;
+
+  /// Whether to automatically adjust the popover position to keep it on screen.
+  ///
+  /// Defaults to true.
+  final bool autoAdjustToScreen;
+
+  /// Minimum distance between the popover and screen edges.
+  ///
+  /// Only applies when [autoAdjustToScreen] is true.
+  /// Defaults to `EdgeInsets.all(12)`.
+  final EdgeInsets screenPadding;
+
+  /// Custom glass settings for the popover container.
+  ///
+  /// If null, inherits from parent [InheritedLiquidGlass] or uses subtle
+  /// overlay defaults.
+  final LiquidGlassSettings? settings;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// If null, inherits from parent quality or defaults via
+  /// [GlassThemeHelpers.resolveQuality].
+  final GlassQuality? quality;
+
+  /// Liquid stretch factor.
+  ///
+  /// Defaults to 0.3 (subtle stretch for popovers).
+  final double stretch;
+
+  /// Scale factor applied on touch.
+  ///
+  /// Defaults to 1.02.
+  final double interactionScale;
+
+  /// The resistance factor to apply to the drag offset.
+  ///
+  /// Higher values make the drag feel "stickier". Default: 0.08.
+  final double stretchResistance;
+
+  /// The axis to constrain the stretch to. If null, stretches in both axes.
+  final Axis? stretchAxis;
+
+  /// Whether to allow stretch in the positive X direction (Right).
+  /// If null, automatically determined by popover position.
+  final bool? allowPositiveX;
+
+  /// Whether to allow stretch in the negative X direction (Left).
+  /// If null, automatically determined by popover position.
+  final bool? allowNegativeX;
+
+  /// Whether to allow stretch in the positive Y direction (Down).
+  /// If null, automatically determined by popover position.
+  final bool? allowPositiveY;
+
+  /// Whether to allow stretch in the negative Y direction (Up).
+  /// If null, automatically determined by popover position.
+  final bool? allowNegativeY;
+
+  /// Whether to show glow/glare on touch for tactile feedback.
+  ///
+  /// Defaults to true.
+  final bool enableInteractionGlow;
+
+  /// Whether the glow should act as a momentary tap indicator.
+  ///
+  /// Defaults to true.
+  final bool glowOnTapOnly;
+
+  /// Custom color for the touch interaction glow.
+  final Color? glowColor;
+
+  /// Radius of the touch interaction glow.
+  ///
+  /// Defaults to 0.6.
+  final double glowRadius;
+
+  /// The intensity of the interactive glow.
+  ///
+  /// Defaults to 0.0.
+  final double glowIntensity;
+
+  /// Called when the popover begins closing.
+  ///
+  /// Fires immediately when a close is triggered — tap outside the barrier,
+  /// re-tapping the trigger, or calling the `close` callback — **before** the
+  /// close animation completes.
+  final VoidCallback? onClose;
+
+  /// Called when the popover begins opening.
+  ///
+  /// Fires immediately when [open] is triggered, before the animation starts.
+  final VoidCallback? onOpen;
+
+  /// Whether tapping outside the popover dismisses it.
+  ///
+  /// Defaults to true.
+  final bool barrierDismissible;
+
+  @override
+  State<GlassPopover> createState() => _GlassPopoverState();
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/glass_sheet.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/glass_sheet.dart
@@ -1,0 +1,722 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../src/renderer/internal/interaction_notification.dart';
+
+import '../../types/glass_quality.dart';
+import '../shared/adaptive_glass.dart';
+import '../../theme/glass_theme_helpers.dart';
+import '../../theme/glass_theme.dart';
+import 'package:flutter/services.dart';
+import 'shared/glass_sheet_defaults.dart';
+
+/// A glass morphism bottom sheet following Apple's iOS 26 design patterns.
+///
+/// [GlassSheet] provides a modal bottom sheet with liquid glass effect,
+/// drag indicator, and iOS-style dismiss behavior.
+///
+/// ## Key Features
+///
+/// - Liquid glass backdrop with blur effect
+/// - Draggable dismissal
+/// - Rounded top corners
+/// - iOS-style drag indicator (pill)
+/// - Safe area handling
+/// - Customizable height and snap points
+/// - Interaction suppression for child widgets (Smart Silence)
+///
+/// ## Usage
+///
+/// ### Basic Usage
+/// ```dart
+/// GlassSheet.show(
+///   context: context,
+///   builder: (context) => const Column(
+///     mainAxisSize: MainAxisSize.min,
+///     children: [
+///       Text('Bottom Sheet Title'),
+///       Text('Content goes here'),
+///     ],
+///   ),
+/// );
+/// ```
+///
+/// ### Smart Interaction (New)
+/// To prevent the sheet from scaling when tapping internal buttons:
+/// ```dart
+/// GlassSheet.show(
+///   context: context,
+///   suppressInteractionOnChildren: true,
+///   builder: (context) => Column(
+///     children: [
+///       GlassInteractionSilence(
+///         child: GlassButton(
+///           onTap: () => print('Button tapped without sheet scale!'),
+///           child: Text('Silent Button'),
+///         ),
+///       ),
+///     ],
+///   ),
+/// );
+/// ```
+///
+/// ### Advanced Interactivity & Styling
+/// Customise the look and feel with glow effects, scaling, and specific glass settings:
+/// ```dart
+/// GlassSheet.show(
+///   context: context,
+///   borderRadius: 40,
+///   margin: const EdgeInsets.all(12),
+///   interactionScale: 1.05,
+///   enableInteractionGlow: true, // Glint follows finger
+///   enableSaturationGlow: true,  // Pulsation on touch
+///   settings: const LiquidGlassSettings(
+///     blur: 20,
+///     saturation: 1.8,
+///   ),
+///   builder: (context) => const Column(
+///     children: [
+///       Text('High Fidelity Glass'),
+///     ],
+///   ),
+/// );
+/// ```
+///
+/// ### Solid Color Mode
+/// Customize barrier and glass effect:
+/// ```dart
+/// GlassSheet.show(
+///   context: context,
+///   settings: const LiquidGlassSettings(blur: 20, thickness: 40),
+///   barrierColor: Colors.black87,
+///   builder: (context) => const Text('Custom Glass'),
+/// );
+/// ```
+
+class GlassSheet extends StatefulWidget {
+  /// Creates a glass sheet widget.
+  ///
+  /// Typically not instantiated directly - use [GlassSheet.show] instead.
+  const GlassSheet({
+    super.key,
+    required this.child,
+    this.settings,
+    this.quality,
+    this.showDragIndicator = true,
+    this.dragIndicatorColor,
+    this.topBorderRadius = 32.0,
+    this.bottomBorderRadius,
+    this.padding,
+    this.margin = const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+    this.isScrollable = true,
+    this.interactionScale = 1.01,
+    this.stretch = 0.5,
+    this.resistance = 0.08,
+    this.stretchAxis = Axis.vertical,
+    this.allowPositiveStretch = false,
+    this.allowNegativeStretch = true,
+    this.enableInteractionGlow = true,
+    this.glowColor,
+    this.glowRadius = 1.5,
+    this.enableSaturationGlow = true,
+    this.suppressInteractionOnChildren = false,
+  });
+
+  // ===========================================================================
+  // Content Properties
+  // ===========================================================================
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  /// Padding around the content (below the drag indicator).
+  final EdgeInsetsGeometry? padding;
+
+  // ===========================================================================
+  // Drag Indicator Properties
+  // ===========================================================================
+
+  /// Whether to show the drag indicator at the top of the sheet.
+  final bool showDragIndicator;
+
+  /// Color of the drag indicator.
+  final Color? dragIndicatorColor;
+
+  // ===========================================================================
+  /// Rendering quality for the glass effect.
+  ///
+  /// Defaults to [GlassQuality.standard], which uses backdrop filter rendering.
+  /// This is recommended for sheets as they may be animated.
+  ///
+  /// [GlassQuality.premium] (shader-based) is not recommended for animated
+  /// sheets but can be used for static sheets.
+  final GlassQuality? quality;
+
+  /// Border radius of the top corners of the sheet.
+  ///
+  /// Defaults to 32.0 for a standard iOS sheet look.
+  final double topBorderRadius;
+
+  /// Border radius of the bottom corners of the sheet.
+  ///
+  /// If null, this is automatically determined based on whether the sheet
+  /// has a bottom margin. If it floats (bottom margin > 0), this defaults
+  /// to 32.0. If it docks to the screen edge (bottom margin == 0), this
+  /// defaults to 0.0.
+  final double? bottomBorderRadius;
+
+  /// External margin around the sheet.
+  ///
+  /// This allows the sheet to "float" above the screen edges.
+  /// Defaults to `EdgeInsets.symmetric(horizontal: 8, vertical: 8)`.
+  final EdgeInsetsGeometry margin;
+
+  /// The scale factor to apply when the user is interacting with the sheet.
+  ///
+  /// A value of 1.0 means no scaling. Defaults to 1.01 (subtle scale).
+  final double interactionScale;
+
+  /// Whether to show glow/glare on touch for tactile feedback.
+  ///
+  /// Defaults to true.
+  final bool enableInteractionGlow;
+
+  /// Whether to show the whole-window saturation/lighting pulse on touch.
+  ///
+  /// Defaults to true.
+  final bool enableSaturationGlow;
+
+  /// The factor to multiply the drag offset by to determine the stretch amount.
+  ///
+  /// Defaults to 0.5.
+  final double stretch;
+
+  /// The resistance factor to apply to the drag offset.
+  ///
+  /// Lower values (0.01-0.1) provide subtle liquid feel. Defaults to 0.08.
+  final double resistance;
+
+  /// The axis to constrain the stretch to.
+  ///
+  /// Defaults to [Axis.vertical].
+  final Axis? stretchAxis;
+
+  /// Whether to allow stretch in the positive direction of the axis (Down).
+  ///
+  /// Defaults to false.
+  final bool allowPositiveStretch;
+
+  /// Whether to allow stretch in the negative direction of the axis (Up).
+  ///
+  /// Defaults to true.
+  final bool allowNegativeStretch;
+
+  /// Whether the content should be scrollable.
+  ///
+  /// Defaults to true.
+  final bool isScrollable;
+
+  /// The color of the interaction glow.
+  ///
+  /// If null, uses white at 15% opacity.
+  final Color? glowColor;
+
+  /// The radius of the interaction glow (relative to shortest side).
+  ///
+  /// Defaults to 1.5.
+  final double glowRadius;
+
+  /// Settings for the liquid glass effect.
+  final LiquidGlassSettings? settings;
+
+  /// Whether to suppress sheet interactions when a child is being touched.
+  ///
+  /// When enabled, any child wrapped in [GlassInteractionSilence] will prevent
+  /// the sheet from scaling or glowing when tapped.
+  ///
+  /// Defaults to false.
+  final bool suppressInteractionOnChildren;
+
+  // ===========================================================================
+  // Static Show Method
+  // ===========================================================================
+
+  /// Shows a glass bottom sheet.
+  ///
+  /// Returns a [Future] that resolves to the value (if any) passed to
+  /// [Navigator.pop] when the sheet is dismissed.
+  ///
+  /// Parameters:
+  /// - [context]: Build context for showing the sheet
+  /// - [builder]: Builder function that creates the sheet content
+  /// - [settings]: Glass effect settings (null uses defaults)
+  /// - [quality]: Rendering quality (defaults to standard)
+  /// - [showDragIndicator]: Whether to show the drag indicator (default: true)
+  /// - [dragIndicatorColor]: Color of the drag indicator
+  /// - [padding]: Padding around the content
+  /// - [borderRadius]: Corner radius of the sheet (default: 54)
+  /// - [margin]: External margin for the "floating" look (default: 8x8)
+  /// - [isScrollable]: Whether the content should be scrollable (default: true)
+  /// - [interactionScale]: Visual scale feedback on touch (default: 1.01)
+  /// - [stretch]: Liquid stretch intensity (default: 0.5)
+  /// - [resistance]: Drag resistance factor (default: 0.08)
+  /// - [stretchAxis]: Axis for the liquid effect (default: vertical)
+  /// - [allowPositiveStretch]: Enable stretch in positive direction (default: false)
+  /// - [allowNegativeStretch]: Enable stretch in negative direction (default: true)
+  /// - [enableInteractionGlow]: Whether to show tactile glare on touch (default: true)
+  /// - [glowColor]: Color of the interaction glow
+  /// - [glowRadius]: Radius of the interaction glow
+  /// - [enableSaturationGlow]: Whether to pulse saturation/lighting on touch (default: true)
+  /// - [suppressInteractionOnChildren]: Enable "Smart Silence" for child interactions
+  /// - [isDismissible]: Whether tapping outside dismisses the sheet (default: true)
+  /// - [enableDrag]: Whether the sheet can be dragged down to dismiss (default: true)
+  /// - [barrierColor]: Color of the modal barrier (defaults to black54)
+  /// - [useRootNavigator]: Whether to show the sheet in the root navigator (default: false)
+  /// - [useSafeArea]: Whether to wrap the content in a safe area (default: true)
+  ///
+  /// Example:
+  /// ```dart
+  /// final result = await GlassSheet.show<String>(
+  ///   context: context,
+  ///   builder: (context) => /* content */,
+  /// );
+  /// ```
+  static Future<T?> show<T>({
+    required BuildContext context,
+    required WidgetBuilder builder,
+    LiquidGlassSettings? settings,
+    GlassQuality? quality,
+    bool showDragIndicator = true,
+    Color? dragIndicatorColor,
+    EdgeInsetsGeometry? padding,
+    double topBorderRadius = 32.0,
+    double? bottomBorderRadius,
+    EdgeInsets margin = const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+    bool isScrollable = true,
+    double interactionScale = 1.01,
+    double stretch = 0.5,
+    double resistance = 0.08,
+    Axis stretchAxis = Axis.vertical,
+    bool allowPositiveStretch = false,
+    bool allowNegativeStretch = true,
+    bool enableInteractionGlow = true,
+    Color? glowColor,
+    double glowRadius = 1.5,
+    bool suppressInteractionOnChildren = false,
+    bool isDismissible = true,
+    bool enableDrag = true,
+    Color? barrierColor,
+    bool useRootNavigator = false,
+    bool useSafeArea = true,
+    bool enableSaturationGlow = true,
+  }) {
+    return showGeneralDialog<T>(
+      context: context,
+      barrierDismissible: isDismissible,
+      barrierLabel: 'Dismiss',
+      barrierColor: barrierColor ?? Colors.black54,
+      useRootNavigator: useRootNavigator,
+      transitionDuration: const Duration(milliseconds: 350),
+      transitionBuilder: (context, animation, secondaryAnimation, child) {
+        return SlideTransition(
+          position: Tween<Offset>(
+            begin: const Offset(0, 1),
+            end: Offset.zero,
+          ).animate(CurvedAnimation(
+            parent: animation,
+            curve: Curves.easeOutCubic,
+            reverseCurve: Curves.easeInCubic,
+          )),
+          child: child,
+        );
+      },
+      pageBuilder: (context, animation, secondaryAnimation) {
+        return SafeArea(
+          bottom: useSafeArea,
+          top: false,
+          left: false,
+          right: false,
+          child: Align(
+            alignment: Alignment.bottomCenter,
+            child: _DismissibleSheetWrapper(
+              enableDrag: enableDrag,
+              child: GlassSheet(
+                settings: settings,
+                quality: quality,
+                showDragIndicator: showDragIndicator,
+                dragIndicatorColor: dragIndicatorColor,
+                padding: padding,
+                topBorderRadius: topBorderRadius,
+                bottomBorderRadius: bottomBorderRadius,
+                margin: margin,
+                isScrollable: isScrollable,
+                interactionScale: interactionScale,
+                stretch: stretch,
+                resistance: resistance,
+                stretchAxis: stretchAxis,
+                allowPositiveStretch: allowPositiveStretch,
+                allowNegativeStretch: allowNegativeStretch,
+                enableInteractionGlow: enableInteractionGlow,
+                glowColor: glowColor,
+                glowRadius: glowRadius,
+                enableSaturationGlow: enableSaturationGlow,
+                suppressInteractionOnChildren: suppressInteractionOnChildren,
+                child: builder(context),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  State<GlassSheet> createState() => _GlassSheetState();
+}
+
+/// Wraps a sheet child with vertical drag-to-dismiss behaviour.
+/// Translates the sheet downward as the user drags, and pops the route
+/// when released past a threshold (25% of the child's height).
+class _DismissibleSheetWrapper extends StatefulWidget {
+  const _DismissibleSheetWrapper({
+    required this.child,
+    required this.enableDrag,
+  });
+
+  final Widget child;
+  final bool enableDrag;
+
+  @override
+  State<_DismissibleSheetWrapper> createState() =>
+      _DismissibleSheetWrapperState();
+}
+
+class _DismissibleSheetWrapperState extends State<_DismissibleSheetWrapper> {
+  double _dragOffset = 0;
+  bool _isDragging = false;
+
+  void _onDragStart(DragStartDetails details) {
+    _isDragging = true;
+  }
+
+  void _onDragUpdate(DragUpdateDetails details) {
+    if (!_isDragging) return;
+    setState(() {
+      // Only allow downward dragging (positive offset).
+      _dragOffset =
+          (_dragOffset + details.delta.dy).clamp(0.0, double.infinity);
+    });
+  }
+
+  void _onDragEnd(DragEndDetails details) {
+    _isDragging = false;
+    final velocity = details.primaryVelocity ?? 0;
+    // Dismiss if dragged past 25% of the sheet height or flung downward.
+    final renderBox = context.findRenderObject() as RenderBox?;
+    final threshold = (renderBox?.size.height ?? 300) * 0.25;
+    if (_dragOffset > threshold || velocity > 500) {
+      Navigator.of(context).pop();
+    } else {
+      setState(() => _dragOffset = 0);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget child = widget.child;
+    if (widget.enableDrag) {
+      child = GestureDetector(
+        onVerticalDragStart: _onDragStart,
+        onVerticalDragUpdate: _onDragUpdate,
+        onVerticalDragEnd: _onDragEnd,
+        child: AnimatedContainer(
+          duration:
+              _isDragging ? Duration.zero : const Duration(milliseconds: 250),
+          curve: Curves.easeOutCubic,
+          transform: Matrix4.translationValues(0, _dragOffset, 0),
+          child: widget.child,
+        ),
+      );
+    }
+    return child;
+  }
+}
+
+class _GlassSheetState extends State<GlassSheet> with TickerProviderStateMixin {
+  late AnimationController _saturationController;
+  late Animation<double> _saturationAnimation;
+  bool _isInteractingWithChild = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _saturationController = AnimationController(
+      duration: const Duration(milliseconds: 100),
+      vsync: this,
+    );
+    _saturationAnimation = CurvedAnimation(
+      parent: _saturationController,
+      curve: Curves.easeOut,
+    ).drive(Tween(begin: 0.0, end: 1.0));
+  }
+
+  @override
+  void dispose() {
+    _saturationController.dispose();
+    super.dispose();
+  }
+
+  void _handlePointerDown(PointerDownEvent event) {
+    if (_isInteractingWithChild) {
+      // Reset flag and ignore this sheet interaction
+      _isInteractingWithChild = false;
+      return;
+    }
+
+    if (widget.enableInteractionGlow) {
+      HapticFeedback.selectionClick();
+    }
+
+    if (widget.enableSaturationGlow) {
+      _saturationController.forward();
+    }
+  }
+
+  void _handlePointerUp(PointerUpEvent event) {
+    _saturationController.reverse();
+    _isInteractingWithChild = false;
+  }
+
+  void _handlePointerCancel(PointerCancelEvent event) {
+    _saturationController.reverse();
+    _isInteractingWithChild = false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Inherit quality from parent layer if not explicitly set
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+      fallback: GlassQuality.premium,
+    );
+
+    final effectiveSettings = GlassThemeHelpers.resolveSettings(
+      context,
+      explicit: widget.settings,
+      fallback: kDefaultSheetSettings,
+    );
+
+    final effectiveTopRadius = widget.topBorderRadius;
+
+    // Automatically determine bottom radius if none is provided.
+    // If the sheet floats (bottom margin > 0), round the bottom corners.
+    // If it is docked (bottom margin == 0), keep the bottom flat.
+    final effectiveBottomRadius = widget.bottomBorderRadius ??
+        (widget.margin.resolve(Directionality.of(context)).bottom > 0
+            ? 32.0
+            : 0.0);
+
+    return AnimatedBuilder(
+      animation: _saturationAnimation,
+      builder: (context, child) {
+        final t = _saturationAnimation.value;
+        final currentTopRadius =
+            lerpDouble(effectiveTopRadius, effectiveTopRadius * 0.98, t)!;
+        final currentBottomRadius =
+            lerpDouble(effectiveBottomRadius, effectiveBottomRadius * 0.98, t)!;
+
+        final shape = LiquidVerticalRoundedSuperellipse(
+          topRadius: currentTopRadius,
+          bottomRadius: currentBottomRadius,
+        );
+
+        final pulsedSettings = effectiveSettings.copyWith(
+          lightIntensity: lerpDouble(effectiveSettings.lightIntensity, 0.8, t)!,
+          saturation: lerpDouble(effectiveSettings.saturation, 2.2, t)!,
+        );
+
+        // The core inner content of the sheet
+        Widget innerContent = SafeArea(
+          bottom: true,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _SheetHeader(
+                showIndicator: widget.showDragIndicator,
+                color: widget.dragIndicatorColor,
+              ),
+              if (widget.isScrollable)
+                Flexible(
+                  child: NotificationListener<ScrollNotification>(
+                    onNotification: (notification) {
+                      if (notification is ScrollStartNotification &&
+                          notification.dragDetails != null) {
+                        GlassGlowLayer.maybeOf(context)?.removeTouch();
+                      }
+                      return false;
+                    },
+                    child: SingleChildScrollView(
+                      physics: const BouncingScrollPhysics(),
+                      padding: widget.padding,
+                      child: RepaintBoundary(child: widget.child),
+                    ),
+                  ),
+                )
+              else
+                Padding(
+                  padding: widget.padding ?? EdgeInsets.zero,
+                  child: RepaintBoundary(child: widget.child),
+                ),
+              const SizedBox(height: 24),
+            ],
+          ),
+        );
+
+        Widget result = AdaptiveGlass(
+          shape: shape,
+          settings: pulsedSettings,
+          quality: effectiveQuality,
+          glowIntensity: 0.0,
+          child: RepaintBoundary(child: innerContent),
+        );
+
+        if (widget.enableInteractionGlow && effectiveSettings.blur > 0.05) {
+          final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+          result = GlassGlow(
+            glowColor: widget.glowColor ??
+                (isDark
+                    ? Colors.white.withValues(alpha: 0.15)
+                    : Colors.black.withValues(alpha: 0.10)),
+            glowRadius: widget.glowRadius,
+            clipper: ShapeBorderClipper(shape: shape),
+            child: result,
+          );
+        }
+
+        Widget sheetContent = Listener(
+          onPointerDown: _handlePointerDown,
+          onPointerUp: _handlePointerUp,
+          onPointerCancel: _handlePointerCancel,
+          behavior: HitTestBehavior.translucent,
+          child: LiquidStretch(
+            interactionScale: widget.interactionScale,
+            stretch: widget.stretch,
+            resistance: widget.resistance,
+            axis: widget.stretchAxis,
+            allowPositive: widget.allowPositiveStretch,
+            allowNegative: widget.allowNegativeStretch,
+            suppressInteractionOnChildren: widget.suppressInteractionOnChildren,
+            anchorStretch: false, // Sheets use jelly-follow, not anchored
+            child: result,
+          ),
+        );
+
+        if (widget.suppressInteractionOnChildren) {
+          sheetContent = NotificationListener<InteractionNotification>(
+            onNotification: (notification) {
+              _isInteractingWithChild = true;
+              return false; // Let it bubble
+            },
+            child: sheetContent,
+          );
+        }
+
+        return Padding(
+          padding: widget.margin,
+          child: sheetContent,
+        );
+      },
+    );
+  }
+}
+
+/// A private component for the sheet header to optimize rebuilds.
+class _SheetHeader extends StatelessWidget {
+  final bool showIndicator;
+  final Color? color;
+
+  const _SheetHeader({
+    required this.showIndicator,
+    this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (showIndicator) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const SizedBox(height: 8),
+          Center(child: _GlassDragIndicator(color: color)),
+          const SizedBox(height: 8),
+        ],
+      );
+    }
+    return const SizedBox(height: 16);
+  }
+}
+
+/// Drag indicator / grab handle widget for glass sheets.
+///
+/// A small pill-shaped bar that indicates the sheet can be dragged,
+/// precisely matching iOS 26's `UISheetPresentationController` grabber:
+/// 36×4dp, white at ~35% opacity.
+class _GlassDragIndicator extends StatelessWidget {
+  const _GlassDragIndicator({
+    this.color,
+  });
+
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    // iOS 26: white at 35% in dark mode, black at 20% in light mode
+    final defaultColor =
+        isDark ? const Color(0x59FFFFFF) : const Color(0x33000000);
+
+    return Semantics(
+      // VoiceOver on iOS announces the grabber as "Drag to resize, double-tap
+      // and hold, then drag up or down." We approximate this.
+      label: 'Drag handle',
+      hint: 'Swipe down to dismiss',
+      child: Container(
+        width: 36,
+        height: 4, // iOS 26 spec: 4dp (not 5dp)
+        decoration: BoxDecoration(
+          color: color ?? defaultColor,
+          borderRadius: BorderRadius.circular(2),
+        ),
+      ),
+    );
+  }
+}
+
+/// A universal wrapper that silences [GlassSheet] interactions for its child.
+///
+/// Wrap any interactive widget (buttons, switches, list tiles) in this
+/// to prevent the parent [GlassSheet] from scaling or glowing when the
+/// child is tapped.
+///
+/// Note: [GlassSheet.suppressInteractionOnChildren] must be set to `true`
+/// for this to have any effect.
+class GlassInteractionSilence extends StatelessWidget {
+  /// The widget that should silence the parent sheet.
+  final Widget child;
+
+  /// Creates a [GlassInteractionSilence].
+  const GlassInteractionSilence({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: (event) {
+        InteractionNotification(event).dispatch(context);
+      },
+      behavior: HitTestBehavior.translucent,
+      child: child,
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/glass_toast.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/glass_toast.dart
@@ -1,0 +1,549 @@
+import 'dart:async';
+import 'package:flutter/cupertino.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../theme/glass_theme_data.dart';
+import '../../theme/glass_theme.dart';
+import '../../types/glass_quality.dart';
+import '../shared/adaptive_liquid_glass_layer.dart';
+
+/// Position where the toast should appear on screen.
+enum GlassToastPosition {
+  /// At the top of the screen, below the status bar
+  top,
+
+  /// Centered in the middle of the screen
+  center,
+
+  /// At the bottom of the screen, above the bottom safe area
+  bottom,
+}
+
+/// Visual style and semantic meaning of the toast.
+enum GlassToastType {
+  /// Success message with green accent (default)
+  success,
+
+  /// Error message with red accent
+  error,
+
+  /// Informational message with blue accent
+  info,
+
+  /// Warning message with orange accent
+  warning,
+
+  /// Neutral message with no semantic color
+  neutral,
+}
+
+/// Action button that can be displayed in a toast.
+class GlassToastAction {
+  /// Creates a toast action button.
+  const GlassToastAction({
+    required this.label,
+    required this.onPressed,
+  });
+
+  /// The label text for the action button
+  final String label;
+
+  /// Callback when the action is pressed
+  final VoidCallback onPressed;
+}
+
+/// A glass morphism toast/snackbar following iOS 26 liquid glass design.
+///
+/// [GlassToast] provides temporary, non-intrusive notifications with:
+/// - iOS 26 liquid glass backdrop effect
+/// - Auto-dismiss with configurable duration
+/// - Slide-in/slide-out animations with spring physics
+/// - Swipe-to-dismiss gesture
+/// - Queue management for multiple toasts
+/// - Semantic toast types (success, error, info, warning)
+/// - Optional action button
+/// - Configurable positioning (top, center, bottom)
+///
+/// ## Usage
+///
+/// ### Basic Success Toast
+/// ```dart
+/// GlassToast.show(
+///   context,
+///   message: 'Settings saved successfully',
+///   type: GlassToastType.success,
+/// );
+/// ```
+///
+/// ### Error Toast with Action
+/// ```dart
+/// GlassToast.show(
+///   context,
+///   message: 'Failed to save changes',
+///   type: GlassToastType.error,
+///   action: GlassToastAction(
+///     label: 'Retry',
+///     onPressed: () => saveChanges(),
+///   ),
+/// );
+/// ```
+///
+/// ### Info Toast at Top
+/// ```dart
+/// GlassToast.show(
+///   context,
+///   message: 'New message received',
+///   type: GlassToastType.info,
+///   icon: Icon(CupertinoIcons.envelope),
+///   position: GlassToastPosition.top,
+/// );
+/// ```
+///
+/// ### Warning Toast with Custom Duration
+/// ```dart
+/// GlassToast.show(
+///   context,
+///   message: 'Storage space running low',
+///   type: GlassToastType.warning,
+///   duration: Duration(seconds: 5),
+/// );
+/// ```
+///
+/// ### Custom Toast with Manual Dismiss
+/// ```dart
+/// GlassToast.show(
+///   context,
+///   message: 'Processing...',
+///   type: GlassToastType.neutral,
+///   duration: Duration.zero, // Won't auto-dismiss
+///   dismissible: true, // Can be swiped away
+/// );
+/// ```
+///
+/// ## iOS 26 Design Principles
+///
+/// - **Pill-shaped morphology**: Rounded capsule with liquid glass backdrop
+/// - **Subtle animations**: Spring physics for natural motion (iOS 26 standard)
+/// - **Non-blocking**: Floats above content without modal barrier
+/// - **Contextual colors**: Semantic colors for different message types
+/// - **Haptic feedback**: Provides tactile response on appearance (if supported)
+/// - **Adaptive positioning**: Respects safe areas and keyboard
+///
+/// ## Queue Management
+///
+/// Toasts are automatically queued when multiple are shown simultaneously.
+/// The queue ensures:
+/// - One toast visible at a time
+/// - Smooth transitions between toasts
+/// - Proper cleanup of dismissed toasts
+///
+/// ## Accessibility
+///
+/// - Uses [Semantics] with [liveRegion: true] for screen reader announcements
+/// - Semantic labels for action buttons
+/// - High contrast mode support via theme
+/// - Respects reduce motion preferences for animations
+class GlassToast extends StatefulWidget {
+  /// Creates a glass toast notification.
+  const GlassToast({
+    required this.message,
+    super.key,
+    this.icon,
+    this.type = GlassToastType.success,
+    this.position = GlassToastPosition.bottom,
+    this.action,
+    this.dismissible = true,
+    this.onDismissed,
+    this.settings,
+    this.quality,
+  });
+
+  /// The message text to display
+  final String message;
+
+  /// Optional icon widget to display before the message
+  final Widget? icon;
+
+  /// Visual style and semantic meaning of the toast
+  final GlassToastType type;
+
+  /// Position where the toast should appear
+  final GlassToastPosition position;
+
+  /// Optional action button
+  final GlassToastAction? action;
+
+  /// Whether the toast can be dismissed by swiping
+  final bool dismissible;
+
+  /// Callback when the toast is dismissed
+  final VoidCallback? onDismissed;
+
+  /// Custom glass settings (overrides theme)
+  final LiquidGlassSettings? settings;
+
+  /// Rendering quality (overrides theme)
+  final GlassQuality? quality;
+
+  /// Shows a toast notification.
+  ///
+  /// Returns a function that can be called to manually dismiss the toast.
+  ///
+  /// Example:
+  /// ```dart
+  /// final dismiss = GlassToast.show(context, message: 'Loading...');
+  /// // Later...
+  /// dismiss();
+  /// ```
+  static VoidCallback show(
+    BuildContext context, {
+    required String message,
+    Widget? icon,
+    GlassToastType type = GlassToastType.success,
+    GlassToastPosition position = GlassToastPosition.bottom,
+    Duration duration = const Duration(seconds: 3),
+    GlassToastAction? action,
+    bool dismissible = true,
+    LiquidGlassSettings? settings,
+    GlassQuality? quality,
+  }) {
+    final overlayState = Overlay.of(context);
+    late OverlayEntry overlayEntry;
+
+    void removeEntry() {
+      overlayEntry.remove();
+    }
+
+    overlayEntry = OverlayEntry(
+      builder: (context) => _GlassToastOverlay(
+        message: message,
+        icon: icon,
+        type: type,
+        position: position,
+        duration: duration,
+        action: action,
+        dismissible: dismissible,
+        settings: settings,
+        quality: quality,
+        onDismissed: removeEntry,
+      ),
+    );
+
+    overlayState.insert(overlayEntry);
+
+    return removeEntry;
+  }
+
+  @override
+  State<GlassToast> createState() => _GlassToastState();
+}
+
+class _GlassToastState extends State<GlassToast> {
+  @override
+  Widget build(BuildContext context) {
+    final themeData = GlassThemeData.of(context);
+    final glowColors = themeData.glowColorsFor(context);
+
+    // Get semantic color based on toast type
+    final Color semanticColor = _getSemanticColor(glowColors);
+
+    // Use user-provided icon or fall back to default for the toast type
+    final Widget displayIcon = widget.icon ??
+        Icon(widget.type == GlassToastType.success
+            ? CupertinoIcons.check_mark_circled_solid
+            : widget.type == GlassToastType.error
+                ? CupertinoIcons.xmark_circle_fill
+                : widget.type == GlassToastType.info
+                    ? CupertinoIcons.info_circle_fill
+                    : widget.type == GlassToastType.warning
+                        ? CupertinoIcons.exclamationmark_triangle_fill
+                        : CupertinoIcons.chat_bubble_fill);
+
+    return Semantics(
+      liveRegion: true,
+      label: widget.message,
+      child: _buildToastContent(context, semanticColor, displayIcon),
+    );
+  }
+
+  Widget _buildToastContent(
+      BuildContext context, Color semanticColor, Widget displayIcon) {
+    final hasAction = widget.action != null;
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    final bgColor = isDark
+        ? CupertinoColors.black.withValues(alpha: 0.7)
+        : CupertinoColors.white.withValues(alpha: 0.7);
+    final textColor = CupertinoColors.label.resolveFrom(context);
+
+    return AdaptiveLiquidGlassLayer(
+      settings: widget.settings ??
+          const LiquidGlassSettings(
+            thickness: 25.0,
+            blur: 6.0,
+            refractiveIndex: 1.15,
+            saturation: 1.3,
+          ),
+      quality: widget.quality,
+      child: Container(
+        constraints: const BoxConstraints(
+          minHeight: 48,
+          maxWidth: 400,
+        ),
+        decoration: BoxDecoration(
+          color: bgColor,
+          borderRadius: BorderRadius.circular(24),
+          border: Border.all(
+            color: semanticColor.withValues(alpha: 0.2),
+            width: 1,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: semanticColor.withValues(alpha: 0.15),
+              blurRadius: 20,
+              spreadRadius: 2,
+            ),
+          ],
+        ),
+        padding: EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: hasAction ? 8 : 12,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Icon
+            IconTheme(
+              data: IconThemeData(color: semanticColor, size: 20),
+              child: displayIcon,
+            ),
+            const SizedBox(width: 12),
+
+            // Message
+            Flexible(
+              child: Text(
+                widget.message,
+                style: TextStyle(
+                  color: textColor,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w500,
+                  letterSpacing: -0.2,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+
+            // Action button
+            if (hasAction) ...[
+              const SizedBox(width: 12),
+              CupertinoButton(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 6,
+                ),
+                onPressed: widget.action!.onPressed,
+                minimumSize: Size(32, 32),
+                child: Text(
+                  widget.action!.label,
+                  style: TextStyle(
+                    color: semanticColor,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _getSemanticColor(GlassGlowColors glowColors) {
+    switch (widget.type) {
+      case GlassToastType.success:
+        return glowColors.success ?? GlassGlowColors.fallback.success!;
+      case GlassToastType.error:
+        return glowColors.danger ?? GlassGlowColors.fallback.danger!;
+      case GlassToastType.info:
+        return glowColors.info ?? GlassGlowColors.fallback.info!;
+      case GlassToastType.warning:
+        return glowColors.warning ?? GlassGlowColors.fallback.warning!;
+      case GlassToastType.neutral:
+        return CupertinoColors.secondaryLabel.resolveFrom(context);
+    }
+  }
+}
+
+/// Overlay wrapper that handles animations and positioning for the toast.
+class _GlassToastOverlay extends StatefulWidget {
+  const _GlassToastOverlay({
+    required this.message,
+    required this.type,
+    required this.position,
+    required this.duration,
+    required this.onDismissed,
+    this.icon,
+    this.action,
+    this.dismissible = true,
+    this.settings,
+    this.quality,
+  });
+
+  final String message;
+  final Widget? icon;
+  final GlassToastType type;
+  final GlassToastPosition position;
+  final Duration duration;
+  final GlassToastAction? action;
+  final bool dismissible;
+  final LiquidGlassSettings? settings;
+  final GlassQuality? quality;
+  final VoidCallback onDismissed;
+
+  @override
+  State<_GlassToastOverlay> createState() => _GlassToastOverlayState();
+}
+
+class _GlassToastOverlayState extends State<_GlassToastOverlay>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<Offset> _slideAnimation;
+  late Animation<double> _fadeAnimation;
+  Timer? _dismissTimer;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Initialize animation controller with spring curve
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 500),
+    );
+
+    // Slide animation based on position
+    final Offset slideBegin = _getSlideOffset();
+    _slideAnimation = Tween<Offset>(
+      begin: slideBegin,
+      end: Offset.zero,
+    ).animate(CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOutCubic,
+      reverseCurve: Curves.easeInCubic,
+    ));
+
+    // Fade animation
+    _fadeAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _controller,
+      curve: const Interval(0.0, 0.5),
+      reverseCurve: const Interval(0.5, 1.0),
+    ));
+
+    // Start entrance animation
+    _controller.forward();
+
+    // Schedule auto-dismiss if duration is non-zero
+    if (widget.duration > Duration.zero) {
+      _dismissTimer = Timer(widget.duration, _dismiss);
+    }
+  }
+
+  Offset _getSlideOffset() {
+    switch (widget.position) {
+      case GlassToastPosition.top:
+        return const Offset(0, -1);
+      case GlassToastPosition.center:
+        return const Offset(0, 1);
+      case GlassToastPosition.bottom:
+        return const Offset(0, 1);
+    }
+  }
+
+  Future<void> _dismiss() async {
+    _dismissTimer?.cancel();
+    await _controller.reverse();
+    widget.onDismissed();
+  }
+
+  @override
+  void dispose() {
+    _dismissTimer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final MediaQueryData mediaQuery = MediaQuery.of(context);
+    final EdgeInsets padding = mediaQuery.padding;
+
+    // Calculate vertical position
+    final double verticalPosition = _calculateVerticalPosition(padding);
+
+    Widget toast = GlassToast(
+      message: widget.message,
+      icon: widget.icon,
+      type: widget.type,
+      position: widget.position,
+      action: widget.action,
+      dismissible: widget.dismissible,
+      settings: widget.settings,
+      quality: widget.quality,
+      onDismissed: _dismiss,
+    );
+
+    // Add swipe-to-dismiss gesture if enabled
+    if (widget.dismissible) {
+      toast = Dismissible(
+        key: const Key('glass_toast_dismissible'),
+        direction: _getDismissDirection(),
+        onDismissed: (_) => _dismiss(),
+        child: toast,
+      );
+    }
+
+    return Positioned(
+      top: widget.position == GlassToastPosition.top ? verticalPosition : null,
+      bottom: widget.position == GlassToastPosition.bottom
+          ? verticalPosition
+          : null,
+      left: 16,
+      right: 16,
+      child: SlideTransition(
+        position: _slideAnimation,
+        child: FadeTransition(
+          opacity: _fadeAnimation,
+          child: widget.position == GlassToastPosition.center
+              ? Center(child: toast)
+              : toast,
+        ),
+      ),
+    );
+  }
+
+  double _calculateVerticalPosition(EdgeInsets padding) {
+    switch (widget.position) {
+      case GlassToastPosition.top:
+        return padding.top + 16;
+      case GlassToastPosition.center:
+        return 0; // Centered via alignment
+      case GlassToastPosition.bottom:
+        return padding.bottom + 16;
+    }
+  }
+
+  DismissDirection _getDismissDirection() {
+    switch (widget.position) {
+      case GlassToastPosition.top:
+        return DismissDirection.up;
+      case GlassToastPosition.center:
+        return DismissDirection.horizontal;
+      case GlassToastPosition.bottom:
+        return DismissDirection.down;
+    }
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -1,0 +1,1013 @@
+part of '../glass_menu.dart';
+
+class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
+  final OverlayPortalController _overlayController = OverlayPortalController();
+
+  late final GlassMorphController _morphController;
+
+  late final ScrollController _scrollController;
+  Size? _triggerSize;
+  double? _triggerBorderRadius;
+  Offset _triggerGlobalPosition = Offset.zero; // captured in _openMenu
+  int? _hoveredIndex;
+  bool _isDragging = false;
+  bool _hasStretched =
+      false; // Prevents closing if we moved into stretch territory
+  double _initialScrollOffset = 0.0;
+  Offset _initialLocalPosition = Offset.zero;
+  double _horizontalOffset = 0.0;
+  double _verticalOffset = 0.0;
+
+  /// Live screen-space nudge added to the captured trigger position while the
+  /// menu is OPEN, so an external owner can keep the floating menu glued to a
+  /// moving anchor (e.g. a canvas tile trailing under a rubberband) WITHOUT
+  /// re-opening. Reset to zero on each [_openMenu]. Applied to both morph blobs
+  /// in [_buildMorphingOverlay]. It deliberately does NOT recompute the
+  /// screen-edge clamping ([_horizontalOffset]/[_verticalOffset]) — trails are
+  /// small and bounded, and recomputing per-frame is not worth the cost. Driven
+  /// via [GlassMenuController.setFollowOffset] / [setFollowOffset].
+  Offset _followOffset = Offset.zero;
+
+  // --- Granular Update System (Performance + No flicker) ---
+  // We cache the outer list but use notifiers to update selection state
+  // without rebuilding the entire menu tree.
+  late final ValueNotifier<int?> _hoveredIndexNotifier;
+  late final ValueNotifier<bool> _isDraggingNotifier;
+  List<Widget>? _cachedWrappedItems;
+
+  @override
+  void didUpdateWidget(GlassMenu oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(widget.controller, oldWidget.controller)) {
+      oldWidget.controller?._detach(this);
+      widget.controller?._attach(this);
+    }
+    if (!identical(widget.items, oldWidget.items)) {
+      _cachedWrappedItems = null;
+      // BUG 12 FIX: Clear hover state if items shrink while menu is open
+      // to prevent RangeError when the selection pill tries to measure
+      // a now-deleted index.
+      if (widget.items.length < oldWidget.items.length) {
+        _hoveredIndex = null;
+        _hoveredIndexNotifier.value = null;
+      }
+    }
+  }
+
+  Alignment _morphAlignment = Alignment.topLeft;
+
+  Alignment? _getAlignment(GlassMenuAlignment align) {
+    switch (align) {
+      case GlassMenuAlignment.none:
+        return null;
+
+      case GlassMenuAlignment.topLeft:
+        return Alignment.topLeft;
+      case GlassMenuAlignment.topCenter:
+        return Alignment.topCenter;
+      case GlassMenuAlignment.topRight:
+        return Alignment.topRight;
+      case GlassMenuAlignment.centerLeft:
+        return Alignment.centerLeft;
+      case GlassMenuAlignment.center:
+        return Alignment.center;
+      case GlassMenuAlignment.centerRight:
+        return Alignment.centerRight;
+      case GlassMenuAlignment.bottomLeft:
+        return Alignment.bottomLeft;
+      case GlassMenuAlignment.bottomCenter:
+        return Alignment.bottomCenter;
+      case GlassMenuAlignment.bottomRight:
+        return Alignment.bottomRight;
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _morphController = GlassMorphController(vsync: this);
+    _morphController.addListener(() {
+      if (mounted) setState(() {});
+
+      // Hide overlay only when the spring has FULLY SETTLED near 0.
+      // Velocity guard prevents premature hiding on first zero-crossing
+      // during the underdamped close bounce.
+      if (_overlayController.isShowing &&
+          _morphController.value <= 0.001 &&
+          _morphController.velocity.abs() < 0.5 &&
+          _morphController.status != AnimationStatus.forward) {
+        _overlayController.hide();
+        // Reset screen-edge clamping offsets so stale values from a previous
+        // open position don't bleed into the next open cycle.
+        _horizontalOffset = 0.0;
+        _verticalOffset = 0.0;
+      }
+    });
+    _scrollController = ScrollController();
+    _hoveredIndexNotifier = ValueNotifier(null);
+    _isDraggingNotifier = ValueNotifier(false);
+    widget.controller?._attach(this);
+  }
+
+  @override
+  void dispose() {
+    widget.controller?._detach(this);
+    _morphController.dispose();
+    _scrollController.dispose();
+    _hoveredIndexNotifier.dispose();
+    _isDraggingNotifier.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Sync the reduced-motion accessibility flag to the morph controller.
+    // This fires on first build and again whenever MediaQuery changes
+    // (e.g. user toggles Reduce Motion in Settings while the app is running).
+    _morphController.setDisableAnimations(
+      MediaQuery.of(context).disableAnimations,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _morphController.animation,
+      builder: (context, child) {
+        final rawValue = _morphController.value;
+
+        // Block trigger taps while menu is significantly open.
+        final isMenuBlocking = _overlayController.isShowing && rawValue > 0.8;
+
+        // Early handoff during close:
+        // When closing and the liquid morph is almost finished, we latch the handoff.
+        // We instantly hide the empty glass overlay and reveal the REAL trigger.
+        // The latch ensures that even if the underdamped spring bounces back up
+        // past 0.15, we don't hide the icon again!
+        final isHandoff =
+            _morphController.isClosing && _morphController.hasHandedOff;
+        final triggerOpacity =
+            (_overlayController.isShowing && !isHandoff) ? 0.0 : 1.0;
+
+        // Calculate the momentum push vector based on the exact same logic as Blob B
+        // so the real trigger precisely inherits the menu's momentum trajectory.
+        final tw = _triggerSize?.width ?? 44.0;
+        final th = _triggerSize?.height ?? 44.0;
+        final menuWidth = widget.menuWidth;
+        final menuHeight = _calculateMenuHeight();
+        final dxMag = (menuWidth - tw) / 2.0;
+        final dyMag = (menuHeight - th) / 2.0;
+        final finalDx = -_morphAlignment.x * dxMag;
+        final finalDy = -_morphAlignment.y * dyMag;
+
+        // Apply the push momentum to the real trigger during the underdamped bounce
+        // Include the offsets so the trajectory is mathematically perfect.
+        final double pushDx =
+            isHandoff ? (finalDx + _horizontalOffset) * rawValue : 0.0;
+        final double pushDy =
+            isHandoff ? (finalDy + _verticalOffset) * rawValue : 0.0;
+
+        return Stack(
+          clipBehavior: Clip.none,
+          children: [
+            // Trigger — physically bounces when slammed by the closing menu!
+            Transform.translate(
+              offset: Offset(pushDx, pushDy),
+              child: Opacity(
+                opacity: triggerOpacity,
+                child: IgnorePointer(
+                  ignoring: isMenuBlocking,
+                  child: widget.triggerBuilder != null
+                      ? widget.triggerBuilder!(context, _toggleMenu)
+                      : GestureDetector(
+                          onTap: _toggleMenu,
+                          child: widget.trigger,
+                        ),
+                ),
+              ),
+            ),
+
+            // Overlay portal for morphing animation
+            // The overlay contents fade out during the handoff so the real button shows instead
+            OverlayPortal(
+              controller: _overlayController,
+              overlayChildBuilder: _buildMorphingOverlay,
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _toggleMenu() {
+    if (_overlayController.isShowing && _morphController.value > 0.1) {
+      _closeMenu();
+    } else {
+      _openMenu();
+    }
+  }
+
+  /// Nudges the OPEN menu by [offset] (screen px) on top of its captured trigger
+  /// position, so an external owner can track a moving anchor live. A no-op
+  /// delta is skipped to avoid needless rebuilds. Has no visible effect while
+  /// closed; the next [_openMenu] resets it to zero.
+  void setFollowOffset(Offset offset) {
+    if (_followOffset == offset) return;
+    setState(() => _followOffset = offset);
+  }
+
+  void _openMenu() {
+    // Capture geometry and screen position for morphing
+    final renderBox = context.findRenderObject() as RenderBox?;
+    if (renderBox == null || !renderBox.hasSize) {
+      // Safety: Cannot open menu if render box is not ready
+      return;
+    }
+
+    _triggerSize = renderBox.size;
+    _triggerBorderRadius = _triggerSize!.height / 2;
+    _triggerGlobalPosition =
+        renderBox.localToGlobal(Offset.zero); // store for overlay
+    // A fresh open must never inherit a previous open's live anchor nudge.
+    _followOffset = Offset.zero;
+    final position = _triggerGlobalPosition;
+    final mediaQuery = MediaQuery.maybeOf(context);
+    final screenWidth = mediaQuery?.size.width ?? double.infinity;
+    final screenHeight = mediaQuery?.size.height ?? double.infinity;
+
+    // Calculate menu height for vertical boundary check
+    final menuHeight = _calculateMenuHeight();
+
+    // 1. Determine base alignment (Auto vs Manual)
+    if (widget.menuAlignment == null ||
+        widget.menuAlignment == GlassMenuAlignment.none) {
+      // Horizontal alignment: left vs right half
+      final isRightHalf = screenWidth.isFinite && position.dx > screenWidth / 2;
+
+      // Vertical alignment: check if menu would overflow bottom
+      final spaceBelow = screenHeight.isFinite
+          ? screenHeight - (position.dy + _triggerSize!.height)
+          : double.infinity;
+      final spaceAbove = screenHeight.isFinite ? position.dy : double.infinity;
+
+      // Prefer downward opening unless insufficient space
+      final shouldFlipVertical =
+          spaceBelow < menuHeight && spaceAbove > menuHeight;
+
+      if (shouldFlipVertical) {
+        _morphAlignment =
+            isRightHalf ? Alignment.bottomRight : Alignment.bottomLeft;
+      } else {
+        _morphAlignment = isRightHalf ? Alignment.topRight : Alignment.topLeft;
+      }
+    } else {
+      // MANUAL: Use the provided alignment directly.
+      // Note: autoAdjustToScreen clamping will still compensate for overflow.
+      _morphAlignment =
+          _getAlignment(widget.menuAlignment!) ?? Alignment.center;
+    }
+
+    // 2. Clamping: calculate offsets to keep menu within screen bounds
+    double hOffset = 0.0;
+    double vOffset = 0.0;
+
+    if (widget.autoAdjustToScreen) {
+      final flutterView = View.of(context);
+      final mqPadding = EdgeInsets.fromViewPadding(
+          flutterView.padding, flutterView.devicePixelRatio);
+
+      final double safeTop = widget.menuPadding.top + mqPadding.top;
+      final double safeBottom = widget.menuPadding.bottom + mqPadding.bottom;
+      final double safeLeft = widget.menuPadding.left + mqPadding.left;
+      final double safeRight = widget.menuPadding.right + mqPadding.right;
+
+      // Calculate global menu position
+      final double targetX =
+          position.dx + (1 + _morphAlignment.x) * _triggerSize!.width / 2;
+      final double targetY =
+          position.dy + (1 + _morphAlignment.y) * _triggerSize!.height / 2;
+      final double menuLeft =
+          targetX - (1 + _morphAlignment.x) * widget.menuWidth / 2;
+      final double menuTop = targetY - (1 + _morphAlignment.y) * menuHeight / 2;
+
+      // Horizontal adjustment
+      if (menuLeft < safeLeft) {
+        hOffset = safeLeft - menuLeft;
+      } else if (screenWidth.isFinite &&
+          menuLeft + widget.menuWidth > screenWidth - safeRight) {
+        hOffset = (screenWidth - safeRight) - (menuLeft + widget.menuWidth);
+      }
+
+      // Vertical adjustment
+      if (menuTop < safeTop) {
+        vOffset = safeTop - menuTop;
+      } else if (screenHeight.isFinite &&
+          menuTop + menuHeight > screenHeight - safeBottom) {
+        vOffset = (screenHeight - safeBottom) - (menuTop + menuHeight);
+      }
+    }
+
+    setState(() {
+      _horizontalOffset = hOffset;
+      _verticalOffset = vOffset;
+    });
+
+    _overlayController.show();
+    // GlassMorphController.open() uses 0.0 velocity — spring starts from rest
+    // for a clean, smooth teardrop expansion with no artificial kick.
+    _morphController.open();
+  }
+
+  void _closeMenu() {
+    setState(() {
+      _hoveredIndex = null;
+      _isDragging = false;
+    });
+    // GlassMorphController.close() injects the -2.5 velocity hint internally,
+    // maximising the rubber-band bounce amplitude at close.
+    _morphController.close();
+    widget.onClose?.call();
+  }
+
+  Widget _buildMorphingOverlay(BuildContext context) {
+    if (_triggerSize == null) return const SizedBox.shrink();
+
+    // Raw value can legitimately exceed [0, 1]: the underdamped spring
+    // overshoots on close (goes negative) to create the J-curve bounce.
+    final rawValue = _morphController.value;
+    final clampedValue = rawValue.clamp(0.0, 1.0);
+
+    final tw = _triggerSize!.width;
+    final th = _triggerSize!.height;
+    final menuWidth = widget.menuWidth.toDouble();
+    final menuHeight = _calculateMenuHeight();
+
+    // The destination of the menu center relative to the trigger center.
+    // By setting dyMag to exactly (menuHeight - th) / 2.0, the final menu
+    // will perfectly align its top edge with the trigger's top edge, effectively
+    // "covering" the faded out menu button.
+    final dxMag = (menuWidth - tw) / 2.0;
+    final dyMag = (menuHeight - th) / 2.0;
+    final finalDx = -_morphAlignment.x * dxMag;
+    final finalDy = -_morphAlignment.y * dyMag;
+
+    // ─── Delegate physics to GlassMorphController ────────────────────────────
+    //
+    // All J-curve, size, push, anchor-scale, blend, and containerScale math
+    // is encapsulated in LiquidMorphPhysics.compute() via the controller.
+    final state = _morphController.computeState(
+      finalDx: finalDx,
+      finalDy: finalDy,
+      horizontalOffset: _horizontalOffset,
+      verticalOffset: _verticalOffset,
+    );
+
+    final targetHeight = widget.menuHeight ?? menuHeight;
+    // Under morphFromZero the body lerps from a zero-size point at the trigger
+    // center (collapse-to-point) rather than from the trigger's own size; the
+    // false path keeps tw/th so the spawn-blob behavior is byte-identical.
+    final double sizeStartW = widget.morphFromZero ? 0.0 : tw;
+    final double sizeStartH = widget.morphFromZero ? 0.0 : th;
+    // Clamp to >= 0: the rubber-band close drives sizeT slightly negative during
+    // the undershoot, which lerps the size below zero for a tiny trigger and
+    // trips a debug BoxConstraints assert. A size can't be negative; 0 (fully
+    // collapsed) is the correct floor and is visually identical to the intended
+    // shrink-to-nothing at the close tail. Under morphFromZero the lerp already
+    // starts at 0, so this same clamp still floors the close undershoot.
+    final currentHeight = lerpDouble(sizeStartH, targetHeight, state.sizeT)!
+        .clamp(0.0, double.infinity);
+    final currentWidth = lerpDouble(sizeStartW, widget.menuWidth, state.sizeT)!
+        .clamp(0.0, double.infinity);
+
+    final inheritedSettings = InheritedLiquidGlass.of(context);
+    final effectiveSettings = widget.settings ??
+        inheritedSettings ??
+        const LiquidGlassSettings(
+          blur: 10,
+          thickness: 10,
+          glassColor: Color.fromRGBO(255, 255, 255, 0.12),
+          lightAngle: GlassDefaults.lightAngle,
+          lightIntensity: 0.7,
+          ambientStrength: 0.4,
+          saturation: 1.2,
+          refractiveIndex: 0.7,
+          chromaticAberration: 0.0,
+        );
+
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+    );
+
+    final maxRadius = math.min(currentWidth, currentHeight) / 2.0;
+    final double radiusT =
+        Curves.easeInExpo.transform(state.sizeT.clamp(0.0, 1.0));
+    final currentRadius =
+        lerpDouble(maxRadius, widget.menuBorderRadius, radiusT)!;
+
+    final blobBLeft = _triggerGlobalPosition.dx +
+        _followOffset.dx +
+        tw / 2.0 +
+        state.currentDx -
+        currentWidth / 2.0 +
+        (_horizontalOffset * clampedValue);
+
+    final blobBTop = _triggerGlobalPosition.dy +
+        _followOffset.dy +
+        th / 2.0 +
+        state.currentDy -
+        currentHeight / 2.0 +
+        (_verticalOffset * clampedValue);
+
+    return Stack(
+      children: [
+        // Invisible full-screen tap-to-close barrier
+        if (clampedValue > 0.3 && widget.showDismissBarrier)
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: _closeMenu,
+              child: Container(color: Colors.black.withValues(alpha: 0.0)),
+            ),
+          ),
+
+        // ── Two-Blob Metaball Morphing ───────────────────────────────────────
+        //
+        // We use LiquidGlassLayer at the root to create the transparent blend group.
+        // Inside it, we use two CompositedTransformFollowers, BOTH anchored to the
+        // trigger's center. This avoids manual coordinate math and prevents pixel drift.
+        Positioned.fill(
+          child: Opacity(
+            opacity:
+                (_morphController.isClosing && _morphController.hasHandedOff)
+                    ? 0.0
+                    : 1.0,
+            child: AdaptiveLiquidGlassLayer(
+              settings: effectiveSettings,
+              quality: effectiveQuality,
+              blendAmount: state.blend,
+              platformViewBackdrop: widget.platformViewBackdrop,
+              child: LiquidGlassBlendGroup(
+                blend: state.blend,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    // ─── Blob A: Trigger Ghost ───────────────────────────────
+                    // Stays perfectly centered on the trigger, BUT absorbs the
+                    // closing momentum (pushDx/pushDy) to bounce when slammed.
+                    // Shrinks to 0 scale over the first 40% of the animation to
+                    // smoothly break the liquid bridge.
+                    // Blob A is the spawn blob; under morphFromZero there is no trigger to ghost.
+                    if (!widget.morphFromZero)
+                      Positioned(
+                        left: _triggerGlobalPosition.dx +
+                            _followOffset.dx +
+                            state.pushDx,
+                        top: _triggerGlobalPosition.dy +
+                            _followOffset.dy +
+                            state.pushDy,
+                        child: Transform.scale(
+                          scale: state.anchorScale,
+                          child: GlassContainer(
+                            useOwnLayer: false,
+                            settings: effectiveSettings,
+                            quality: effectiveQuality,
+                            platformViewBackdrop: widget.platformViewBackdrop,
+                            width: tw,
+                            height: th,
+                            shape: LiquidRoundedSuperellipse(
+                              borderRadius: _triggerBorderRadius ??
+                                  _triggerSize!.shortestSide / 2.0,
+                            ),
+                          ),
+                        ),
+                      ),
+
+                    // ── Blob B: Menu Body ───────────────────────────────────
+                    // Its center travels diagonally relative to the trigger.
+                    // By scaling the x/y offsets with the width/height curves,
+                    // its edges stay perfectly pinned while it grows!
+                    Positioned(
+                      left: blobBLeft,
+                      top: blobBTop,
+                      child: IgnorePointer(
+                        ignoring: clampedValue < 0.8,
+                        child: _buildMorphingContainer(
+                          state,
+                          clampedValue,
+                          currentWidth,
+                          currentHeight,
+                          currentRadius,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  double _calculateMenuHeight() {
+    if (widget.menuHeight != null) {
+      return widget.menuHeight!;
+    }
+
+    // Account for system text scaling when calculating natural height.
+    // Without this, increased text size causes items to render taller than
+    // the height budget, triggering unwanted scrolling (GitHub issue).
+    final mediaQuery = MediaQuery.maybeOf(context);
+
+    // Sum all menu item heights, scaled by text scaler
+    final itemHeights = widget.items.fold<double>(
+      0.0,
+      (sum, item) => sum + _getScaledItemHeight(item, context),
+    );
+
+    // Add vertical padding (12px top + 12px bottom = 24px total)
+    // plus vertical gaps between items (2px each)
+    final gaps = (widget.items.length - 1) * 2.0;
+    final naturalHeight = itemHeights + 24.0 + gaps;
+
+    if (widget.autoAdjustToScreen) {
+      if (mediaQuery != null) {
+        final flutterView = View.of(context);
+        final mqPadding = EdgeInsets.fromViewPadding(
+            flutterView.padding, flutterView.devicePixelRatio);
+
+        // Clamp to screen height minus safe areas and a 20px safety buffer
+        final maxHeight = mediaQuery.size.height -
+            mqPadding.vertical -
+            widget.menuPadding.vertical -
+            20.0;
+        return math.min(naturalHeight, math.max(0.0, maxHeight));
+      }
+    }
+
+    return naturalHeight;
+  }
+
+  Widget _buildMorphingContainer(LiquidMorphState state, double clampedValue,
+      double currentWidth, double currentHeight, double currentRadius) {
+    // Sub-pixel blob registers no blend-group shape: skip it so the premium
+    // Impeller geometry never rasterizes a 0-area matte (Invalid image dimensions).
+    // The 1.0 logical-px floor is provably safe at every devicePixelRatio: a
+    // logical size in [0.5, 1.0) can still snap to a 0-area matte at dpr=1.0
+    // (matteBounds = (bounds * dpr).snapToPixels(1); ceil() == 0), which would
+    // reach the unclamped toImageSync in the geometry raster. Below 1.0 px is
+    // invisible on any display, so flooring here costs nothing visually.
+    if (currentWidth < 1.0 || currentHeight < 1.0) {
+      return const SizedBox.shrink();
+    }
+
+    // Inherit quality from parent layer if not explicitly set
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+    );
+
+    // ─── True Metaball Morphing ──────────────────────────────────────────────
+    //
+    // By using the pure spring value for both width and height, the menu container
+    // expands uniformly while moving diagonally. This is the SECRET to the native
+    // iOS liquid teardrop. The metaball shader naturally creates the bulbous bottom
+    // and the pinched neck connecting back to the trigger.
+    //
+    // No more faking the shape with tall, thin rectangles! Let the shader do the work.
+
+    // Build the shape
+    final teardropShape = LiquidRoundedSuperellipse(
+      borderRadius: currentRadius,
+    );
+
+    // containerScale is pre-computed by LiquidMorphPhysics inside GlassMorphController.
+    final containerScale = state.containerScale;
+
+    // ─── Item Stagger ─────────────────────────────────────────────────────────
+    // Pre-compute per-item stagger offsets (used in _buildMorphingContainer
+    // via the items list length).  Each item is offset by 20ms relative to
+    // the previous one so they cascade in smoothly from top-to-bottom.
+
+    // Inherit settings from context (like GlassCard/GlassContainer)
+    // If user provides custom settings, use those. Otherwise, check for inherited
+    // settings from parent layer. If none, use subtle overlay defaults.
+    // This matches the pattern used by all other glass widgets.
+    final inheritedSettings = InheritedLiquidGlass.of(context);
+    final effectiveSettings = widget.settings ??
+        inheritedSettings ??
+        const LiquidGlassSettings(
+          blur: 10,
+          thickness: 10,
+          glassColor: Color.fromRGBO(255, 255, 255, 0.12),
+          lightAngle: GlassDefaults.lightAngle, // Apple iOS 26 standard
+          lightIntensity: 0.7,
+          ambientStrength: 0.4,
+          saturation: 1.2,
+          refractiveIndex: 0.7, // Thin rim - iOS 26 delicate aesthetic
+          chromaticAberration: 0.0,
+        );
+
+    final glassContent = LiquidStretch(
+      stretch: widget.stretch,
+      interactionScale: widget.interactionScale,
+      resistance: widget.stretchResistance,
+      axis: widget.stretchAxis,
+      suppressInteractionOnChildren: false,
+      anchorStretch: false, // Menus use jelly-follow, not anchored
+      // Constrain stretch to 'Down' and 'Away from screen edge' by default,
+      // but allow explicit user overrides.
+      allowPositiveX: widget.allowPositiveX ?? (_morphAlignment.x < 0),
+      allowNegativeX: widget.allowNegativeX ?? (_morphAlignment.x > 0),
+      allowPositiveY: widget.allowPositiveY ?? (_morphAlignment.y < 0),
+      allowNegativeY: widget.allowNegativeY ?? (_morphAlignment.y > 0),
+      child: GlassContainer(
+        useOwnLayer: false, // blends with the trigger ghost
+        settings: effectiveSettings,
+        quality: effectiveQuality,
+        platformViewBackdrop: widget.platformViewBackdrop,
+        allowElevation:
+            false, // Menu is overlay - don't darken when outside parent
+        width: currentWidth,
+        height: currentHeight, // Constrained during morph, natural when open
+        shape: teardropShape,
+        clipBehavior:
+            Clip.antiAlias, // Clip items at the edges for edge-to-edge feel
+        glowIntensity: widget.glowIntensity,
+        child: Builder(builder: (context) {
+          final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+          return GlassGlow(
+            enabled: widget.enableInteractionGlow,
+            glowOnTapOnly: widget.glowOnTapOnly,
+            glowColor: widget.glowColor ??
+                (isDark
+                    ? Colors.white.withValues(alpha: 0.15)
+                    : Colors.black.withValues(alpha: 0.10)),
+            glowRadius: widget.glowRadius,
+            glowBlurRadius: 40,
+            clipper: ShapeBorderClipper(
+              shape: teardropShape,
+            ),
+            child: Transform.scale(
+              scale: containerScale,
+              alignment: Alignment.center,
+              child: Stack(
+                alignment: _morphAlignment, // Align internal stack content
+                clipBehavior:
+                    Clip.none, // Prevent double-clip artifacts during stretch
+                children: [
+                  // Menu content scales up with the container morph — items
+                  // enter the tree at 30% and scale from 0.5× to 1.0×.
+                  if (clampedValue > 0.3)
+                    Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        // Sliding selection pill (background)
+                        ValueListenableBuilder<int?>(
+                          valueListenable: _hoveredIndexNotifier,
+                          builder: (context, hoveredIndex, _) {
+                            if (hoveredIndex == null) {
+                              return const SizedBox.shrink();
+                            }
+                            return AnimatedPositioned(
+                              duration: const Duration(milliseconds: 150),
+                              curve: Curves.easeOutCubic,
+                              left: 12,
+                              right: 12,
+                              top: _getItemOffset(hoveredIndex, context) -
+                                  (_scrollController.hasClients
+                                      ? _scrollController.offset
+                                      : 0.0),
+                              height: _getScaledItemHeight(
+                                  widget.items[hoveredIndex], context),
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: widget.selectionColor,
+                                  borderRadius: BorderRadius.circular(
+                                      widget.itemBorderRadius),
+                                  border: Border.all(
+                                    color: GlassTheme.brightnessOf(context) ==
+                                            Brightness.dark
+                                        ? const Color(0x0DFFFFFF)
+                                        : const Color(0x0D000000),
+                                    width: 0.5,
+                                  ),
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                        Listener(
+                          onPointerDown: (event) {
+                            _isDragging = true;
+                            _isDraggingNotifier.value = true;
+                            _hasStretched = false;
+                            _initialLocalPosition = event.localPosition;
+                            _initialScrollOffset = _scrollController.hasClients
+                                ? _scrollController.offset
+                                : 0.0;
+                            _updateHoveredIndex(event.localPosition);
+                          },
+                          onPointerMove: (event) {
+                            if (_isDragging) {
+                              _updateHoveredIndex(event.localPosition);
+                            }
+                          },
+                          onPointerUp: (event) {
+                            if (_isDragging) {
+                              final currentOffset = _scrollController.hasClients
+                                  ? _scrollController.offset
+                                  : 0.0;
+                              final scrollDisplacement =
+                                  (currentOffset - _initialScrollOffset).abs();
+                              final dragDisplacement =
+                                  (event.localPosition - _initialLocalPosition)
+                                      .distance;
+
+                              // Slide-to-select tap logic (only for non-scrollable menus)
+                              if (scrollDisplacement < 10 &&
+                                  dragDisplacement < 10 &&
+                                  !_isScrollable) {
+                                final indexToTap = _hoveredIndex ??
+                                    _calculateIndexFromPosition(
+                                        event.localPosition, context);
+                                if (indexToTap != null) {
+                                  final item = widget.items[indexToTap];
+                                  if (item is GlassMenuItem && item.enabled) {
+                                    item.onTap();
+                                    _closeMenu();
+                                  }
+                                }
+                              }
+                              _isDragging = false;
+                              _isDraggingNotifier.value = false;
+                              _hoveredIndex = null;
+                              _hoveredIndexNotifier.value = null;
+                              _hasStretched = false;
+                            }
+                          },
+                          onPointerCancel: (_) {
+                            _isDragging = false;
+                            _isDraggingNotifier.value = false;
+                            _hoveredIndex = null;
+                            _hoveredIndexNotifier.value = null;
+                          },
+                          child: SizedBox(
+                            width: currentWidth,
+                            height: widget.menuHeight, // Apply fixed height
+                            child: Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 12),
+                              child: SingleChildScrollView(
+                                controller: _scrollController,
+                                physics: _isScrollable
+                                    ? const ClampingScrollPhysics() // iOS-style
+                                    : const NeverScrollableScrollPhysics(),
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: [
+                                    const SizedBox(height: 12), // Top padding
+                                    ..._buildWrappedItems()
+                                        .asMap()
+                                        .entries
+                                        .expand((entry) {
+                                      final itemOpacity =
+                                          ((clampedValue - 0.3) / 0.4)
+                                              .clamp(0.0, 1.0);
+                                      final itemScale = lerpDouble(
+                                        0.5,
+                                        1.0,
+                                        Curves.easeOut.transform(
+                                          ((clampedValue - 0.3) / 0.7)
+                                              .clamp(0.0, 1.0),
+                                        ),
+                                      )!;
+                                      return [
+                                        Opacity(
+                                          opacity: itemOpacity,
+                                          child: Transform.scale(
+                                            scale: itemScale,
+                                            child: entry.value,
+                                          ),
+                                        ),
+                                        if (entry.key < widget.items.length - 1)
+                                          const SizedBox(height: 2),
+                                      ];
+                                    }),
+                                    const SizedBox(
+                                        height: 12), // Bottom padding
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                ],
+              ), // outer Stack
+            ), // Transform.scale
+          ); // GlassGlow
+        }), // Builder
+      ), // GlassContainer
+    ); // LiquidStretch (glassContent)
+
+    // The blob is always fully opaque — shape morph is the only animation.
+    return glassContent;
+  }
+
+  List<Widget> _buildWrappedItems() {
+    return _cachedWrappedItems ??= widget.items.asMap().entries.map((entry) {
+      final item = entry.value;
+
+      if (item is GlassMenuItem) {
+        return _SelectionItemWrapper(
+          index: entry.key,
+          hoverNotifier: _hoveredIndexNotifier,
+          dragNotifier: _isDraggingNotifier,
+          builder: (context, isSelected, isPressed) {
+            return GlassMenuItem(
+              key: item.key ?? ValueKey(item.title),
+              title: item.title,
+              subtitle: item.subtitle,
+              icon: item.icon,
+              isDestructive: item.isDestructive,
+              enabled: item.enabled,
+              trailing: item.trailing,
+              height: item.height,
+              titleStyle: item.titleStyle,
+              subtitleStyle: item.subtitleStyle,
+              iconColor: item.iconColor,
+              iconSize: item.iconSize,
+              maxLines: item.maxLines,
+              isSelected: isSelected,
+              isPressed: isPressed,
+              onTap: () {
+                // For scrollable menus, we delegate taps to the native GestureDetector
+                // so it can properly participate in the gesture arena with the ScrollView.
+                if (_isScrollable && item.enabled) {
+                  item.onTap();
+                  _closeMenu();
+                }
+              },
+            );
+          },
+        );
+      }
+      return item;
+    }).toList();
+  }
+
+  bool get _isScrollable {
+    final visibleHeight = _calculateMenuHeight();
+    final itemHeights = widget.items.fold<double>(
+      0.0,
+      (sum, item) => sum + _getScaledItemHeight(item, context),
+    );
+    final gaps = (widget.items.length - 1) * 2.0;
+    final naturalHeight = itemHeights + 24.0 + gaps;
+    return widget.menuHeight != null || visibleHeight < naturalHeight - 1.0;
+  }
+
+  /// Accounts for system text scaling.
+  ///
+  /// When the user increases the system text size, GlassMenuItem renders
+  /// with scaled text inside a ConstrainedBox (minHeight). The text content
+  /// may push the actual height beyond the nominal [GlassMenuItem.height].
+  /// This method estimates the rendered height to prevent the menu from
+  /// becoming scrollable when it shouldn't be.
+  double _getScaledItemHeight(Widget item, BuildContext context) {
+    final mediaQuery = MediaQuery.maybeOf(context);
+    final textScaler = mediaQuery?.textScaler ?? TextScaler.noScaling;
+
+    if (item is GlassMenuItem) {
+      // The item has 8px vertical padding top + bottom = 16px fixed chrome.
+      // The remaining space is text content that scales with system text size.
+      const fixedPadding = 16.0;
+      final baseFontSize = item.titleStyle?.fontSize ?? 17.0;
+      final scaledFontSize = textScaler.scale(baseFontSize);
+      final lineHeight = scaledFontSize * 1.2; // Approximate line height
+      final textHeight = lineHeight * item.maxLines;
+
+      // Subtitle adds another scaled line
+      double subtitleHeight = 0;
+      if (item.subtitle != null) {
+        final subFontSize = item.subtitleStyle?.fontSize ?? 13.0;
+        subtitleHeight = textScaler.scale(subFontSize) * 1.2;
+      }
+
+      final contentHeight = textHeight + subtitleHeight + fixedPadding;
+      // Use the larger of nominal height or scaled content height
+      return math.max(item.height, contentHeight);
+    }
+    // Dividers and labels don't contain user-facing scaled text
+    if (item is GlassMenuDivider) return item.height;
+    if (item is GlassMenuLabel) return item.height;
+    return 44.0;
+  }
+
+  double _getItemOffset(int index, BuildContext context) {
+    double offset = 12.0; // Top padding
+    for (int i = 0; i < index; i++) {
+      offset += _getScaledItemHeight(widget.items[i], context) +
+          2.0; // height + 2px gap
+    }
+    return offset;
+  }
+
+  int? _calculateIndexFromPosition(Offset localPosition, BuildContext context) {
+    final visibleHeight = _calculateMenuHeight();
+    final x = localPosition.dx;
+    final dy = localPosition.dy;
+    final y =
+        dy + (_scrollController.hasClients ? _scrollController.offset : 0.0);
+
+    final isWithinActiveZone = x > -20 &&
+        x < widget.menuWidth + 20 &&
+        dy > -20 &&
+        dy < visibleHeight + 20;
+
+    if (!isWithinActiveZone) return null;
+
+    double currentOffset = 12.0;
+    for (int i = 0; i < widget.items.length; i++) {
+      final item = widget.items[i];
+      final itemHeight = _getScaledItemHeight(item, context);
+
+      if (y >= currentOffset && y <= currentOffset + itemHeight) {
+        if (item is GlassMenuItem && item.enabled) {
+          return i;
+        }
+        break;
+      }
+      currentOffset += itemHeight + 2.0; // height + 2px gap
+    }
+    return null;
+  }
+
+  void _updateHoveredIndex(Offset localPosition) {
+    // Detect if we've moved into "stretch territory" (outside visible menu bounds)
+    // We use the visible container height if fixed, otherwise the natural height.
+    final visibleHeight = _calculateMenuHeight();
+    final x = localPosition.dx;
+    final dy = localPosition.dy;
+
+    // We add a 100px buffer to allow for intense liquid stretching without accidental closure.
+    // We also allow cancelling the stretch if the user moves their finger back.
+    final outsideBounds = dy < -100 ||
+        dy > visibleHeight + 100 ||
+        x < -100 ||
+        x > widget.menuWidth + 100;
+
+    if (_hasStretched != outsideBounds) {
+      setState(() => _hasStretched = outsideBounds);
+    }
+
+    int? detectedIndex;
+
+    // Only calculate hover selection for non-scrollable menus (slide-to-select).
+    if (!_isScrollable) {
+      detectedIndex = _calculateIndexFromPosition(localPosition, context);
+    }
+
+    _hoveredIndex = detectedIndex;
+    _hoveredIndexNotifier.value = detectedIndex;
+  }
+}
+
+/// Internal helper to update selection state for cached items.
+class _SelectionItemWrapper extends StatelessWidget {
+  final int index;
+  final ValueNotifier<int?> hoverNotifier;
+  final ValueNotifier<bool> dragNotifier;
+  final Widget Function(BuildContext context, bool isSelected, bool isPressed)
+      builder;
+
+  const _SelectionItemWrapper({
+    required this.index,
+    required this.hoverNotifier,
+    required this.dragNotifier,
+    required this.builder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<int?>(
+      valueListenable: hoverNotifier,
+      builder: (context, hoveredIndex, _) {
+        final isSelected = hoveredIndex == index;
+        return ValueListenableBuilder<bool>(
+          valueListenable: dragNotifier,
+          builder: (context, isDragging, _) {
+            return builder(context, isSelected, isDragging && isSelected);
+          },
+        );
+      },
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
@@ -1,0 +1,769 @@
+part of '../glass_modal_sheet.dart';
+
+class _SheetLayout extends StatelessWidget {
+  final double interactionScale;
+  final bool enableInteractionGlow;
+  final Color? glowColor;
+  final double glowRadius;
+  final double stretch;
+  final double interactionStretch;
+  final double resistance;
+  final double hPad;
+  final double effectiveBottom;
+  final double effectiveHeight;
+  final double topRadius;
+  final double bottomRadius;
+  final double colorOpacity;
+  final double glassOpacity;
+  final Color effectiveExpandedColor;
+  final LiquidGlassSettings fadedSettings;
+  final GlassQuality effectiveQuality;
+  final bool platformViewBackdrop;
+  final Animation<double> saturationAnimation;
+  final double expandProgress;
+  final PointerDownEventListener onPointerDown;
+  final PointerMoveEventListener onPointerMove;
+  final PointerUpEventListener onPointerUp;
+  final PointerCancelEventListener onPointerCancel;
+  final ScrollController scrollController;
+  final ValueNotifier<GlassSheetState> currentStateNotifier;
+  final double expandProgressValue;
+  final Widget child;
+  final bool showDragIndicator;
+  final Color? dragIndicatorColor;
+  final double dragIndicatorWidth;
+  final EdgeInsetsGeometry? padding;
+  final bool maintainContentGlass;
+  final LiquidGlassSettings? fullStateContentSettings;
+  final bool enableTopFade;
+  final double topFadeHeight;
+  final bool enableSaturationGlow;
+  final VoidCallback onFocusGained;
+  final bool suppressInteractionOnChildren;
+
+  const _SheetLayout({
+    required this.interactionScale,
+    required this.enableInteractionGlow,
+    this.glowColor,
+    required this.glowRadius,
+    required this.stretch,
+    required this.interactionStretch,
+    required this.resistance,
+    required this.hPad,
+    required this.effectiveBottom,
+    required this.effectiveHeight,
+    required this.topRadius,
+    required this.bottomRadius,
+    required this.colorOpacity,
+    required this.glassOpacity,
+    required this.effectiveExpandedColor,
+    required this.fadedSettings,
+    required this.effectiveQuality,
+    required this.platformViewBackdrop,
+    required this.saturationAnimation,
+    required this.expandProgress,
+    required this.onPointerDown,
+    required this.onPointerMove,
+    required this.onPointerUp,
+    required this.onPointerCancel,
+    required this.scrollController,
+    required this.currentStateNotifier,
+    required this.expandProgressValue,
+    required this.child,
+    required this.showDragIndicator,
+    this.dragIndicatorColor,
+    required this.dragIndicatorWidth,
+    this.padding,
+    required this.maintainContentGlass,
+    this.fullStateContentSettings,
+    required this.enableTopFade,
+    required this.topFadeHeight,
+    required this.enableSaturationGlow,
+    required this.onFocusGained,
+    required this.suppressInteractionOnChildren,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final handleZone = _SheetHandleZone(indicatorWidth: dragIndicatorWidth);
+
+    final contentZone = _SheetContent(
+      scrollController: scrollController,
+      isFullScreen: expandProgressValue > 0.95,
+      padding: padding,
+      child: child,
+    );
+
+    return Positioned(
+      left: hPad,
+      right: hPad,
+      bottom: effectiveBottom,
+      height: effectiveHeight,
+      child: Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: onPointerDown,
+        onPointerMove: onPointerMove,
+        onPointerUp: onPointerUp,
+        onPointerCancel: onPointerCancel,
+        child: AnimatedBuilder(
+          animation: saturationAnimation,
+          child: _applyTopFade(contentZone),
+          builder: (context, child) {
+            final pulseT = saturationAnimation.value;
+            final pulsedSettings = fadedSettings.copyWith(
+              lightIntensity: lerpDouble(
+                fadedSettings.lightIntensity,
+                0.8 * glassOpacity,
+                pulseT,
+              )!,
+              saturation: lerpDouble(
+                fadedSettings.saturation,
+                2.2 * glassOpacity + (1.0 - glassOpacity),
+                pulseT,
+              )!,
+            );
+
+            final currentTopRadius = topRadius;
+            final currentBottomRadius = bottomRadius;
+
+            // Content settings: vibrant glass settings when maintainContentGlass
+            // is true and the sheet is nearly full.
+            final contentSettings =
+                (maintainContentGlass && expandProgressValue > 0.9)
+                    ? (fullStateContentSettings ??
+                        pulsedSettings.copyWith(
+                          lightIntensity:
+                              pulsedSettings.lightIntensity.clamp(0.4, 1.0),
+                          saturation: pulsedSettings.saturation.clamp(1.5, 3.0),
+                          blur: pulsedSettings.blur.clamp(15.0, 40.0),
+                        ))
+                    : pulsedSettings;
+
+            // Compute dynamic glass visibility for current expansion state.
+            final bool isFullyExpanded = expandProgressValue > 0.98;
+            final double glassVisibility = isFullyExpanded
+                ? (maintainContentGlass ? 1.0 : 0.0)
+                : (glassOpacity * 5.0).clamp(0.0, 1.0);
+
+            // Fade glass uniformly via settings rather than an Opacity widget.
+            //
+            // IMPORTANT: blur is clamped to a minimum of 0.001 rather than
+            // allowing it to reach exactly 0. When `AdaptiveGlass` receives
+            // `settings.effectiveBlur == 0` it switches its return type from
+            // the normal glass widget to `_FrostedFallback`. A type change at
+            // the same slot causes Flutter to tear down the existing element
+            // subtree and rebuild it from scratch — firing `initState` on all
+            // child `State` objects and destroying scroll positions, controllers,
+            // etc. A 0.001 blur is visually imperceptible but keeps the tree
+            // structure (and therefore the element identity) stable.
+            final currentSettings = contentSettings.copyWith(
+              glassColor: contentSettings.glassColor.withValues(
+                alpha: contentSettings.glassColor.a * glassVisibility,
+              ),
+              blur: (contentSettings.blur * glassVisibility)
+                  .clamp(0.001, double.infinity),
+              thickness: contentSettings.thickness * glassVisibility,
+            );
+
+            final shape = LiquidVerticalRoundedSuperellipse(
+              topRadius: currentTopRadius,
+              bottomRadius: currentBottomRadius,
+            );
+
+            return GlassModalSheetStateProvider(
+              info: SheetStateInfo(
+                state: currentStateNotifier.value,
+                progress: expandProgressValue,
+                isExpanded: expandProgressValue > 0.9,
+              ),
+              child: LiquidStretch(
+                interactionScale: interactionScale,
+                stretch: interactionStretch,
+                resistance: resistance,
+                hitTestBehavior: HitTestBehavior.translucent,
+                suppressInteractionOnChildren: suppressInteractionOnChildren,
+                axis: Axis.vertical,
+                allowPositive: false,
+                allowNegative: true,
+                anchorStretch:
+                    false, // Modal sheets use jelly-follow, not anchored
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    // 1. Empty slot placeholder — kept so the glass surface below
+                    //    keeps its element identity (this Stack is sensitive to slot
+                    //    shifts re-initing the glass). It used to hold a BoxShadow
+                    //    for faux depth, but behind the transparent fill + the
+                    //    translucent frost it never read as a drop shadow: it bled
+                    //    THROUGH the glass as interior darkening (an inner-shadow /
+                    //    vignette), was invisible behind the opaque full state, and
+                    //    broke light mode. Apple's glass sheets don't darken their
+                    //    interior — removed.
+                    Positioned.fill(
+                      child: const SizedBox.shrink(
+                        key: Key('glass_modal_sheet_shadow_slot'),
+                      ),
+                    ),
+                    // 2. Single unified glass surface — owns the SDF clip,
+                    //    solid fill, glow, and content. Consolidating into one
+                    //    AdaptiveGlass prevents the dual-stencil fragmentation
+                    //    that caused ghosting in Impeller Premium mode.
+                    Positioned.fill(
+                      child: AdaptiveGlass(
+                        shape: shape,
+                        settings: currentSettings,
+                        quality: effectiveQuality,
+                        platformViewBackdrop: platformViewBackdrop,
+                        useOwnLayer: true,
+                        clipBehavior: Clip.antiAlias,
+                        child: Stack(
+                          children: [
+                            // 3. Solid fill — inside AdaptiveGlass so it shares
+                            //    the same SDF mask and clip path. Always rendered
+                            //    (transparent when colorOpacity≈0) to keep the
+                            //    Stack structure stable — inserting/removing this
+                            //    child would shift GlassGlow's slot index, causing
+                            //    Flutter to tear down its subtree and fire
+                            //    initState on all child State objects.
+                            Positioned.fill(
+                              child: DecoratedBox(
+                                key: const Key('glass_modal_sheet_fill'),
+                                decoration: BoxDecoration(
+                                  color: effectiveExpandedColor.withValues(
+                                    alpha: colorOpacity,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            // 4. Glow overlay + content.
+                            Positioned.fill(
+                              child: Builder(builder: (innerContext) {
+                                final isDark =
+                                    GlassTheme.brightnessOf(innerContext) ==
+                                        Brightness.dark;
+                                return GlassGlow(
+                                  glowColor: (enableInteractionGlow &&
+                                          glassOpacity > 0.05 &&
+                                          expandProgress < 0.9)
+                                      ? (glowColor ??
+                                          (isDark
+                                              ? Colors.white
+                                                  .withValues(alpha: 0.15)
+                                              : Colors.black
+                                                  .withValues(alpha: 0.10)))
+                                      : Colors.transparent,
+                                  glowRadius: glowRadius,
+                                  hitTestBehavior: HitTestBehavior.translucent,
+                                  pulse: (enableSaturationGlow &&
+                                          expandProgress < 0.9)
+                                      ? saturationAnimation.value
+                                      : 0,
+                                  child: Stack(
+                                    children: [
+                                      Positioned.fill(
+                                        child: Material(
+                                          color: Colors.transparent,
+                                          child: child!,
+                                        ),
+                                      ),
+                                      if (showDragIndicator)
+                                        Positioned(
+                                          top: 0,
+                                          left: 0,
+                                          right: 0,
+                                          height: 44,
+                                          child: handleZone,
+                                        ),
+                                    ],
+                                  ),
+                                ); // GlassGlow
+                              }), // Builder
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _applyTopFade(Widget content) {
+    if (!enableTopFade) return content;
+
+    // Use a smooth fade for the ShaderMask stops to avoid abrupt tree mutations
+    // and provide a seamless transition as the sheet reaches the top.
+    final fadeT = ((expandProgressValue - 0.8) / 0.2).clamp(0.0, 1.0);
+
+    return ShaderMask(
+      shaderCallback: (Rect bounds) {
+        // When fadeT is 0, the 'transparent' stop is pushed above the bounds (0.0),
+        // effectively making the whole mask opaque.
+        final stop = lerpDouble(0.0, topFadeHeight, fadeT)!;
+        return LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: const [
+            Colors.transparent,
+            Colors.black,
+          ],
+          stops: [0.0, (stop / bounds.height).clamp(0.0, 1.0)],
+        ).createShader(bounds);
+      },
+      blendMode: BlendMode.dstIn,
+      child: content,
+    );
+  }
+}
+
+// ===========================================================================
+// Internal UI Support
+// ===========================================================================
+
+class _SheetHandleZone extends StatelessWidget {
+  const _SheetHandleZone({required this.indicatorWidth});
+
+  final double indicatorWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = GlassModalSheetStateProvider.of(context);
+    final isGlass = state != null ? state.progress < 0.9 : true;
+
+    return RepaintBoundary(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const SizedBox(height: 8),
+          _GlassDragIndicator(isGlass: isGlass, width: indicatorWidth),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}
+
+class _GlassDragIndicator extends StatelessWidget {
+  const _GlassDragIndicator({required this.isGlass, required this.width});
+
+  final bool isGlass;
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    // iOS 26: white at 35% in dark mode, black at 20% in light mode
+    final defaultColor =
+        isDark ? const Color(0x59FFFFFF) : const Color(0x33000000);
+
+    return Semantics(
+      label: 'Drag handle',
+      hint: 'Swipe down to dismiss',
+      child: Container(
+        width: width,
+        height: 4,
+        decoration: BoxDecoration(
+          color: defaultColor,
+          borderRadius: BorderRadius.circular(2),
+        ),
+      ),
+    );
+  }
+}
+
+class _SheetContent extends StatelessWidget {
+  final Widget child;
+  final ScrollController scrollController;
+  final bool isFullScreen;
+  final EdgeInsetsGeometry? padding;
+
+  const _SheetContent({
+    required this.child,
+    required this.scrollController,
+    required this.isFullScreen,
+    this.padding,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ScrollControllerProvider(
+      controller: scrollController,
+      physics: isFullScreen
+          ? const _ClampingTopScrollPhysics()
+          : const NeverScrollableScrollPhysics(),
+      child: Padding(
+        padding: padding ?? EdgeInsets.zero,
+        child: child,
+      ),
+    );
+  }
+}
+
+// ===========================================================================
+// Custom Scroll Physics
+// ===========================================================================
+
+class _ClampingTopScrollPhysics extends BouncingScrollPhysics {
+  const _ClampingTopScrollPhysics({super.parent});
+
+  @override
+  _ClampingTopScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return _ClampingTopScrollPhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  double applyBoundaryConditions(ScrollMetrics position, double value) {
+    if (value < position.pixels &&
+        position.pixels <= position.minScrollExtent) {
+      return value - position.pixels; // Under-scroll (top)
+    }
+    if (value < position.minScrollExtent &&
+        position.minScrollExtent < position.pixels) {
+      return value - position.minScrollExtent; // Hit top
+    }
+    return super.applyBoundaryConditions(position, value);
+  }
+}
+
+// ===========================================================================
+// State Providers
+// ===========================================================================
+
+class ScrollControllerProvider extends InheritedWidget {
+  final ScrollController controller;
+  final ScrollPhysics physics;
+
+  const ScrollControllerProvider({
+    super.key,
+    required this.controller,
+    required this.physics,
+    required super.child,
+  });
+
+  static ScrollControllerProvider? of(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<ScrollControllerProvider>();
+  }
+
+  @override
+  bool updateShouldNotify(ScrollControllerProvider old) =>
+      controller != old.controller || physics != old.physics;
+}
+
+/// Information about the current state of a [GlassModalSheet].
+class SheetStateInfo {
+  /// The current snap state.
+  final GlassSheetState state;
+
+  /// Expansion progress from 0.0 (hidden/peek) to 1.0 (full).
+  final double progress;
+
+  /// Whether the sheet is currently in its expanded (full) state.
+  final bool isExpanded;
+
+  const SheetStateInfo({
+    required this.state,
+    required this.progress,
+    required this.isExpanded,
+  });
+}
+
+/// Inherited widget that provides [SheetStateInfo] to its descendants.
+class GlassModalSheetStateProvider extends InheritedWidget {
+  final SheetStateInfo info;
+
+  const GlassModalSheetStateProvider({
+    super.key,
+    required this.info,
+    required super.child,
+  });
+
+  static SheetStateInfo? of(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<GlassModalSheetStateProvider>()
+        ?.info;
+  }
+
+  @override
+  bool updateShouldNotify(GlassModalSheetStateProvider oldWidget) {
+    return info.state != oldWidget.info.state ||
+        info.progress != oldWidget.info.progress ||
+        info.isExpanded != oldWidget.info.isExpanded;
+  }
+}
+
+// ===========================================================================
+// Scaffold implementation
+// ===========================================================================
+
+class GlassModalSheetScaffold extends StatelessWidget {
+  /// Body widget (e.g., a map or a list) that stays under the sheet.
+  final Widget body;
+
+  /// Sheet widget displayed inside the glass sheet.
+  final Widget sheet;
+
+  /// Height in the 'half' state (0.0 - 1.0 fraction or absolute pixels). Default: 0.45.
+  final double halfSize;
+
+  /// Maximum sheet height in 'full' state. If null, defaults to screen height minus 90px.
+  final double? fullSize;
+
+  /// Initial state when the scaffold is first displayed.
+  final GlassSheetState initialState;
+
+  /// Height in the 'peek' state. Default: 90.0.
+  final double peekSize;
+
+  /// Corner radius of the top edges in its floating state.
+  final double? topBorderRadius;
+
+  /// Corner radius of the bottom edges in its floating state.
+  final double? bottomBorderRadius;
+
+  /// Corner radius of the top edges when fully expanded.
+  final double? fullTopBorderRadius;
+
+  /// Corner radius of the bottom edges when fully expanded.
+  final double? fullBottomBorderRadius;
+
+  /// Horizontal padding between the sheet and the screen edges.
+  final double horizontalMargin;
+
+  /// Bottom padding from the screen edge.
+  final double bottomMargin;
+
+  /// Threshold (0.0 - 1.0) at which the sheet starts turning into a solid color.
+  final double fillThreshold;
+
+  /// Glass morphism effect settings (blur, thickness, lighting).
+  final LiquidGlassSettings? settings;
+
+  /// Background color used when the sheet is fully expanded and opaque.
+  final Color? expandedColor;
+
+  /// Rendering quality (BackdropFilter vs Shader). Defaults to standard.
+  final GlassQuality? quality;
+
+  /// Forces the BackdropFilter fallback so premium glass renders cleanly over
+  /// an iOS PlatformView. Forwarded to the sheet's [AdaptiveGlass].
+  final bool platformViewBackdrop;
+
+  /// Color/Saturation transition mode when expanding to full.
+  final GlassFillTransition fillTransition;
+
+  /// Scale factor applied during interaction for tactile feedback. Default: 1.01.
+  final double interactionScale;
+
+  /// Whether to show glow/glare on touch for tactile feedback. Default: true.
+  final bool enableInteractionGlow;
+
+  /// Whether to pulse saturation/lighting of the whole sheet on touch. Default: true.
+  final bool enableSaturationGlow;
+
+  /// Optional state-specific settings that override the base [settings].
+  final LiquidGlassSettings? peekSettings;
+  final LiquidGlassSettings? halfSettings;
+  final LiquidGlassSettings? fullSettings;
+
+  /// Liquid stretch multiplier for over-scroll/drag effects. Default: 0.5.
+  final double stretch;
+
+  /// Resistance factor when dragging beyond bounds. Default: 0.08.
+  final double resistance;
+
+  /// Snap progress threshold (0.0 - 1.0). Default: 0.4.
+  final double snapThreshold;
+
+  /// Velocity threshold for flick gestures (pixels/sec). Default: 700.0.
+  final double velocityThreshold;
+
+  /// Custom color for the touch interaction glow.
+  final Color? glowColor;
+
+  /// Radius of the touch interaction glow. Default: 1.5.
+  final double glowRadius;
+
+  /// Whether to prevent sheet scaling when interacting with children. Default: false.
+  final bool suppressInteractionOnChildren;
+
+  /// Internal padding for the sheet content.
+  final EdgeInsetsGeometry? padding;
+
+  /// Controller for programmatic sheet control.
+  final GlassModalSheetController? controller;
+
+  /// Callback triggered when the sheet snaps to a new state.
+  final ValueChanged<GlassSheetState>? onStateChanged;
+
+  /// Interaction mode (dismissible vs persistent). Default: [GlassSheetMode.dismissible].
+  final GlassSheetMode mode;
+
+  /// Whether to show the iOS-style drag handle at the top. Default: true.
+  final bool showDragIndicator;
+
+  /// Custom color for the drag handle.
+  final Color? dragIndicatorColor;
+
+  /// Width of the drag handle pill in logical pixels. Defaults to 36
+  /// (iOS native). Bump higher (e.g. 64) for sheets where the handle
+  /// reads as the primary affordance and the thinner default feels
+  /// too subtle relative to the rest of the sheet's content.
+  final double dragIndicatorWidth;
+
+  /// Whether to enable a gradient fade effect at the top.
+  final bool enableTopFade;
+
+  /// Height of the top fade effect.
+  final double topFadeHeight;
+
+  /// Whether to maintain high glass vibrancy for content even when the sheet is solid (full state).
+  final bool maintainContentGlass;
+
+  /// Custom glass settings for content specifically for the 'full' state.
+  final LiquidGlassSettings? fullStateContentSettings;
+
+  /// Whether the 'peek' state is enabled.
+  final bool? enablePeek;
+
+  /// Horizontal padding specifically for the 'peek' state.
+  final double? peekHorizontalMargin;
+
+  /// Bottom padding specifically for the 'peek' state.
+  final double? peekBottomMargin;
+
+  /// Fixed width for the 'peek' state.
+  final double? peekWidth;
+
+  /// Corner radius for 'peek' state.
+  final double? peekTopBorderRadius;
+
+  /// Corner radius for 'peek' state.
+  final double? peekBottomRadius;
+
+  const GlassModalSheetScaffold({
+    super.key,
+    required this.body,
+    required this.sheet,
+    this.halfSize = 0.45,
+    this.fullSize,
+    this.initialState = GlassSheetState.half,
+    this.topBorderRadius,
+    this.bottomBorderRadius,
+    this.fullTopBorderRadius,
+    this.fullBottomBorderRadius,
+    this.horizontalMargin = 8.0,
+    this.bottomMargin = 8.0,
+    this.fillThreshold = 0.85,
+    this.settings,
+    this.expandedColor,
+    this.controller,
+    this.onStateChanged,
+    this.mode = GlassSheetMode.dismissible,
+    this.peekSize = 90.0,
+    this.quality = GlassQuality.standard,
+    this.platformViewBackdrop = false,
+    this.interactionScale = 1.01,
+    this.enableInteractionGlow = true,
+    this.enableSaturationGlow = true,
+    this.peekSettings,
+    this.halfSettings,
+    this.fullSettings,
+    this.stretch = 0.5,
+    this.resistance = 0.08,
+    this.snapThreshold = 0.4,
+    this.velocityThreshold = 700.0,
+    this.fillTransition = GlassFillTransition.gradual,
+    this.showDragIndicator = true,
+    this.dragIndicatorColor,
+    this.dragIndicatorWidth = 36,
+    this.glowColor,
+    this.glowRadius = 1.5,
+    this.suppressInteractionOnChildren = false,
+    this.padding,
+    this.enableTopFade = false,
+    this.topFadeHeight = 40.0,
+    this.maintainContentGlass = true,
+    this.fullStateContentSettings,
+    this.enablePeek,
+    this.peekHorizontalMargin,
+    this.peekBottomMargin,
+    this.peekWidth,
+    this.peekTopBorderRadius,
+    this.peekBottomRadius,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Positioned.fill(
+          child: mode == GlassSheetMode.dismissible
+              ? GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () {
+                    controller?.snapToState(GlassSheetState.hidden);
+                  },
+                  child: RepaintBoundary(child: body),
+                )
+              : RepaintBoundary(child: body),
+        ),
+        GlassModalSheet(
+          halfSize: halfSize,
+          fullSize: fullSize,
+          initialState: initialState,
+          topBorderRadius: topBorderRadius,
+          bottomBorderRadius: bottomBorderRadius,
+          fullTopBorderRadius: fullTopBorderRadius,
+          fullBottomBorderRadius: fullBottomBorderRadius,
+          horizontalMargin: horizontalMargin,
+          bottomMargin: bottomMargin,
+          fillThreshold: fillThreshold,
+          settings: settings,
+          expandedColor: expandedColor,
+          controller: controller,
+          onStateChanged: onStateChanged,
+          mode: mode,
+          peekSize: peekSize,
+          quality: quality,
+          platformViewBackdrop: platformViewBackdrop,
+          interactionScale: interactionScale,
+          enableInteractionGlow: enableInteractionGlow,
+          enableSaturationGlow: enableSaturationGlow,
+          peekSettings: peekSettings,
+          halfSettings: halfSettings,
+          fullSettings: fullSettings,
+          stretch: stretch,
+          resistance: resistance,
+          snapThreshold: snapThreshold,
+          velocityThreshold: velocityThreshold,
+          fillTransition: fillTransition,
+          showDragIndicator: showDragIndicator,
+          dragIndicatorColor: dragIndicatorColor,
+          dragIndicatorWidth: dragIndicatorWidth,
+          glowColor: glowColor,
+          glowRadius: glowRadius,
+          suppressInteractionOnChildren: suppressInteractionOnChildren,
+          padding: padding,
+          enableTopFade: enableTopFade,
+          topFadeHeight: topFadeHeight,
+          maintainContentGlass: maintainContentGlass,
+          fullStateContentSettings: fullStateContentSettings,
+          enablePeek: enablePeek,
+          peekHorizontalMargin: peekHorizontalMargin,
+          peekBottomMargin: peekBottomMargin,
+          peekWidth: peekWidth,
+          peekTopBorderRadius: peekTopBorderRadius,
+          peekBottomRadius: peekBottomRadius,
+          child: sheet,
+        ),
+      ],
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/shared/glass_modal_sheet_mechanics.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/shared/glass_modal_sheet_mechanics.dart
@@ -1,0 +1,422 @@
+part of '../glass_modal_sheet.dart';
+
+// ===========================================================================
+// Sheet States & Modes
+// ===========================================================================
+
+enum GlassSheetState { hidden, peek, half, full }
+
+enum GlassSheetMode {
+  /// Scenario 1: hidden ↔ half ↔ full
+  /// Can swipe down from half to hidden. From full → half → hidden.
+  dismissible,
+
+  /// Scenario 2: peek ↔ half ↔ full
+  /// peek is the minimum state, cannot be hidden.
+  /// Swiping down from half returns to peek, not hidden.
+  persistent,
+}
+
+enum GlassFillTransition {
+  /// Gradual transition through gradient (current behavior)
+  gradual,
+
+  /// Instant color change after reaching threshold
+  instant,
+}
+
+// ===========================================================================
+// SheetStateMachine — isolated state machine
+// ===========================================================================
+
+/// Immutable state of the sheet at any given moment.
+class SheetSnapshot {
+  final GlassSheetState state;
+  final double position; // 0.0 .. 1.0 fraction of screen height
+  final double velocity; // pixels/second, positive = up
+  final Size screenSize;
+
+  const SheetSnapshot({
+    required this.state,
+    required this.position,
+    this.velocity = 0.0,
+    required this.screenSize,
+  });
+
+  SheetSnapshot copyWith({
+    GlassSheetState? state,
+    double? position,
+    double? velocity,
+    Size? screenSize,
+  }) =>
+      SheetSnapshot(
+        state: state ?? this.state,
+        position: position ?? this.position,
+        velocity: velocity ?? this.velocity,
+        screenSize: screenSize ?? this.screenSize,
+      );
+
+  double get expandProgress {
+    final halfPos =
+        SheetGeometry.positionFor(GlassSheetState.half, screenSize.height);
+    final fullPos =
+        SheetGeometry.positionFor(GlassSheetState.full, screenSize.height);
+    if (fullPos <= halfPos) return 0.0;
+    return ((position - halfPos) / (fullPos - halfPos)).clamp(0.0, 1.0);
+  }
+
+  @override
+  String toString() =>
+      'SheetSnapshot(state: $state, pos: ${position.toStringAsFixed(4)}, vel: ${velocity.toStringAsFixed(1)})';
+}
+
+/// Pure geometry calculations — no BuildContext, no side effects.
+class SheetGeometry {
+  final GlassSheetMode mode;
+  final double halfSize;
+  final double? fullSize;
+  final double peekSize;
+  final bool enablePeek;
+
+  const SheetGeometry({
+    required this.mode,
+    required this.halfSize,
+    this.fullSize,
+    required this.peekSize,
+    this.enablePeek = true,
+  });
+
+  static double positionFor(
+    GlassSheetState state,
+    double screenHeight, {
+    GlassSheetMode? mode,
+    double? halfSize,
+    double? fullSize,
+    double? peekSize,
+  }) {
+    switch (state) {
+      case GlassSheetState.hidden:
+        return 0.0;
+      case GlassSheetState.peek:
+        double pos = peekSize ?? 5.0;
+        return pos > 1.0 ? pos / screenHeight : pos;
+      case GlassSheetState.half:
+        double pos = halfSize ?? 0.45;
+        return pos > 1.0 ? pos / screenHeight : pos;
+      case GlassSheetState.full:
+        double? target = fullSize;
+        if (target != null) {
+          return target > 1.0 ? target / screenHeight : target;
+        }
+        // Strictly use the specified inset (default 90.0) for accurate top positioning
+        final topInset = 90.0;
+        return (screenHeight - topInset) / screenHeight;
+    }
+  }
+
+  double positionForState(GlassSheetState state, double screenHeight) {
+    final hiddenPos = positionFor(GlassSheetState.hidden, screenHeight,
+        mode: mode, halfSize: halfSize, fullSize: fullSize, peekSize: peekSize);
+    final peekPos = positionFor(GlassSheetState.peek, screenHeight,
+        mode: mode, halfSize: halfSize, fullSize: fullSize, peekSize: peekSize);
+    final halfPos = positionFor(GlassSheetState.half, screenHeight,
+        mode: mode, halfSize: halfSize, fullSize: fullSize, peekSize: peekSize);
+    final fullPos = positionFor(GlassSheetState.full, screenHeight,
+        mode: mode, halfSize: halfSize, fullSize: fullSize, peekSize: peekSize);
+
+    // Cascade constraint: ensure order hidden <= peek <= half <= full
+    final safePeek = peekPos.clamp(hiddenPos, 1.0);
+    final safeHalf = halfPos.clamp(safePeek, 1.0);
+    final safeFull = fullPos.clamp(safeHalf, 1.0);
+
+    switch (state) {
+      case GlassSheetState.hidden:
+        return hiddenPos;
+      case GlassSheetState.peek:
+        return safePeek;
+      case GlassSheetState.half:
+        return safeHalf;
+      case GlassSheetState.full:
+        return safeFull;
+    }
+  }
+
+  GlassSheetState get minState =>
+      enablePeek ? GlassSheetState.peek : GlassSheetState.hidden;
+
+  /// Computes target state based on current position and velocity.
+  GlassSheetState resolveTarget(
+    SheetSnapshot current, {
+    required double snapThreshold,
+    required double velocityThreshold,
+  }) {
+    // Build the ordered sequence of available states for the current mode
+    final List<GlassSheetState> states = [];
+    if (!enablePeek && mode == GlassSheetMode.dismissible) {
+      states.add(GlassSheetState.hidden);
+    }
+    if (enablePeek) {
+      states.add(GlassSheetState.peek);
+    }
+    // Skip half state when halfSize is 0 — allows direct full→hidden.
+    if (halfSize > 0) {
+      states.add(GlassSheetState.half);
+    }
+    states.add(GlassSheetState.full);
+
+    final positions = states
+        .map((s) => positionForState(s, current.screenSize.height))
+        .toList();
+    final velocity = current.velocity;
+
+    // Fast flick handling
+    if (velocity > velocityThreshold) {
+      // Find the next state above current
+      for (int i = 0; i < states.length - 1; i++) {
+        if (current.position < positions[i + 1] - 0.001) return states[i + 1];
+      }
+      return GlassSheetState.full;
+    }
+    if (velocity < -velocityThreshold) {
+      // Find the next state below current
+      for (int i = states.length - 1; i > 0; i--) {
+        if (current.position > positions[i - 1] + 0.001) return states[i - 1];
+      }
+      return states.first;
+    }
+
+    // Boundary safety: if outside the range of segments, snap to extremes
+    if (current.position <= positions.first) return states.first;
+    if (current.position >= positions.last) return states.last;
+
+    // Static snap handling: find which segment we are in
+    for (int i = 0; i < states.length - 1; i++) {
+      final s1 = states[i];
+      final s2 = states[i + 1];
+      final p1 = positions[i];
+      final p2 = positions[i + 1];
+
+      if (current.position >= p1 && current.position <= p2) {
+        final range = p2 - p1;
+        if (range <= 0.0001) continue;
+
+        final progress = (current.position - p1) / range;
+
+        // If we were moving towards s2, check if we crossed threshold
+        if (current.state == s1) {
+          return progress >= snapThreshold ? s2 : s1;
+        }
+        // If we were moving towards s1, check if we crossed threshold
+        if (current.state == s2) {
+          return (1.0 - progress) >= snapThreshold ? s1 : s2;
+        }
+
+        // Default: snap to nearest
+        return progress >= 0.5 ? s2 : s1;
+      }
+    }
+
+    // Final fallback: return the closest state overall
+    double minDistance = double.infinity;
+    GlassSheetState closest = current.state;
+    for (int i = 0; i < states.length; i++) {
+      final dist = (current.position - positions[i]).abs();
+      if (dist < minDistance) {
+        minDistance = dist;
+        closest = states[i];
+      }
+    }
+    return closest;
+  }
+
+  /// Applies rubber-band resistance when dragging beyond bounds.
+  double applyResistance(
+    double rawPosition,
+    double screenHeight, {
+    required double resistance,
+  }) {
+    final minPos = positionForState(minState, screenHeight);
+    final fullPos = positionForState(GlassSheetState.full, screenHeight);
+
+    if (rawPosition < minPos) {
+      final overflow = minPos - rawPosition;
+      return minPos - overflow * resistance;
+    }
+    if (rawPosition > fullPos) {
+      final overflow = rawPosition - fullPos;
+      return fullPos + overflow * resistance;
+    }
+    return rawPosition;
+  }
+}
+
+// ===========================================================================
+// Controllers
+// ===========================================================================
+
+class GlassModalSheetController {
+  _GlassModalSheetState? _state;
+
+  void _attach(_GlassModalSheetState state) => _state = state;
+  void _detach() => _state = null;
+
+  void snapToState(GlassSheetState state,
+      {bool animate = true, double velocity = 0}) {
+    _state?._snapToState(state, animate: animate, velocity: velocity);
+  }
+
+  GlassSheetState get currentState =>
+      _state?._currentState ?? GlassSheetState.hidden;
+
+  /// Internal expansion value (0.0 to 1.0).
+  /// Primarily used for testing and synchronized animations.
+  double get value => _state?._currentPosition ?? 0.0;
+  set value(double newValue) {
+    _state?._jumpTo(newValue);
+  }
+
+  /// Live progress between the half and full snaps: 0.0 at (or below) the half
+  /// snap, 1.0 at full. Use with [progressListenable] to react during a drag.
+  double get progress => _state?._expandProgress ?? 0.0;
+
+  /// Notifies on every sheet position change — drag and snap animation alike.
+  /// Null until the sheet is mounted; read [progress] from inside the listener.
+  Listenable? get progressListenable => _state?._progressNotifier;
+}
+
+// ===========================================================================
+// GestureArena — unified gesture handling
+// ===========================================================================
+
+enum GesturePhase { idle, handleDrag, contentDrag, scrolling }
+
+class GestureArena {
+  GesturePhase phase = GesturePhase.idle;
+  double dragStartY = 0.0;
+  double dragStartX = 0.0;
+  double dragStartSheetPosition = 0.0;
+  bool isVerticalGesture = false;
+  VelocityTracker velocityTracker =
+      VelocityTracker.withKind(PointerDeviceKind.touch);
+
+  void reset() {
+    phase = GesturePhase.idle;
+    isVerticalGesture = false;
+  }
+
+  void beginHandleDrag(double y, double sheetPosition) {
+    phase = GesturePhase.handleDrag;
+    dragStartY = y;
+    dragStartSheetPosition = sheetPosition;
+  }
+
+  void beginPointer(
+      double y, double x, double sheetPosition, PointerDeviceKind kind) {
+    phase = GesturePhase.idle;
+    dragStartY = y;
+    dragStartX = x;
+    dragStartSheetPosition = sheetPosition;
+    isVerticalGesture = false;
+    velocityTracker = VelocityTracker.withKind(kind);
+  }
+
+  /// Returns true if gesture should be claimed by sheet (not scroll).
+  bool evaluateMove(
+    double y,
+    double x,
+    GlassSheetState currentState,
+    double threshold, {
+    required bool canScrollListUp,
+    required bool hasScrollClients,
+  }) {
+    if (phase == GesturePhase.contentDrag) return true;
+    if (phase == GesturePhase.scrolling) return false;
+    if (phase == GesturePhase.handleDrag) return true;
+
+    final dy = (y - dragStartY).abs();
+    final dx = (x - dragStartX).abs();
+
+    if (dy > threshold && dy > dx) {
+      if (currentState == GlassSheetState.full) {
+        if ((y - dragStartY) < 0) {
+          // Swiping UP
+          if (hasScrollClients) {
+            phase = GesturePhase.scrolling;
+            return false;
+          } else {
+            phase = GesturePhase.contentDrag;
+            isVerticalGesture = true;
+            return true;
+          }
+        } else {
+          // Swiping DOWN
+          if (canScrollListUp) {
+            phase = GesturePhase.scrolling;
+            return false;
+          } else {
+            phase = GesturePhase.contentDrag;
+            isVerticalGesture = true;
+            return true;
+          }
+        }
+      } else {
+        phase = GesturePhase.contentDrag;
+        isVerticalGesture = true;
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+// ===========================================================================
+// FrozenState — immutable freeze record
+// ===========================================================================
+
+class FrozenState {
+  final double bottomScale;
+  final double heightAtFreeze;
+
+  const FrozenState({
+    required this.bottomScale,
+    required this.heightAtFreeze,
+  });
+
+  @override
+  String toString() =>
+      'FrozenState(scale: ${bottomScale.toStringAsFixed(3)}, height: ${heightAtFreeze.toStringAsFixed(1)})';
+}
+
+// ===========================================================================
+// RenderMetrics — Internal record for build geometry calculations
+// ===========================================================================
+
+class _RenderMetrics {
+  final double stretchT;
+  final double effectiveHeight;
+  final double effectiveBottom;
+  final double topRadius;
+  final double bottomRadius;
+  final double hPad;
+  final double colorOpacity;
+  final double glassOpacity;
+  final LiquidGlassSettings effectiveSettings;
+  final double interactionScale;
+  final double interactionStretch;
+  final Color effectiveExpandedColor;
+
+  const _RenderMetrics({
+    required this.stretchT,
+    required this.effectiveHeight,
+    required this.effectiveBottom,
+    required this.topRadius,
+    required this.bottomRadius,
+    required this.hPad,
+    required this.colorOpacity,
+    required this.glassOpacity,
+    required this.effectiveSettings,
+    required this.interactionScale,
+    required this.interactionStretch,
+    required this.effectiveExpandedColor,
+  });
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -1,0 +1,876 @@
+part of '../glass_modal_sheet.dart';
+
+class _GlassModalSheetState extends State<GlassModalSheet>
+    with TickerProviderStateMixin, WidgetsBindingObserver {
+  // ── Animation Controllers ─────────────────────────────────────────────────
+  late AnimationController _animationController;
+  late AnimationController _saturationController;
+  late Animation<double> _saturationAnimation;
+  final _progressNotifier = _ProgressNotifier();
+
+  // ── State ─────────────────────────────────────────────────────────────────
+  late final ValueNotifier<GlassSheetState> _currentStateNotifier;
+  GlassSheetState get _currentState => _currentStateNotifier.value;
+  set _currentState(GlassSheetState v) => _currentStateNotifier.value = v;
+
+  /// The state most recently published to consumers via
+  /// [GlassModalSheet.onStateChanged] (and from which haptics and
+  /// scroll-to-top side effects fired).
+  ///
+  /// Distinct from [_currentState]: that value is mutated mid-gesture
+  /// by [_applyDrag] and [_jumpTo] to drive in-flight visual
+  /// interpolation (radii, expand-progress, glass settings) toward the
+  /// resolved snap target. Comparing the snap target against
+  /// [_currentState] in [_snapToState] therefore silently skips the
+  /// side-effects branch whenever the drag itself had already crossed
+  /// a snap threshold — by the time the user releases, [_currentState]
+  /// already equals the target.
+  ///
+  /// [_settledState] is updated only inside the side-effects branch,
+  /// so the equality check correctly answers "did the state change
+  /// since the last time we told consumers about it".
+  late GlassSheetState _settledState;
+
+  double _currentPosition = 0.0;
+  double _currentEffectiveHeight = 0.0;
+
+  FrozenState? _frozenState;
+  Size _lastPhysicalSize = Size.zero;
+
+  bool _isInteractingWithChild = false;
+  bool _suppressScalingForSession = false;
+
+  // ── Unified Gesture & Scroll ──────────────────────────────────────────────
+  final GestureArena _gestureArena = GestureArena();
+  final ScrollController _scrollController = ScrollController();
+
+  // ── Geometry & Metrics ────────────────────────────────────────────────────
+  late SheetGeometry _geometry;
+  Size _screenSize = Size.zero;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+
+    _currentStateNotifier = ValueNotifier(widget.initialState);
+    _settledState = widget.initialState;
+    _geometry = _buildGeometry();
+
+    _animationController = AnimationController.unbounded(vsync: this);
+    _animationController.addListener(_progressNotifier.notify);
+    _saturationController = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: this,
+    );
+    _saturationAnimation =
+        CurvedAnimation(parent: _saturationController, curve: Curves.easeOut);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _updateScreenSize();
+        _lastPhysicalSize = View.of(context).physicalSize;
+        _snapToState(_currentState, animate: false);
+      }
+    });
+
+    widget.controller?._attach(this);
+  }
+
+  @override
+  void didUpdateWidget(GlassModalSheet oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.controller != oldWidget.controller) {
+      oldWidget.controller?._detach();
+      widget.controller?._attach(this);
+    }
+
+    final oldGeometry = _geometry;
+    _geometry = _buildGeometry();
+
+    // Hot Reload reaction: if dimensions changed, force position recalculation
+    if (oldGeometry.halfSize != _geometry.halfSize ||
+        oldGeometry.fullSize != _geometry.fullSize) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _gestureArena.phase == GesturePhase.idle) {
+          _snapToState(_currentState, animate: true);
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    widget.controller?._detach();
+    _animationController.removeListener(_progressNotifier.notify);
+    _animationController.dispose();
+    _progressNotifier.dispose();
+    _saturationController.dispose();
+    _scrollController.dispose();
+    _currentStateNotifier.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    super.didChangeMetrics();
+    if (!mounted) return;
+
+    final view = View.of(context);
+    // Filter system call spam: the spring only jitters if the window size actually changes
+    if (_lastPhysicalSize != view.physicalSize) {
+      if (_lastPhysicalSize != Size.zero) {
+        _updateScreenSize();
+        _snapToState(_currentState, animate: true);
+      }
+      _lastPhysicalSize = view.physicalSize;
+    }
+  }
+
+  SheetGeometry _buildGeometry() => SheetGeometry(
+        mode: widget.mode,
+        halfSize: widget.halfSize,
+        fullSize: widget.fullSize,
+        peekSize: widget.peekSize,
+        enablePeek:
+            widget.enablePeek ?? (widget.mode == GlassSheetMode.persistent),
+      );
+
+  void _updateScreenSize() {
+    final view = View.of(context);
+    _screenSize = view.physicalSize / view.devicePixelRatio;
+  }
+
+  // ════════════════════════════════════════════════════════════════════════
+  // Snap & State Management
+  // ════════════════════════════════════════════════════════════════════════
+
+  void _snapToState(GlassSheetState state,
+      {bool animate = true, double velocity = 0}) {
+    if (!mounted) return;
+
+    if (widget.mode == GlassSheetMode.persistent &&
+        state == GlassSheetState.hidden) {
+      state = GlassSheetState.peek;
+    }
+
+    final screenHeight = MediaQuery.sizeOf(context).height;
+    final targetPosition = _geometry.positionForState(state, screenHeight);
+
+    if (animate) {
+      final simulation = SpringSimulation(
+        const SpringDescription(mass: 1.0, stiffness: 220.0, damping: 30.0),
+        _currentPosition,
+        targetPosition,
+        velocity / screenHeight,
+      );
+      _animationController.animateWith(simulation);
+    } else {
+      _animationController.value = targetPosition;
+    }
+
+    // Compare against `_settledState`, not `_currentState` — see the
+    // doc comment on `_settledState` for why. Briefly: `_currentState`
+    // tracks the in-flight snap target during drag (mutated silently
+    // by `_applyDrag` and `_jumpTo`), so checking it here would skip
+    // side effects whenever the drag itself had already updated the
+    // target mid-gesture. `_settledState` only updates inside this
+    // branch, ensuring side effects fire on every consumer-visible
+    // state transition.
+    if (state != _settledState) {
+      if (state == GlassSheetState.peek || state == GlassSheetState.hidden) {
+        HapticFeedback.lightImpact();
+      } else {
+        HapticFeedback.mediumImpact();
+      }
+
+      _currentState = state;
+      _settledState = state;
+      widget.onStateChanged?.call(state);
+
+      if (state != GlassSheetState.full && _scrollController.hasClients) {
+        _scrollController.jumpTo(0);
+      }
+    }
+  }
+
+  void _jumpTo(double value) {
+    if (!mounted) return;
+    _animationController.value = value;
+    _currentPosition = value;
+
+    // Update current state based on position if needed
+    final snapshot = SheetSnapshot(
+      state: _currentState,
+      position: value,
+      screenSize: _screenSize,
+    );
+    final target = _geometry.resolveTarget(
+      snapshot,
+      snapThreshold: widget.snapThreshold,
+      velocityThreshold: widget.velocityThreshold,
+    );
+    if (target != _currentState) {
+      _currentState = target;
+    }
+  }
+
+  // ════════════════════════════════════════════════════════════════════════
+  // Gesture Handlers — Handle Drag & Scroll Notification
+  // ════════════════════════════════════════════════════════════════════════
+
+  bool _onScrollNotification(ScrollNotification notification) {
+    if (notification is OverscrollNotification && notification.overscroll < 0) {
+      if (_gestureArena.phase == GesturePhase.scrolling ||
+          _gestureArena.phase == GesturePhase.idle) {
+        _gestureArena.phase = GesturePhase.contentDrag;
+        if (notification.dragDetails != null) {
+          _gestureArena.dragStartY =
+              notification.dragDetails!.globalPosition.dy;
+        }
+        _gestureArena.dragStartSheetPosition = _currentPosition;
+
+        if (_animationController.isAnimating) {
+          _animationController.stop();
+        }
+      }
+    }
+    return false;
+  }
+
+  // ════════════════════════════════════════════════════════════════════════
+  // Gesture Handlers — Pointer Events (Content Zone)
+  // ════════════════════════════════════════════════════════════════════════
+
+  void _onPointerDown(PointerDownEvent event) {
+    // ALWAYS initialize the gesture arena so swipes can start from anywhere,
+    // even from buttons or interactive children.
+    _gestureArena.beginPointer(
+        event.position.dy, event.position.dx, _currentPosition, event.kind);
+
+    // If the touch is in the handle zone (top 44 pixels), immediately set phase.
+    if (event.localPosition.dy <= 44.0) {
+      _gestureArena.phase = GesturePhase.handleDrag;
+    }
+
+    // Now, if we are interacting with a child (e.g. a button), we SUPPRESS
+    // the visual feedback (scaling/glow) for the duration of this gesture,
+    // BUT ONLY if the feature is enabled via suppressInteractionOnChildren.
+    if (widget.suppressInteractionOnChildren && _isInteractingWithChild) {
+      _suppressScalingForSession = true;
+      _isInteractingWithChild = false;
+      // Do NOT fire haptic or saturation — this touch is silenced.
+      return;
+    }
+
+    // Always reset suppression state if we didn't return above
+    _isInteractingWithChild = false;
+    _suppressScalingForSession = false;
+
+    // Haptic and saturation only fire for genuine sheet-level touches
+    // (not for touches on child buttons that were suppressed above).
+    final isFull = _currentState == GlassSheetState.full;
+
+    if (widget.enableInteractionGlow && !isFull) {
+      HapticFeedback.selectionClick();
+    }
+
+    if (widget.enableSaturationGlow && !isFull) {
+      _saturationController.forward();
+    }
+
+    _frozenState = null;
+  }
+
+  void _onPointerMove(PointerMoveEvent event) {
+    if (_isInteractingWithChild) {
+      return;
+    }
+
+    _gestureArena.velocityTracker.addPosition(event.timeStamp, event.position);
+
+    // If we're already dragging the handle, just apply the drag
+    if (_gestureArena.phase == GesturePhase.handleDrag) {
+      _applyDrag(event.position.dy);
+      return;
+    }
+
+    final shouldClaim = _gestureArena.evaluateMove(
+      event.position.dy,
+      event.position.dx,
+      _currentState,
+      10.0,
+      hasScrollClients: _scrollController.hasClients,
+      canScrollListUp:
+          _scrollController.hasClients && _scrollController.offset > 0,
+    );
+
+    if (shouldClaim) {
+      if (_animationController.isAnimating) {
+        _animationController.stop();
+        _gestureArena.dragStartY = event.position.dy;
+        _gestureArena.dragStartSheetPosition = _currentPosition;
+      }
+
+      final dy = event.position.dy - _gestureArena.dragStartY;
+      if ((_currentState == GlassSheetState.half ||
+              _currentState == GlassSheetState.peek) &&
+          dy < 0) {
+        _frozenState = FrozenState(
+          bottomScale: widget.interactionScale,
+          heightAtFreeze: _currentEffectiveHeight,
+        );
+      }
+
+      _applyDrag(event.position.dy);
+    }
+  }
+
+  void _onPointerUp(PointerUpEvent event) {
+    _isInteractingWithChild = false;
+    _suppressScalingForSession = false;
+    _saturationController.reverse();
+
+    final wasDragging = _gestureArena.phase == GesturePhase.contentDrag ||
+        _gestureArena.phase == GesturePhase.handleDrag;
+    _gestureArena.reset();
+    _frozenState = null;
+
+    if (!wasDragging) return;
+
+    final estimate = _gestureArena.velocityTracker.getVelocityEstimate();
+    final velocity = -(estimate?.pixelsPerSecond.dy ?? 0.0);
+
+    final snapshot = SheetSnapshot(
+      state: _currentState,
+      position: _currentPosition,
+      velocity: velocity,
+      screenSize: _screenSize,
+    );
+    final target = _geometry.resolveTarget(
+      snapshot,
+      snapThreshold: widget.snapThreshold,
+      velocityThreshold: widget.velocityThreshold,
+    );
+
+    _snapToState(target, velocity: velocity);
+  }
+
+  void _onPointerCancel(PointerCancelEvent event) {
+    _isInteractingWithChild = false;
+    _suppressScalingForSession = false;
+    _saturationController.reverse();
+    _gestureArena.reset();
+    _frozenState = null;
+  }
+
+  // ════════════════════════════════════════════════════════════════════════
+  // Drag Application
+  // ════════════════════════════════════════════════════════════════════════
+
+  void _applyDrag(double currentY) {
+    final delta = currentY - _gestureArena.dragStartY;
+    double newPosition =
+        _gestureArena.dragStartSheetPosition - delta / _screenSize.height;
+
+    newPosition = _geometry.applyResistance(newPosition, _screenSize.height,
+        resistance: widget.resistance);
+    _animationController.value = newPosition;
+
+    final snapshot = SheetSnapshot(
+      state: _currentState,
+      position: newPosition,
+      velocity: 0,
+      screenSize: _screenSize,
+    );
+    final target = _geometry.resolveTarget(
+      snapshot,
+      snapThreshold: widget.snapThreshold,
+      velocityThreshold: widget.velocityThreshold,
+    );
+
+    if (target != _currentState &&
+        (widget.mode != GlassSheetMode.dismissible ||
+            target != GlassSheetState.hidden)) {
+      _currentState = target;
+    }
+  }
+
+  // ════════════════════════════════════════════════════════════════════════
+  // Metrics Calculation Helpers
+  // ════════════════════════════════════════════════════════════════════════
+
+  double get _expandProgress {
+    final halfPos =
+        _geometry.positionForState(GlassSheetState.half, _screenSize.height);
+    final fullPos =
+        _geometry.positionForState(GlassSheetState.full, _screenSize.height);
+    if (fullPos <= halfPos) return 0.0;
+    return ((_currentPosition - halfPos) / (fullPos - halfPos)).clamp(0.0, 1.0);
+  }
+
+  _RenderMetrics _calculateMetrics({
+    required double pos,
+    required double t,
+    required double halfPos,
+    required double minPos,
+    required double extraHeight,
+    required double mqHeight,
+    required LiquidGlassSettings baseSettings,
+    required Color effectiveExpandedColor,
+    required double topRadiusBase,
+    required double bottomRadiusBase,
+    required double topRadiusFull,
+    required double bottomRadiusFull,
+    required double fullPos,
+  }) {
+    late LiquidGlassSettings effectiveSettings;
+    // Disable scaling in full state by lerping effective interactionScale to 1.0
+    // Also disable scaling if we are interacting with a child (Smart Silence)
+    final baseInteractionScale =
+        _suppressScalingForSession ? 1.0 : widget.interactionScale;
+
+    final effectiveInteractionScale = lerpDouble(baseInteractionScale, 1.0, t)!;
+    final effectiveInteractionStretch =
+        lerpDouble(_suppressScalingForSession ? 0.0 : widget.stretch, 0.0, t)!;
+
+    double stretchT = 1.0;
+    // Protection against division by zero if halfPos == minPos
+    final range = halfPos - minPos;
+    if (pos < halfPos && range > 0.0001) {
+      stretchT = ((pos - minPos) / range).clamp(0.0, 1.0);
+    }
+
+    late double effectiveHeight;
+    late double effectiveBottom;
+    late double topRadius;
+    late double bottomRadius;
+    late double hPad;
+    late double colorOpacity;
+    late double glassOpacity;
+
+    // Ideal target visual height of the window
+    final targetVisualHeight = pos * mqHeight;
+
+    // baseSettings is now passed from outside to avoid theme lookups every frame.
+
+    // Calculate state-specific settings interpolation
+    final peekPos = _geometry.positionForState(GlassSheetState.peek, mqHeight);
+
+    final sPeek = widget.peekSettings ?? baseSettings;
+    final sHalf = widget.halfSettings ?? baseSettings;
+    final sFull = widget.fullSettings ?? baseSettings;
+
+    // Determine target expanded colors for each state
+    // If blur is 0, the state itself provides the solid color
+    final cPeek = sPeek.blur == 0 ? sPeek.glassColor : effectiveExpandedColor;
+    final cHalf = sHalf.blur == 0 ? sHalf.glassColor : effectiveExpandedColor;
+    final cFull = sFull.blur == 0 ? sFull.glassColor : effectiveExpandedColor;
+
+    Color currentExpandedColor;
+
+    if (pos < halfPos) {
+      final range = halfPos - peekPos;
+      final tProgress =
+          range > 0.0001 ? ((pos - peekPos) / range).clamp(0.0, 1.0) : 1.0;
+
+      effectiveSettings = LiquidGlassSettings.lerp(sPeek, sHalf, tProgress);
+      currentExpandedColor = Color.lerp(cPeek, cHalf, tProgress)!;
+
+      if (sPeek.blur > 0 && sHalf.blur == 0) {
+        colorOpacity = tProgress;
+      } else if (sPeek.blur == 0 && sHalf.blur > 0) {
+        colorOpacity = 1.0 - tProgress;
+      } else if (sPeek.blur == 0 && sHalf.blur == 0) {
+        colorOpacity = 1.0;
+      } else {
+        colorOpacity = 0.0;
+      }
+      glassOpacity = 1.0 - colorOpacity;
+    } else {
+      final range = fullPos - halfPos;
+      final tProgress =
+          range > 0.0001 ? ((pos - halfPos) / range).clamp(0.0, 1.0) : 1.0;
+
+      effectiveSettings = LiquidGlassSettings.lerp(sHalf, sFull, tProgress);
+      currentExpandedColor = Color.lerp(cHalf, cFull, tProgress)!;
+
+      if (widget.fullSettings != null) {
+        // Use explicit state settings for opacity transition
+        if (sHalf.blur > 0 && sFull.blur == 0) {
+          colorOpacity = tProgress;
+        } else if (sHalf.blur == 0 && sFull.blur > 0) {
+          colorOpacity = 1.0 - tProgress;
+        } else if (sHalf.blur == 0 && sFull.blur == 0) {
+          colorOpacity = 1.0;
+        } else {
+          colorOpacity = 0.0;
+        }
+      } else {
+        // Fallback to classic threshold logic OR maintain solid if half was solid
+        if (sHalf.blur == 0) {
+          colorOpacity = 1.0;
+        } else if (baseSettings.blur == 0) {
+          colorOpacity = 1.0;
+        } else {
+          final fadeRange = (1.0 - widget.fillThreshold).clamp(0.01, 1.0);
+          switch (widget.fillTransition) {
+            case GlassFillTransition.gradual:
+              const plateau = 0.04;
+              final rawT =
+                  ((tProgress - widget.fillThreshold) / (fadeRange - plateau))
+                      .clamp(0.0, 1.0);
+              colorOpacity = Curves.easeInOutCubic.transform(rawT);
+              break;
+            case GlassFillTransition.instant:
+              colorOpacity = tProgress >= widget.fillThreshold ? 1.0 : 0.0;
+              break;
+          }
+        }
+      }
+      glassOpacity = 1.0 - colorOpacity;
+    }
+
+    // Apply saturation glow pulse if enabled
+    if (widget.enableSaturationGlow && _saturationAnimation.value > 0) {
+      effectiveSettings = effectiveSettings.copyWith(
+        saturation: effectiveSettings.saturation *
+            (1.0 + _saturationAnimation.value * 0.25),
+        lightIntensity: effectiveSettings.lightIntensity *
+            (1.0 + _saturationAnimation.value * 0.35),
+      );
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Peek to Half Morphing
+    // ════════════════════════════════════════════════════════════════════════
+    if (pos < halfPos) {
+      final range = halfPos - peekPos;
+      final tProgressRaw =
+          range > 0.0001 ? ((pos - peekPos) / range).clamp(0.0, 1.0) : 1.0;
+
+      // Calibrate for Apple Maps behavior:
+      // Morphing should be almost instant (complete within first 15% of movement)
+      final tMorph = (tProgressRaw / 0.15).clamp(0.0, 1.0);
+      final tProgress = Curves.easeOut.transform(tMorph);
+
+      // 1. Resolve Peek-specific geometry
+      final peekHMargin =
+          widget.peekHorizontalMargin ?? widget.horizontalMargin;
+      final peekBMargin = widget.peekBottomMargin ?? widget.bottomMargin;
+      final peekTRadius = widget.peekTopBorderRadius ?? topRadiusBase;
+      final peekBRadius = widget.peekBottomRadius ?? bottomRadiusBase;
+
+      // 2. Resolve Peek-specific width (hPad)
+      double peekHPad = peekHMargin;
+      if (widget.peekWidth != null && mqHeight > 0) {
+        peekHPad = ((_screenSize.width - widget.peekWidth!) / 2.0)
+            .clamp(0.0, _screenSize.width / 2.0);
+      }
+
+      if (widget.mode == GlassSheetMode.persistent) {
+        // Morph from peek metrics to half metrics
+        effectiveBottom =
+            lerpDouble(peekBMargin, widget.bottomMargin, tProgress)!;
+        hPad = lerpDouble(peekHPad, widget.horizontalMargin, tProgress)!;
+
+        // Morph corner radii
+        final targetTRadius =
+            lerpDouble(peekTRadius, topRadiusBase, tProgress)!;
+        final targetBRadius =
+            lerpDouble(peekBRadius, bottomRadiusBase, tProgress)!;
+
+        if (_frozenState != null) {
+          final pivotScale = _frozenState!.bottomScale;
+          topRadius = lerpDouble(targetTRadius, targetTRadius * pivotScale,
+              _saturationAnimation.value)!;
+          bottomRadius = lerpDouble(targetBRadius, targetBRadius * pivotScale,
+              _saturationAnimation.value)!;
+        } else {
+          topRadius = lerpDouble(
+              targetTRadius,
+              targetTRadius * effectiveInteractionScale,
+              _saturationAnimation.value)!;
+          bottomRadius = lerpDouble(
+              targetBRadius,
+              targetBRadius * effectiveInteractionScale,
+              _saturationAnimation.value)!;
+        }
+
+        // Window changes height visually
+        effectiveHeight = targetVisualHeight - effectiveBottom;
+      } else {
+        // Dismissible mode: hiding downwards
+        final pivotPos = _geometry.enablePeek
+            ? _geometry.positionForState(GlassSheetState.peek, mqHeight)
+            : halfPos;
+
+        final pivotVisualHeight = pivotPos * mqHeight;
+
+        if (pos < pivotPos && pivotPos > 0.001) {
+          // Sliding from hidden up to pivot
+          final slideProgress = (pos / pivotPos).clamp(0.0, 1.0);
+          final offscreenBottom = -(pivotVisualHeight + 100.0);
+          effectiveBottom =
+              lerpDouble(offscreenBottom, peekBMargin, slideProgress)!;
+          effectiveHeight = pivotVisualHeight - peekBMargin;
+          hPad = peekHPad;
+          topRadius = peekTRadius;
+          bottomRadius = peekBRadius;
+        } else {
+          // Morphing between pivot (peek) and half
+          effectiveBottom =
+              lerpDouble(peekBMargin, widget.bottomMargin, tProgress)!;
+          hPad = lerpDouble(peekHPad, widget.horizontalMargin, tProgress)!;
+          effectiveHeight = targetVisualHeight - effectiveBottom;
+          topRadius = lerpDouble(peekTRadius, topRadiusBase, tProgress)!;
+          bottomRadius = lerpDouble(peekBRadius, bottomRadiusBase, tProgress)!;
+        }
+      }
+    } else {
+      // From half to full
+      final halfVisualHeight = halfPos * mqHeight;
+      final frozenScale = _frozenState?.bottomScale ?? 1.0;
+
+      final halfPhysicalHeight = halfVisualHeight - widget.bottomMargin;
+      final frozenBottomOffset =
+          (_frozenState?.heightAtFreeze ?? halfPhysicalHeight) *
+              (frozenScale - 1.0) /
+              2.0;
+      final frozenBottom = widget.bottomMargin - frozenBottomOffset;
+
+      // Phase 1: Wrap corners (t: 0.0 -> 0.92) - movement is diagonal towards the screen corners.
+      // Phase 2: Final sink (t: 0.92 -> 1.0) - the sheet submerges only when it's fully expanded.
+      const transitionEnd = 0.92;
+      final marginProgress = (t / transitionEnd).clamp(0.0, 1.0);
+      final sinkProgress =
+          ((t - transitionEnd) / (1.0 - transitionEnd)).clamp(0.0, 1.0);
+
+      if (_frozenState != null) {
+        final baseBottom = lerpDouble(frozenBottom, 0.0, marginProgress)!;
+        effectiveBottom = lerpDouble(baseBottom, -extraHeight, sinkProgress)!;
+      } else {
+        final baseBottom =
+            lerpDouble(widget.bottomMargin, 0.0, marginProgress)!;
+        effectiveBottom = lerpDouble(baseBottom, -extraHeight, sinkProgress)!;
+      }
+
+      // Physical height adjusts so the top edge always stays at targetVisualHeight
+      effectiveHeight = targetVisualHeight - effectiveBottom;
+
+      hPad =
+          lerpDouble(widget.horizontalMargin, 0.0, (t / 0.92).clamp(0.0, 1.0))!;
+      // Independent lerp for top and bottom radii
+      final baseRadiusTop = lerpDouble(
+          topRadiusBase,
+          topRadiusBase * effectiveInteractionScale,
+          _saturationAnimation.value)!;
+      final baseRadiusBottom = lerpDouble(
+          bottomRadiusBase,
+          bottomRadiusBase * effectiveInteractionScale,
+          _saturationAnimation.value)!;
+
+      topRadius = lerpDouble(baseRadiusTop, topRadiusFull, t)!;
+      bottomRadius = sinkProgress > 0
+          ? lerpDouble(baseRadiusBottom, bottomRadiusFull, sinkProgress)!
+          : baseRadiusBottom;
+    }
+
+    return _RenderMetrics(
+      stretchT: stretchT,
+      effectiveHeight: effectiveHeight,
+      effectiveBottom: effectiveBottom,
+      topRadius: topRadius,
+      bottomRadius: bottomRadius,
+      hPad: hPad,
+      colorOpacity: colorOpacity,
+      glassOpacity: glassOpacity,
+      effectiveSettings: effectiveSettings,
+      interactionScale: effectiveInteractionScale,
+      interactionStretch: effectiveInteractionStretch,
+      effectiveExpandedColor: currentExpandedColor,
+    );
+  }
+
+  // ════════════════════════════════════════════════════════════════════════
+  // Build
+  // ════════════════════════════════════════════════════════════════════════
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    final effectiveExpandedColor = widget.expandedColor ??
+        (isDark ? const Color(0xFF1C1C1E) : Colors.white);
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+      fallback: GlassQuality.premium,
+    );
+    final mqSize = MediaQuery.sizeOf(context);
+    final mqHeight = mqSize.height;
+    final mqPadding = MediaQuery.paddingOf(context);
+
+    final adaptive = GlassThemeHelpers.resolveAdaptiveRadius(context);
+    final topRadiusBase = widget.topBorderRadius ?? adaptive;
+    final bottomRadiusBase = widget.bottomBorderRadius ?? adaptive;
+
+    // Use explicit full radii if provided, otherwise default to a sensible constant
+    // or fallback to the base radii.
+    final topRadiusFull = widget.fullTopBorderRadius ?? topRadiusBase;
+    final bottomRadiusFull = widget.fullBottomBorderRadius ?? bottomRadiusBase;
+
+    final extraHeight = mqPadding.bottom + bottomRadiusBase;
+
+    final baseSettings = GlassThemeHelpers.resolveSettings(
+      context,
+      explicit: widget.settings,
+      fallback: kDefaultSheetSettings,
+    );
+
+    // Focus listener that snaps the sheet to full whenever a focusable
+    // descendant gains focus (e.g. tapping a TextField inside the sheet).
+    //
+    // IMPORTANT: this Focus widget intentionally carries NO key.
+    // Any key derived from `widget.child` (e.g. `GlobalObjectKey(widget.child)`)
+    // changes every time the parent rebuilds — because the parent passes a
+    // fresh `child` widget instance each frame — and Flutter responds to a
+    // changed key by tearing down the entire child Element subtree and
+    // rebuilding it. That destroys child State (calling `dispose` and
+    // re-running `initState`) on every sheet expand/collapse, which surfaces
+    // as scroll position resets, re-initialised controllers, re-fired fetches,
+    // etc. The FocusNode is owned internally by the Focus widget's Element and
+    // persists correctly without an external key.
+    final focusBridge = Focus(
+      onFocusChange: (hasFocus) {
+        if (hasFocus && _currentState != GlassSheetState.full) {
+          _snapToState(GlassSheetState.full);
+        }
+      },
+      child: widget.child,
+    );
+
+    return AnimatedBuilder(
+      animation:
+          Listenable.merge([_animationController, _saturationController]),
+      builder: (context, _) {
+        final fullPos =
+            _geometry.positionForState(GlassSheetState.full, mqHeight);
+        final halfPos =
+            _geometry.positionForState(GlassSheetState.half, mqHeight);
+        final minPos = _geometry.positionForState(_geometry.minState, mqHeight);
+
+        double pos = _animationController.value;
+
+        // Snap to exact positions when not dragging
+        if (_gestureArena.phase == GesturePhase.idle) {
+          if ((pos - halfPos).abs() < 0.002) pos = halfPos;
+          if ((pos - fullPos).abs() < 0.002) pos = fullPos;
+          if ((pos - minPos).abs() < 0.002) pos = minPos;
+        }
+
+        _currentPosition = pos;
+        final t = _expandProgress;
+
+        final metrics = _calculateMetrics(
+          pos: pos,
+          t: t,
+          halfPos: halfPos,
+          minPos: minPos,
+          extraHeight: extraHeight,
+          mqHeight: mqHeight,
+          baseSettings: baseSettings,
+          effectiveExpandedColor: effectiveExpandedColor,
+          topRadiusBase: topRadiusBase,
+          bottomRadiusBase: bottomRadiusBase,
+          topRadiusFull: topRadiusFull,
+          bottomRadiusFull: bottomRadiusFull,
+          fullPos: fullPos,
+        );
+
+        _currentEffectiveHeight = metrics.effectiveHeight;
+
+        final fadedSettings = metrics.effectiveSettings.copyWith(
+          glassColor: metrics.effectiveSettings.glassColor.withValues(
+              alpha: metrics.effectiveSettings.glassColor.a *
+                  metrics.glassOpacity),
+          blur: metrics.effectiveSettings.blur * metrics.glassOpacity,
+          lightIntensity:
+              metrics.effectiveSettings.lightIntensity * metrics.glassOpacity,
+          ambientStrength:
+              metrics.effectiveSettings.ambientStrength * metrics.glassOpacity,
+        );
+
+        Widget result = _SheetLayout(
+          interactionScale: metrics.interactionScale,
+          enableInteractionGlow: widget.enableInteractionGlow,
+          platformViewBackdrop: widget.platformViewBackdrop,
+          glowColor: widget.glowColor,
+          glowRadius: widget.glowRadius,
+          stretch: widget.stretch,
+          interactionStretch: metrics.interactionStretch,
+          resistance: widget.resistance,
+          hPad: metrics.hPad,
+          effectiveBottom: metrics.effectiveBottom,
+          effectiveHeight: metrics.effectiveHeight,
+          topRadius: metrics.topRadius,
+          bottomRadius: metrics.bottomRadius,
+          showDragIndicator: widget.showDragIndicator,
+          dragIndicatorColor: widget.dragIndicatorColor,
+          dragIndicatorWidth: widget.dragIndicatorWidth,
+          colorOpacity: metrics.colorOpacity,
+          glassOpacity: metrics.glassOpacity,
+          effectiveExpandedColor: metrics.effectiveExpandedColor,
+          fadedSettings: fadedSettings,
+          effectiveQuality: effectiveQuality,
+          saturationAnimation: _saturationAnimation,
+          expandProgress: t,
+          onPointerDown: _onPointerDown,
+          onPointerMove: _onPointerMove,
+          onPointerUp: _onPointerUp,
+          onPointerCancel: _onPointerCancel,
+          padding: widget.padding,
+          scrollController: _scrollController,
+          currentStateNotifier: _currentStateNotifier,
+          expandProgressValue: t,
+          maintainContentGlass: widget.maintainContentGlass,
+          fullStateContentSettings: widget.fullStateContentSettings,
+          enableSaturationGlow: widget.enableSaturationGlow,
+          enableTopFade: widget.enableTopFade,
+          topFadeHeight: widget.topFadeHeight,
+          onFocusGained: () {
+            if (_currentState != GlassSheetState.full) {
+              _snapToState(GlassSheetState.full);
+            }
+          },
+          suppressInteractionOnChildren: widget.suppressInteractionOnChildren,
+          child: focusBridge,
+        );
+
+        if (widget.suppressInteractionOnChildren) {
+          result = NotificationListener<InteractionNotification>(
+            onNotification: (notification) {
+              if (widget.suppressInteractionOnChildren) {
+                _isInteractingWithChild = true;
+              }
+              return false;
+            },
+            child: result,
+          );
+        }
+
+        return NotificationListener<ScrollNotification>(
+          onNotification: _onScrollNotification,
+          child: result,
+        );
+      },
+    );
+  }
+}
+
+/// Minimal [ChangeNotifier] subclass that exposes [notifyListeners] publicly
+/// via [notify], avoiding `invalid_use_of_protected_member` lint when the
+/// controller is used as an animation listener target from outside the class.
+class _ProgressNotifier extends ChangeNotifier {
+  void notify() => notifyListeners();
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/shared/glass_popover_internal.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/shared/glass_popover_internal.dart
@@ -1,0 +1,733 @@
+part of '../glass_popover.dart';
+
+class _GlassPopoverState extends State<GlassPopover>
+    with TickerProviderStateMixin {
+  final OverlayPortalController _overlayController = OverlayPortalController();
+
+  late final GlassMorphController _morphController;
+
+  Size? _triggerSize;
+  double? _triggerBorderRadius;
+  Offset _triggerGlobalPosition = Offset.zero;
+  double _horizontalOffset = 0.0;
+  double _verticalOffset = 0.0;
+
+  Alignment _morphAlignment = Alignment.topLeft;
+
+  /// Measured intrinsic height of the popover content.
+  /// Only used when [widget.popoverHeight] is null.
+  double? _measuredContentHeight;
+
+  /// True once the first measurement pass has fired for the current open cycle,
+  /// so we never queue a second [postFrameCallback] while the first is still
+  /// pending or after measurement has settled.
+  bool _contentMeasured = false;
+
+  /// Cached widget subtree from [widget.contentBuilder].
+  ///
+  /// Set exactly once in [_openPopover] and again in [didUpdateWidget] when the
+  /// widget configuration changes while the popover is showing. It is NEVER
+  /// mutated inside [build] — that would violate Flutter's purity contract.
+  Widget? _cachedContent;
+
+  /// Key used to measure the intrinsic height of the content subtree.
+  final GlobalKey _contentKey = GlobalKey();
+
+  // ---------------------------------------------------------------------------
+  // Alignment helper
+  // ---------------------------------------------------------------------------
+
+  Alignment? _getAlignment(GlassMenuAlignment align) {
+    switch (align) {
+      case GlassMenuAlignment.none:
+        return null;
+      case GlassMenuAlignment.topLeft:
+        return Alignment.topLeft;
+      case GlassMenuAlignment.topCenter:
+        return Alignment.topCenter;
+      case GlassMenuAlignment.topRight:
+        return Alignment.topRight;
+      case GlassMenuAlignment.centerLeft:
+        return Alignment.centerLeft;
+      case GlassMenuAlignment.center:
+        return Alignment.center;
+      case GlassMenuAlignment.centerRight:
+        return Alignment.centerRight;
+      case GlassMenuAlignment.bottomLeft:
+        return Alignment.bottomLeft;
+      case GlassMenuAlignment.bottomCenter:
+        return Alignment.bottomCenter;
+      case GlassMenuAlignment.bottomRight:
+        return Alignment.bottomRight;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  @override
+  void initState() {
+    super.initState();
+    _morphController = GlassMorphController(vsync: this);
+    _morphController.addListener(() {
+      // Hide the overlay only when the spring has FULLY SETTLED near zero.
+      // The velocity guard prevents premature hiding on the first zero-crossing
+      // during the underdamped close bounce.
+      if (_overlayController.isShowing &&
+          _morphController.value <= 0.001 &&
+          _morphController.velocity.abs() < 0.5 &&
+          _morphController.status != AnimationStatus.forward) {
+        _overlayController.hide();
+        // Reset per-open-cycle state so stale values from a previous position
+        // never bleed into the next open cycle.
+        setState(() {
+          _horizontalOffset = 0.0;
+          _verticalOffset = 0.0;
+          _measuredContentHeight = null;
+          _contentMeasured = false;
+          _cachedContent = null;
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _morphController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Sync the reduced-motion accessibility flag to the morph controller.
+    _morphController.setDisableAnimations(
+      MediaQuery.of(context).disableAnimations,
+    );
+  }
+
+  @override
+  void didUpdateWidget(GlassPopover oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // If the popover is showing and the widget configuration changed, refresh
+    // the cached content tree so the user sees up-to-date data. This is the
+    // correct lifecycle hook — never do this inside build().
+    if (_overlayController.isShowing &&
+        (oldWidget.contentBuilder != widget.contentBuilder ||
+            oldWidget.popoverWidth != widget.popoverWidth ||
+            oldWidget.popoverHeight != widget.popoverHeight)) {
+      setState(() {
+        _cachedContent = widget.contentBuilder(context, _closePopover);
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build
+  // ---------------------------------------------------------------------------
+
+  @override
+  Widget build(BuildContext context) {
+    // Mirror the GlassMenu structure exactly:
+    //   AnimatedBuilder (top-level, no render object) →
+    //     builder returns Stack([trigger, OverlayPortal])
+    //
+    // This matters for _openPopover(): context.findRenderObject() traverses
+    // down from the GlassPopover element. Because AnimatedBuilder has NO render
+    // object, it keeps descending into the builder's returned Stack. That Stack
+    // is always sized to the trigger button, so localToGlobal(Offset.zero) gives
+    // the correct global position of the trigger on screen.
+    //
+    // If we return an outer Stack from build() instead, findRenderObject() stops
+    // at the outer Stack, whose origin can be corrupted by the OverlayPortal
+    // sibling when the overlay is visible.
+    //
+    // The trigger is passed as AnimatedBuilder's `child` (not rebuilt inside
+    // the builder closure) so it is stable across animation ticks.
+    final Widget triggerContent = widget.triggerBuilder != null
+        ? widget.triggerBuilder!(context, _togglePopover)
+        : GestureDetector(
+            onTap: _togglePopover,
+            child: widget.trigger,
+          );
+
+    return AnimatedBuilder(
+      animation: _morphController.animation,
+      builder: (context, child) {
+        final rawValue = _morphController.value;
+
+        // Block trigger taps while the popover is meaningfully open.
+        final isPopoverBlocking =
+            _overlayController.isShowing && rawValue > 0.8;
+
+        // During the closing handoff the real trigger becomes visible again
+        // and inherits the liquid momentum from the collapsing blob.
+        final isHandoff =
+            _morphController.isClosing && _morphController.hasHandedOff;
+        final triggerOpacity =
+            (_overlayController.isShowing && !isHandoff) ? 0.0 : 1.0;
+
+        // Push vector: the trigger physically recoils as the popover snaps shut.
+        // These values mirror _buildMorphingOverlay's finalDx/finalDy so the
+        // trajectory is mathematically identical to the blob's path.
+        final tw = _triggerSize?.width ?? 44.0;
+        final th = _triggerSize?.height ?? 44.0;
+        final dxMag = (widget.popoverWidth - tw) / 2.0;
+        final dyMag = (_effectivePopoverHeight() - th) / 2.0;
+        final double pushDx = isHandoff
+            ? (-_morphAlignment.x * dxMag + _horizontalOffset) * rawValue
+            : 0.0;
+        final double pushDy = isHandoff
+            ? (-_morphAlignment.y * dyMag + _verticalOffset) * rawValue
+            : 0.0;
+
+        return Stack(
+          clipBehavior: Clip.none,
+          children: [
+            // ── Trigger ────────────────────────────────────────────────────
+            // Only apply Transform/Opacity/IgnorePointer layers when actually needed
+            // to prevent unnecessary compositing layers that cause BackdropFilter
+            // flickering (Premium quality) during scroll.
+            pushDx != 0.0 || pushDy != 0.0
+                ? Transform.translate(
+                    offset: Offset(pushDx, pushDy),
+                    child: Opacity(
+                      opacity: triggerOpacity,
+                      child: IgnorePointer(
+                        ignoring: isPopoverBlocking,
+                        child: child, // triggerContent
+                      ),
+                    ),
+                  )
+                : triggerOpacity < 1.0
+                    ? Opacity(
+                        opacity: triggerOpacity,
+                        child: IgnorePointer(
+                          ignoring: isPopoverBlocking,
+                          child: child,
+                        ),
+                      )
+                    : isPopoverBlocking
+                        ? IgnorePointer(
+                            ignoring: true,
+                            child: child,
+                          )
+                        : child ??
+                            const SizedBox
+                                .shrink(), // Raw trigger when completely idle
+
+            // ── Overlay portal ─────────────────────────────────────────────
+            // OverlayPortal renders in the overlay layer, not in-tree, so it
+            // is zero-sized here and does not affect the Stack's dimensions.
+            OverlayPortal(
+              controller: _overlayController,
+              overlayChildBuilder: _buildMorphingOverlay,
+            ),
+          ],
+        );
+      },
+      child: triggerContent,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Popover open / close
+  // ---------------------------------------------------------------------------
+
+  void _togglePopover() {
+    if (_overlayController.isShowing && _morphController.value > 0.1) {
+      _closePopover();
+    } else {
+      _openPopover();
+    }
+  }
+
+  void _closePopover() {
+    if (!mounted) return;
+    // GlassMorphController.close() injects the −2.5 velocity hint internally,
+    // maximising the rubber-band bounce amplitude on close.
+    _morphController.close();
+    widget.onClose?.call();
+  }
+
+  void _openPopover() {
+    // context.findRenderObject() works correctly here because build() returns
+    // AnimatedBuilder at the top level. AnimatedBuilder has no render object of
+    // its own, so the traversal descends into the builder's returned Stack,
+    // which is always sized to the trigger button. localToGlobal therefore gives
+    // the trigger's actual screen position.
+    final renderBox = context.findRenderObject() as RenderBox?;
+
+    if (renderBox == null || !renderBox.hasSize) return;
+
+    _triggerSize = renderBox.size;
+    _triggerBorderRadius = _triggerSize!.height / 2;
+    _triggerGlobalPosition = renderBox.localToGlobal(Offset.zero);
+
+    // Build the content widget exactly once for this open cycle. All
+    // subsequent frames read _cachedContent; didUpdateWidget refreshes it
+    // if the parent rebuilds with changed props while the popover is open.
+    _cachedContent = widget.contentBuilder(context, _closePopover);
+
+    // If popoverHeight is explicitly provided, measurement is already known.
+    // Mark it measured so the Offstage pass is skipped and we open immediately.
+    _contentMeasured = widget.popoverHeight != null;
+
+    // Compute alignment / clamping offsets and notify Flutter in a single
+    // setState so the first overlay build sees fully consistent values.
+    // If popoverHeight is null, we can't compute clamping yet — the first
+    // frame will be an invisible Offstage measurement pass instead.
+    setState(() {
+      if (_contentMeasured) {
+        _updatePositionAndClamping();
+      }
+      _overlayController.show();
+    });
+
+    if (_contentMeasured) {
+      _morphController.open();
+    }
+    widget.onOpen?.call();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Layout helpers
+  // ---------------------------------------------------------------------------
+
+  /// Returns the maximum height the popover may occupy, bounded by the
+  /// safe-area-inset screen height.
+  ///
+  /// Falls back to a finite sentinel (800 dp) instead of [double.infinity]
+  /// so downstream lerp / arithmetic never yields NaN or Infinity when
+  /// [MediaQuery] is unavailable (e.g. in some test environments).
+  double _getMaxPopoverHeight([EdgeInsets? precomputedPadding]) {
+    final mediaQuery = MediaQuery.maybeOf(context);
+    if (mediaQuery == null) return 800.0;
+
+    final screenHeight = mediaQuery.size.height;
+    final insets = precomputedPadding ?? _viewInsets();
+    final double safeTop = widget.screenPadding.top + insets.top;
+    final double safeBottom = widget.screenPadding.bottom + insets.bottom;
+    return math.max(0.0, screenHeight - safeTop - safeBottom);
+  }
+
+  /// Computes [EdgeInsets] from the platform view padding once so callers
+  /// that need both max-height and edge clamping share the same values.
+  EdgeInsets _viewInsets() {
+    final flutterView = View.of(context);
+    return EdgeInsets.fromViewPadding(
+        flutterView.padding, flutterView.devicePixelRatio);
+  }
+
+  double _effectivePopoverHeight([EdgeInsets? precomputedPadding]) {
+    if (widget.popoverHeight != null) return widget.popoverHeight!;
+    final maxH = _getMaxPopoverHeight(precomputedPadding);
+    // By the time the morph animation uses this value, _measuredContentHeight
+    // is guaranteed to be populated via the Offstage measurement pass.
+    return math.min(_measuredContentHeight ?? 0.0, maxH);
+  }
+
+  /// Recomputes [_morphAlignment], [_horizontalOffset], and [_verticalOffset]
+  /// from the current trigger geometry and screen metrics.
+  ///
+  /// Must only be called when [_triggerSize] is non-null.
+  /// Safe to call inside a [setState] callback; it only mutates fields and
+  /// never calls [setState] itself.
+  void _updatePositionAndClamping() {
+    if (_triggerSize == null) return;
+
+    final position = _triggerGlobalPosition;
+    final mediaQuery = MediaQuery.maybeOf(context);
+    final screenWidth = mediaQuery?.size.width ?? double.infinity;
+    final screenHeight = mediaQuery?.size.height ?? double.infinity;
+
+    // Compute view insets once and share between max-height and clamping.
+    final insets = _viewInsets();
+    final popoverHeight = _effectivePopoverHeight(insets);
+
+    // 1. Determine alignment (auto vs. manual)
+    if (widget.alignment == null ||
+        widget.alignment == GlassMenuAlignment.none) {
+      final isRightHalf = screenWidth.isFinite && position.dx > screenWidth / 2;
+
+      final spaceBelow = screenHeight.isFinite
+          ? screenHeight - (position.dy + _triggerSize!.height)
+          : double.infinity;
+      final spaceAbove = screenHeight.isFinite ? position.dy : double.infinity;
+
+      final shouldFlipVertical =
+          spaceBelow < popoverHeight && spaceAbove > popoverHeight;
+
+      _morphAlignment = shouldFlipVertical
+          ? (isRightHalf ? Alignment.bottomRight : Alignment.bottomLeft)
+          : (isRightHalf ? Alignment.topRight : Alignment.topLeft);
+    } else {
+      _morphAlignment = _getAlignment(widget.alignment!) ?? Alignment.center;
+    }
+
+    // 2. Edge clamping: compute offsets to keep the popover within the safe area
+    double hOffset = 0.0;
+    double vOffset = 0.0;
+
+    if (widget.autoAdjustToScreen) {
+      final double safeTop = widget.screenPadding.top + insets.top;
+      final double safeBottom = widget.screenPadding.bottom + insets.bottom;
+      final double safeLeft = widget.screenPadding.left + insets.left;
+      final double safeRight = widget.screenPadding.right + insets.right;
+
+      final double targetX =
+          position.dx + (1 + _morphAlignment.x) * _triggerSize!.width / 2;
+      final double targetY =
+          position.dy + (1 + _morphAlignment.y) * _triggerSize!.height / 2;
+      final double popoverLeft =
+          targetX - (1 + _morphAlignment.x) * widget.popoverWidth / 2;
+      final double popoverTop =
+          targetY - (1 + _morphAlignment.y) * popoverHeight / 2;
+
+      // Horizontal
+      if (popoverLeft < safeLeft) {
+        hOffset = safeLeft - popoverLeft;
+      } else if (screenWidth.isFinite &&
+          popoverLeft + widget.popoverWidth > screenWidth - safeRight) {
+        hOffset =
+            (screenWidth - safeRight) - (popoverLeft + widget.popoverWidth);
+      }
+
+      // Vertical
+      if (popoverTop < safeTop) {
+        vOffset = safeTop - popoverTop;
+      } else if (screenHeight.isFinite &&
+          popoverTop + popoverHeight > screenHeight - safeBottom) {
+        vOffset = (screenHeight - safeBottom) - (popoverTop + popoverHeight);
+      }
+    }
+
+    _horizontalOffset = hOffset;
+    _verticalOffset = vOffset;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Overlay rendering
+  // ---------------------------------------------------------------------------
+
+  Widget _buildMorphingOverlay(BuildContext context) {
+    if (_triggerSize == null) return const SizedBox.shrink();
+
+    if (!_contentMeasured) {
+      // Invisible measurement pass.
+      // Renders the content offstage to allow Flutter's layout engine to
+      // synchronously calculate its exact intrinsic height before we launch
+      // the morph animation on the very next frame.
+      return Offstage(
+        child: OverflowBox(
+          alignment: Alignment.center,
+          minWidth: widget.popoverWidth,
+          maxWidth: widget.popoverWidth,
+          minHeight: 0,
+          maxHeight: double.infinity,
+          child: Builder(builder: (context) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!mounted || _contentMeasured) return;
+              final renderBox =
+                  _contentKey.currentContext?.findRenderObject() as RenderBox?;
+              if (renderBox != null && renderBox.hasSize) {
+                setState(() {
+                  _measuredContentHeight = renderBox.size.height;
+                  _contentMeasured = true;
+                  _updatePositionAndClamping();
+                });
+                _morphController.open();
+              }
+            });
+            return SizedBox(
+              key: _contentKey,
+              width: widget.popoverWidth,
+              child: _cachedContent ?? const SizedBox.shrink(),
+            );
+          }),
+        ),
+      );
+    }
+
+    // ── Values computed ONCE per overlay build ──────────────────────────────
+    // These are hoisted outside AnimatedBuilder so they are never recomputed
+    // on every animation tick (60 fps). They only change when the overlay is
+    // rebuilt due to a setState (open, close-complete, or measurement update).
+
+    final tw = _triggerSize!.width;
+    final th = _triggerSize!.height;
+    final popoverWidth = widget.popoverWidth;
+    final popoverHeight = _effectivePopoverHeight();
+
+    final dxMag = (popoverWidth - tw) / 2.0;
+    final dyMag = (popoverHeight - th) / 2.0;
+    final finalDx = -_morphAlignment.x * dxMag;
+    final finalDy = -_morphAlignment.y * dyMag;
+
+    // InheritedWidget lookups — traverses the element tree; must NOT be inside
+    // the AnimatedBuilder's builder closure.
+    final inheritedSettings = InheritedLiquidGlass.of(context);
+    final effectiveSettings = widget.settings ??
+        inheritedSettings ??
+        const LiquidGlassSettings(
+          blur: 10,
+          thickness: 10,
+          glassColor: Color.fromRGBO(255, 255, 255, 0.12),
+          lightAngle: GlassDefaults.lightAngle,
+          lightIntensity: 0.7,
+          ambientStrength: 0.4,
+          saturation: 1.2,
+          refractiveIndex: 0.7,
+          chromaticAberration: 0.0,
+        );
+
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+    );
+
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+
+    // ── Per-frame AnimatedBuilder ────────────────────────────────────────────
+    return AnimatedBuilder(
+      animation: _morphController.animation,
+      builder: (context, child) {
+        final rawValue = _morphController.value;
+        final clampedValue = rawValue.clamp(0.0, 1.0);
+
+        // Physics delegated to GlassMorphController — pure arithmetic, no
+        // tree traversal, safe at 60 fps.
+        final state = _morphController.computeState(
+          finalDx: finalDx,
+          finalDy: finalDy,
+          horizontalOffset: _horizontalOffset,
+          verticalOffset: _verticalOffset,
+        );
+
+        final currentHeight = lerpDouble(th, popoverHeight, state.sizeT)!;
+        final currentWidth = lerpDouble(tw, popoverWidth, state.sizeT)!;
+
+        return Stack(
+          children: [
+            // ── Tap-to-close barrier ─────────────────────────────────────────
+            if (clampedValue > 0.3 && widget.barrierDismissible)
+              Positioned.fill(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTap: _closePopover,
+                  child: const ColoredBox(color: Colors.transparent),
+                ),
+              ),
+
+            // ── Non-dismissible barrier (absorbs taps without closing) ───────
+            if (clampedValue > 0.3 && !widget.barrierDismissible)
+              const Positioned.fill(
+                child: AbsorbPointer(),
+              ),
+
+            // ── Two-blob metaball morphing ───────────────────────────────────
+            Positioned.fill(
+              child: Opacity(
+                opacity: (_morphController.isClosing &&
+                        _morphController.hasHandedOff)
+                    ? 0.0
+                    : 1.0,
+                child: LiquidGlassLayer(
+                  settings: effectiveSettings,
+                  child: InheritedLiquidGlass(
+                    settings: effectiveSettings,
+                    quality: effectiveQuality,
+                    isBlurProvidedByAncestor: false,
+                    child: LiquidGlassBlendGroup(
+                      blend: state.blend,
+                      child: Stack(
+                        clipBehavior: Clip.none,
+                        children: [
+                          // ── Blob A: Trigger ghost ────────────────────────
+                          // Stays centred on the trigger and shrinks to 0
+                          // over the first 40 % of the open animation,
+                          // smoothly breaking the liquid bridge.
+                          Positioned(
+                            left: _triggerGlobalPosition.dx + state.pushDx,
+                            top: _triggerGlobalPosition.dy + state.pushDy,
+                            child: Transform.scale(
+                              scale: state.anchorScale,
+                              child: GlassContainer(
+                                useOwnLayer: false,
+                                settings: effectiveSettings,
+                                quality: effectiveQuality,
+                                width: tw,
+                                height: th,
+                                shape: LiquidRoundedSuperellipse(
+                                  borderRadius: _triggerBorderRadius ??
+                                      _triggerSize!.shortestSide / 2.0,
+                                ),
+                              ),
+                            ),
+                          ),
+
+                          // ── Blob B: Popover body ─────────────────────────
+                          Positioned(
+                            left: _triggerGlobalPosition.dx +
+                                tw / 2.0 +
+                                state.currentDx -
+                                currentWidth / 2.0 +
+                                (_horizontalOffset * clampedValue),
+                            top: _triggerGlobalPosition.dy +
+                                th / 2.0 +
+                                state.currentDy -
+                                currentHeight / 2.0 +
+                                (_verticalOffset * clampedValue),
+                            child: IgnorePointer(
+                              ignoring: clampedValue < 0.8,
+                              child: _buildPopoverContainer(
+                                state,
+                                clampedValue,
+                                currentWidth,
+                                currentHeight,
+                                effectiveSettings,
+                                effectiveQuality,
+                                isDark,
+                                popoverHeight,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildPopoverContainer(
+    LiquidMorphState state,
+    double clampedValue,
+    double currentWidth,
+    double currentHeight,
+    LiquidGlassSettings effectiveSettings,
+    GlassQuality effectiveQuality,
+    bool isDark,
+    double targetHeight,
+  ) {
+    // Morph border radius from pill → target corner radius.
+    final maxRadius = math.min(currentWidth, currentHeight) / 2.0;
+    final double radiusT =
+        Curves.easeInExpo.transform(state.sizeT.clamp(0.0, 1.0));
+    final currentRadius =
+        lerpDouble(maxRadius, widget.popoverBorderRadius, radiusT)!;
+
+    final teardropShape = LiquidRoundedSuperellipse(
+      borderRadius: currentRadius,
+    );
+
+    return LiquidStretch(
+      stretch: widget.stretch,
+      interactionScale: widget.interactionScale,
+      resistance: widget.stretchResistance,
+      axis: widget.stretchAxis,
+      suppressInteractionOnChildren: false,
+      anchorStretch: false,
+      allowPositiveX: widget.allowPositiveX ?? (_morphAlignment.x < 0),
+      allowNegativeX: widget.allowNegativeX ?? (_morphAlignment.x > 0),
+      allowPositiveY: widget.allowPositiveY ?? (_morphAlignment.y < 0),
+      allowNegativeY: widget.allowNegativeY ?? (_morphAlignment.y > 0),
+      child: GlassContainer(
+        useOwnLayer: false,
+        settings: effectiveSettings,
+        quality: effectiveQuality,
+        allowElevation: false,
+        width: currentWidth,
+        height: currentHeight,
+        shape: teardropShape,
+        clipBehavior: Clip.antiAlias,
+        glowIntensity: widget.glowIntensity,
+        child: GlassGlow(
+          enabled: widget.enableInteractionGlow,
+          glowOnTapOnly: widget.glowOnTapOnly,
+          glowColor: widget.glowColor ??
+              (isDark
+                  ? Colors.white.withValues(alpha: 0.15)
+                  : Colors.black.withValues(alpha: 0.10)),
+          glowRadius: widget.glowRadius,
+          glowBlurRadius: 40,
+          clipper: ShapeBorderClipper(shape: teardropShape),
+          child: Transform.scale(
+            scale: state.containerScale,
+            alignment: Alignment.center,
+            child: Stack(
+              alignment: _morphAlignment,
+              clipBehavior: Clip.none,
+              children: [
+                // Content enters at 30 % morph progress and scales 0.5 → 1.0.
+                // On close the reverse plays, matching GlassMenu behaviour.
+                if (clampedValue > 0.3)
+                  _buildContentWithMeasurement(clampedValue, targetHeight),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContentWithMeasurement(
+      double clampedValue, double targetHeight) {
+    // Fade in smoothly: fully opaque by 70 % morph progress.
+    final contentOpacity = ((clampedValue - 0.3) / 0.4).clamp(0.0, 1.0);
+
+    // Scale 0.5 → 1.0 with easeOut, in sync with the expanding container.
+    final contentScale = lerpDouble(
+      0.5,
+      1.0,
+      Curves.easeOut.transform(
+        ((clampedValue - 0.3) / 0.7).clamp(0.0, 1.0),
+      ),
+    )!;
+
+    // _cachedContent was set in _openPopover (or refreshed in didUpdateWidget).
+    // The null-coalesce is a last-resort safety net only.
+    final content =
+        _cachedContent ?? widget.contentBuilder(context, _closePopover);
+
+    Widget measuredContent;
+    if (widget.popoverHeight == null) {
+      measuredContent = SizedBox(
+        width: widget.popoverWidth,
+        child: content,
+      );
+    } else {
+      measuredContent = SizedBox(
+        width: widget.popoverWidth,
+        height: widget.popoverHeight,
+        child: content,
+      );
+    }
+
+    // OverflowBox provides the full target size to the content during layout
+    // while the container is still morphing. The visual illusion is maintained
+    // by the Transform.scale above; GlassContainer's Clip.antiAlias clips
+    // anything outside the current morph boundary.
+    return OverflowBox(
+      alignment: Alignment.center,
+      minWidth: widget.popoverWidth,
+      maxWidth: widget.popoverWidth,
+      minHeight: 0,
+      maxHeight:
+          widget.popoverHeight ?? _measuredContentHeight ?? double.infinity,
+      child: Opacity(
+        opacity: contentOpacity,
+        child: Transform.scale(
+          scale: contentScale,
+          child: measuredContent,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/overlays/shared/glass_sheet_defaults.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/overlays/shared/glass_sheet_defaults.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/widgets.dart';
+import '../../../src/renderer/liquid_glass_renderer.dart';
+
+// =============================================================================
+// kDefaultSheetSettings — shared glass preset for sheets
+// =============================================================================
+
+/// Default [LiquidGlassSettings] for both [GlassSheet] and [GlassModalSheet].
+///
+/// Centralised here so that all sheet types produce visually identical glass
+/// following the Apple News / iOS 26 modal aesthetic:
+/// - `thickness: 10` — moderate surface feel for large overlay surfaces.
+/// - `blur: 10` — standard background frosting (matches iOS 26 overlay blur).
+/// - `refractiveIndex: 0.15` — minimal rim. The lightweight shader computes
+///   rim alpha from kRimAlphaBase(0.65) × directional/ambient factors ×
+///   refractiveIndex. At 0.15 this produces a barely-perceptible glassy
+///   edge matching iOS 26's large-surface modal aesthetic.
+const kDefaultSheetSettings = LiquidGlassSettings(
+  glassColor: Color(0x1FFFFFFF), // ~12% white — matches iOS 26 modal tint
+  thickness: 10.0,
+  blur: 10.0,
+  lightIntensity: 0.7,
+  lightAngle: 2.356194, // 0.75 * pi — upper-left, iOS 26 standard
+  chromaticAberration: 0.0,
+  refractiveIndex: 0.15, // Rim opacity = 0.8 × 0.15 = 0.12 (subtle edge)
+  saturation: 1.2,
+  ambientStrength: 0.4,
+);

--- a/packages/liquid_glass_widgets/lib/widgets/shared/adaptive_glass.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/adaptive_glass.dart
@@ -1,0 +1,999 @@
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../theme/glass_theme.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+
+import '../../types/glass_quality.dart';
+import '../../utils/glass_performance_monitor.dart';
+import 'glass_accessibility_scope.dart';
+import 'glass_isolation_scope.dart';
+import 'lightweight_liquid_glass.dart';
+import 'inherited_liquid_glass.dart';
+
+/// A renderer-agnostic glass surface that intelligently selects the best
+/// rendering path based on [GlassQuality] and the active Flutter renderer.
+///
+/// **Fallback chain:**
+/// 1. Premium quality + Impeller available → Full shader (best quality)
+/// 2. Premium quality + Skia/web → Lightweight shader (our calibrated shader)
+/// 3. Standard quality → Always lightweight shader
+/// 4. If lightweight shader fails → FakeGlass (final fallback)
+///
+/// Prefer this over [LiquidGlass] directly: [LiquidGlass] is Impeller-only
+/// and silently renders nothing on Skia/Web.
+///
+/// Example:
+/// ```dart
+/// AdaptiveGlass(
+///   shape: LiquidRoundedSuperellipse(borderRadius: 20),
+///   settings: LiquidGlassSettings(blur: 8),
+///   child: Text('Hello glass'),
+/// )
+/// ```
+class AdaptiveGlass extends StatelessWidget {
+  const AdaptiveGlass({
+    required this.shape,
+    required this.settings,
+    required this.child,
+    this.quality = GlassQuality.standard,
+    this.useOwnLayer = true,
+    this.clipBehavior = Clip.antiAlias,
+    this.allowElevation = true,
+    this.glowIntensity = 0.0,
+    this.isInteractive = false,
+    this.platformViewBackdrop = false,
+    super.key,
+  });
+
+  /// The shape that defines the outline and clipping path of the glass surface.
+  final LiquidShape shape;
+
+  /// Visual parameters for the glass effect (blur radius, tint, specular etc.).
+  final LiquidGlassSettings settings;
+
+  /// The widget displayed inside the glass surface.
+  final Widget child;
+
+  /// Controls render fidelity. Defaults to [GlassQuality.standard].
+  ///
+  /// [GlassQuality.premium] enables the full shader pipeline with specular
+  /// reflections and dynamic refraction.
+  /// [GlassQuality.minimal] always renders the frosted fallback, avoiding the
+  /// shader entirely (useful during animations or on low-end devices).
+  final GlassQuality quality;
+
+  /// If `true`, wraps the glass layer in a [RepaintBoundary] (own compositing
+  /// layer). This can improve performance when the glass surface moves
+  /// independently of the rest of the widget tree, at the cost of extra GPU
+  /// memory. Defaults to `true`.
+  final bool useOwnLayer;
+
+  /// How to clip the child widget to the [shape] boundary.
+  /// Defaults to [Clip.antiAlias].
+  final Clip clipBehavior;
+
+  /// When `true`, optimises the frosted fallback for surfaces that update their
+  /// layout bounds frequently (e.g. spring-animated buttons). Omits the
+  /// [BackdropFilter] on [GlassQuality.minimal] to avoid compositor flicker.
+  final bool isInteractive;
+
+  /// Whether to allow "Specular Elevation" when in a grouped context.
+  /// Should be true for interactive objects (buttons) and false for layers/containers.
+  final bool allowElevation;
+
+  /// Interactive glow intensity for Skia/Web (0.0-1.0).
+  ///
+  /// On Impeller, this is ignored and [GlassGlow] widget is used instead.
+  /// On Skia/Web, this controls shader-based button press feedback.
+  ///
+  /// Defaults to 0.0 (no glow).
+  final double glowIntensity;
+
+  /// When true, this glass renders via the live `BackdropFilter` path (the
+  /// lightweight render) EVEN at [GlassQuality.premium] — because the premium
+  /// shader samples a `toImageSync` texture, which cannot capture an iOS
+  /// PlatformView (map, video). Set this on glass directly over a PlatformView
+  /// so the live view shows through instead of a solid slab. Refraction is lost
+  /// (no texture), but rim/lighting and the live blur remain. Premium children
+  /// that refract Flutter content (e.g. the indicator) should NOT set this.
+  final bool platformViewBackdrop;
+
+  /// Detects if Impeller rendering engine is active.
+  ///
+  /// Returns true when shader filters are supported (Impeller),
+  /// false when using Skia or web renderers.
+  ///
+  /// This is the same check used internally by liquid_glass_renderer.
+  static bool get _canUseImpeller => ui.ImageFilter.isShaderFilterSupported;
+
+  /// Static helper to render glass in a grouped context without creating a new layer.
+  /// This is the adaptive replacement for [LiquidGlass.withOwnLayer].
+  static Widget grouped({
+    required LiquidShape shape,
+    required Widget child,
+    GlassQuality quality = GlassQuality.standard,
+    Clip clipBehavior = Clip.antiAlias,
+    double glowIntensity = 0.0,
+    bool isInteractive = false,
+    bool platformViewBackdrop = false,
+  }) {
+    return AdaptiveGlass(
+      shape: shape,
+      settings: const LiquidGlassSettings(), // Inherited via inLayer
+      quality: quality,
+      useOwnLayer: false,
+      clipBehavior: clipBehavior,
+      glowIntensity: glowIntensity,
+      isInteractive: isInteractive,
+      platformViewBackdrop: platformViewBackdrop,
+      child: child,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 1. Resolve Settings
+    // In grouped mode, the explicit `settings` field is a const placeholder;
+    // we must inherit the real settings from the ancestor layer.
+    final inherited =
+        context.dependOnInheritedWidgetOfExactType<InheritedLiquidGlass>();
+    final baseSettings =
+        (!useOwnLayer && inherited != null) ? inherited.settings : settings;
+
+    // ---- MINIMAL FAST-PATH ---------------------------------------------------
+    // GlassQuality.minimal bypasses all custom shaders. Renders via
+    // _FrostedFallback: ClipPath(ShapeBorderClipper) + BackdropFilter + tint.
+    // ClipPath correctly clips ALL shape types (oval, superellipse, rect).
+    // Zero fragment shader cost on any device.
+    //
+    // platformViewBackdrop ALSO routes here: over a PlatformView only a live
+    // BackdropFilter samples the composited map. The premium/standard shaders
+    // read a captured backdrop that EXCLUDES the platform view (see
+    // canUsePremiumShader below), so they render inert there — the frost is the
+    // one tier that actually blurs over a PlatformView. This finally delivers
+    // the "live BackdropFilter path" the canUsePremiumShader comment promises.
+    // --------------------------------------------------------------------------
+    if (quality == GlassQuality.minimal ||
+        baseSettings.effectiveBlur == 0 ||
+        platformViewBackdrop) {
+      return _wrapWithDecorations(
+        context,
+        baseSettings,
+        _FrostedFallback(
+          shape: shape,
+          settings: baseSettings,
+          clipBehavior: clipBehavior,
+          glowIntensity: glowIntensity,
+          isAccessibilityFallback: false,
+          isInteractive: isInteractive,
+          platformViewBackdrop: platformViewBackdrop,
+          child: child,
+        ),
+      );
+    }
+
+    // ---- IP1: ACCESSIBILITY FAST-PATH ----------------------------------------
+    // iOS 26 glass degrades to a solid frosted panel when "Reduce Transparency"
+    // is enabled. We honour the equivalent Flutter signal (highContrast, which
+    // is the closest available platform proxy for isReduceTransparencyEnabled).
+    //
+    // When triggered, the entire glass shader pipeline is bypassed. The fallback
+    // is a ClipRRect + BackdropFilter(blur) + semi-opaque tinted container —
+    // still visually layered, but with no refraction, no specular, and no
+    // chromatic aberration. Zero GPU shader cost.
+    //
+    // GlassAccessibilityScope must be in the widget tree for this to activate;
+    // without it, defaults.reduceTransparency = false and we proceed normally.
+    // --------------------------------------------------------------------------
+    final accessibilityData = GlassAccessibilityData.of(context);
+    if (accessibilityData.reduceTransparency) {
+      return _wrapWithDecorations(
+        context,
+        baseSettings,
+        _FrostedFallback(
+          shape: shape,
+          settings: baseSettings,
+          clipBehavior: clipBehavior,
+          glowIntensity: glowIntensity,
+          isAccessibilityFallback: true,
+          isInteractive: isInteractive,
+          child: child,
+        ),
+      );
+    }
+
+    // If we are on Skia/Web, we CANNOT use LiquidGlass.withOwnLayer or withOwnLayer
+    // because those will fall back to FakeGlass (solid color) inside the renderer.
+    // We MUST use our LightweightLiquidGlass to get actual glass effects.
+
+    // platformViewBackdrop forces the live BackdropFilter path even at premium:
+    // the premium shader's toImageSync backdrop can't capture a PlatformView, so
+    // over one it must use BackdropFilter (live) instead. The local/cheap checks
+    // are evaluated before the platform shader-support query (_canUseImpeller).
+    final bool canUsePremiumShader = !kIsWeb &&
+        !platformViewBackdrop &&
+        quality == GlassQuality.premium &&
+        _canUseImpeller;
+
+    if (!canUsePremiumShader) {
+      // 1. Detect Grouped Elevation
+      // When a parent provides the blur (Batch-Blur Optimization), we lose the
+      // "double-darkening" effect of nested blurs. We compensate with the
+      // densityFactor parameter (0.0-1.0) which triggers synthetic density physics
+      // in the shader to make elevated widgets "pop" against the background.
+      final bool shouldElevate =
+          allowElevation && (inherited?.isBlurProvidedByAncestor ?? false);
+
+      // Calculate density factor for shader (0.0 = normal, 1.0 = elevated)
+      final double densityFactor = shouldElevate ? 1.0 : 0.0;
+
+      // Normalise settings for the 2D lightweight shader to prevent it from looking
+      // overpowering when the user has tuned their settings for the 3D premium shader.
+      //
+      // BYPASS: When quality is explicitly GlassQuality.standard, the settings
+      // are already calibrated for the Standard renderer — skip normalization.
+      // Normalization only makes sense when adapting Premium-tuned settings to
+      // Standard; if the caller already knows they're on Standard, their values
+      // must be passed through unchanged so tuning sliders take full effect.
+      final bool skipNormalization = quality == GlassQuality.standard;
+
+      final LiquidGlassSettings normalizedSettings;
+      if (skipNormalization) {
+        normalizedSettings = baseSettings.copyWith(
+          glassColor: baseSettings.glassColor.withValues(
+            alpha: (baseSettings.glassColor.a *
+                    baseSettings.standardOpacityMultiplier)
+                .clamp(0.0, 1.0),
+          ),
+        );
+      } else {
+        // Frosting normalization: adapts Premium settings for the 2D shader.
+        // Thickness scaled down (2D inner shadows look much thicker than 3D bevels).
+        // Light intensity scaled down (2D gradients look brighter than 3D speculars).
+        normalizedSettings = baseSettings.copyWith(
+          thickness: (baseSettings.effectiveThickness * 0.4)
+              .clamp(0.0, double.infinity),
+          lightIntensity:
+              (baseSettings.effectiveLightIntensity * 0.6).clamp(0.0, 10.0),
+          glassColor: baseSettings.glassColor.withValues(
+            alpha: (baseSettings.glassColor.a *
+                    baseSettings.standardOpacityMultiplier)
+                .clamp(0.0, 1.0),
+          ),
+        );
+      }
+
+      // Apply subtle elevation boost to settings (preserves saturation!)
+      final color = normalizedSettings.effectiveGlassColor;
+      final effectiveSettings = shouldElevate
+          ? LiquidGlassSettings(
+              glassColor:
+                  color, // Removed flat +0.2 alpha boost for predictability
+              refractiveIndex: normalizedSettings.refractiveIndex,
+              thickness: normalizedSettings.effectiveThickness,
+              lightAngle: normalizedSettings.lightAngle,
+              lightIntensity: (normalizedSettings.effectiveLightIntensity * 1.2)
+                  .clamp(0.0, 10.0),
+              chromaticAberration: normalizedSettings.chromaticAberration,
+              blur: normalizedSettings.effectiveBlur,
+              visibility: normalizedSettings.visibility,
+              saturation: normalizedSettings.effectiveSaturation,
+              ambientStrength:
+                  (normalizedSettings.effectiveAmbientStrength * 0.4)
+                      .clamp(0.0, 1.0),
+              glowIntensity: normalizedSettings.glowIntensity,
+              // Preserve whiten through the elevation rebuild; otherwise the
+              // whitening would silently drop to 0 for grouped/elevated
+              // surfaces such as bars.
+              whitenStrength: normalizedSettings.whitenStrength,
+              whitenGated: normalizedSettings.whitenGated,
+            )
+          : normalizedSettings;
+
+      // If this is a container (allowElevation=false), we are providing a blur
+      // for all our children to use. We update the InheritedLiquidGlass tree.
+      if (!allowElevation) {
+        return _wrapWithDecorations(
+          context,
+          baseSettings,
+          LightweightLiquidGlass(
+            shape: shape,
+            settings: effectiveSettings,
+            densityFactor: 0.0, // Containers are never elevated
+            glowIntensity: 0.0, // Containers don't glow
+            child: InheritedLiquidGlass(
+              settings: effectiveSettings,
+              quality: quality,
+              isBlurProvidedByAncestor: true,
+              child: child,
+            ),
+          ),
+        );
+      }
+
+      // Elevated widgets use PATH B (no backgroundKey). They composite via
+      // SrcOver against the container's output.
+      final Widget lightweightWidget = LightweightLiquidGlass(
+        shape: shape,
+        settings: effectiveSettings,
+        densityFactor: densityFactor, // 0.0 or 1.0 based on elevation
+        glowIntensity:
+            glowIntensity * 0.35, // Normalise additive glow to match Impeller
+        child: child,
+      );
+
+      return _wrapWithDecorations(context, baseSettings, lightweightWidget);
+    }
+
+    // Impeller + Premium Path: Use the renderer's native path.
+    // Wrap in PremiumGlassTracker so GlassPerformanceMonitor can correlate
+    // slow raster frames with active premium surfaces.
+    //
+    // Force useOwnLayer when inside a GlassIsolationScope (e.g. GlassScaffold
+    // bottom bar). This gives bars their own compositing layer so body glass
+    // cards don't composite over bar buttons.
+    //
+    // NOTE: isInteractive is NOT included here. It only controls
+    // RepaintBoundary wrapping (lines below). Including it would force
+    // every GlassButton into its own compositing layer, breaking grouped
+    // rendering inside bars (e.g. BottomBarExtraBtn must blend with the
+    // tab pill, not render as a separate glass surface). Buttons that need
+    // independent refraction should set useOwnLayer: true explicitly.
+    //
+    // De-isolate children of the own-layer so nested glass (e.g. tab
+    // items inside a bottom bar) groups with this layer rather than
+    // creating additional own-layers (which would cause double-glass).
+    final effectiveUseOwnLayer =
+        useOwnLayer || GlassIsolationScope.isIsolated(context);
+
+    if (effectiveUseOwnLayer) {
+      // Resolve shadows for the GPU cutout method
+      final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+      final shadows = (isDark || _FrostedFallback._isFlatEdge(shape))
+          ? const <BoxShadow>[]
+          : baseSettings.effectiveShadow;
+
+      Widget premium = LiquidGlass.withOwnLayer(
+        shape: shape,
+        settings: settings,
+        shadows: shadows,
+        clipBehavior: clipBehavior,
+        // De-isolate children so nested glass groups with this own-layer
+        // rather than creating its own (which causes double-glass).
+        // Carry the parent's defaultQuality through so quality hints
+        // (e.g. premium for bars) are preserved even when de-isolated.
+        child: GlassIsolationScope(
+          isolated: false,
+          defaultQuality: GlassIsolationScope.defaultQualityOf(context),
+          child: child,
+        ),
+      );
+
+      return _wrapWithBacker(
+        baseSettings,
+        PremiumGlassTracker(
+          child: premium,
+        ),
+      );
+    } else {
+      // Grouped elements (e.g. inside GlassBottomBar) rely on the ancestor's
+      // LiquidGlassLayer to provide the RepaintBoundary and BackdropGroup.
+      // IMPORTANT: Do NOT wrap grouped elements with the shadow Stack — it
+      // inserts a widget between the grouped glass and its ancestor blend
+      // group, breaking metaball morphing (the blend SDF pass requires
+      // grouped render objects to be direct descendants of the shared layer).
+      return PremiumGlassTracker(
+        child: LiquidGlass.grouped(
+          shape: shape,
+          clipBehavior: clipBehavior,
+          child: child,
+        ),
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Light-mode drop shadow — iOS 26 glass elevation
+  //
+  // Apple's iOS 26 uses a soft, diffuse drop shadow to give glass surfaces
+  // depth and elevation in light mode, instead of relying on a visible border.
+  // In dark mode, the shadow is invisible (absorbed by the dark background),
+  // so we skip it entirely to avoid unnecessary compositing cost.
+  //
+  // Suppressed for flat-edge shapes (borderRadius: 0) like app bars and bottom
+  // bars, which span edge-to-edge and don't need individual elevation.
+  // ---------------------------------------------------------------------------
+  Widget _wrapWithLightModeShadow(
+      BuildContext context, LiquidGlassSettings baseSettings, Widget glass) {
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+
+    // Skip shadow in dark mode or for flat-edge shapes (bars, full-width surfaces).
+    if (isDark || _FrostedFallback._isFlatEdge(shape)) {
+      return glass;
+    }
+
+    // Resolve the shadow from settings (per-widget or inherited).
+    final shadows = baseSettings.effectiveShadow;
+    if (shadows.isEmpty) return glass;
+
+    // Extract border radius from the shape for the shadow decoration.
+    final borderRadius = _borderRadiusFromShape(shape);
+
+    return Stack(
+      fit: StackFit.passthrough,
+      clipBehavior: Clip.none,
+      children: [
+        // 1. The glass surface (BackdropFilter captures only the background)
+        glass,
+
+        // 2. The drop shadow (painted on top, but inverse-clipped so it only
+        // appears OUTSIDE the glass). This prevents the glass from blurring its
+        // own shadow, which would otherwise create a dirty dark rim.
+        Positioned.fill(
+          child: IgnorePointer(
+            child: ClipPath(
+              clipBehavior: Clip.antiAlias,
+              clipper: _InverseShapeClipper(shape),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: borderRadius,
+                  boxShadow: shadows,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Applies the backer (behind the glass) and the light-mode drop shadow
+  /// (outside the glass) to [glass]. Both are no-ops when their respective
+  /// settings are unset, so existing recipes are unaffected. Same signature as
+  /// [_wrapWithLightModeShadow] so the non-premium call sites just swap names.
+  Widget _wrapWithDecorations(
+      BuildContext context, LiquidGlassSettings baseSettings, Widget glass) {
+    return _wrapWithBacker(
+      baseSettings,
+      _wrapWithLightModeShadow(context, baseSettings, glass),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Backer — Apple "dimming layer" behind the glass
+  //
+  // A shape-matched color pad composited BEHIND the glass (the inverse of the
+  // drop shadow, which sits OUTSIDE the boundary). Gives a control's content
+  // contrast over rich/colorful backdrops — video, maps, photography — where
+  // the glass tint alone can't. Rendered at the widget level via [_ShapeClip]
+  // (ClipRRect for superellipses, so the clip forwards to the iOS PlatformView
+  // mutator stack), independent of the shader tier — so it works over a
+  // PlatformView, where a shader-side tint cannot reach.
+  //
+  // Unlike the shadow, it applies in BOTH brightnesses and for flat-edge shapes
+  // (a bar over a map is a primary use case). NOT applied on the grouped path:
+  // like the shadow, inserting a Stack between a grouped glass and its shared
+  // layer would break metaball morphing.
+  // ---------------------------------------------------------------------------
+  Widget _wrapWithBacker(LiquidGlassSettings baseSettings, Widget glass) {
+    final backerColor = baseSettings.backerColor;
+    if (backerColor == null || backerColor.a == 0) return glass;
+
+    return Stack(
+      fit: StackFit.passthrough,
+      clipBehavior: Clip.none,
+      children: [
+        // 1. The dimming pad — BEHIND the glass, clipped to the glass shape.
+        Positioned.fill(
+          child: IgnorePointer(
+            child: _ShapeClip(
+              shape: shape,
+              platformViewBackdrop: platformViewBackdrop,
+              child: ColoredBox(color: backerColor),
+            ),
+          ),
+        ),
+        // 2. The glass on top; its translucency lets the pad dim it through.
+        glass,
+      ],
+    );
+  }
+
+  /// Extracts a [BorderRadius] from a [LiquidShape] for shadow decoration.
+  static BorderRadius? _borderRadiusFromShape(LiquidShape shape) {
+    if (shape is LiquidRoundedSuperellipse) {
+      return BorderRadius.circular(shape.borderRadius);
+    }
+    if (shape is LiquidRoundedRectangle) {
+      return BorderRadius.circular(shape.borderRadius);
+    }
+    if (shape is LiquidVerticalRoundedSuperellipse) {
+      return BorderRadius.vertical(
+        top: Radius.circular(shape.topRadius),
+        bottom: Radius.circular(shape.bottomRadius),
+      );
+    }
+    if (shape is LiquidVerticalRoundedRectangle) {
+      return BorderRadius.vertical(
+        top: Radius.circular(shape.topRadius),
+        bottom: Radius.circular(shape.bottomRadius),
+      );
+    }
+    if (shape is LiquidOval) {
+      // Large radius approximation for oval/circle shapes.
+      return BorderRadius.circular(9999);
+    }
+    return null;
+  }
+}
+
+/// Clips out the interior of a shape, leaving only the exterior.
+/// Used to prevent drop shadows from bleeding under translucent glass.
+class _InverseShapeClipper extends CustomClipper<Path> {
+  const _InverseShapeClipper(this.shape);
+
+  final LiquidShape shape;
+
+  @override
+  Path getClip(Size size) {
+    final rect = Offset.zero & size;
+    final shapePath = shape.getOuterPath(rect);
+
+    // Create an outer rect that encompasses the entire shadow blur radius
+    // 50px is plenty for our 12px max blur radius.
+    final outerRect = rect.inflate(50.0);
+    final outerPath = Path()..addRect(outerRect);
+
+    // Subtract the shape from the outer bounds, leaving a hole in the middle.
+    // Uses CPU path operations (supported in Impeller).
+    return Path.combine(PathOperation.difference, outerPath, shapePath);
+  }
+
+  @override
+  bool shouldReclip(_InverseShapeClipper oldClipper) =>
+      oldClipper.shape != shape;
+}
+
+// ---------------------------------------------------------------------------
+// _FrostedFallback — shader-free glass fallback surface
+//
+// Used by:
+//   • GlassQuality.minimal      — developer-requested safe mode
+//   • GlassAccessibilityScope   — OS Reduce Transparency preference
+//
+// Visual quality parity with upstream FakeGlass (whynotmake.it):
+//   • BackdropFilter blur  — same sigma as the normal glass blur
+//   • Saturation matrix    — Rec. 709 luma-coefficient ColorFilter
+//   • Specular rim         — two Canvas strokes with a light-angle linear
+//                            gradient (pure srcOver — no GPU readback)
+//   • Shape clipping       — ClipRRect for rect/squircle, or ClipOval
+//
+// No GLSL shaders. No FragmentShader. No Impeller-specific paths.
+// Runs identically on Skia, Impeller, Web, Windows, and Linux.
+// ---------------------------------------------------------------------------
+class _FrostedFallback extends StatelessWidget {
+  const _FrostedFallback({
+    required this.shape,
+    required this.settings,
+    required this.child,
+    this.clipBehavior = Clip.antiAlias,
+    this.glowIntensity = 0.0,
+    this.isAccessibilityFallback = false,
+    this.isInteractive = false,
+    this.platformViewBackdrop = false,
+  });
+
+  final LiquidShape shape;
+  final LiquidGlassSettings settings;
+  final Widget child;
+  final Clip clipBehavior;
+  final double glowIntensity;
+
+  /// When true (OS Reduce Transparency), opacity is boosted for legibility:
+  /// alpha = (tint.a × 0.5 + 0.40).clamp(0.40, 0.80).
+  ///
+  /// When false (GlassQuality.minimal — developer choice), the glass color
+  /// alpha is used more directly so the surface stays translucent:
+  /// alpha = tint.a.clamp(0.05, 0.55).
+  final bool isAccessibilityFallback;
+
+  /// Signals that this surface frequently updates its layout bounds or transform
+  /// via spring animations (e.g. GlassButton, interactive pill indicators).
+  ///
+  /// When true, during [GlassQuality.minimal] we omit the [BackdropFilter] to
+  /// prevent compositor desync flicker caused by the bounds changing continuously.
+  final bool isInteractive;
+
+  /// When true, this frost sits directly over a PlatformView (map/video) via the
+  /// `platformViewBackdrop` route. The live [BackdropFilter] is the ONLY path
+  /// that blurs a hybrid-composed PlatformView, so it must run even for
+  /// interactive surfaces — otherwise the [isInteractive] blur-omission below
+  /// leaves over-map buttons with no blur at all (the brief tap-scale flicker is
+  /// negligible next to having no blur).
+  final bool platformViewBackdrop;
+
+  /// Rec. 709 saturation matrix — identical to upstream FakeGlass.
+  ///
+  /// saturation = 0  → grayscale
+  /// saturation = 1  → unchanged
+  /// saturation > 1  → over-saturated (default glass is 1.5)
+  static List<double> _saturationMatrix(double saturation) {
+    const lumR = 0.299;
+    const lumG = 0.587;
+    const lumB = 0.114;
+    final s = saturation;
+    final inv = 1.0 - s;
+    return [
+      lumR * inv + s, lumG * inv, lumB * inv, 0, 0, // R
+      lumR * inv, lumG * inv + s, lumB * inv, 0, 0, // G
+      lumR * inv, lumG * inv, lumB * inv + s, 0, 0, // B
+      0, 0, 0, 1, 0, // A
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final blur = settings.effectiveBlur.clamp(0.0, 40.0);
+    // Whiten veil: lift the tint toward white by a ramp of
+    // [LiquidGlassSettings.whitenStrength], matching the Standard path
+    // (lightweight_liquid_glass.dart). This is why minimal-tier controls
+    // whiten from the same single knob — no per-widget code needed. The veil
+    // ramp uses the same gain as the Standard path so a single whitenStrength
+    // value reads consistently across tiers. Minimal's tint is already a
+    // uniform flat fill, so this lerp is the whole whiten here.
+    const double kWhitenVeilGain = 1.5;
+    final double whiten = settings.whitenStrength.clamp(0.0, 1.0).toDouble();
+    final double veil = whiten <= 0.0
+        ? 0.0
+        : (whiten * kWhitenVeilGain).clamp(0.0, 1.0).toDouble();
+    final tint = veil <= 0.0
+        ? settings.effectiveGlassColor
+        : Color.lerp(
+            settings.effectiveGlassColor, const Color(0xFFFFFFFF), veil)!;
+
+    final double frostedAlpha = isAccessibilityFallback
+        // Accessibility: boost opacity so content remains legible
+        // even when Reduce Transparency removes blur on older hardware.
+        ? (tint.a * 0.5 + 0.40).clamp(0.40, 0.80)
+        // Minimal (developer choice): honour the specified glass color alpha,
+        // allowing it to go up to 1.0 for solid color modes.
+        : tint.a.clamp(0.05, 1.0);
+    final frostedColor = tint.withValues(alpha: frostedAlpha);
+
+    final sat = settings.effectiveSaturation;
+    final bool needsSaturation = (sat - 1.0).abs() > 0.01;
+
+    // ── Layer stack (bottom to top) ─────────────────────────────────────────
+    //
+    // Accessibility fallback: opacity heavily boosted for legibility (Reduce
+    // Transparency intent — less see-through = more readable).
+    //
+    // Minimal developer mode: alpha is used more directly (honours the
+    // developer's specified glassColor), giving a lighter, more translucent
+    // surface.
+    //
+    // BackdropFilter rules:
+    // - Always used in accessibility mode to ensure strong contrast.
+    // - In minimal mode, used for STATIONARY surfaces (app bar, bottom bar)
+    //   to retain the frosted glass aesthetic.
+    // - OMITTED for INTERACTIVE surfaces (buttons, sliding pills) in minimal
+    //   mode because BackdropFilter re-samples the background every frame and
+    //   desyncs with spring bounds changes, causing a "flashing" or flickering
+    //   artifact beneath the element.
+    // - EXCEPT when platformViewBackdrop is set: over a PlatformView the live
+    //   BackdropFilter is the only path that blurs the (hybrid-composed) map, so
+    //   it must run even for interactive buttons. Without this, #128's frost
+    //   route delivers no blur for over-map controls (heading, 2D, ⋯ buttons).
+    // ────────────────────────────────────────────────────────────────────────
+    final bool useBlur =
+        (isAccessibilityFallback || !isInteractive || platformViewBackdrop) &&
+            blur > 0;
+
+    Widget body;
+    if (useBlur) {
+      body = BackdropFilter(
+        filter: ui.ImageFilter.blur(sigmaX: blur, sigmaY: blur),
+        child: DecoratedBox(
+          decoration: BoxDecoration(color: frostedColor),
+          child: needsSaturation
+              ? BackdropFilter(
+                  filter: ui.ColorFilter.matrix(_saturationMatrix(sat)),
+                  child: const SizedBox.expand(),
+                )
+              : const SizedBox.expand(),
+        ),
+      );
+    } else {
+      // Minimal interactive path: blur-free frosted tint prevents cache flicker
+      // when updating rapidly during spring physics drag.
+      body = DecoratedBox(
+        decoration: BoxDecoration(color: frostedColor),
+        child: const SizedBox.expand(),
+      );
+    }
+
+    return Stack(
+      fit: StackFit.passthrough,
+      clipBehavior: Clip
+          .hardEdge, // Locks dirty region to widget bounds — prevents page-wide flicker
+      children: [
+        if (useBlur)
+          // Stationary surfaces: blur + tint clipped to shape.
+          //
+          // Use ClipRRect when the shape resolves to a rounded rect —
+          // Flutter PR #177551 (in 3.41+) forwards ClipRRect clip data
+          // to iOS PlatformView mutators, so ClipRRect (not ClipPath)
+          // is what lets the engine clip a descendant BackdropFilter
+          // over a PlatformView. Eliminates the rectangular blur halo
+          // around rounded glass surfaces stacked over PlatformViews
+          // (e.g. mapbox_maps_flutter, video_player on iOS).
+          Positioned.fill(
+            child: _ShapeClip(
+              shape: shape,
+              platformViewBackdrop: platformViewBackdrop,
+              child: body,
+            ),
+          ),
+
+        if (!useBlur)
+          // Interactive surfaces: pure ShapeDecoration vector — bypasses the
+          // stencil buffer so sub-pixel spring deceleration never causes edge flicker.
+          Positioned.fill(
+            child: DecoratedBox(
+              decoration: ShapeDecoration(color: frostedColor, shape: shape),
+              child: const SizedBox.expand(),
+            ),
+          ),
+
+        // Glow intensity wrapper for GlassButton tap feedback
+        if (glowIntensity > 0)
+          Positioned.fill(
+            child: DecoratedBox(
+              decoration: ShapeDecoration(
+                shape: shape,
+                color: (GlassTheme.brightnessOf(context) == Brightness.dark
+                        ? Colors.white
+                        : Colors.black)
+                    .withValues(alpha: 0.15 * glowIntensity),
+              ),
+            ),
+          ),
+
+        // Text and contents MUST be strictly clipped to corner radii.
+        // Same ClipRRect-over-ClipPath rationale as the blur body
+        // above — see the [_ShapeClip] doc comment.
+        _ShapeClip(
+          shape: shape,
+          platformViewBackdrop: platformViewBackdrop,
+          child: child,
+        ),
+
+        // Specular Rim: drawn as a pure native overlay vector perfectly on top.
+        // Wrapped in _ShapeClip because canvas.drawPath draws a center-aligned
+        // stroke. Clipping it removes the outer half, creating a true 'inner
+        // border' which is optically correct for glass internal reflections.
+        //
+        // Suppressed for flat-edge shapes (borderRadius: 0) like app bars,
+        // where the rim looks like a Material divider rather than a glass edge.
+        if (!_isFlatEdge(shape))
+          Positioned.fill(
+            child: IgnorePointer(
+              child: _ShapeClip(
+                shape: shape,
+                platformViewBackdrop: platformViewBackdrop,
+                child: CustomPaint(
+                  painter: _SpecularRimPainter(
+                    shape: shape,
+                    settings: settings,
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  /// Returns true when [shape] has no rounded corners (borderRadius == 0).
+  ///
+  /// Full-width surfaces (app bars, bottom bars) use `borderRadius: 0` and
+  /// the specular rim on their straight edges looks like a Material divider
+  /// rather than an internal glass reflection.
+  static bool _isFlatEdge(LiquidShape shape) {
+    if (shape is LiquidRoundedRectangle && shape.borderRadius == 0) return true;
+    if (shape is LiquidRoundedSuperellipse && shape.borderRadius == 0) {
+      return true;
+    }
+    if (shape is LiquidVerticalRoundedRectangle &&
+        shape.topRadius == 0 &&
+        shape.bottomRadius == 0) {
+      return true;
+    }
+    if (shape is LiquidVerticalRoundedSuperellipse &&
+        shape.topRadius == 0 &&
+        shape.bottomRadius == 0) {
+      return true;
+    }
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// _SpecularRimPainter — light-angle specular rim stroke
+//
+// Ported from FakeGlass._paintSpecular() (whynotmake.it, MIT).
+// Pure Canvas drawing: two gradient strokes with BlendMode.hardLight and
+// BlendMode.overlay. Zero GPU shader cost on any platform.
+// ---------------------------------------------------------------------------
+class _SpecularRimPainter extends CustomPainter {
+  const _SpecularRimPainter({
+    required this.shape,
+    required this.settings,
+  });
+
+  final LiquidShape shape;
+  final LiquidGlassSettings settings;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final lightIntensity = settings.effectiveLightIntensity.clamp(0.0, 1.0);
+    if (lightIntensity == 0) return;
+
+    final ambientStrength = settings.effectiveAmbientStrength.clamp(0.0, 1.0);
+    final alpha = Curves.easeOut.transform(lightIntensity);
+    final white = Colors.white.withValues(alpha: alpha);
+
+    final rad = settings.lightAngle;
+    final x = math.cos(rad);
+    // Invert Y to match the GLSL fragment shader coordinate space (up is positive).
+    final y = -math.sin(rad);
+
+    // Expand to a square so the gradient angle matches the light angle exactly:
+    // a squashed gradient rect distorts the effective direction.
+    final bounds = Offset.zero & size;
+    final squareBounds = Rect.fromCircle(
+      center: bounds.center,
+      radius: bounds.size.longestSide / 2,
+    );
+
+    // How far the light covers the glass (gradient stop spread).
+    final lightCoverage = ui.lerpDouble(.3, .5, lightIntensity)!;
+
+    // Adjust gradient scale for non-square aspect ratios.
+    final aspectRatio = size.width / size.height.clamp(0.001, double.infinity);
+    final alignmentWithShortestSide = (aspectRatio < 1 ? y : x).abs();
+    final aspectAdjustment = 1 - 1 / aspectRatio.clamp(0.001, double.infinity);
+    final gradientScale = aspectAdjustment * (1 - alignmentWithShortestSide);
+
+    final inset = ui.lerpDouble(0, .5, gradientScale.clamp(0, 1))!;
+    final secondInset =
+        ui.lerpDouble(lightCoverage, .5, gradientScale.clamp(0, 1))!;
+
+    final gradient = LinearGradient(
+      colors: [
+        white,
+        white.withValues(alpha: ambientStrength),
+        white.withValues(alpha: ambientStrength),
+        white,
+      ],
+      stops: [inset, secondInset, 1 - secondInset, 1 - inset],
+      begin: Alignment(x, y),
+      end: Alignment(-x, -y),
+    ).createShader(squareBounds);
+
+    final path = shape.getOuterPath(bounds);
+
+    // Pass 1: soft base stroke.
+    // Doubled width since it is now clipped to the inner half.
+    // BlendMode.overlay ensures the highlight reacts organically to the
+    // background color underneath, rather than looking like a flat white line.
+    canvas.drawPath(
+      path,
+      Paint()
+        ..shader = gradient
+        ..color = white.withValues(alpha: white.a * 0.4)
+        ..blendMode = BlendMode.overlay
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = ui.lerpDouble(1.0, 2.0, lightIntensity)!,
+    );
+
+    // Pass 2: sharp inner rim.
+    // Doubled width since it is clipped to the inner half.
+    canvas.drawPath(
+      path,
+      Paint()
+        ..shader = gradient
+        ..color = white.withValues(alpha: white.a * 0.6)
+        ..blendMode = BlendMode.overlay
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = (settings.effectiveThickness / 20).clamp(0.5, 2.0),
+    );
+  }
+
+  @override
+  bool shouldRepaint(_SpecularRimPainter old) =>
+      old.settings != settings || old.shape != shape;
+}
+
+/// Wraps [child] in [ClipRRect] when the shape resolves to a
+/// `RoundedRectangleBorder` (i.e. [LiquidRoundedSuperellipse] or
+/// [LiquidVerticalRoundedSuperellipse]), otherwise falls back to
+/// [ClipPath] with `ShapeBorderClipper`.
+///
+/// **Why this matters:** Flutter framework PR #177551 (merged Dec 2025,
+/// shipped in 3.41.0-0.0.pre and forward) forwards `ClipRRect` clip data
+/// to the iOS PlatformView mutator stack — which lets the engine
+/// correctly clip a descendant [BackdropFilter] over a PlatformView.
+/// The same fix does NOT apply to `ClipPath`, even when the path inside
+/// is mathematically a rounded rect.
+///
+/// Eliminates the rectangular blur halo that appeared around rounded
+/// `_FrostedFallback` surfaces when stacked over a PlatformView (e.g.
+/// `mapbox_maps_flutter`'s `MapWidget`, `video_player` on iOS).
+///
+/// When [platformViewBackdrop] is true, any shape that can be expressed
+/// as a [BorderRadius] (including [LiquidOval] → `circular(9999)` and
+/// [LiquidRoundedRectangle]) is also routed through [ClipRRect] so the
+/// clip is forwarded and the frost is bounded to the shape on PlatformViews.
+/// Off a PlatformView, [LiquidOval] retains an exact [ClipPath] ellipse.
+class _ShapeClip extends StatelessWidget {
+  const _ShapeClip({
+    required this.shape,
+    required this.child,
+    this.platformViewBackdrop = false,
+  });
+
+  final LiquidShape shape;
+  final Widget child;
+
+  /// When the clipped subtree sits over an iOS PlatformView, force a
+  /// [ClipRRect]-based clip even for shapes that would otherwise fall through to
+  /// a [ClipPath] (e.g. [LiquidOval], [LiquidRoundedRectangle]).
+  ///
+  /// Flutter's clip forwarding (#177551, 3.41+) only sends ClipRRect clip data
+  /// to the iOS PlatformView mutator stack — a ClipPath leaves a descendant
+  /// [BackdropFilter] unclipped, so the frost leaks a rectangular halo around
+  /// the (visually round) surface. A ClipRRect with a full radius renders the
+  /// same circle/stadium but IS forwarded, bounding the frost to the shape.
+  /// Off a PlatformView the ClipPath path is exact (a true ellipse), so the swap
+  /// is gated on this flag.
+  final bool platformViewBackdrop;
+
+  @override
+  Widget build(BuildContext context) {
+    final shape = this.shape;
+    if (shape is LiquidRoundedSuperellipse) {
+      return ClipRRect(
+        borderRadius: BorderRadius.all(Radius.circular(shape.borderRadius)),
+        child: child,
+      );
+    }
+    if (shape is LiquidVerticalRoundedSuperellipse) {
+      return ClipRRect(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(shape.topRadius),
+          bottom: Radius.circular(shape.bottomRadius),
+        ),
+        child: child,
+      );
+    }
+    // Over a PlatformView, route any radius-expressible shape (oval →
+    // circle/stadium, rounded rect, vertical variants) through ClipRRect so the
+    // clip is forwarded to the PlatformView mutator and a descendant
+    // BackdropFilter is bounded to the shape — eliminating the rectangular halo.
+    // #177551 only forwards ClipRRect, never ClipPath.
+    if (platformViewBackdrop) {
+      final borderRadius = AdaptiveGlass._borderRadiusFromShape(shape);
+      if (borderRadius != null) {
+        return ClipRRect(borderRadius: borderRadius, child: child);
+      }
+    }
+    return ClipPath(
+      clipper: ShapeBorderClipper(shape: shape),
+      child: child,
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/adaptive_liquid_glass_layer.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/adaptive_liquid_glass_layer.dart
@@ -1,0 +1,198 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/cupertino.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../theme/glass_theme.dart';
+import '../../theme/glass_theme_data.dart';
+import '../../types/glass_quality.dart';
+import '../../utils/glass_performance_monitor.dart';
+import 'glass_isolation_scope.dart';
+import 'inherited_liquid_glass.dart';
+
+/// An adaptive liquid glass layer that provides a glass background with proper
+/// fallback handling across all platforms.
+///
+/// This is a custom replacement for `LiquidGlassLayer` that uses `AdaptiveGlass`
+/// for rendering, ensuring the background uses the lightweight shader on web/Skia
+/// instead of falling back to FakeGlass.
+///
+/// **Fallback chain for background:**
+/// - Premium + Impeller → Full shader (best quality) + blending support
+/// - Premium + Skia/web → Lightweight shader (not FakeGlass!)
+/// - Standard → Lightweight shader
+///
+/// **Blending:**
+/// - `blendAmount` parameter only works on Impeller (requires full renderer)
+/// - On Skia, blending is ignored (widgets render separately)
+/// - This matches chromatic aberration behavior (Impeller-only features)
+///
+/// **Usage:**
+/// ```dart
+/// // With explicit settings:
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(...),
+///   quality: GlassQuality.premium,
+///   shape: LiquidRoundedSuperellipse(borderRadius: 32),
+///   blendAmount: 10.0, // Impeller-only
+///   child: YourContent(),
+/// )
+///
+/// // Or use theme (recommended):
+/// AdaptiveLiquidGlassLayer(
+///   child: YourContent(), // Uses GlassTheme settings automatically
+/// )
+/// ```
+class AdaptiveLiquidGlassLayer extends StatefulWidget {
+  const AdaptiveLiquidGlassLayer({
+    required this.child,
+    this.shape = const LiquidRoundedSuperellipse(borderRadius: 0),
+    this.settings,
+    this.quality,
+    this.clipBehavior = Clip.antiAlias,
+    this.clipExpansion = EdgeInsets.zero,
+    this.blendAmount = 10.0,
+    this.platformViewBackdrop = false,
+    super.key,
+  });
+
+  /// The widget to display inside the glass layer.
+  final Widget child;
+
+  /// The shape of the glass background.
+  final LiquidShape shape;
+
+  /// Glass effect settings for the background.
+  ///
+  /// If null, uses settings from [GlassTheme] based on current brightness.
+  final LiquidGlassSettings? settings;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// If null, uses quality from [GlassTheme].
+  final GlassQuality? quality;
+
+  /// Clip behavior for the glass shape.
+  final Clip clipBehavior;
+
+  /// Expansion margin for the compositor clip rect to allow jelly physics to exceed bounds.
+  final EdgeInsets clipExpansion;
+
+  /// Blend amount for smooth glass transitions (Impeller-only).
+  ///
+  /// Higher values create smoother blending between overlapping glass elements.
+  /// Only works on Impeller - ignored on Skia (like chromatic aberration).
+  ///
+  /// Defaults to 10.0.
+  final double blendAmount;
+
+  /// When true (typically for iOS PlatformViews), forces the fallback rendering
+  /// path (BackdropFilter) instead of the Impeller-native shader.
+  final bool platformViewBackdrop;
+
+  /// Detects if Impeller rendering engine is active.
+  static bool get _canUseImpeller => ui.ImageFilter.isShaderFilterSupported;
+
+  @override
+  State<AdaptiveLiquidGlassLayer> createState() =>
+      _AdaptiveLiquidGlassLayerState();
+}
+
+class _AdaptiveLiquidGlassLayerState extends State<AdaptiveLiquidGlassLayer> {
+  // Stable identity for the child subtree across the structural wrapper toggle
+  // in build(). `useFullRenderer` (which flips with [platformViewBackdrop])
+  // decides whether the child is wrapped in a [LiquidGlassBlendGroup]. Without a
+  // stable key, toggling the flag changes the child's depth in the element tree,
+  // so Flutter REMOUNTS the whole subtree — re-running initState on any
+  // animation controllers inside it. For a bottom bar that re-seeds the
+  // selected-indicator springs at their settled value, so the indicator SNAPS
+  // to the new tab instead of morphing. A GlobalKey lets Flutter reparent the
+  // subtree across the wrapper change (preserving the live controllers) instead.
+  final GlobalKey _contentKey = GlobalKey();
+
+  @override
+  Widget build(BuildContext context) {
+    // Resolve settings: start with base defaults, apply theme partial override
+    // (only non-null fields), then let explicit widget settings win entirely.
+    final themeData = GlassThemeData.of(context);
+    const baseSettings = LiquidGlassSettings();
+    final themeOverride = themeData.settingsFor(context);
+    final withTheme = themeOverride?.applyTo(baseSettings) ?? baseSettings;
+    final effectiveSettings = widget.settings ?? withTheme;
+    final effectiveQuality = widget.quality ??
+        themeData.qualityFor(context) ??
+        GlassQuality.standard;
+
+    // ---- TRANSPARENT PASS-THROUGH FAST-PATHS --------------------------------
+    // Two cases share the same pass-through structure (no LiquidGlassLayer
+    // wrapper, no blend group — just InheritedLiquidGlass so descendants can
+    // read settings and quality):
+    //
+    // 1. GlassQuality.minimal:
+    //    Skips LiquidGlassLayer entirely. The layer has no shape — it wraps
+    //    the full bounds including any padding around pill/circle children.
+    //    Painting a BackdropFilter + tinted Container here bleeds into that
+    //    padding area, creating the dark rectangle visible above/around the
+    //    individual glass shapes. Glass tinting and blur come entirely from
+    //    child AdaptiveGlass widgets, each rendered as _FrostedFallback with
+    //    correct shape-aware clipping.
+    //
+    // 2. platformViewBackdrop == true (e.g. glass over an iOS map/video):
+    //    LiquidGlassLayer pushes an Impeller fragment-shader ImageFilter layer.
+    //    Attempting to run a shader filter over a UIKitView crashes on iOS.
+    //    We bypass it entirely; child AdaptiveGlass widgets already route to
+    //    _FrostedFallback (live BackdropFilter) when platformViewBackdrop is
+    //    set, which correctly samples through the PlatformView compositor.
+    // -------------------------------------------------------------------------
+    if (effectiveQuality == GlassQuality.minimal ||
+        widget.platformViewBackdrop) {
+      return GlassIsolationScope(
+        isolated: false,
+        child: InheritedLiquidGlass(
+          settings: effectiveSettings,
+          quality: effectiveQuality,
+          isBlurProvidedByAncestor: false,
+          child: KeyedSubtree(key: _contentKey, child: widget.child),
+        ),
+      );
+    }
+
+    // Detect if we should use the full Impeller-native rendering pipeline.
+    // platformViewBackdrop is never true here — that case returned above.
+    final bool useFullRenderer = AdaptiveLiquidGlassLayer._canUseImpeller &&
+        effectiveQuality == GlassQuality.premium;
+
+    // Resolve shadow for SDF rendering. Shadows only apply in light mode.
+    final bool isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    final List<BoxShadow> resolvedShadows =
+        isDark ? const <BoxShadow>[] : effectiveSettings.effectiveShadow;
+
+    // Keep the child subtree's element identity stable across the wrapper toggle
+    // below (see [_contentKey]) so its animation controllers survive.
+    final Widget keyedContent =
+        KeyedSubtree(key: _contentKey, child: widget.child);
+
+    return PremiumGlassTracker(
+      child: LiquidGlassLayer(
+        settings: effectiveSettings,
+        shadows: resolvedShadows,
+        clipExpansion: widget.clipExpansion,
+        child: GlassIsolationScope(
+          isolated: false,
+          child: InheritedLiquidGlass(
+            settings: effectiveSettings,
+            quality: effectiveQuality,
+            isBlurProvidedByAncestor:
+                false, // Root never provides the blur; containers do.
+            child: useFullRenderer
+                ? LiquidGlassBlendGroup(
+                    blend: widget.blendAmount,
+                    child: keyedContent,
+                  )
+                : keyedContent,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/animated_glass_indicator.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/animated_glass_indicator.dart
@@ -1,0 +1,578 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart' show listEquals;
+import 'dart:ui' show ImageFilter;
+
+import 'package:flutter/material.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../constants/glass_defaults.dart';
+import '../../theme/glass_theme.dart';
+import '../../types/glass_quality.dart';
+import '../../utils/draggable_indicator_physics.dart';
+import 'glass_effect.dart';
+
+/// A shared component that renders the interactive "Jelly" indicator
+/// used in [GlassTabBar], [GlassSegmentedControl], and [GlassBottomBar].
+///
+/// Handles:
+/// - Jelly physics (squash and stretch)
+/// - Thickness-based crossfade between background and glass
+/// - Positioning and expansion
+class AnimatedGlassIndicator extends StatelessWidget {
+  /// Optional background key for Skia/Web refraction
+  final GlobalKey? backgroundKey;
+
+  /// Current velocity of the drag gesture.
+  final double velocity;
+
+  /// Number of items (tabs/segments).
+  final int itemCount;
+
+  /// Current alignment of the indicator.
+  final Alignment alignment;
+
+  /// Animation value (0.0 to 1.0) indicating drag state.
+  /// 0 = resting, >0 = dragging/animating.
+  final double thickness;
+
+  /// Rendering quality (standard/premium).
+  final GlassQuality quality;
+
+  /// Base color for the indicator (used for background mode).
+  final Color indicatorColor;
+
+  /// Whether this is the background (non-glass) pass.
+  final bool isBackgroundIndicator;
+
+  /// Whether to render the solid background color pass.
+  final bool paintBackground;
+
+  /// Whether to render the glass effect shader pass.
+  final bool paintGlass;
+
+  /// Border radius of the indicator.
+  final double borderRadius;
+
+  /// Optional glass settings override.
+  ///
+  /// When non-null, fields in [settings] that differ from the
+  /// [LiquidGlassSettings()] constructor defaults are applied **on top of**
+  /// [baseIndicatorSettings] — not as a full replacement. This means
+  /// `chromaticAberration: 0.15` (the iOS 26 iridescent rim default) is
+  /// preserved unless the caller explicitly overrides it.
+  ///
+  /// Example — only change blur while keeping iOS 26 aberration:
+  /// ```dart
+  /// indicatorSettings: LiquidGlassSettings(blur: 2)
+  /// ```
+  ///
+  /// To fully reset to the `LiquidGlassSettings()` constructor defaults,
+  /// start from that and specify every field you want:
+  /// ```dart
+  /// indicatorSettings: AnimatedGlassIndicator.baseIndicatorSettings
+  ///     .copyWith(blur: 2, chromaticAberration: 0.0)
+  /// ```
+  final LiquidGlassSettings? settings;
+
+  /// Padding to apply around the indicator (e.g., for GlassBottomBar).
+  final EdgeInsetsGeometry padding;
+
+  /// How much to expand the indicator during drag.
+  final EdgeInsetsGeometry expansion;
+
+  /// Whether to use LiquidRoundedSuperellipse (Apple style) or standard RoundedRectangle.
+  final bool useSuperellipse;
+
+  /// Optional exact width for varying tab sizes (bypasses widthFactor).
+  /// Used in scrollable mode where tabs have different widths.
+  final double? exactWidth;
+
+  /// Optional exact offset from the left (bypasses alignment).
+  /// Used in scrollable mode where tabs have different widths.
+  final double? exactOffset;
+
+  /// Optional shadows for the solid background indicator.
+  ///
+  /// Shadows are applied only to the resting (non-glass) pill so they do not
+  /// muddy the liquid glass animation. Pass `null` (default) for no shadow.
+  final List<BoxShadow>? shadows;
+
+  /// Maximum concave lens pinch strength for the active indicator pill.
+  ///
+  /// During a drag, the pill's left and right edges appear to pinch inward
+  /// (iOS 26 "through a lens" effect). This value is the ceiling of that
+  /// effect at [thickness] == 1.0.
+  ///
+  /// - `1.0` (default) — full Apple-calibrated pinch
+  /// - `0.5` — half the pinch depth
+  /// - `0.0` — pinch fully disabled
+  ///
+  /// Configure per-bar via [GlassBottomBar.indicatorPinchStrength],
+  /// [GlassTabBar.indicatorPinchStrength], etc.
+  final double pinchStrength;
+
+  /// Sigma of the backdrop blur painted behind the RESTING selected pill
+  /// (Apple-style "frost at rest"). Scaled internally by the resting opacity so
+  /// it is full when settled and fades out as the pill morphs into the
+  /// liquid-glass lens during a drag/tap — keeping motion crisp. `0.0` (default)
+  /// disables it. Only renders on the background-painting indicator
+  /// ([paintBackground] == true); reads through a translucent [indicatorColor].
+  final double innerBlur;
+
+  const AnimatedGlassIndicator({
+    super.key,
+    required this.velocity,
+    required this.itemCount,
+    required this.alignment,
+    required this.thickness,
+    required this.quality,
+    required this.indicatorColor,
+    required this.isBackgroundIndicator,
+    required this.borderRadius,
+    this.settings,
+    this.padding = EdgeInsets.zero,
+    this.expansion = const EdgeInsets.all(8.0),
+    this.useSuperellipse = true,
+    this.backgroundKey,
+    this.paintBackground = true,
+    this.paintGlass = true,
+    this.exactWidth,
+    this.exactOffset,
+    this.shadows,
+    this.pinchStrength = 1.0,
+    this.innerBlur = 0.0,
+  });
+
+  /// The iOS 26-calibrated default glass settings for all indicator pills.
+  ///
+  /// Used as the merge base when the caller provides [settings]. Fields the
+  /// caller leaves at [LiquidGlassSettings()] defaults are filled in from
+  /// here, so `chromaticAberration: 0.15` persists unless explicitly changed.
+  ///
+  /// Pass this as a starting point when you need partial overrides while
+  /// keeping iOS 26 parity:
+  /// ```dart
+  /// indicatorSettings: AnimatedGlassIndicator.baseIndicatorSettings
+  ///     .copyWith(blur: 2)
+  /// ```
+  static const baseIndicatorSettings = LiquidGlassSettings(
+    glassColor: Color.from(
+      alpha: 0.0,
+      red: 1,
+      green: 1,
+      blue: 1,
+    ),
+    refractiveIndex: GlassDefaults.refractiveIndex,
+    lightIntensity: GlassDefaults.lightIntensity,
+    // Real iOS 26 glass has visible iridescent/rainbow fringing at edges.
+    chromaticAberration: 0.15,
+    lightAngle: GlassDefaults.lightAngle,
+    blur: 0,
+  );
+
+  // Sentinel representing the LiquidGlassSettings() constructor defaults, used
+  // by _mergeWithBase to detect which fields the caller explicitly changed.
+  static const _settingsDefaults = LiquidGlassSettings();
+
+  /// Merges [override] on top of [baseIndicatorSettings].
+  ///
+  /// Only fields that differ from [LiquidGlassSettings()] defaults are
+  /// treated as intentional overrides. Fields the caller left at the
+  /// constructor default are filled from [baseIndicatorSettings] instead.
+  ///
+  /// Edge-case: if a caller explicitly wants a field value that happens to
+  /// equal the [LiquidGlassSettings()] default (e.g. `chromaticAberration:
+  /// 0.01`), they should start from [baseIndicatorSettings] and use
+  /// [LiquidGlassSettings.copyWith] directly to express the intent clearly.
+  static LiquidGlassSettings _mergeWithBase(LiquidGlassSettings override) {
+    return baseIndicatorSettings.copyWith(
+      glassColor: override.glassColor != _settingsDefaults.glassColor
+          ? override.glassColor
+          : null,
+      thickness: override.thickness != _settingsDefaults.thickness
+          ? override.thickness
+          : null,
+      blur: override.blur != _settingsDefaults.blur ? override.blur : null,
+      chromaticAberration:
+          override.chromaticAberration != _settingsDefaults.chromaticAberration
+              ? override.chromaticAberration
+              : null,
+      lightAngle: override.lightAngle != _settingsDefaults.lightAngle
+          ? override.lightAngle
+          : null,
+      lightIntensity:
+          override.lightIntensity != _settingsDefaults.lightIntensity
+              ? override.lightIntensity
+              : null,
+      ambientStrength:
+          override.ambientStrength != _settingsDefaults.ambientStrength
+              ? override.ambientStrength
+              : null,
+      ambientRim: override.ambientRim != _settingsDefaults.ambientRim
+          ? override.ambientRim
+          : null,
+      refractiveIndex:
+          override.refractiveIndex != _settingsDefaults.refractiveIndex
+              ? override.refractiveIndex
+              : null,
+      saturation: override.saturation != _settingsDefaults.saturation
+          ? override.saturation
+          : null,
+      glowIntensity: override.glowIntensity != _settingsDefaults.glowIntensity
+          ? override.glowIntensity
+          : null,
+      specularSharpness:
+          override.specularSharpness != _settingsDefaults.specularSharpness
+              ? override.specularSharpness
+              : null,
+      standardOpacityMultiplier: override.standardOpacityMultiplier !=
+              _settingsDefaults.standardOpacityMultiplier
+          ? override.standardOpacityMultiplier
+          : null,
+      shadowElevation:
+          override.shadowElevation != _settingsDefaults.shadowElevation
+              ? override.shadowElevation
+              : null,
+      shadow: override.shadow,
+      whitenStrength:
+          override.whitenStrength != _settingsDefaults.whitenStrength
+              ? override.whitenStrength
+              : null,
+      whitenGated: override.whitenGated != _settingsDefaults.whitenGated
+          ? override.whitenGated
+          : null,
+      // backerColor was added to LiquidGlassSettings after this merge was
+      // written; without it the indicator silently drops any backerColor passed
+      // via indicatorSettings (e.g. the per-mode over-map stand-in colour).
+      backerColor: override.backerColor != _settingsDefaults.backerColor
+          ? override.backerColor
+          : null,
+    );
+  }
+
+  /// Clip budget for the Impeller BackdropFilterLayer.
+  ///
+  /// A constant margin is used rather than a velocity-proportional one:
+  /// the proportional approach changes [clipExpansion] every frame, which
+  /// triggers [markNeedsPaint] every frame via the setter's change detection,
+  /// causing constant geometry rebuilds and showing stale geometry during fast
+  /// drags. A constant value lets the setter's equality check short-circuit
+  /// with no repaint.
+  ///
+  ///  - Horizontal 20 px: covers glass shader antialiased edge rendering.
+  ///  - Vertical 15 px: covers max jelly scaleY plus headroom for the concave
+  ///    vertical pinch shader to sample the bar behind it without hitting the clamp edge.
+  static const _jellyClipExpansion = EdgeInsets.symmetric(
+    horizontal: 20.0,
+    vertical: 15.0,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    // Calculate expansion rectangle based on thickness
+    final resolvedExpansion = expansion.resolve(Directionality.of(context));
+    final rect = RelativeRect.lerp(
+      RelativeRect.fill,
+      RelativeRect.fromLTRB(
+        -resolvedExpansion.left,
+        -resolvedExpansion.top,
+        -resolvedExpansion.right,
+        -resolvedExpansion.bottom,
+      ),
+      thickness,
+    );
+
+    final bool isStdPath =
+        quality == GlassQuality.standard || quality == GlassQuality.minimal;
+
+    // Provide the doubled radius to layout layers when superellipse is active
+    // so they match the shader's true shape exactly.
+    final effectiveRadius = useSuperellipse ? borderRadius * 2 : borderRadius;
+
+    final shape = useSuperellipse
+        ? LiquidRoundedSuperellipse(borderRadius: borderRadius * 2)
+        : LiquidRoundedRectangle(borderRadius: borderRadius);
+
+    // 1. Background Indicator (Resting state)
+    // Fade out as the drag spring thickness increases toward 0.15.
+    final backgroundOpacity = (1.0 - (thickness / 0.15)).clamp(0.0, 1.0);
+    final backgroundIndicator = IgnorePointer(
+      child: Opacity(
+        opacity: backgroundOpacity,
+        child: DecoratedBox(
+          decoration: ShapeDecoration(
+            color: indicatorColor,
+            shape: shape,
+            shadows: shadows,
+          ),
+          child: const SizedBox.expand(),
+        ),
+      ),
+    );
+
+    // 2. Glass Indicator (Active/Dragging state)
+    // We fade the glass in/out by setting `visibility` on the settings rather
+    // than wrapping the widget in `Opacity`.
+    final fade = thickness.clamp(0.0, 1.0);
+    final base =
+        settings != null ? _mergeWithBase(settings!) : baseIndicatorSettings;
+
+    // Stabilise the pinch UV shift against jelly spring micro-oscillation.
+    //
+    // The spring targets thickness=1.0 when active and overshoots, leaving
+    // `fade` oscillating in the 0.9–1.0 range while the pill settles.
+    // Using `fade` directly as the pinch multiplier amplifies this oscillation
+    // into the UV warp, making icons/labels jitter visibly through the lens.
+    //
+    // The quadratic ease-out formula 1−(1−f)² compresses the near-1.0
+    // oscillation range from ±0.10 → ±0.01 (≈10× reduction) while still
+    // mapping 0→0 and 1→1 cleanly. `visibility` is left on the raw `fade`
+    // so glass opacity still tracks the spring naturally — only the UV
+    // distortion is stabilised.
+    final stablePinchFade = 1.0 - (1.0 - fade) * (1.0 - fade);
+    final effectiveSettings = base
+        .copyWith(visibility: fade)
+        .copyWithPinch(stablePinchFade * pinchStrength);
+
+    final glassWidget = GlassEffect(
+      shape: shape,
+      settings: effectiveSettings,
+      quality: quality,
+      interactionIntensity: thickness,
+      backgroundKey: backgroundKey,
+      clipExpansion: _jellyClipExpansion,
+      // rimThickness translation: Premium uses thickness as 3D glass depth
+      // (Impeller SDF — no visible border drawn). Standard uses rimThickness
+      // as a literal pixel-width border in the GLSL shader, so the same raw
+      // value (default 30) would produce a ~2.8 px ring (clamped 8.0 × 0.35).
+      //
+      // For graceful fallback parity — the primary use case is Premium quality
+      // with Standard as an automatic device fallback — we proportionally map
+      // the depth intent to an equivalent rim weight:
+      //   anchor : thickness=30 (default) → 0.5 pre-norm → 0.175 px actual
+      //   floor  : 0.35 → minimum hairline even at very low thickness (5–20),
+      //            where Premium still reads via optical depth but Standard
+      //            would otherwise have a sub-pixel invisible rim.
+      //   cap    : 1.5 → prevents extreme thickness values producing thick rings.
+      rimThickness: isStdPath
+          ? ((settings?.effectiveThickness ?? 30.0) * (0.5 / 30.0))
+              .clamp(0.35, 1.5)
+          : (settings?.effectiveThickness ?? 0.8).clamp(0.8, 8.0),
+      // iOS 26 Standard glass matching GlassSwitch/Slider pattern.
+      // settings.ambientRim (default 0) overrides the hardcoded floor — the
+      // omnidirectional ring that the directional key/kick highlights can't
+      // provide. Same field boosts the premium Fresnel rim, so one knob
+      // brightens the ring on either quality path.
+      ambientRim: (effectiveSettings.ambientRim > 0)
+          ? effectiveSettings.ambientRim
+          : (isStdPath ? 0.08 : 0.1),
+      baseAlphaMultiplier:
+          isStdPath ? 0.08 : 0.2, // Match GlassSlider (near clear center)
+      edgeAlphaMultiplier:
+          isStdPath ? 0.15 : 0.4, // Match GlassSlider/Switch (subtle rim)
+      child: const GlassGlow(
+        glowColor: Colors.transparent,
+        child: SizedBox.expand(),
+      ),
+    );
+
+    // Drop shadow for the moving glass jelly. GlassEffect itself never paints
+    // LiquidGlassSettings.effectiveShadow (only container widgets like
+    // AdaptiveGlass do), so without this the jelly renders shadowless no
+    // matter what the caller sets. Gated on an EXPLICIT shadow/shadowElevation
+    // in the caller's indicator settings — the constructor default (1.0) must
+    // not grow a shadow under every existing indicator. Alpha tracks [fade] so
+    // the shadow materialises with the glass and vanishes at rest.
+    // Shadows only apply in light mode — same rule as every other
+    // effectiveShadow consumer (AdaptiveGlass, AdaptiveLiquidGlassLayer,
+    // the tab-bar shadow overlay).
+    final jellyShadowIsDark =
+        GlassTheme.brightnessOf(context) == Brightness.dark;
+    final explicitJellyShadows = (!jellyShadowIsDark &&
+            settings != null &&
+            (settings!.shadow != null ||
+                settings!.shadowElevation != _settingsDefaults.shadowElevation))
+        ? effectiveSettings.effectiveShadow
+        : const <BoxShadow>[];
+    final shadowedGlass = explicitJellyShadows.isEmpty
+        ? glassWidget
+        : CustomPaint(
+            painter: _OuterShadowPainter(
+              borderRadius: effectiveRadius,
+              shadows: explicitJellyShadows,
+              opacity: fade,
+            ),
+            child: glassWidget,
+          );
+
+    // Mount early (0.01) so geometry is built before the indicator is visible.
+    // We MUST NOT wrap this in a RepaintBoundary because the jelly Transform
+    // below will apply a sub-pixel shift/scale. If we pre-rasterise the glass
+    // with a RepaintBoundary, the pre-computed AA will misalign with the pixel
+    // grid during the transform, causing stair-stepping on the edges.
+    final interactiveIndicator =
+        thickness > 0.01 ? shadowedGlass : const SizedBox.expand();
+
+    // Standard: background pill included inside Transform so the solid pill
+    // carries the jelly squish visually. The glass lens alone is too
+    // translucent on Standard (baseAlpha 0.08) to show the squish.
+    // Premium: glass lens only inside Transform — the Impeller SDF lens has
+    // full 3D optical contrast and carries the squish without the solid pill.
+    final glassChild = Stack(
+      clipBehavior: Clip.none,
+      children: [
+        if (paintBackground && isStdPath && backgroundOpacity > 0)
+          backgroundIndicator,
+        if (paintGlass && fade > 0.05) interactiveIndicator,
+      ],
+    );
+
+    final indicatorBody = Stack(
+      clipBehavior: Clip.none,
+      children: [
+        // Rest-blur: an Apple-style backdrop frost behind the RESTING pill.
+        // Sigma is scaled by backgroundOpacity so it is full when settled and
+        // fades toward zero as the pill morphs into the glass lens (motion stays
+        // crisp). Sits at the bottom of the stack so the (translucent) pill +
+        // icons read on top of the frosted backdrop.
+        //
+        // The ClipRRect + BackdropFilter stay MOUNTED for the whole gesture — we
+        // gate only on [innerBlur] > 0, never on backgroundOpacity. Adding or
+        // removing a clip layer over an iOS PlatformView mid-gesture makes the
+        // engine reconstruct the platform-view clip-view chain, which cancels
+        // the in-flight touch and freezes an interactive bar overlaid on it.
+        // Fading the sigma (rather than unmounting the layer) keeps the look
+        // without the churn; a small sigma floor keeps it a real backdrop layer
+        // so the engine can't drop it on its own either.
+        if (paintBackground && innerBlur > 0)
+          Positioned.fromRelativeRect(
+            rect: rect!,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(borderRadius),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(
+                  sigmaX: (innerBlur * backgroundOpacity)
+                      .clamp(0.001, double.infinity),
+                  sigmaY: (innerBlur * backgroundOpacity)
+                      .clamp(0.001, double.infinity),
+                ),
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        // Premium: background pill is rigid (outside Transform). The Impeller
+        // glass lens has enough 3D contrast to carry the jelly on its own.
+        if (paintBackground && !isStdPath && backgroundOpacity > 0)
+          Positioned.fromRelativeRect(
+            rect: rect!,
+            child: backgroundIndicator,
+          ),
+        // Jelly-physics Transform.
+        // Standard: wraps both the solid background pill + glass lens so the
+        //   pill itself flexes (the only element with enough visual weight).
+        //   maxDistortion is capped at 0.35 — enough to feel organic, below the
+        //   threshold where 2D ClipPath corners start looking boxy.
+        // Premium: wraps only the glass lens. The 3D SDF shader absorbs the
+        //   full 0.8 distortion naturally via optical pinch.
+        Positioned.fromRelativeRect(
+          rect: rect!,
+          child: Transform(
+            alignment: Alignment.center,
+            transform: DraggableIndicatorPhysics.buildJellyTransform(
+              velocity: Offset(velocity, 0),
+              maxDistortion: isStdPath ? 0.35 : 0.8,
+              velocityScale: 10,
+            ),
+            child: glassChild,
+          ),
+        ),
+      ],
+    );
+
+    Widget positioning;
+    if (exactWidth != null && exactOffset != null) {
+      // Exact pixel positioning for scrollable mode with variable-width tabs
+      positioning = Positioned(
+        left: exactOffset,
+        top: 0,
+        bottom: 0,
+        width: exactWidth,
+        child: indicatorBody,
+      );
+    } else {
+      // Fractional positioning for fixed-width tabs
+      positioning = Positioned.fill(
+        child: FractionallySizedBox(
+          widthFactor: 1 / itemCount,
+          alignment: alignment,
+          child: indicatorBody,
+        ),
+      );
+    }
+
+    return Positioned.fill(
+      child: Padding(
+        padding: padding,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [positioning],
+        ),
+      ),
+    );
+  }
+}
+
+/// Paints [shadows] around a rounded-rect silhouette with the shape's own
+/// interior clipped out (even-odd), so a TRANSLUCENT child shows no shadow
+/// body through itself — outer halo only. A plain BoxShadow behind clear
+/// glass reads as an inner shadow because its filled blurred body is visible
+/// through the glass.
+class _OuterShadowPainter extends CustomPainter {
+  const _OuterShadowPainter({
+    required this.borderRadius,
+    required this.shadows,
+    required this.opacity,
+  });
+
+  final double borderRadius;
+  final List<BoxShadow> shadows;
+  final double opacity;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rrect = RRect.fromRectAndRadius(
+      Offset.zero & size,
+      Radius.circular(borderRadius),
+    );
+    var slack = 0.0;
+    for (final s in shadows) {
+      slack = math.max(
+        slack,
+        s.blurRadius + s.spreadRadius + s.offset.distance,
+      );
+    }
+    final clip = Path()
+      ..fillType = PathFillType.evenOdd
+      ..addRect((Offset.zero & size).inflate(slack + 16))
+      ..addRRect(rrect);
+    canvas.save();
+    canvas.clipPath(clip);
+    for (final s in shadows) {
+      final paint = Paint()
+        ..color = s.color.withValues(alpha: s.color.a * opacity)
+        ..maskFilter = MaskFilter.blur(BlurStyle.normal, s.blurSigma);
+      canvas.drawRRect(
+        rrect.shift(s.offset).inflate(s.spreadRadius),
+        paint,
+      );
+    }
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(_OuterShadowPainter oldDelegate) =>
+      oldDelegate.borderRadius != borderRadius ||
+      oldDelegate.opacity != opacity ||
+      !listEquals(oldDelegate.shadows, shadows);
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/glass_accessibility_scope.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/glass_accessibility_scope.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import '../../utils/accessibility_config.dart' as glass_config;
+
+// ---------------------------------------------------------------------------
+// GlassAccessibilityScope — IP1
+//
+// Propagates system accessibility preferences to all glass widgets in the
+// subtree. Respects:
+//
+//   • Reduce Motion  — MediaQuery.disableAnimationsOf(context)
+//     When true, jelly/spring animations collapse to instant snaps.
+//     Affects: GlassSegmentedControl, GlassTabBar, GlassBottomBar, GlassSwitch,
+//              GlassSlider — every widget that uses GlassSpring internally.
+//
+//   • Reduce Transparency — MediaQuery.highContrastOf(context)
+//     Flutter does not expose UIAccessibility.isReduceTransparencyEnabled
+//     directly. highContrast is the closest platform signal available.
+//     When true, AdaptiveGlass replaces the glass shader with a solid frosted
+//     surface (a plain BackdropFilter blur + opaque tinted panel), eliminating
+//     all refraction, specular, and chromatic aberration.
+//
+// ## Default behaviour — no setup required
+//
+// GlassAccessibilityScope is NOT required. [GlassAccessibilityData.of] falls
+// back to reading [MediaQuery] directly when no scope is in the tree, so
+// system Reduce Motion and Reduce Transparency are always respected. Every
+// glass widget in this package does the right thing out of the box.
+//
+// ## Why add GlassAccessibilityScope at all?
+//
+// 1. Performance: a single InheritedWidget propagates the data once through
+//    the subtree; without it every [GlassAccessibilityData.of] call does its
+//    own [MediaQuery] lookup (cheap, but duplicated).
+//
+// 2. Overrides: useful in tests and showcase UIs to force a specific state
+//    without changing the OS setting.
+//
+// ## Optional usage
+//
+// Place once near the root, inside MaterialApp.builder so that MediaQuery is
+// available:
+//
+// ```dart
+// MaterialApp(
+//   builder: (context, child) => GlassAccessibilityScope(
+//     child: GlassTheme(data: ..., child: child!),
+//   ),
+// )
+// ```
+//
+// Access anywhere below:
+// ```dart
+// final scope = GlassAccessibilityData.of(context);
+// if (scope.reduceMotion) { /* skip animation */ }
+// ```
+//
+// ## Overriding
+//
+// Pass explicit values to override the system defaults — useful in tests or
+// showcase UIs where you want to demo the fallback appearance:
+//
+// ```dart
+// GlassAccessibilityScope(
+//   reduceTransparency: true, // force frosted fallback
+//   child: ...,
+// )
+// ```
+// ---------------------------------------------------------------------------
+
+/// Accessibility state for the liquid glass widget tree.
+///
+/// Obtain with [GlassAccessibilityData.of] or [GlassAccessibilityData.maybeOf].
+@immutable
+class GlassAccessibilityData {
+  const GlassAccessibilityData({
+    required this.reduceMotion,
+    required this.reduceTransparency,
+  });
+
+  /// When true, animated glass physics (jelly springs) should be disabled.
+  ///
+  /// Corresponds to iOS "Reduce Motion" / Android "Remove animations".
+  /// Sourced from [MediaQuery.disableAnimationsOf].
+  final bool reduceMotion;
+
+  /// When true, the glass shader should degrade to a plain frosted surface.
+  ///
+  /// Sourced from [MediaQuery.highContrastOf] as the closest available
+  /// Flutter proxy for iOS "Reduce Transparency".
+  final bool reduceTransparency;
+
+  /// The no-accessibility-restriction default used when no scope is in tree.
+  static const GlassAccessibilityData defaults = GlassAccessibilityData(
+    reduceMotion: false,
+    reduceTransparency: false,
+  );
+
+  /// Returns the nearest [GlassAccessibilityData] in the widget tree.
+  ///
+  /// Priority order:
+  /// 1. An explicit [GlassAccessibilityScope] in the widget tree (always wins).
+  /// 2. System `MediaQuery` flags, **if**
+  ///    `LiquidGlassWidgets.respectSystemAccessibility` is `true` (the default).
+  /// 3. [GlassAccessibilityData.defaults] (no restrictions) when accessibility
+  ///    is disabled globally via
+  ///    `LiquidGlassWidgets.wrap(respectSystemAccessibility: false)`.
+  static GlassAccessibilityData of(BuildContext context) {
+    // 1. Prefer an explicit scope — allows overrides and avoids duplicate
+    // MediaQuery lookups in subtrees that do add the scope.
+    final inherited = context
+        .dependOnInheritedWidgetOfExactType<_InheritedGlassAccessibility>();
+    if (inherited != null) return inherited.data;
+
+    // 2. If the global flag is off, skip MediaQuery entirely.
+    if (!glass_config.respectSystemAccessibility) {
+      return GlassAccessibilityData.defaults;
+    }
+
+    // 3. Read system flags so accessibility is respected with no dev setup.
+    return GlassAccessibilityData(
+      reduceMotion: MediaQuery.disableAnimationsOf(context),
+      reduceTransparency: MediaQuery.highContrastOf(context),
+    );
+  }
+
+  /// Returns the nearest [GlassAccessibilityData], or null if not found.
+  static GlassAccessibilityData? maybeOf(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<_InheritedGlassAccessibility>()
+        ?.data;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GlassAccessibilityData &&
+          runtimeType == other.runtimeType &&
+          reduceMotion == other.reduceMotion &&
+          reduceTransparency == other.reduceTransparency;
+
+  @override
+  int get hashCode => Object.hash(reduceMotion, reduceTransparency);
+
+  @override
+  String toString() => 'GlassAccessibilityData(reduceMotion: $reduceMotion, '
+      'reduceTransparency: $reduceTransparency)';
+}
+
+/// Reads system accessibility preferences and makes them available to all
+/// glass widgets below it in the widget tree.
+///
+/// See the file-level documentation for full usage details.
+class GlassAccessibilityScope extends StatelessWidget {
+  /// Creates a [GlassAccessibilityScope].
+  ///
+  /// [reduceMotion] and [reduceTransparency] are optional overrides.
+  /// When null (the default), the scope reads the values from [MediaQuery].
+  const GlassAccessibilityScope({
+    required this.child,
+    this.reduceMotion,
+    this.reduceTransparency,
+    super.key,
+  });
+
+  /// Override for the reduce-motion preference.
+  ///
+  /// When null, the value is sourced from [MediaQuery.disableAnimationsOf].
+  final bool? reduceMotion;
+
+  /// Override for the reduce-transparency preference.
+  ///
+  /// When null, the value is sourced from [MediaQuery.highContrastOf].
+  final bool? reduceTransparency;
+
+  /// The widget subtree that will have access to the glass accessibility data.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final data = GlassAccessibilityData(
+      reduceMotion: reduceMotion ?? MediaQuery.disableAnimationsOf(context),
+      reduceTransparency:
+          reduceTransparency ?? MediaQuery.highContrastOf(context),
+    );
+
+    return _InheritedGlassAccessibility(
+      data: data,
+      child: child,
+    );
+  }
+}
+
+/// Internal InheritedWidget that carries [GlassAccessibilityData] down the tree.
+class _InheritedGlassAccessibility extends InheritedWidget {
+  const _InheritedGlassAccessibility({
+    required this.data,
+    required super.child,
+  });
+
+  final GlassAccessibilityData data;
+
+  @override
+  bool updateShouldNotify(_InheritedGlassAccessibility oldWidget) =>
+      data != oldWidget.data;
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/glass_adaptive_scope.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/glass_adaptive_scope.dart
@@ -1,0 +1,740 @@
+// ---------------------------------------------------------------------------
+// GlassAdaptiveScope — v0.8.0
+//
+// Wraps any subtree and automatically adjusts GlassQuality based on real
+// raster performance observed from SchedulerBinding frame timings.
+//
+// ## Three-phase adaptation
+//
+// Phase 1 — Static probe (synchronous, at scope mount):
+//   Tests hard device capabilities. Forces minimal on software renderers and
+//   broken shader drivers (ImageFilter.isShaderFilterSupported == false).
+//   Caps at standard on web (kIsWeb).
+//
+// Phase 2 — Warm-up benchmark (first 180 frames ≈ 3 s at 60 fps):
+//   Collects raster durations and computes P75 to estimate the device baseline.
+//   P75 < 20 ms  → start at maxQuality (premium by default)
+//   P75 20-28 ms → step to standard
+//   P75 > 28 ms  → step to minimal
+//
+// Phase 3 — Runtime hysteresis (ongoing, very low overhead):
+//   Degrades quality when P95 > targetFrameMs × 1.5 for 3 consecutive windows.
+//   Upgrades quality (if allowStepUp) when P95 < targetFrameMs × 0.6
+//   for 10 consecutive windows. Hard 8-second cooldown between any change.
+//   Degradation is 3× faster than recovery — jank is noticed immediately;
+//   recovery should be invisible and stable.
+//
+// ## Key design constraint
+//
+// GlassAdaptiveScope acts as a **quality ceiling**, not a floor.
+// A widget that explicitly requests GlassQuality.minimal will not be upgraded
+// to standard even when the scope is at premium. A widget that requests
+// premium will be silently capped to standard if the scope has stepped down
+// to standard.
+//
+// This ceiling is enforced by GlassThemeHelpers.resolveQuality, which reads
+// GlassAdaptiveScopeData.maybeOf(context) after resolving the widget-level
+// and inherited qualities.
+//
+// Widgets with an **explicit** quality parameter are not affected — the
+// resolution chain handles this: the explicit param is resolved before the
+// adaptive cap is applied. (That is intentional — the developer's explicit
+// override wins.)
+//
+// ## Debug / Profile builds
+//
+// In debug and profile builds, GlassPerformanceMonitor continues to run
+// alongside GlassAdaptiveScope. The monitor emits developer warnings; the
+// scope acts on them. They share SchedulerBinding's callback list — Flutter
+// handles multiple listeners correctly.
+//
+// ## Usage
+//
+// ```dart
+// // Minimal — zero config, sensible defaults
+// GlassAdaptiveScope(
+//   child: MaterialApp(...),
+// )
+//
+// // Advanced — full control
+// GlassAdaptiveScope(
+//   minQuality: GlassQuality.standard,  // never go below standard
+//   maxQuality: GlassQuality.premium,
+//   targetFrameMs: 8,                   // 120 Hz ProMotion target
+//   allowStepUp: true,                  // allow recovery after throttle
+//   onQualityChanged: (from, to) {
+//     analytics.log('glass_quality', {'from': from.name, 'to': to.name});
+//   },
+//   child: child,
+// )
+//
+// // Read from any descendant
+// final quality = GlassAdaptiveScopeData.of(context).effectiveQuality;
+// ```
+// ---------------------------------------------------------------------------
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
+
+import '../../types/glass_quality.dart';
+import '../../types/glass_quality_change_reason.dart';
+import '../../utils/glass_quality_adapter.dart';
+
+// ---------------------------------------------------------------------------
+// GlassAdaptiveScopeData — immutable data carried by the InheritedWidget
+// ---------------------------------------------------------------------------
+
+/// Data propagated by [GlassAdaptiveScope] to all glass widgets below it.
+///
+/// Obtain via [GlassAdaptiveScopeData.of] or [GlassAdaptiveScopeData.maybeOf].
+@immutable
+class GlassAdaptiveScopeData {
+  /// Creates [GlassAdaptiveScopeData].
+  const GlassAdaptiveScopeData({
+    required this.effectiveQuality,
+    required this.phase,
+  });
+
+  /// The current quality ceiling enforced by the scope.
+  ///
+  /// All glass widgets that inherit quality (those without an explicit
+  /// `quality:` parameter) will be capped at this level via
+  /// [GlassThemeHelpers.resolveQuality].
+  final GlassQuality effectiveQuality;
+
+  /// The current adaptation phase (probe → warmup → runtime).
+  ///
+  /// Useful for analytics or development UIs. Widgets should not change their
+  /// behaviour based on this value.
+  final AdaptivePhase phase;
+
+  /// Returns the nearest [GlassAdaptiveScopeData] from the widget tree.
+  ///
+  /// Throws a [FlutterError] if no [GlassAdaptiveScope] ancestor is found.
+  /// Use [maybeOf] in contexts where the scope may not be present.
+  static GlassAdaptiveScopeData of(BuildContext context) {
+    final data = maybeOf(context);
+    assert(
+      data != null,
+      'GlassAdaptiveScopeData.of() was called on a context that does not have '
+      'a GlassAdaptiveScope ancestor. Make sure GlassAdaptiveScope is placed '
+      'above this widget in the tree.',
+    );
+    return data!;
+  }
+
+  /// Returns the nearest [GlassAdaptiveScopeData], or `null` if not found.
+  ///
+  /// Glass widgets use this variant internally — if no scope is present, the
+  /// normal quality resolution chain runs unchanged.
+  static GlassAdaptiveScopeData? maybeOf(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<_InheritedAdaptiveQuality>()
+        ?.data;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GlassAdaptiveScopeData &&
+          runtimeType == other.runtimeType &&
+          effectiveQuality == other.effectiveQuality &&
+          phase == other.phase;
+
+  @override
+  int get hashCode => Object.hash(effectiveQuality, phase);
+
+  @override
+  String toString() =>
+      'GlassAdaptiveScopeData(quality: $effectiveQuality, phase: $phase)';
+}
+
+// ---------------------------------------------------------------------------
+// GlassAdaptiveDiagnostic — rich event emitted on quality changes
+// ---------------------------------------------------------------------------
+
+/// Rich diagnostic snapshot emitted by [GlassAdaptiveScope] whenever the
+/// effective quality changes.
+///
+/// Passed to [GlassAdaptiveScope.onDiagnostic] and printed by
+/// [GlassAdaptiveScope.debugLogDiagnostics]. Contains the full context of
+/// *why* the quality changed — P75/P95 timing, phase, frame count, and reason.
+///
+/// **Use [reason] to filter analytics:**
+/// - [GlassQualityChangeReason.warmupComplete] — the most useful event for
+///   threshold calibration. [p75Ms] will be set.
+/// - [GlassQualityChangeReason.thermalDegradation] — thermal throttle detected.
+///   [p95Ms] will be set.
+/// - [GlassQualityChangeReason.restoredFromCache] — skip in analytics; this
+///   fires on every remount and carries no new timing data.
+@experimental
+@immutable
+class GlassAdaptiveDiagnostic {
+  /// Creates a [GlassAdaptiveDiagnostic].
+  const GlassAdaptiveDiagnostic({
+    required this.from,
+    required this.to,
+    required this.reason,
+    required this.phase,
+    this.p75Ms,
+    this.p95Ms,
+    this.framesMeasured,
+  });
+
+  /// The quality tier before the change.
+  final GlassQuality from;
+
+  /// The quality tier after the change.
+  final GlassQuality to;
+
+  /// What triggered this quality change.
+  final GlassQualityChangeReason reason;
+
+  /// The adaptation phase at the moment of the change.
+  final AdaptivePhase phase;
+
+  /// The P75 raster time (ms) measured during Phase 2 warm-up.
+  ///
+  /// Only set when [reason] is [GlassQualityChangeReason.warmupComplete].
+  /// This is the threshold calibration data point — please post it to the
+  /// [community discussion](https://github.com/sdegenaar/liquid_glass_widgets/discussions).
+  final double? p75Ms;
+
+  /// The P95 raster time (ms) from the Phase 3 window that triggered this change.
+  ///
+  /// Only set when [reason] is [GlassQualityChangeReason.thermalDegradation]
+  /// or [GlassQualityChangeReason.thermalRecovery].
+  final double? p95Ms;
+
+  /// Number of frames measured to reach this decision.
+  ///
+  /// Equals [GlassQualityAdapter.warmupFrames] for [GlassQualityChangeReason.warmupComplete]
+  /// and [GlassQualityAdapter.windowSize] for Phase 3 changes.
+  final int? framesMeasured;
+
+  @override
+  String toString() {
+    final buf = StringBuffer()
+      ..write('GlassAdaptiveDiagnostic(')
+      ..write('${from.name}\u2192${to.name}')
+      ..write(', reason: ${reason.name}')
+      ..write(', phase: ${phase.name}');
+    if (p75Ms != null) buf.write(', p75: ${p75Ms!.toStringAsFixed(1)}ms');
+    if (p95Ms != null) buf.write(', p95: ${p95Ms!.toStringAsFixed(1)}ms');
+    if (framesMeasured != null) buf.write(', frames: $framesMeasured');
+    buf.write(')');
+    return buf.toString();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GlassAdaptiveScopeConfig — bundled configuration value object
+// ---------------------------------------------------------------------------
+
+/// Bundles all [GlassAdaptiveScope] configuration into a single, portable
+/// value object.
+///
+/// **Experimental** — this API is available in 0.8.0 for community feedback.
+/// Phase 2 timing thresholds (12 ms / 20 ms P75) have been validated by
+/// reasoning but not yet by broad real-device data. If you observe unexpected
+/// quality degradation or promotion, please file an issue with your device
+/// model, raster timings (from Flutter DevTools), and the quality tier you
+/// expected vs received.
+///
+/// Use this when passing scope configuration through an API that cannot
+/// accept individual widget parameters directly — e.g. [LiquidGlassWidgets.wrap]:
+///
+/// ```dart
+/// runApp(LiquidGlassWidgets.wrap(
+///   const MyApp(),
+///   adaptiveQuality: true,
+///   adaptiveConfig: GlassAdaptiveScopeConfig(
+///     initialQuality: GlassQuality.standard, // earn your way up to premium
+///     allowStepUp: true,
+///   ),
+/// ));
+/// ```
+///
+/// All fields mirror the corresponding parameters on [GlassAdaptiveScope].
+@experimental
+@immutable
+class GlassAdaptiveScopeConfig {
+  /// Creates a [GlassAdaptiveScopeConfig] with sensible defaults.
+  const GlassAdaptiveScopeConfig({
+    this.minQuality = GlassQuality.minimal,
+    this.maxQuality = GlassQuality.premium,
+    this.initialQuality,
+    this.targetFrameMs = 16,
+    this.allowStepUp = true,
+    this.warmupPremiumThresholdMs = 20.0,
+    this.warmupStandardThresholdMs = 28.0,
+    this.onQualityChanged,
+    this.onDiagnostic,
+    this.debugLogDiagnostics = false,
+  });
+
+  /// The lowest quality tier the scope will ever enforce.
+  /// Defaults to [GlassQuality.minimal].
+  final GlassQuality minQuality;
+
+  /// The highest quality tier the scope may use.
+  /// Defaults to [GlassQuality.premium].
+  final GlassQuality maxQuality;
+
+  /// The quality to display before the warm-up benchmark completes.
+  /// When null (the default), [maxQuality] is used.
+  final GlassQuality? initialQuality;
+
+  /// The raster frame duration target in milliseconds. Defaults to `16` (60 fps).
+  final int targetFrameMs;
+
+  /// When `true`, the scope may step quality **up** after a sustained period
+  /// of good performance (e.g. after thermal recovery).
+  /// Defaults to `true` — allows Phase 3 to self-correct a conservative Phase 2
+  /// warmup decision. Step-up requires 10 consecutive under-budget windows
+  /// (≈ 20 seconds) plus an 8-second cooldown, so the transition is invisible.
+  final bool allowStepUp;
+
+  /// The P75 warmup threshold (ms) below which the device is classified as
+  /// capable of [GlassQuality.premium]. Defaults to `20.0`.
+  ///
+  /// **Community calibration param** — if the default causes incorrect
+  /// degradation on your hardware, try raising this (e.g. to `24.0`) and
+  /// post your P75 from [GlassAdaptiveDiagnostic.p75Ms] along with your device
+  /// model to the [discussions](https://github.com/sdegenaar/liquid_glass_widgets/discussions).
+  final double warmupPremiumThresholdMs;
+
+  /// The P75 warmup threshold (ms) at or below which the device is classified
+  /// as capable of [GlassQuality.standard] (when above [warmupPremiumThresholdMs]).
+  /// Defaults to `28.0`.
+  ///
+  /// Devices with P75 above this value are classified as [GlassQuality.minimal].
+  final double warmupStandardThresholdMs;
+
+  /// Called whenever the effective quality tier changes.
+  final void Function(GlassQuality from, GlassQuality to)? onQualityChanged;
+
+  /// Called with rich diagnostic data whenever the effective quality changes.
+  ///
+  /// Provides [GlassAdaptiveDiagnostic] with P75/P95 timing, reason, phase,
+  /// and frame count. Useful for analytics and for posting to the
+  /// [Threshold Calibration Discussion](https://github.com/sdegenaar/liquid_glass_widgets/discussions).
+  ///
+  /// See also [debugLogDiagnostics] for a zero-wiring alternative.
+  final void Function(GlassAdaptiveDiagnostic)? onDiagnostic;
+
+  /// When `true`, prints a structured diagnostic log to the console on every
+  /// quality change — debug builds only (no-op in release/profile).
+  ///
+  /// Zero setup required. Add this to quickly capture data for bug reports:
+  ///
+  /// ```dart
+  /// GlassAdaptiveScopeConfig(debugLogDiagnostics: true)
+  /// ```
+  ///
+  /// Defaults to `false`.
+  final bool debugLogDiagnostics;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GlassAdaptiveScopeConfig &&
+          runtimeType == other.runtimeType &&
+          minQuality == other.minQuality &&
+          maxQuality == other.maxQuality &&
+          initialQuality == other.initialQuality &&
+          targetFrameMs == other.targetFrameMs &&
+          allowStepUp == other.allowStepUp &&
+          debugLogDiagnostics == other.debugLogDiagnostics;
+
+  @override
+  int get hashCode => Object.hash(
+        minQuality,
+        maxQuality,
+        initialQuality,
+        targetFrameMs,
+        allowStepUp,
+        debugLogDiagnostics,
+      );
+}
+
+// ---------------------------------------------------------------------------
+// GlassAdaptiveScope — public widget
+// ---------------------------------------------------------------------------
+
+/// Automatically adjusts [GlassQuality] for its subtree based on real device
+/// raster performance, handling three scenarios developers can't easily test:
+///
+/// - **Broken/slow shader drivers** (Pixel 4a, Galaxy A22 class devices):
+///   detected in Phase 1 (static probe) and capped immediately.
+/// - **Warm-up jank** ("wrong quality at startup"):
+///   resolved by Phase 2 benchmark over the first 180 frames.
+/// - **Thermal throttling** ("fine at launch, janky after 10 minutes"):
+///   detected and corrected by Phase 3 runtime hysteresis.
+///
+/// The scope acts as a **quality ceiling** — it only caps inherited quality,
+/// never overrides explicit `quality:` widget parameters. See the file-level
+/// documentation for the complete architecture description.
+///
+/// **Experimental** — available in 0.8.0 for community feedback. The Phase 2
+/// timing thresholds (P75 < 20 ms → premium, 20–28 ms → standard, > 28 ms →
+/// minimal) were updated in 0.9.6 based on real-device community data showing
+/// that Android GPU clock-scaling and shader-cache inflation can raise P75 by
+/// 4–6 ms on capable mid-range devices during the warmup window. If you
+/// observe unexpected behaviour, please file an issue with your device model
+/// and raster timings.
+///
+/// ```dart
+/// GlassAdaptiveScope(
+///   child: MaterialApp(home: MyHome()),
+/// )
+/// ```
+@experimental
+class GlassAdaptiveScope extends StatefulWidget {
+  /// Creates a [GlassAdaptiveScope].
+  ///
+  /// [child] is required. All other parameters have sensible defaults.
+  const GlassAdaptiveScope({
+    required this.child,
+    this.minQuality = GlassQuality.minimal,
+    this.maxQuality = GlassQuality.premium,
+    this.initialQuality,
+    this.targetFrameMs = 16,
+    this.allowStepUp = true,
+    this.warmupPremiumThresholdMs = 20.0,
+    this.warmupStandardThresholdMs = 28.0,
+    this.onQualityChanged,
+    this.onDiagnostic,
+    this.debugLogDiagnostics = false,
+    super.key,
+  });
+
+  /// The widget subtree that will have its glass quality automatically managed.
+  final Widget child;
+
+  /// The lowest quality tier the scope will ever enforce.
+  ///
+  /// Widgets in the subtree will never be capped lower than this value.
+  /// Defaults to [GlassQuality.minimal] (allow full degradation to
+  /// shader-free BackdropFilter mode).
+  final GlassQuality minQuality;
+
+  /// The highest quality tier the scope may use.
+  ///
+  /// The Phase 2 warm-up benchmark respects this ceiling — even on a fast
+  /// device, quality will not exceed [maxQuality].
+  /// Defaults to [GlassQuality.premium].
+  final GlassQuality maxQuality;
+
+  /// The quality to start at, skipping Phase 2 (the warm-up benchmark).
+  ///
+  /// When non-null, the adapter jumps directly to Phase 3 (runtime hysteresis)
+  /// using this quality as the starting point — eliminating the ~3-second
+  /// warm-up jank window on repeat launches.
+  ///
+  /// **Use this to restore a persisted quality across cold starts:**
+  ///
+  /// ```dart
+  /// // In main.dart — persist settled quality to SharedPreferences:
+  /// final prefs = await SharedPreferences.getInstance();
+  /// final saved = prefs.getString('glass_quality');
+  /// final initial = saved != null
+  ///     ? GlassQuality.values.byName(saved)
+  ///     : null; // null = run Phase 2 on first launch
+  ///
+  /// runApp(LiquidGlassWidgets.wrap(
+  ///   const MyApp(),
+  ///   adaptiveQuality: true,
+  ///   adaptiveConfig: GlassAdaptiveScopeConfig(
+  ///     initialQuality: initial,
+  ///     allowStepUp: true,
+  ///     onQualityChanged: (_, to) => prefs.setString('glass_quality', to.name),
+  ///   ),
+  /// ));
+  /// ```
+  ///
+  /// Within a single app process, [GlassQualityAdapter._sessionSettledQuality]
+  /// also auto-skips Phase 2 on remounts — no extra code required.
+  final GlassQuality? initialQuality;
+
+  /// The raster frame duration target in milliseconds.
+  ///
+  /// Used as the reference for Phase 3 thresholds:
+  ///   - Degrade when P95 > [targetFrameMs] × 1.5
+  ///   - Upgrade when P95 < [targetFrameMs] × 0.6 (if [allowStepUp])
+  ///
+  /// Set to `8` for 120 Hz ProMotion displays.
+  /// Defaults to `16` (60 fps budget).
+  final int targetFrameMs;
+
+  /// When `true`, the scope may step quality **up** to [maxQuality] after a
+  /// sustained period of good performance (e.g. after thermal recovery or a
+  /// conservative Phase 2 warmup decision).
+  ///
+  /// Defaults to `true`. Step-up uses a 10-window window (≈ 20 seconds) plus
+  /// an 8-second cooldown to prevent oscillation — users should not perceive
+  /// any flicker. Setting this to `false` locks quality at whatever Phase 2
+  /// decided for the entire session.
+  final bool allowStepUp;
+
+  /// The P75 warmup threshold (ms) below which the device is classified as
+  /// capable of [GlassQuality.premium]. Defaults to `20.0`.
+  ///
+  /// **Community calibration param** — if the default causes incorrect
+  /// degradation on your hardware, try raising this (e.g. to `24.0`) and
+  /// post your P75 from [GlassAdaptiveDiagnostic.p75Ms] along with your device
+  /// model to the [discussions](https://github.com/sdegenaar/liquid_glass_widgets/discussions).
+  final double warmupPremiumThresholdMs;
+
+  /// The P75 warmup threshold (ms) at or below which the device is classified
+  /// as capable of [GlassQuality.standard] (when above [warmupPremiumThresholdMs]).
+  /// Defaults to `28.0`.
+  ///
+  /// Devices with P75 above this value are classified as [GlassQuality.minimal].
+  final double warmupStandardThresholdMs;
+
+  /// Called on the main thread whenever the effective quality changes.
+  ///
+  /// Receives `(GlassQuality from, GlassQuality to)`. Use [onDiagnostic] for
+  /// richer context including P75/P95 timings and change reason.
+  final void Function(GlassQuality from, GlassQuality to)? onQualityChanged;
+
+  /// Called with a [GlassAdaptiveDiagnostic] whenever the effective quality
+  /// changes. Provides P75/P95 raster timings, change reason, phase, and frame
+  /// count — everything needed for bug reports and analytics.
+  ///
+  /// ```dart
+  /// onDiagnostic: (d) {
+  ///   if (d.reason == GlassQualityChangeReason.warmupComplete) {
+  ///     analytics.log('glass_warmup', {'p75': d.p75Ms, 'quality': d.to.name});
+  ///   }
+  /// },
+  /// ```
+  final void Function(GlassAdaptiveDiagnostic)? onDiagnostic;
+
+  /// When `true`, prints a structured diagnostic log on every quality change
+  /// in debug builds (no-op in profile/release).
+  ///
+  /// ```dart
+  /// GlassAdaptiveScope(debugLogDiagnostics: true, child: child)
+  /// ```
+  ///
+  /// Defaults to `false`.
+  final bool debugLogDiagnostics;
+
+  @override
+  State<GlassAdaptiveScope> createState() => _GlassAdaptiveScopeState();
+}
+
+class _GlassAdaptiveScopeState extends State<GlassAdaptiveScope>
+    with WidgetsBindingObserver {
+  late GlassQualityAdapter _adapter;
+  late GlassQuality _effectiveQuality;
+
+  @override
+  void initState() {
+    super.initState();
+    // Seed _effectiveQuality using the same source priority the adapter will
+    // use in start(): developer-provided initialQuality beats session cache
+    // beats maxQuality. Doing this before creating and starting the adapter
+    // ensures the very first rendered frame shows the correct quality and
+    // there is no one-frame flash from maxQuality to a cached lower value.
+    _effectiveQuality = widget.initialQuality ??
+        GlassQualityAdapter.sessionSettledQuality ??
+        widget.maxQuality;
+    _createAdapter();
+    WidgetsBinding.instance.addObserver(this);
+    _adapter.start();
+  }
+
+  @override
+  void didUpdateWidget(GlassAdaptiveScope oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    // Recreate the adapter if configuration changed.
+    if (oldWidget.minQuality != widget.minQuality ||
+        oldWidget.maxQuality != widget.maxQuality ||
+        oldWidget.targetFrameMs != widget.targetFrameMs ||
+        oldWidget.allowStepUp != widget.allowStepUp ||
+        oldWidget.warmupPremiumThresholdMs != widget.warmupPremiumThresholdMs ||
+        oldWidget.warmupStandardThresholdMs !=
+            widget.warmupStandardThresholdMs) {
+      _adapter.stop();
+      // Mirror the same seeding logic as initState to avoid a one-frame flash.
+      _effectiveQuality = widget.initialQuality ??
+          GlassQualityAdapter.sessionSettledQuality ??
+          widget.maxQuality;
+      _createAdapter();
+      _adapter.start();
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _adapter.stop();
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // On resume, reset the benchmark so thermal recovery is detected.
+    // The adapter re-runs Phase 2 from a clean slate while preserving the
+    // current quality until the new benchmark completes.
+    if (state == AppLifecycleState.resumed) {
+      _adapter.reset();
+    }
+  }
+
+  void _createAdapter() {
+    _adapter = GlassQualityAdapter(
+      minQuality: widget.minQuality,
+      maxQuality: widget.maxQuality,
+      targetFrameMs: widget.targetFrameMs,
+      allowStepUp: widget.allowStepUp,
+      initialQuality: widget.initialQuality,
+      warmupPremiumThresholdMs: widget.warmupPremiumThresholdMs,
+      warmupStandardThresholdMs: widget.warmupStandardThresholdMs,
+      onQualityChanged: _onQualityChanged,
+      onWarmupComplete: _onWarmupComplete,
+    );
+  }
+
+  /// Called by the adapter whenever Phase 2 completes — even if quality
+  /// didn't change. This is the critical path for fast devices (e.g. iPhone,
+  /// flagship Android) that stay at [GlassQuality.premium] throughout warmup:
+  /// [_onQualityChanged] never fires for them, so without this callback their
+  /// P75 data would be completely invisible.
+  void _onWarmupComplete(GlassQuality settled, double p75Ms, int frames) {
+    // Snapshot synchronously: did quality change as a result of warmup?
+    // If yes, _onQualityChanged already fired for this event and will emit the
+    // diagnostic — avoid double-firing.
+    final noQualityChange = _effectiveQuality == settled;
+
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      // Nothing to update in state here — _effectiveQuality is already correct.
+      // Only emit diagnostic for the no-change path; the changed path was
+      // already handled by _onQualityChanged.
+      if (noQualityChange) {
+        final diagnostic = GlassAdaptiveDiagnostic(
+          from: settled,
+          to: settled,
+          reason: GlassQualityChangeReason.warmupComplete,
+          phase: AdaptivePhase.runtime,
+          p75Ms: p75Ms,
+          framesMeasured: frames,
+        );
+        widget.onDiagnostic?.call(diagnostic);
+        if (widget.debugLogDiagnostics) _logDiagnostic(diagnostic);
+      }
+    });
+  }
+
+  void _onQualityChanged(GlassQuality from, GlassQuality to) {
+    // Snapshot diagnostic fields from the adapter NOW (before the async gap)
+    // since the adapter may process further frames in the meantime.
+    final reason = _adapter.lastChangeReason;
+    final p75 = _adapter.lastP75Ms;
+    final p95 = _adapter.lastP95Ms;
+    final frames = _adapter.lastFramesMeasured;
+    final phase = _adapter.phase;
+
+    // Defer setState to after the next frame draw to avoid causing the very
+    // frame drop we are trying to fix. addPostFrameCallback is properly
+    // drained in widget tests (unlike scheduleTask).
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() => _effectiveQuality = to);
+
+      // Legacy callback — unchanged signature for backward compatibility.
+      widget.onQualityChanged?.call(from, to);
+
+      // Rich diagnostic callback.
+      final diagnostic = GlassAdaptiveDiagnostic(
+        from: from,
+        to: to,
+        reason: reason,
+        phase: phase,
+        p75Ms: p75,
+        p95Ms: p95,
+        framesMeasured: frames,
+      );
+      widget.onDiagnostic?.call(diagnostic);
+
+      if (widget.debugLogDiagnostics) {
+        _logDiagnostic(diagnostic);
+      }
+    });
+  }
+
+  /// Prints a structured diagnostic block. Always gated on [kDebugMode] —
+  /// no output in profile or release builds regardless of the flag value.
+  void _logDiagnostic(GlassAdaptiveDiagnostic d) {
+    if (!kDebugMode) return;
+    final noChange = d.from == d.to;
+    final buf = StringBuffer()
+      ..writeln(
+          '┌─ 📊 GlassAdaptiveScope ─────────────────────────────────────');
+    if (noChange) {
+      buf.writeln('│  Stayed  : ${d.to.name} (no change needed)');
+    } else {
+      buf.writeln('│  Change  : ${d.from.name} → ${d.to.name}');
+    }
+    buf
+      ..writeln('│  Reason  : ${d.reason.name}')
+      ..writeln('│  Phase   : ${d.phase.name}');
+    if (d.p75Ms != null) {
+      buf.writeln('│  P75     : ${d.p75Ms!.toStringAsFixed(1)} ms');
+    }
+    if (d.p95Ms != null) {
+      buf.writeln('│  P95     : ${d.p95Ms!.toStringAsFixed(1)} ms');
+    }
+    if (d.framesMeasured != null) {
+      buf.writeln('│  Frames  : ${d.framesMeasured}');
+    }
+    buf
+      ..writeln('│')
+      ..writeln(
+          '│  📬 Post to: github.com/sdegenaar/liquid_glass_widgets/discussions')
+      ..write('└──────────────────────────────────────────────────────────');
+    // ignore: avoid_print
+    debugPrint(buf.toString());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _InheritedAdaptiveQuality(
+      data: GlassAdaptiveScopeData(
+        effectiveQuality: _effectiveQuality,
+        phase: _adapter.phase,
+      ),
+      child: widget.child,
+    );
+  }
+
+  /// Exposes the adapter for widget-level testing.
+  @visibleForTesting
+  GlassQualityAdapter get adapter => _adapter;
+}
+
+// ---------------------------------------------------------------------------
+// _InheritedAdaptiveQuality — internal InheritedWidget
+// ---------------------------------------------------------------------------
+
+/// Internal [InheritedWidget] that carries [GlassAdaptiveScopeData] down the
+/// tree. Not exported — access only via [GlassAdaptiveScopeData.of].
+class _InheritedAdaptiveQuality extends InheritedWidget {
+  const _InheritedAdaptiveQuality({
+    required this.data,
+    required super.child,
+  });
+
+  final GlassAdaptiveScopeData data;
+
+  @override
+  bool updateShouldNotify(_InheritedAdaptiveQuality oldWidget) =>
+      data != oldWidget.data;
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/glass_backdrop_scope.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/glass_backdrop_scope.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/widgets.dart';
+
+/// **Deprecated** — this widget is now a no-op. Remove it from your tree.
+///
+/// Prior to 0.14.0, this widget installed a shared [BackdropGroup] that all
+/// glass surfaces used for GPU blur-sharing. Each [LiquidGlassLayer] now
+/// manages its own isolated [BackdropGroup], which:
+///
+/// - **Fixes visual corruption** on Impeller when multiple layers shared one
+///   [BackdropGroup] (e.g. app bar backgrounds disappearing).
+/// - **Reduces GPU bandwidth** — each layer captures only its own clipped
+///   bounding box instead of a full-screen texture.
+/// - **Eliminates ghost artefacts** on route transitions — no stale texture
+///   from the previous page can bleed through.
+///
+/// `GlassPage` handles backdrop isolation automatically. If you were using
+/// `GlassBackdropScope` manually, simply remove it.
+@Deprecated(
+  'Backdrop isolation is now handled automatically by GlassPage and individual '
+  'glass layers. This widget is a no-op and can be safely removed. '
+  'Deprecated in v0.14.0',
+)
+class GlassBackdropScope extends StatelessWidget {
+  /// Creates a [GlassBackdropScope].
+  ///
+  /// This widget is now a no-op and returns its child directly.
+  const GlassBackdropScope({
+    super.key,
+    required this.child,
+  });
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    // BackdropGroup is no longer used at the root level because Impeller
+    // crashes when multiple RepaintBoundarys (LiquidGlassLayers) try to share
+    // the same BackdropId.
+    // Instead, each LiquidGlassLayer now creates its own isolated BackdropGroup.
+    // This widget is retained as a no-op to avoid breaking user code.
+    return child;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/glass_content_aware_scope.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/glass_content_aware_scope.dart
@@ -1,0 +1,924 @@
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+
+import '../../theme/glass_theme.dart';
+import '../../theme/glass_theme_data.dart';
+
+/// Signature for [GlassContentAwareBrightness.builder].
+///
+/// [brightness] is the committed content-aware verdict for the control.
+/// [darkAmount] is the animated cross-fade position between the light (0.0)
+/// and dark (1.0) appearance — it eases toward `brightness` over the flip
+/// duration, so consumers can interpolate their own colors during the
+/// transition.
+typedef GlassBrightnessWidgetBuilder = Widget Function(
+  BuildContext context,
+  Brightness brightness,
+  double darkAmount,
+);
+
+/// Drives iOS 26-style content-aware light/dark adaptation for glass
+/// controls floating over scrolling content.
+///
+/// iOS 26 bars and controls watch the content scrolling underneath them and
+/// flip between their light and dark appearance so the glyphs always keep
+/// contrast — light controls over bright photos, dark controls over a dark
+/// album cover. This scope productizes that behavior:
+///
+/// 1. Wrap the screen (typically the `Scaffold`) in a
+///    [GlassContentAwareScope].
+/// 2. Wrap the **scrolling content** — not the bars — in a
+///    [GlassContentAwareContent]. This marks the region that is sampled.
+///    The glass controls themselves must stay outside of it so the capture
+///    sees the content *behind* them rather than their own rendering.
+/// 3. Set `adaptiveBrightness: true` on `GlassBottomBar` /
+///    `GlassSearchableBottomBar` (or wrap any custom control in a
+///    [GlassContentAwareBrightness]).
+///
+/// ```dart
+/// GlassContentAwareScope(
+///   child: Scaffold(
+///     extendBody: true, // content scrolls underneath the bar
+///     body: GlassContentAwareContent(
+///       child: ListView(...),
+///     ),
+///     bottomNavigationBar: GlassBottomBar(
+///       adaptiveBrightness: true,
+///       ...
+///     ),
+///   ),
+/// )
+/// ```
+///
+/// The same wiring applies with [GlassScaffold]: wrap the scaffold in the
+/// scope and the scrolling content inside `body` in a
+/// [GlassContentAwareContent]. The scroll-edge fade that [GlassScaffold]
+/// renders sits outside the captured region, so it never feeds back into
+/// the vote.
+///
+/// ## How the verdict is decided
+///
+/// The scope captures the content boundary **once** per sample (a heavily
+/// downscaled, asynchronous `toImage` readback) and serves every registered
+/// control from that single capture. Each control's own rectangle is mapped
+/// into the captured image, divided into a small grid of cells, and each
+/// cell casts a vote: *which glyph color reads better over this content —
+/// the light variant's dark glyphs, or the dark variant's light glyphs?*
+/// The comparison uses WCAG contrast ratios, so the verdict is a **contrast
+/// vote, not a luminance threshold**: dark glyphs hold contrast over light
+/// *and* medium content, which keeps controls in their light appearance
+/// through the medium range and only flips them when the content is
+/// genuinely dark — matching the native behavior and resisting mode-flapping
+/// on mixed content such as photo grids.
+///
+/// On top of the vote, two flap-prevention layers are applied per control:
+///
+/// - **Sticky ties** — a tied or sub-threshold vote keeps the current
+///   appearance.
+/// - **Dual-threshold hysteresis** — flipping light → dark requires the dark
+///   vote fraction to reach [lightToDarkThreshold], while flipping back
+///   requires the light fraction to reach [darkToLightThreshold]. Content
+///   sitting right at the boundary therefore cannot oscillate.
+///
+/// ## Sampling cost
+///
+/// Sampling is scroll-aware: a [ScrollNotification] listener inside the
+/// scope starts a periodic sampler (every [sampleInterval]) when scrolling
+/// begins and stops it when scrolling ends, with one trailing sample to
+/// capture the settled state. While nothing moves, the sample rate is zero.
+/// The capture itself is downscaled to roughly 16 physical pixels per grid
+/// cell, so the readback is a few kilobytes regardless of screen size.
+///
+/// Because the automatic triggers are scroll-driven, content that changes
+/// **without** emitting scroll notifications — pan/zoom viewers such as
+/// [InteractiveViewer], asynchronously decoded images, programmatic
+/// restyles — should request a sample explicitly when it settles:
+///
+/// ```dart
+/// GlassContentAwareScope.maybeOf(context)?.requestSample();
+/// ```
+///
+/// ## Known limit: PlatformViews
+///
+/// Content rendered by an iOS PlatformView (e.g. a map) cannot be captured
+/// by `toImage` — the same wall as `platformViewBackdrop`. For those
+/// screens, drive the appearance explicitly with
+/// `GlassBottomBar.brightnessOverride` (which bypasses the sampler
+/// entirely) keyed off your own signal, such as the active map style.
+///
+/// See also:
+///
+/// * [GlassContentAwareContent], which marks the sampled region.
+/// * [GlassContentAwareBrightness], the per-control consumer used by the
+///   bars and available to custom controls.
+class GlassContentAwareScope extends StatefulWidget {
+  /// Creates a content-aware brightness scope.
+  const GlassContentAwareScope({
+    required this.child,
+    this.sampleInterval = const Duration(milliseconds: 180),
+    this.flipDuration = const Duration(milliseconds: 200),
+    this.flipCurve = Curves.easeInOut,
+    this.lightToDarkThreshold = 0.6,
+    this.darkToLightThreshold = 0.6,
+    this.backgroundColor,
+    super.key,
+  })  : assert(
+          lightToDarkThreshold >= 0.5 && lightToDarkThreshold <= 1.0,
+          'lightToDarkThreshold must be within [0.5, 1.0]',
+        ),
+        assert(
+          darkToLightThreshold >= 0.5 && darkToLightThreshold <= 1.0,
+          'darkToLightThreshold must be within [0.5, 1.0]',
+        );
+
+  /// The subtree containing both the sampled content and the adaptive
+  /// controls.
+  final Widget child;
+
+  /// Minimum interval between samples while scrolling is active.
+  ///
+  /// Scrolling starts a periodic sampler at this rate; when scrolling ends
+  /// the sampler stops (after one trailing sample), so idle screens cost
+  /// nothing. Defaults to 180 ms — roughly 5 samples per second during an
+  /// active scroll, which tracks content changes without competing with
+  /// frame production.
+  final Duration sampleInterval;
+
+  /// Duration of the light ⇄ dark cross-fade when a control flips.
+  ///
+  /// Applied by every [GlassContentAwareBrightness] registered in this
+  /// scope. Defaults to 200 ms, matching the iOS 26 appearance transition.
+  final Duration flipDuration;
+
+  /// Curve of the light ⇄ dark cross-fade when a control flips.
+  final Curve flipCurve;
+
+  /// Vote fraction required to flip a control from light to dark.
+  ///
+  /// A control in its light appearance flips dark only when at least this
+  /// fraction of its grid cells vote for light glyphs (dark appearance).
+  /// Together with [darkToLightThreshold] this forms a hysteresis band:
+  /// content sitting right at the contrast boundary cannot flap the control
+  /// back and forth. Must be within `[0.5, 1.0]`; defaults to 0.6.
+  final double lightToDarkThreshold;
+
+  /// Vote fraction required to flip a control from dark back to light.
+  ///
+  /// The counterpart to [lightToDarkThreshold]. Must be within
+  /// `[0.5, 1.0]`; defaults to 0.6.
+  final double darkToLightThreshold;
+
+  /// Color substituted for fully transparent pixels in the capture.
+  ///
+  /// The content boundary may not paint every pixel (e.g. a transparent
+  /// scaffold background). Transparent pixels are evaluated as this color so
+  /// the vote reflects what the user actually sees behind the control. When
+  /// null, defaults to white in light mode and black in dark mode.
+  final Color? backgroundColor;
+
+  /// The [GlassContentAwareScopeState] from the closest enclosing scope, or
+  /// null if there is none.
+  ///
+  /// Used by [GlassContentAwareBrightness] (and available to custom
+  /// controls) to register for verdicts.
+  static GlassContentAwareScopeState? maybeOf(BuildContext context) {
+    final marker =
+        context.dependOnInheritedWidgetOfExactType<_ContentAwareScopeMarker>();
+    return marker?.state;
+  }
+
+  /// Decides a control's [Brightness] from a raw RGBA capture.
+  ///
+  /// Exposed for tests; production code goes through the sampling pipeline.
+  /// [cellRects] are the control's grid cells in pixel coordinates of the
+  /// [width]×[height] image. Each cell votes via WCAG contrast (light
+  /// variant's dark glyphs vs dark variant's light glyphs over the cell's
+  /// average color, with [background] substituted for transparent pixels);
+  /// the verdict applies sticky ties and the dual-threshold hysteresis
+  /// described on [GlassContentAwareScope].
+  @visibleForTesting
+  static Brightness computeVerdict({
+    required Uint8List rgba,
+    required int width,
+    required int height,
+    required List<Rect> cellRects,
+    required Brightness current,
+    required double lightToDarkThreshold,
+    required double darkToLightThreshold,
+    required Color background,
+  }) {
+    if (width <= 0 || height <= 0) return current;
+    var votesLight = 0;
+    var votesDark = 0;
+    for (final r in cellRects) {
+      final x0 = r.left.floor().clamp(0, width - 1);
+      final x1 = r.right.ceil().clamp(x0 + 1, width);
+      final y0 = r.top.floor().clamp(0, height - 1);
+      final y1 = r.bottom.ceil().clamp(y0 + 1, height);
+      var sumR = 0.0, sumG = 0.0, sumB = 0.0;
+      var n = 0;
+      for (var y = y0; y < y1; y++) {
+        for (var x = x0; x < x1; x++) {
+          final i = (y * width + x) * 4;
+          final a = rgba[i + 3] / 255.0;
+          if (a < 0.02) {
+            // Unpainted pixel — evaluate as the page background.
+            sumR += background.r;
+            sumG += background.g;
+            sumB += background.b;
+          } else {
+            sumR += rgba[i] / 255.0;
+            sumG += rgba[i + 1] / 255.0;
+            sumB += rgba[i + 2] / 255.0;
+          }
+          n++;
+        }
+      }
+      if (n == 0) continue;
+      final cellLuma = _wcagLuma(sumR / n, sumG / n, sumB / n);
+      // Which glyph reads better over this cell? The light variant uses dark
+      // glyphs, the dark variant uses light glyphs. Dark glyphs hold
+      // contrast over light AND medium content; light glyphs only win once
+      // the content is genuinely dark — so the vote keeps controls light
+      // through the medium range and flips late, like the native bars.
+      final lightVariantContrast = _contrast(_lightVariantGlyphLuma, cellLuma);
+      final darkVariantContrast = _contrast(_darkVariantGlyphLuma, cellLuma);
+      if (lightVariantContrast >= darkVariantContrast) {
+        votesLight++;
+      } else {
+        votesDark++;
+      }
+    }
+    final total = votesLight + votesDark;
+    if (total == 0) return current;
+    // Dual-threshold hysteresis on top of sticky ties: each direction needs
+    // a supermajority, so boundary content keeps the current appearance.
+    if (current == Brightness.light) {
+      return votesDark / total >= lightToDarkThreshold
+          ? Brightness.dark
+          : Brightness.light;
+    }
+    return votesLight / total >= darkToLightThreshold
+        ? Brightness.light
+        : Brightness.dark;
+  }
+
+  /// WCAG relative luminance of the light variant's glyphs (near-black).
+  static const double _lightVariantGlyphLuma = 0.0;
+
+  /// WCAG relative luminance of the dark variant's glyphs (white).
+  static const double _darkVariantGlyphLuma = 1.0;
+
+  /// WCAG contrast ratio between two relative luminances.
+  static double _contrast(double l1, double l2) {
+    final hi = math.max(l1, l2);
+    final lo = math.min(l1, l2);
+    return (hi + 0.05) / (lo + 0.05);
+  }
+
+  /// WCAG relative luminance from non-linear sRGB channels in `[0, 1]`.
+  static double _wcagLuma(double r, double g, double b) {
+    double lin(double c) => c <= 0.03928
+        ? c / 12.92
+        : math.pow((c + 0.055) / 1.055, 2.4).toDouble();
+    return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+  }
+
+  @override
+  State<GlassContentAwareScope> createState() => GlassContentAwareScopeState();
+}
+
+/// State (and registration surface) of a [GlassContentAwareScope].
+///
+/// Custom controls obtain this via [GlassContentAwareScope.maybeOf] and call
+/// [register]; the bars do this internally through
+/// [GlassContentAwareBrightness].
+class GlassContentAwareScopeState extends State<GlassContentAwareScope> {
+  final List<GlassContentAwareSubscription> _subscriptions =
+      <GlassContentAwareSubscription>[];
+  GlobalKey? _contentKey;
+  Timer? _scrollTimer;
+  bool _samplePending = false;
+  bool _sampling = false;
+
+  /// Fraction of a control's height trimmed from the top and bottom before
+  /// gridding. Glyphs sit in the vertical middle of a control; edge rows
+  /// would bias the vote with content that never sits behind a glyph.
+  static const double _kVerticalInsetFraction = 0.18;
+
+  /// Capture downscale target: physical pixels per grid cell edge.
+  static const double _kTargetCellPixels = 16.0;
+
+  /// Registers a glass control to receive content-aware verdicts.
+  ///
+  /// [controlBox] returns the control's render box at sample time (or null
+  /// while it is unmounted — the control is skipped for that sample). The
+  /// control's rectangle is divided into [gridColumns] × [gridRows] voting
+  /// cells — 6×1 suits wide bars; a compact button would use a square grid.
+  /// [onBrightnessChanged] fires only when the verdict actually flips;
+  /// [initialBrightness] seeds the hysteresis state.
+  ///
+  /// Call [GlassContentAwareSubscription.cancel] when the control goes away.
+  GlassContentAwareSubscription register({
+    required RenderBox? Function() controlBox,
+    required ValueChanged<Brightness> onBrightnessChanged,
+    required Brightness initialBrightness,
+    int gridColumns = 6,
+    int gridRows = 1,
+  }) {
+    assert(gridColumns > 0 && gridRows > 0, 'Grid must have at least 1 cell');
+    final sub = GlassContentAwareSubscription._(
+      this,
+      controlBox,
+      onBrightnessChanged,
+      gridColumns,
+      gridRows,
+      initialBrightness,
+    );
+    _subscriptions.add(sub);
+    requestSample();
+    return sub;
+  }
+
+  /// Schedules a single sample after the next frame.
+  ///
+  /// Coalesces multiple requests; used for the initial verdict, trailing
+  /// scroll-end samples, and external invalidation (e.g. the app theme
+  /// changed). Sampling only happens when content is registered, so this is
+  /// free on screens without a [GlassContentAwareContent].
+  void requestSample() {
+    if (_samplePending || !mounted) return;
+    _samplePending = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _samplePending = false;
+      unawaited(_sample());
+    });
+    // Make sure a frame actually comes — the screen may be fully idle.
+    WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
+  /// Runs one sample immediately and returns when verdicts are delivered.
+  @visibleForTesting
+  Future<void> sampleNow() => _sample();
+
+  /// Whether the periodic scroll sampler is currently running.
+  @visibleForTesting
+  bool get isScrollSamplingActive => _scrollTimer != null;
+
+  void _attachContent(GlobalKey boundaryKey) {
+    assert(
+      _contentKey == null || _contentKey == boundaryKey,
+      'A GlassContentAwareScope supports a single GlassContentAwareContent. '
+      'Found a second content region under the same scope.',
+    );
+    _contentKey = boundaryKey;
+    requestSample();
+  }
+
+  void _detachContent(GlobalKey boundaryKey) {
+    if (_contentKey == boundaryKey) _contentKey = null;
+  }
+
+  bool _onScrollNotification(ScrollNotification notification) {
+    if (notification is ScrollStartNotification) {
+      _startScrollSampling();
+    } else if (notification is ScrollEndNotification) {
+      _stopScrollSampling();
+    } else if (notification is ScrollUpdateNotification ||
+        notification is OverscrollNotification) {
+      // A Start may have been swallowed (e.g. programmatic jumps) — make
+      // sure the sampler runs whenever positions are actually moving.
+      _startScrollSampling();
+    }
+    return false;
+  }
+
+  bool _onScrollMetrics(ScrollMetricsNotification notification) {
+    // Content geometry changed without a scroll (new items, viewport
+    // resize). One sample keeps idle verdicts honest; the periodic sampler
+    // already covers the scrolling case.
+    if (_scrollTimer == null) requestSample();
+    return false;
+  }
+
+  void _startScrollSampling() {
+    if (_scrollTimer != null) return;
+    requestSample();
+    _scrollTimer = Timer.periodic(
+      widget.sampleInterval,
+      (_) => unawaited(_sample()),
+    );
+  }
+
+  void _stopScrollSampling() {
+    if (_scrollTimer == null) return;
+    _scrollTimer!.cancel();
+    _scrollTimer = null;
+    // Trailing sample so the settled content decides the resting verdict.
+    requestSample();
+  }
+
+  @override
+  void didUpdateWidget(GlassContentAwareScope oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.sampleInterval != widget.sampleInterval &&
+        _scrollTimer != null) {
+      _scrollTimer!.cancel();
+      _scrollTimer = Timer.periodic(
+        widget.sampleInterval,
+        (_) => unawaited(_sample()),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollTimer?.cancel();
+    _scrollTimer = null;
+    for (final sub in _subscriptions) {
+      sub._cancelled = true;
+    }
+    _subscriptions.clear();
+    super.dispose();
+  }
+
+  Future<void> _sample() async {
+    if (!mounted || _sampling || _subscriptions.isEmpty) return;
+    final boundary = _contentKey?.currentContext?.findRenderObject();
+    if (boundary is! RenderRepaintBoundary ||
+        !boundary.hasSize ||
+        boundary.size.isEmpty) {
+      return;
+    }
+    // Skip frames that are mid-paint. debugNeedsPaint is DEBUG-ONLY — its
+    // backing value is assigned inside an assert, so reading it in profile
+    // or release builds throws. Only consult it behind an assert closure;
+    // release builds sample post-frame where the boundary is always clean.
+    var midPaint = false;
+    assert(() {
+      midPaint = boundary.debugNeedsPaint;
+      return true;
+    }());
+    if (midPaint) return;
+    _sampling = true;
+    try {
+      // Resolve each registered control's grid cells in boundary-local
+      // coordinates, and the smallest cell height for the downscale factor.
+      final work = <(GlassContentAwareSubscription, List<Rect>)>[];
+      var minCellExtent = double.infinity;
+      for (final sub in List.of(_subscriptions)) {
+        final box = sub._controlBox();
+        if (box == null || !box.attached || !box.hasSize) continue;
+        final origin = boundary.globalToLocal(box.localToGlobal(Offset.zero));
+        var rect = origin & box.size;
+        final inset = rect.height * _kVerticalInsetFraction;
+        rect = Rect.fromLTRB(
+          rect.left,
+          rect.top + inset,
+          rect.right,
+          rect.bottom - inset,
+        ).intersect(Offset.zero & boundary.size);
+        if (rect.isEmpty) continue;
+        final cellW = rect.width / sub.gridColumns;
+        final cellH = rect.height / sub.gridRows;
+        final cells = <Rect>[
+          for (var gy = 0; gy < sub.gridRows; gy++)
+            for (var gx = 0; gx < sub.gridColumns; gx++)
+              Rect.fromLTWH(
+                rect.left + gx * cellW,
+                rect.top + gy * cellH,
+                cellW,
+                cellH,
+              ),
+        ];
+        minCellExtent = math.min(minCellExtent, cellH);
+        work.add((sub, cells));
+      }
+      if (work.isEmpty) return;
+
+      // Downscale so a cell maps to ~16 physical pixels — enough for a
+      // stable average, cheap enough to read back at scroll rates.
+      final pixelRatio =
+          (_kTargetCellPixels / math.max(minCellExtent, 1.0)).clamp(0.05, 0.5);
+      final image = await boundary.toImage(pixelRatio: pixelRatio);
+      final width = image.width;
+      final height = image.height;
+      final byteData =
+          await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      image.dispose();
+      if (!mounted || byteData == null) return;
+      final rgba = byteData.buffer.asUint8List();
+      final background = widget.backgroundColor ??
+          (MediaQuery.maybePlatformBrightnessOf(context) == Brightness.dark
+              ? const Color(0xFF000000)
+              : const Color(0xFFFFFFFF));
+
+      for (final (sub, cells) in work) {
+        if (sub._cancelled) continue;
+        final pixelCells = <Rect>[
+          for (final c in cells)
+            Rect.fromLTRB(
+              c.left * pixelRatio,
+              c.top * pixelRatio,
+              c.right * pixelRatio,
+              c.bottom * pixelRatio,
+            ),
+        ];
+        final verdict = GlassContentAwareScope.computeVerdict(
+          rgba: rgba,
+          width: width,
+          height: height,
+          cellRects: pixelCells,
+          current: sub._brightness,
+          lightToDarkThreshold: widget.lightToDarkThreshold,
+          darkToLightThreshold: widget.darkToLightThreshold,
+          background: background,
+        );
+        if (verdict != sub._brightness) {
+          sub._brightness = verdict;
+          sub._onBrightnessChanged(verdict);
+        }
+      }
+    } catch (e, stack) {
+      // Transient capture failure (boundary mid-mutation, detached layer).
+      // The next scroll tick retries; never let sampling take a screen down.
+      // Surface errors in debug/profile so programming mistakes are visible.
+      assert(() {
+        FlutterError.reportError(FlutterErrorDetails(
+          exception: e,
+          stack: stack,
+          library: 'liquid_glass_widgets',
+          context: ErrorDescription(
+            'during content-aware brightness sample',
+          ),
+          silent: true,
+        ));
+        return true;
+      }());
+    } finally {
+      _sampling = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _ContentAwareScopeMarker(
+      state: this,
+      child: NotificationListener<ScrollMetricsNotification>(
+        onNotification: _onScrollMetrics,
+        child: NotificationListener<ScrollNotification>(
+          onNotification: _onScrollNotification,
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+}
+
+/// A live registration of a glass control with a [GlassContentAwareScope].
+///
+/// Returned by [GlassContentAwareScopeState.register]. Holds the control's
+/// hysteresis state; [cancel] detaches the control from the scope.
+class GlassContentAwareSubscription {
+  GlassContentAwareSubscription._(
+    this._scope,
+    this._controlBox,
+    this._onBrightnessChanged,
+    this.gridColumns,
+    this.gridRows,
+    this._brightness,
+  );
+
+  final GlassContentAwareScopeState _scope;
+  final RenderBox? Function() _controlBox;
+  final ValueChanged<Brightness> _onBrightnessChanged;
+
+  /// Number of horizontal voting cells for this control.
+  final int gridColumns;
+
+  /// Number of vertical voting cells for this control.
+  final int gridRows;
+
+  Brightness _brightness;
+  bool _cancelled = false;
+
+  /// The control's current content-aware verdict.
+  Brightness get brightness => _brightness;
+
+  /// Detaches the control from the scope. Safe to call more than once.
+  void cancel() {
+    if (_cancelled) return;
+    _cancelled = true;
+    _scope._subscriptions.remove(this);
+  }
+}
+
+class _ContentAwareScopeMarker extends InheritedWidget {
+  const _ContentAwareScopeMarker({
+    required this.state,
+    required super.child,
+  });
+
+  final GlassContentAwareScopeState state;
+
+  @override
+  bool updateShouldNotify(_ContentAwareScopeMarker oldWidget) =>
+      state != oldWidget.state;
+}
+
+/// Marks the sampled content region of a [GlassContentAwareScope].
+///
+/// Wrap the scrolling content — and only the content — in this widget. It
+/// installs the [RepaintBoundary] that the scope captures, so the adaptive
+/// glass controls themselves must stay **outside** of it (e.g. in
+/// `Scaffold.bottomNavigationBar` with `extendBody: true`); otherwise the
+/// capture would see the controls' own rendering instead of the content
+/// behind them.
+///
+/// A scope supports a single content region. Without one, the scope never
+/// samples and adaptive controls keep their ambient appearance.
+class GlassContentAwareContent extends StatefulWidget {
+  /// Creates a sampled content region.
+  const GlassContentAwareContent({required this.child, super.key});
+
+  /// The scrolling content to sample.
+  final Widget child;
+
+  @override
+  State<GlassContentAwareContent> createState() =>
+      _GlassContentAwareContentState();
+}
+
+class _GlassContentAwareContentState extends State<GlassContentAwareContent> {
+  final GlobalKey _boundaryKey = GlobalKey();
+  GlassContentAwareScopeState? _scope;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final scope = GlassContentAwareScope.maybeOf(context);
+    if (scope != _scope) {
+      _scope?._detachContent(_boundaryKey);
+      _scope = scope;
+      _scope?._attachContent(_boundaryKey);
+    }
+  }
+
+  @override
+  void dispose() {
+    _scope?._detachContent(_boundaryKey);
+    _scope = null;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(key: _boundaryKey, child: widget.child);
+  }
+}
+
+/// Gives a single glass control a content-aware light/dark appearance.
+///
+/// This is the per-control consumer of [GlassContentAwareScope] — the bars
+/// use it internally when `adaptiveBrightness: true`, and custom glass
+/// controls can wrap themselves in it directly.
+///
+/// The widget resolves the control's [Brightness] from one of three
+/// sources, in priority order:
+///
+/// 1. [brightnessOverride] — an external [ValueListenable] that bypasses
+///    the sampler entirely. Use this over PlatformViews, where the content
+///    cannot be captured, and drive it from your own signal.
+/// 2. The enclosing [GlassContentAwareScope], by registering the control's
+///    rectangle for the per-control contrast vote.
+/// 3. The ambient platform brightness, when neither is available.
+///
+/// Every verdict change cross-fades rather than snapping: an internal
+/// animation eases `darkAmount` between 0 (light) and 1 (dark) over
+/// [flipDuration] with [flipCurve] (falling back to the scope's values,
+/// then to 200 ms / [Curves.easeInOut]). During the fade the subtree built
+/// by [builder] is wrapped so the swap "just works" end to end:
+///
+/// - [GlassTheme] is replaced with the lerp of its light and dark variants
+///   (see [GlassThemeVariant.lerp]) — themed glass settings, glow palettes
+///   and radii cross-fade smoothly.
+/// - `MediaQuery.platformBrightness` and the [CupertinoTheme] brightness
+///   flip at the fade midpoint, where the blend makes the discrete residue
+///   (shadows, resolved dynamic colors in user content) least visible.
+///
+/// [onBrightnessChanged] fires once per verdict flip — use it to swap
+/// colors the package cannot see, such as custom-painted icons.
+class GlassContentAwareBrightness extends StatefulWidget {
+  /// Creates a content-aware brightness consumer around [builder].
+  const GlassContentAwareBrightness({
+    required this.builder,
+    this.brightnessOverride,
+    this.onBrightnessChanged,
+    this.flipDuration,
+    this.flipCurve,
+    this.gridColumns = 6,
+    this.gridRows = 1,
+    super.key,
+  }) : assert(
+          gridColumns > 0 && gridRows > 0,
+          'Grid must have at least 1 cell',
+        );
+
+  /// Builds the control under the brightness overrides.
+  ///
+  /// See [GlassBrightnessWidgetBuilder] for the parameters.
+  final GlassBrightnessWidgetBuilder builder;
+
+  /// External brightness source that bypasses the sampler entirely.
+  ///
+  /// When non-null, the control never registers with the scope and follows
+  /// this listenable instead — the escape hatch for content that cannot be
+  /// captured (iOS PlatformViews such as maps).
+  final ValueListenable<Brightness>? brightnessOverride;
+
+  /// Called when the committed verdict flips (not for the initial value).
+  final ValueChanged<Brightness>? onBrightnessChanged;
+
+  /// Cross-fade duration override; falls back to the scope's
+  /// [GlassContentAwareScope.flipDuration], then 200 ms.
+  final Duration? flipDuration;
+
+  /// Cross-fade curve override; falls back to the scope's
+  /// [GlassContentAwareScope.flipCurve], then [Curves.easeInOut].
+  final Curve? flipCurve;
+
+  /// Horizontal voting cells for this control's rect. Defaults to 6 — the
+  /// bar-shaped grid. Compact controls should use a square grid (e.g. 2×2).
+  final int gridColumns;
+
+  /// Vertical voting cells for this control's rect. Defaults to 1.
+  final int gridRows;
+
+  @override
+  State<GlassContentAwareBrightness> createState() =>
+      _GlassContentAwareBrightnessState();
+}
+
+class _GlassContentAwareBrightnessState
+    extends State<GlassContentAwareBrightness>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _flip;
+  late Brightness _brightness;
+  Brightness? _lastAmbient;
+  bool _initialized = false;
+  GlassContentAwareScopeState? _scope;
+  GlassContentAwareSubscription? _subscription;
+
+  static const Duration _kDefaultFlipDuration = Duration(milliseconds: 200);
+
+  @override
+  void initState() {
+    super.initState();
+    _flip = AnimationController(vsync: this, duration: _kDefaultFlipDuration);
+    widget.brightnessOverride?.addListener(_onOverrideChanged);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final ambient =
+        MediaQuery.maybePlatformBrightnessOf(context) ?? Brightness.light;
+    if (!_initialized) {
+      _initialized = true;
+      _brightness = widget.brightnessOverride?.value ?? ambient;
+      _flip.value = _brightness == Brightness.dark ? 1.0 : 0.0;
+    } else if (_lastAmbient != ambient && widget.brightnessOverride == null) {
+      // The app theme flipped underneath us — the old verdict was computed
+      // against content that just restyled. Re-anchor to the ambient
+      // brightness and let the next sample re-vote.
+      _setBrightness(ambient);
+      _scope?.requestSample();
+    }
+    _lastAmbient = ambient;
+  }
+
+  @override
+  void didUpdateWidget(GlassContentAwareBrightness oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.brightnessOverride != widget.brightnessOverride) {
+      oldWidget.brightnessOverride?.removeListener(_onOverrideChanged);
+      widget.brightnessOverride?.addListener(_onOverrideChanged);
+      final override = widget.brightnessOverride;
+      if (override != null) _setBrightness(override.value);
+      // Scope registration is re-resolved in build via _syncSources.
+    }
+    if (oldWidget.gridColumns != widget.gridColumns ||
+        oldWidget.gridRows != widget.gridRows) {
+      // Grid changed — drop the registration; build re-registers with the
+      // new dimensions.
+      _subscription?.cancel();
+      _subscription = null;
+      _scope = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.brightnessOverride?.removeListener(_onOverrideChanged);
+    _subscription?.cancel();
+    _flip.dispose();
+    super.dispose();
+  }
+
+  void _onOverrideChanged() {
+    _setBrightness(widget.brightnessOverride!.value);
+  }
+
+  void _setBrightness(Brightness brightness) {
+    if (brightness == _brightness) return;
+    _brightness = brightness;
+    widget.onBrightnessChanged?.call(brightness);
+    final duration = widget.flipDuration ??
+        _scope?.widget.flipDuration ??
+        _kDefaultFlipDuration;
+    final curve =
+        widget.flipCurve ?? _scope?.widget.flipCurve ?? Curves.easeInOut;
+    _flip.animateTo(
+      brightness == Brightness.dark ? 1.0 : 0.0,
+      duration: duration,
+      curve: curve,
+    );
+    // AnimatedBuilder listens to _flip and rebuilds on every tick;
+    // no explicit setState needed.
+  }
+
+  /// Keeps the scope registration in sync with the widget configuration.
+  ///
+  /// Runs at the top of build (inherited lookups are legal there and this
+  /// is where dependencies must be registered anyway) and is idempotent.
+  void _syncSources() {
+    final wantScope = widget.brightnessOverride == null
+        ? GlassContentAwareScope.maybeOf(context)
+        : null;
+    if (wantScope == _scope && (_subscription != null) == (wantScope != null)) {
+      return;
+    }
+    _subscription?.cancel();
+    _subscription = null;
+    _scope = wantScope;
+    if (wantScope != null) {
+      _subscription = wantScope.register(
+        controlBox: () {
+          if (!mounted) return null;
+          final ro = context.findRenderObject();
+          return ro is RenderBox ? ro : null;
+        },
+        onBrightnessChanged: _setBrightness,
+        initialBrightness: _brightness,
+        gridColumns: widget.gridColumns,
+        gridRows: widget.gridRows,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _syncSources();
+    return AnimatedBuilder(
+      animation: _flip,
+      builder: (context, _) {
+        final t = _flip.value;
+        // The discrete residue (shadow gating, dynamic-color resolution in
+        // user content) flips at the fade midpoint, where the lerped colors
+        // cross and the swap is least visible.
+        final displayBrightness = t >= 0.5 ? Brightness.dark : Brightness.light;
+        final baseTheme = GlassThemeData.of(context);
+        final variant = GlassThemeVariant.lerp(
+          baseTheme.light,
+          baseTheme.dark,
+          t,
+        );
+        Widget result = Builder(
+          builder: (inner) => widget.builder(inner, _brightness, t),
+        );
+        result = GlassTheme(
+          data: baseTheme.copyWith(light: variant, dark: variant),
+          child: result,
+        );
+        result = CupertinoTheme(
+          data: CupertinoTheme.of(context)
+              .copyWith(brightness: displayBrightness),
+          child: result,
+        );
+        final mq = MediaQuery.maybeOf(context);
+        if (mq != null) {
+          result = MediaQuery(
+            data: mq.copyWith(platformBrightness: displayBrightness),
+            child: result,
+          );
+        }
+        return result;
+      },
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/glass_effect.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/glass_effect.dart
@@ -1,0 +1,1092 @@
+// ignore_for_file: require_trailing_commas
+
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
+import 'package:flutter/scheduler.dart';
+import '../../theme/glass_theme.dart';
+import '../../widgets/interactive/liquid_glass_scope.dart';
+import 'inherited_liquid_glass.dart';
+
+import '../../types/glass_quality.dart';
+import 'adaptive_glass.dart';
+import 'liquid_shape_shader_geometry.dart';
+
+/// Enhanced glass renderer specifically for interactive indicators.
+///
+/// Uses a specialized shader on Skia/Web to match Impeller's visual quality
+/// with magnification effects, enhanced rim lighting, and radial brightness.
+///
+/// On Impeller with premium quality, it uses the native LiquidGlass renderer.
+/// On Skia/Web or standard quality, it uses the enhanced GlassEffect
+/// shader with magnification and structural rim effects.
+class GlassEffect extends StatefulWidget {
+  const GlassEffect({
+    required this.shape,
+    required this.settings,
+    required this.interactionIntensity,
+    required this.child,
+    this.quality = GlassQuality.standard,
+    this.densityFactor = 0.0,
+    this.backgroundKey,
+    this.ambientRim = 0.1,
+    this.baseAlphaMultiplier = 0.2,
+    this.edgeAlphaMultiplier = 0.4,
+    this.rimThickness = 0.5,
+    this.rimSmoothing = 1.5,
+    this.clipExpansion = EdgeInsets.zero,
+    super.key,
+  });
+
+  final Widget child;
+  final LiquidShape shape;
+  final LiquidGlassSettings settings;
+  final GlassQuality quality;
+
+  /// Defaults to 0.0.
+  final double densityFactor;
+
+  /// GlobalKey of a RepaintBoundary wrapping the background content.
+  /// Used for Skia/Web background sampling.
+  final GlobalKey? backgroundKey;
+
+  /// Interaction intensity (0.0 = resting, 1.0 = fully active)
+  /// Drives magnification and enhancement effects
+  final double interactionIntensity;
+
+  /// Minimum rim brightness regardless of light direction (default: 0.1)
+  final double ambientRim;
+
+  /// Center transparency multiplier (default: 0.2)
+  final double baseAlphaMultiplier;
+
+  /// Edge opacity multiplier (default: 0.4)
+  final double edgeAlphaMultiplier;
+
+  /// Rim offset/thickness in logical pixels (default: 0.5)
+  final double rimThickness;
+
+  /// Rim edge smoothing multiplier (default: 1.5)
+  final double rimSmoothing;
+
+  /// Extra clip budget forwarded to [LiquidGlass.withOwnLayer] on the Impeller
+  /// premium path.  Use this to prevent the glass BackdropFilterLayer from
+  /// hard-clipping pixels that an ancestor Transform (e.g. jelly physics) has
+  /// pushed outside the tight geometry bounds.
+  ///
+  /// Defaults to [EdgeInsets.zero] — no extra cost for static glass.
+  final EdgeInsets clipExpansion;
+
+  static ui.FragmentProgram? _cachedProgram;
+  static bool _isPreparing = false;
+
+  /// Detects if Impeller rendering engine is active
+  static bool get _canUseImpeller => ui.ImageFilter.isShaderFilterSupported;
+
+  static ui.Image? _dummyImage;
+
+  static Future<void> preWarm() async {
+    if (_cachedProgram != null || _isPreparing) return;
+    _isPreparing = true;
+    const path =
+        'packages/liquid_glass_widgets/shaders/interactive_indicator.frag';
+    const testPath = 'shaders/interactive_indicator.frag';
+
+    try {
+      ui.FragmentProgram program;
+      try {
+        program = await ui.FragmentProgram.fromAsset(path);
+      } catch (_) {
+        // Fallback for unit tests where package prefix may not be resolved
+        program = await ui.FragmentProgram.fromAsset(testPath);
+      }
+      _cachedProgram = program;
+
+      // Create a 1x1 transparent dummy image to satisfy sampler index 0.
+      // toImageSync (not toImage) — synchronous, consistent with
+      // LightweightLiquidGlass.preWarm(). For a 1×1 image the GPU cost
+      // is negligible and we avoid a 1-frame async initialization delay.
+      final recorder = ui.PictureRecorder();
+      Canvas(recorder);
+      final picture = recorder.endRecording();
+      _dummyImage = picture.toImageSync(1, 1);
+      picture.dispose();
+    } catch (e) {
+      debugPrint('[GlassEffect] Pre-warm failed: $e');
+    } finally {
+      _isPreparing = false;
+    }
+  }
+
+  @override
+  State<GlassEffect> createState() => _GlassEffectState();
+}
+
+class _GlassEffectState extends State<GlassEffect>
+    with SingleTickerProviderStateMixin, WidgetsBindingObserver {
+  ui.FragmentShader? _localShader;
+  bool _isDisposed = false;
+  ui.Image? _backgroundImage;
+  late Ticker _ticker;
+  Size? _lastCaptureSize;
+  Offset? _lastCapturePosition;
+  // Web only: guards against overlapping async captures.
+  bool _isCapturingAsync = false;
+  // Device pixel ratio — updated in didChangeDependencies so it is always
+  // current when _captureBackgroundSync / _captureBackgroundAsync runs.
+  double _devicePixelRatio = 1.0;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    // Skip shader init entirely in minimal quality — build() returns early via
+    // the _FrostedFallback path and the shader is never used.
+    if (widget.quality != GlassQuality.minimal) {
+      _initShader();
+    }
+
+    _ticker = createTicker(_handleTick);
+
+    // Defer ticker update until after first frame to ensure shader is ready
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _updateTicker();
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant GlassEffect oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.quality != widget.quality) {
+      if (_activeShader == null) {
+        _initShader();
+      }
+    }
+    _updateTicker();
+  }
+
+  GlobalKey? _cachedScopeKey;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _cachedScopeKey = LiquidGlassScope.of(context);
+    // Keep DPR in sync — changes on orientation, accessibility zoom, or
+    // moving between displays with different densities.
+    _devicePixelRatio = View.of(context).devicePixelRatio;
+    _updateTicker();
+  }
+
+  /// Halts background-capture Tickers during app lifecycle transitions.
+  ///
+  /// Stopping captures on [AppLifecycleState.inactive] / [paused] prevents
+  /// GPU texture creation/destruction from racing with [surfaceChanged] on
+  /// the raster thread — the root cause of the ANR observed on Vulkan devices.
+  /// Captures restart one frame after [resumed] to let the new surface
+  /// stabilise before any [toImageSync] calls.
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.paused:
+      case AppLifecycleState.hidden:
+        if (_ticker.isActive) _ticker.stop();
+        break;
+      case AppLifecycleState.resumed:
+        // Restart one frame after resume so surfaceChanged has completed
+        // and the raster thread is not holding any surface locks.
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && !_isDisposed) _updateTicker();
+        });
+        break;
+      case AppLifecycleState.detached:
+        break;
+    }
+  }
+
+  GlobalKey? get _effectiveKey => widget.backgroundKey ?? _cachedScopeKey;
+
+  void _updateTicker() {
+    // Background capture requirements:
+    //  1. Widget is actively interacting (cost only paid during gesture)
+    //  2. A valid capture key is available
+    //  3. blur > 0 — when blur is 0 the component intentionally uses synthetic
+    //     glass (e.g. GlassSwitch thumb). Capturing the background would let the
+    //     green track bleed through as a dark/tinted frosted overlay, which
+    //     contradicts the intended white glass bloom effect.
+    final bool shouldCapture = widget.interactionIntensity > 0.01 &&
+        _effectiveKey != null &&
+        widget.settings.blur > 0.0;
+    if (shouldCapture) {
+      if (!_ticker.isActive) {
+        _ticker.start();
+        // debugPrint(
+        //     '[GlassEffect] 📸 Starting capture loop. Intensity: ${widget.interactionIntensity.toStringAsFixed(2)}');
+      }
+    } else {
+      if (_ticker.isActive) {
+        _ticker.stop();
+        _backgroundImage?.dispose();
+        _backgroundImage = null;
+        // debugPrint(
+        //     '[GlassEffect] 📸 Interaction finished, cleared snapshot.');
+      }
+    }
+  }
+
+  void _handleTick(Duration elapsed) {
+    if (_isDisposed) return; // belt-and-suspenders: post-frame callbacks can
+    // outlive dispose() on rapid navigation; bail out before any GPU access.
+    final key = _effectiveKey;
+    if (key == null) return;
+
+    final boundary =
+        key.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+    if (boundary == null) return;
+
+    // Guard: boundary may not be laid out yet (e.g. when the glass widget
+    // is mounted early for Standard quality before the first frame completes).
+    if (!boundary.hasSize) return;
+
+    final currentSize = boundary.size;
+    final currentPos = (key.currentContext?.findRenderObject() as RenderBox?)
+        ?.localToGlobal(Offset.zero);
+
+    // Capture on geometry change always; during interaction capture every frame
+    // since toImageSync() is synchronous (no GPU readback, no CPU copy).
+    final bool isInteracting = widget.interactionIntensity > 0.05;
+    bool needsCapture = _backgroundImage == null;
+    needsCapture |= _lastCaptureSize != currentSize;
+    needsCapture |= _lastCapturePosition != currentPos;
+    needsCapture |= isInteracting; // every frame during drag — free cost
+
+    if (needsCapture) {
+      _captureBackground(boundary, currentSize, currentPos);
+    }
+  }
+
+  /// Background capture — platform-adaptive.
+  ///
+  /// **Native (Impeller / Skia):** [RenderRepaintBoundary.toImageSync] —
+  /// fully synchronous, stays in GPU memory, zero CPU←GPU readback.
+  /// Runs every frame during active interaction at negligible cost.
+  ///
+  /// **Web (CanvasKit):** async [RenderRepaintBoundary.toImage] at
+  /// `pixelRatio: 1.0`. [toImageSync] is unreliable across CanvasKit versions
+  /// and unavailable in the legacy HTML renderer. The async path is still a
+  /// significant improvement over the previous `pixelRatio: dpr` approach —
+  /// same 1/DPR² memory reduction, with a 1-frame delivery lag during a drag.
+  /// An `_isCapturingAsync` guard prevents overlapping futures.
+  void _captureBackground(
+      RenderRepaintBoundary boundary, Size size, Offset? pos) {
+    assert(() {
+      if (boundary.size.isEmpty) {
+        debugPrint(
+          '⚠️ [GlassEffect] Background boundary has zero size.\n'
+          '   Ensure GlassRefractionSource (or LiquidGlassScope.stack) wraps\n'
+          '   a widget with non-zero dimensions.',
+        );
+      }
+      return true;
+    }());
+
+    if (kIsWeb) {
+      _captureBackgroundAsync(boundary, size, pos);
+    } else {
+      _captureBackgroundSync(boundary, size, pos);
+    }
+  }
+
+  /// Synchronous capture path for native (non-web) platforms.
+  void _captureBackgroundSync(
+      RenderRepaintBoundary boundary, Size size, Offset? pos) {
+    try {
+      // Capture at the device's physical pixel ratio so the background texture
+      // has full-DPR resolution. This gives the bilinear filter in
+      // interactive_indicator.frag genuine sub-pixel texels to interpolate
+      // across, eliminating the blocky 3×3 pixel "staircase" aliasing on
+      // Retina/3× displays when pixelRatio: 1.0 was used.
+      final dpr = _devicePixelRatio;
+      final image = boundary.toImageSync(pixelRatio: dpr);
+      // Guard: if the widget was disposed between the toImageSync call and
+      // this point (possible during rapid navigation), dispose the image
+      // immediately rather than leaking it into a dead State.
+      if (!mounted) {
+        image.dispose();
+        return;
+      }
+      _backgroundImage?.dispose();
+      _backgroundImage = image;
+      _lastCaptureSize = size;
+      _lastCapturePosition = pos;
+      setState(() {});
+    } catch (e) {
+      assert(() {
+        debugPrint('[GlassEffect] toImageSync failed: $e');
+        return true;
+      }());
+    }
+  }
+
+  /// Async capture path for web (CanvasKit / HTML renderer).
+  ///
+  /// [toImageSync] is not reliably available across all CanvasKit builds and
+  /// is absent in the legacy HTML renderer. Using async at `pixelRatio: 1.0`
+  /// still achieves the same memory reduction with an acceptable 1-frame lag.
+  Future<void> _captureBackgroundAsync(
+      RenderRepaintBoundary boundary, Size size, Offset? pos) async {
+    if (_isCapturingAsync) return; // prevent overlapping futures
+    _isCapturingAsync = true;
+    try {
+      // Web: async at full DPR. Still a 1-frame lag during drag but now
+      // provides full-resolution texels for the bilinear filter.
+      final image = await boundary.toImage(
+          pixelRatio: _devicePixelRatio); // coverage:ignore-line
+      if (mounted) {
+        setState(() {
+          _backgroundImage?.dispose();
+          _backgroundImage = image;
+          _lastCaptureSize = size;
+          _lastCapturePosition = pos;
+        });
+      }
+    } catch (e) {
+      assert(() {
+        debugPrint('[GlassEffect] toImage (web) failed: $e');
+        return true;
+      }());
+    } finally {
+      _isCapturingAsync = false;
+    }
+  }
+
+  Future<void> _initShader() async {
+    // Check if shader is already available
+    if (GlassEffect._cachedProgram == null) {
+      // Shader not ready, load it asynchronously
+      await GlassEffect.preWarm();
+
+      // Force rebuild now that shader is ready
+      if (mounted) {
+        setState(() {});
+      }
+    }
+
+    if (GlassEffect._cachedProgram != null && _localShader == null) {
+      if (mounted) {
+        setState(() {
+          // Always create a local shader instance for state isolation
+          _localShader = GlassEffect._cachedProgram!.fragmentShader();
+        });
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    WidgetsBinding.instance.removeObserver(this);
+    _ticker.dispose();
+    // Null backgroundImage BEFORE disposing the shader to break the reference
+    // chain: _backgroundImage → render object → engine layer tree → GPU texture.
+    // On Mali GPUs, if the shader’s DlRuntimeEffectColorSource retains a
+    // texture reference during isolate shutdown, the Vulkan mutex is accessed
+    // after destruction (Crash 2).
+    _backgroundImage?.dispose();
+    _backgroundImage = null;
+    _localShader?.dispose();
+    _localShader = null;
+    super.dispose();
+  }
+
+  ui.FragmentShader? get _activeShader {
+    // We only return the shader if the dummy image is ready,
+    // to prevent "missing sampler" build errors.
+    if (GlassEffect._dummyImage == null) return null;
+    return _localShader;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 1. Detect Environment & Constraints
+    final bool isImpeller = !kIsWeb && GlassEffect._canUseImpeller;
+
+    final bool avoidsRefraction = context
+            .dependOnInheritedWidgetOfExactType<InheritedLiquidGlass>()
+            ?.avoidsRefraction ??
+        false;
+
+    // 2. Resolve the background refraction source
+    final effectiveKey = widget.backgroundKey ?? LiquidGlassScope.of(context);
+    final shader = _activeShader;
+
+    // VQ4: Content-adaptive glass strength proxy.
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    final backdropLuma = isDark ? 0.15 : 0.85;
+
+    // 3. Selection Logic:
+
+    // Path A: Minimal (shader-free — BackdropFilter + ClipPath via _FrostedFallback)
+    // Routes through AdaptiveGlass which uses ClipPath(ShapeBorderClipper) for
+    // correct clipping on all shape types. No fragment shaders on any platform.
+    //
+    // IMPORTANT: always pass Clip.antiAlias here — never Clip.none.
+    // clipExpansion is only relevant for the LiquidStretch jelly displacement
+    // used in the full-shader path. _FrostedFallback has no displacement, so
+    // Clip.none would skip clipping entirely and let BackdropFilter blur the
+    // full rectangular bounds (the grey-square artifact).
+    if (widget.quality == GlassQuality.minimal || avoidsRefraction) {
+      return AdaptiveGlass(
+        shape: widget.shape,
+        settings: widget.settings,
+        quality: GlassQuality.minimal,
+        useOwnLayer: true,
+        clipBehavior: Clip.antiAlias,
+        isInteractive: true,
+        child: widget.child,
+      );
+    }
+
+    // Path B: Native Impeller (Premium only)
+    if (isImpeller && widget.quality == GlassQuality.premium) {
+      // No outer ClipPath here: a ClipPath clips in the widget's LOCAL (pre-jelly)
+      // coordinate space. When the parent Transform stretches the indicator taller
+      // during jelly physics, the already-clipped content has a hard edge at the
+      // original pill height, which becomes visible as a cutoff after scaling.
+      // LiquidGlass.withOwnLayer performs its own internal ClipPath for the child,
+      // and the shader uses SDF alpha masking for the pill boundary — both of which
+      // DO stretch correctly with the parent Transform.
+      //
+      // Capture path: when _backgroundImage is available (the ticker has already
+      // captured the background boundary at least once), pass it directly to
+      // LiquidGlass.withOwnLayer so the shader reads from the deterministic
+      // captured texture instead of emitting a live BackdropFilterLayer.
+      // This eliminates the Impeller compositor ordering dependency that caused
+      // the opaque-white indicator bug (#99) while preserving the full 3D
+      // geometry rendering pipeline. Performance is strictly better: one
+      // toImageSync capture per frame (already happening) replaces a heavyweight
+      // BackdropFilterLayer compositor pass.
+      //
+      // Falls back to the live BackdropFilter path if no capture is available
+      // yet (first frame before the ticker has fired) — zero visual difference
+      // since the indicator is invisible until thickness > 0.01 anyway.
+      //
+      // coverage:ignore-start
+      // Unreachable in unit tests: isImpeller=false (no real GPU renderer).
+      // Tested on physical device / Impeller integration tests only.
+      return LiquidGlass.withOwnLayer(
+        shape: widget.shape,
+        settings: widget.settings,
+        clipExpansion: widget.clipExpansion,
+        captureImage: _backgroundImage,
+        captureOriginInScreenSpace: _lastCapturePosition ?? Offset.zero,
+        child: widget.child,
+      );
+      // coverage:ignore-end
+    }
+
+    // 4. Resolve if we can use the high-fidelity refraction shader
+    final bool canUseRefraction = effectiveKey != null && !avoidsRefraction;
+
+    // Standard-path structural normalization for interactive_indicator.frag.
+    // The Premium Impeller path renders a real 3D bevel with natural gradient
+    // falloff. The 2D indicator shader draws a flat rim that reads as heavier
+    // at the same parameter values. Scaling these structural params down brings
+    // the pill's visual weight in line with the Premium bevel.
+    //
+    // NOTE: This mirrors the AdaptiveGlass normalization for lightweight_glass.frag
+    // (cards/buttons). Both are intentional Standard-path normalization sites —
+    // each scoped to its own shader's parameter space.
+    // Premium exits above via LiquidGlass.withOwnLayer; this block never runs there.
+    final double effectiveRimThickness = widget.quality == GlassQuality.standard
+        ? widget.rimThickness * 0.35
+        : widget.rimThickness;
+    final double effectiveAmbientRim = widget.quality == GlassQuality.standard
+        ? widget.ambientRim * 0.7
+        : widget.ambientRim;
+    final double effectiveEdgeAlpha = widget.quality == GlassQuality.standard
+        ? widget.edgeAlphaMultiplier * 0.7
+        : widget.edgeAlphaMultiplier;
+
+    // Normalise LiquidGlassSettings for the Standard path.
+    // The 2D interactive_indicator.frag renders thickness and specular highlights
+    // heavier than the Impeller 3D path at equal parameter values.
+    // Ratios are identical to AdaptiveGlass (thickness × 0.4, lightIntensity × 0.6)
+    // so the visual language stays consistent between static and interactive surfaces.
+    //
+    // NOTE: glassColor.alpha is intentionally NOT normalised here (unlike AdaptiveGlass).
+    // Interactive thumb body opacity is already governed by
+    //   standardBaseAlpha = baseAlphaMultiplier × interactionIntensity
+    // inside the shader — normalising alpha here would double-count it.
+    final LiquidGlassSettings effectiveSettings;
+    if (widget.quality == GlassQuality.standard) {
+      final base = widget.settings;
+      effectiveSettings = base.copyWith(
+        thickness: (base.effectiveThickness * 0.4).clamp(0.0, double.infinity),
+        lightIntensity: (base.effectiveLightIntensity * 0.6).clamp(0.0, 10.0),
+        ambientStrength: (base.effectiveAmbientStrength * 0.25).clamp(0.0, 1.0),
+        glowIntensity: (base.glowIntensity * 0.50).clamp(0.0, 5.0),
+      );
+    } else {
+      effectiveSettings = widget.settings;
+    }
+
+    // Path B: High-Fidelity Refraction Shader (Custom GLSL)
+    // This is the "New Shader" featuring magnification and liquid distortion.
+    // No outer ClipPath: the shader computes SDF alpha internally for the pill
+    // boundary. An outer ClipPath would clip in local (pre-jelly) space,
+    // producing a hard cutoff at the original pill height when the parent
+    // jelly Transform stretches the indicator vertically. Blur is constrained
+    // to the pill path via an inner ClipPathLayer in the render object's paint.
+    if (canUseRefraction && shader != null) {
+      return _InteractiveIndicatorEffect(
+        shader: shader,
+        settings: effectiveSettings,
+        shape: widget.shape,
+        interactionIntensity: widget.interactionIntensity,
+        densityFactor: widget.densityFactor,
+        backdropLuma: backdropLuma,
+        backgroundImage: _backgroundImage,
+        backgroundKey: effectiveKey,
+        devicePixelRatio: View.of(context).devicePixelRatio,
+        ambientRim: effectiveAmbientRim,
+        baseAlphaMultiplier: widget.baseAlphaMultiplier,
+        edgeAlphaMultiplier: effectiveEdgeAlpha,
+        rimThickness: effectiveRimThickness,
+        rimSmoothing: widget.rimSmoothing,
+        clipExpansion: widget.clipExpansion,
+        child: widget.child,
+      );
+    }
+
+    // Path C: Unified Indicator Fallback
+    // Even if no background image is available, we use the custom indicator shader
+    // to preserve the signature lighting, rim highlights, and structural "vibe".
+    // The shader will automatically switch to "Synthetic Frost" mode.
+    // No outer ClipPath — same reason as Path B (jelly clipping).
+    if (shader != null) {
+      return _InteractiveIndicatorEffect(
+        shader: shader,
+        settings: effectiveSettings.copyWith(blur: 0),
+        shape: widget.shape,
+        interactionIntensity: widget.interactionIntensity,
+        densityFactor: widget.densityFactor,
+        backdropLuma: backdropLuma,
+        backgroundImage: null, // Fallback mode
+        backgroundKey: null,
+        devicePixelRatio: View.of(context).devicePixelRatio,
+        ambientRim: effectiveAmbientRim,
+        baseAlphaMultiplier: widget.baseAlphaMultiplier,
+        edgeAlphaMultiplier: effectiveEdgeAlpha,
+        rimThickness: effectiveRimThickness,
+        rimSmoothing: widget.rimSmoothing,
+        clipExpansion: widget.clipExpansion,
+        child: widget.child,
+      );
+    }
+
+    // Ultra-clean fallback if shader hasn't loaded yet — transparent, no clip.
+    return widget.child;
+  }
+}
+
+class _InteractiveIndicatorEffect extends SingleChildRenderObjectWidget {
+  const _InteractiveIndicatorEffect({
+    required this.shader,
+    required this.settings,
+    required this.shape,
+    required this.interactionIntensity,
+    required this.densityFactor,
+    required this.backdropLuma,
+    this.backgroundImage,
+    this.backgroundKey,
+    required this.devicePixelRatio,
+    required this.ambientRim,
+    required this.baseAlphaMultiplier,
+    required this.edgeAlphaMultiplier,
+    required this.rimThickness,
+    required this.rimSmoothing,
+    this.clipExpansion = EdgeInsets.zero,
+    required super.child,
+  });
+
+  final ui.FragmentShader shader;
+  final LiquidGlassSettings settings;
+  final LiquidShape shape;
+  final double interactionIntensity;
+  final double densityFactor;
+  final double backdropLuma;
+  final ui.Image? backgroundImage;
+  final GlobalKey? backgroundKey;
+  final double devicePixelRatio;
+  final double ambientRim;
+  final double baseAlphaMultiplier;
+  final double edgeAlphaMultiplier;
+  final double rimThickness;
+  final double rimSmoothing;
+
+  /// Inflation budget matching the parent [AnimatedGlassIndicator._jellyClipExpansion].
+  /// The shader drawRect is inflated by this amount so that pixels pushed
+  /// outside the pill's layout bounds by horizontal/vertical jelly physics
+  /// are still painted by the shader (which self-masks via SDF alpha).
+  final EdgeInsets clipExpansion;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderInteractiveIndicator(
+      shader: shader,
+      settings: settings,
+      shape: shape,
+      interactionIntensity: interactionIntensity,
+      densityFactor: densityFactor,
+      backdropLuma: backdropLuma,
+      backgroundImage: backgroundImage,
+      backgroundKey: backgroundKey,
+      devicePixelRatio: devicePixelRatio,
+      ambientRim: ambientRim,
+      baseAlphaMultiplier: baseAlphaMultiplier,
+      edgeAlphaMultiplier: edgeAlphaMultiplier,
+      rimThickness: rimThickness,
+      rimSmoothing: rimSmoothing,
+      clipExpansion: clipExpansion,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    covariant _RenderInteractiveIndicator renderObject,
+  ) {
+    renderObject
+      ..shader = shader
+      ..settings = settings
+      ..shape = shape
+      ..interactionIntensity = interactionIntensity
+      ..densityFactor = densityFactor
+      ..backdropLuma = backdropLuma
+      ..backgroundImage = backgroundImage
+      ..backgroundKey = backgroundKey
+      ..devicePixelRatio = devicePixelRatio
+      ..ambientRim = ambientRim
+      ..baseAlphaMultiplier = baseAlphaMultiplier
+      ..edgeAlphaMultiplier = edgeAlphaMultiplier
+      ..rimThickness = rimThickness
+      ..rimSmoothing = rimSmoothing
+      ..clipExpansion = clipExpansion;
+  }
+}
+
+class _RenderInteractiveIndicator extends RenderProxyBox {
+  _RenderInteractiveIndicator({
+    required ui.FragmentShader shader,
+    required LiquidGlassSettings settings,
+    required LiquidShape shape,
+    required double interactionIntensity,
+    required double densityFactor,
+    required double backdropLuma,
+    ui.Image? backgroundImage,
+    GlobalKey? backgroundKey,
+    required double devicePixelRatio,
+    required double ambientRim,
+    required double baseAlphaMultiplier,
+    required double edgeAlphaMultiplier,
+    required double rimThickness,
+    required double rimSmoothing,
+    EdgeInsets clipExpansion = EdgeInsets.zero,
+  })  : _shader = shader,
+        _settings = settings,
+        _shape = shape,
+        _interactionIntensity = interactionIntensity,
+        _densityFactor = densityFactor,
+        _backdropLuma = backdropLuma,
+        _backgroundImage = backgroundImage,
+        _backgroundKey = backgroundKey,
+        _devicePixelRatio = devicePixelRatio,
+        _ambientRim = ambientRim,
+        _baseAlphaMultiplier = baseAlphaMultiplier,
+        _edgeAlphaMultiplier = edgeAlphaMultiplier,
+        _rimThickness = rimThickness,
+        _rimSmoothing = rimSmoothing,
+        _clipExpansion = clipExpansion,
+        _cachedLightCos = math.cos(settings.lightAngle),
+        _cachedLightSin = -math.sin(settings.lightAngle);
+
+  ui.FragmentShader _shader;
+  set shader(ui.FragmentShader value) {
+    if (_shader == value) return;
+    _shader = value;
+    markNeedsPaint();
+  }
+
+  LiquidGlassSettings _settings;
+  set settings(LiquidGlassSettings value) {
+    if (_settings == value) return;
+    // Invalidate cached filter when blur changes.
+    if (value.effectiveBlur != _settings.effectiveBlur) {
+      _cachedInteractiveFilter = null;
+    }
+    // Recompute trig only when lightAngle actually changes.
+    if (value.lightAngle != _settings.lightAngle) {
+      _cachedLightCos = math.cos(value.lightAngle);
+      _cachedLightSin = -math.sin(value.lightAngle);
+    }
+    _settings = value;
+    markNeedsPaint();
+  }
+
+  LiquidShape _shape;
+  set shape(LiquidShape value) {
+    if (_shape == value) return;
+    _shape = value;
+    markNeedsPaint();
+  }
+
+  double _interactionIntensity;
+  set interactionIntensity(double value) {
+    if (_interactionIntensity == value) return;
+    _interactionIntensity = value;
+    markNeedsPaint();
+  }
+
+  double _densityFactor;
+  set densityFactor(double value) {
+    if (_densityFactor == value) return;
+    _densityFactor = value;
+    markNeedsPaint();
+  }
+
+  double _backdropLuma;
+  set backdropLuma(double value) {
+    if (_backdropLuma == value) return;
+    _backdropLuma = value;
+    markNeedsPaint();
+  }
+
+  ui.Image? _backgroundImage;
+  set backgroundImage(ui.Image? value) {
+    if (_backgroundImage == value) return;
+    _backgroundImage = value;
+    markNeedsPaint();
+  }
+
+  GlobalKey? _backgroundKey;
+  set backgroundKey(GlobalKey? value) {
+    if (_backgroundKey == value) return;
+    _backgroundKey = value;
+    markNeedsPaint();
+  }
+
+  double _devicePixelRatio;
+  set devicePixelRatio(double value) {
+    if (_devicePixelRatio == value) return;
+    _devicePixelRatio = value;
+    markNeedsPaint();
+  }
+
+  double _ambientRim;
+  set ambientRim(double value) {
+    if (_ambientRim == value) return;
+    _ambientRim = value;
+    markNeedsPaint();
+  }
+
+  double _baseAlphaMultiplier;
+  set baseAlphaMultiplier(double value) {
+    if (_baseAlphaMultiplier == value) return;
+    _baseAlphaMultiplier = value;
+    markNeedsPaint();
+  }
+
+  double _edgeAlphaMultiplier;
+  set edgeAlphaMultiplier(double value) {
+    if (_edgeAlphaMultiplier == value) return;
+    _edgeAlphaMultiplier = value;
+    markNeedsPaint();
+  }
+
+  double _rimThickness;
+  set rimThickness(double value) {
+    if (_rimThickness == value) return;
+    _rimThickness = value;
+    markNeedsPaint();
+  }
+
+  double _rimSmoothing;
+  set rimSmoothing(double value) {
+    if (_rimSmoothing == value) return;
+    _rimSmoothing = value;
+    markNeedsPaint();
+  }
+
+  EdgeInsets _clipExpansion;
+  set clipExpansion(EdgeInsets value) {
+    if (_clipExpansion == value) return;
+    _clipExpansion = value;
+    markNeedsPaint();
+  }
+
+  // ── Cached light direction ────────────────────────────────────────────────
+  // Avoids recomputing cos/sin on every _updateShaderUniforms call.
+  // Matches the caching pattern in _RenderLightweightGlass.
+  double _cachedLightCos;
+  double _cachedLightSin;
+
+  // Only force compositing when blur > 0 (the BackdropFilterLayer path).
+  // When blur is 0, _paintGlassContent draws directly — no compositing layer.
+  @override
+  bool get alwaysNeedsCompositing => _settings.effectiveBlur > 0;
+
+  // ── Cached brightness+blur filter ─────────────────────────────────────────
+  // The brightness ColorFilter matrix is constant (mult=1.15, add=0.05), so
+  // the composed filter only changes when blurSigma changes. Caching avoids
+  // a 20-element List<double> allocation per frame per interactive indicator.
+  ui.ImageFilter? _cachedInteractiveFilter;
+  double _cachedInteractiveBlur = -1;
+
+  ui.ImageFilter _getInteractiveFilter(double blurSigma) {
+    if (_cachedInteractiveFilter != null &&
+        _cachedInteractiveBlur == blurSigma) {
+      return _cachedInteractiveFilter!;
+    }
+
+    const double mult = 1.15;
+    const double add = 0.05;
+    final ui.ColorFilter brightnessFilter = ui.ColorFilter.matrix(<double>[
+      mult,
+      0.0,
+      0.0,
+      0.0,
+      add * 255.0,
+      0.0,
+      mult,
+      0.0,
+      0.0,
+      add * 255.0,
+      0.0,
+      0.0,
+      mult,
+      0.0,
+      add * 255.0,
+      0.0,
+      0.0,
+      0.0,
+      1.0,
+      0.0,
+    ]);
+
+    _cachedInteractiveFilter = ui.ImageFilter.compose(
+      outer: brightnessFilter,
+      inner: ui.ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma),
+    );
+    _cachedInteractiveBlur = blurSigma;
+    return _cachedInteractiveFilter!;
+  }
+
+  // Reusable layer handles — avoid allocation on every spring/route frame.
+  final _clipPathLayerHandle = LayerHandle<ClipPathLayer>();
+  final _backdropFilterLayerHandle = LayerHandle<BackdropFilterLayer>();
+
+  @override
+  void dispose() {
+    _clipPathLayerHandle.layer = null;
+    _backdropFilterLayerHandle.layer = null;
+    super.dispose();
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    if (child == null) return;
+
+    final blurSigma = _settings.effectiveBlur;
+    if (blurSigma > 0) {
+      final filter = _getInteractiveFilter(blurSigma);
+      final backdropLayer = (_backdropFilterLayerHandle.layer ??=
+          BackdropFilterLayer())
+        ..filter = filter;
+
+      // Clip blur to the pill shape so the BackdropFilterLayer does not bleed
+      // into the expansion zone around the jelly-physics draw rect.
+      //
+      // Clip.antiAlias is used (not Clip.antiAliasWithSaveLayer) because
+      // antiAliasWithSaveLayer would isolate the BackdropFilter from the real
+      // compositor backdrop via a saveLayer, destroying the frosted-glass effect.
+      // antiAlias creates a ClipPathLayer with no saveLayer, giving sub-pixel AA
+      // on the pill edge without compositor isolation.
+      final pillPath = _shape.getOuterPath(offset & size);
+      _clipPathLayerHandle.layer = context.pushClipPath(
+        needsCompositing,
+        offset,
+        offset & size,
+        pillPath,
+        (context, offset) {
+          context.pushLayer(
+            backdropLayer,
+            (context, offset) {
+              _paintGlassContent(context, offset);
+            },
+            offset,
+          );
+        },
+        clipBehavior: Clip.antiAlias,
+        oldLayer: _clipPathLayerHandle.layer,
+      );
+    } else {
+      _clipPathLayerHandle.layer = null;
+      _backdropFilterLayerHandle.layer = null;
+      _paintGlassContent(context, offset);
+    }
+  }
+
+  void _paintGlassContent(PaintingContext context, Offset offset) {
+    // 1. Paint Child content (glow etc)
+    super.paint(context, offset);
+
+    // 2. Prepare shader uniforms
+    final canvas = context.canvas;
+    final matrix = canvas.getTransform();
+
+    final canvasPhysicalX = matrix[12];
+    final canvasPhysicalY = matrix[13];
+    final scaleX = matrix[0];
+    final scaleY = matrix[5];
+
+    final physicalOrigin = Offset(
+      canvasPhysicalX + (offset.dx * scaleX),
+      canvasPhysicalY + (offset.dy * scaleY),
+    );
+
+    // Keep uScale from canvas for shape calculations
+    final uScale = Offset(scaleX, scaleY);
+
+    // Relative Offset Mapping - ALL IN LOGICAL PIXELS
+    Offset bgRelativeOffset = Offset.zero;
+    Size bgSize = const Size(1, 1);
+
+    if (_backgroundKey != null && _backgroundImage != null) {
+      final boundary = _backgroundKey!.currentContext?.findRenderObject()
+          as RenderRepaintBoundary?;
+      if (boundary != null) {
+        // Get screen positions (localToGlobal gives logical coords)
+        final bgGlobalPos = boundary.localToGlobal(Offset.zero);
+        final indGlobalPos = localToGlobal(Offset.zero);
+
+        // Keep in LOGICAL pixels (don't multiply by DPR)
+        bgRelativeOffset = indGlobalPos - bgGlobalPos;
+
+        // Image is now captured at pixelRatio: _devicePixelRatio.
+        // Divide by DPR to convert physical pixel dimensions back to logical
+        // pixels, keeping uBackgroundSize in the same coordinate space as
+        // localLogical/posInBg in the shader. The bilinear function in GLSL
+        // uses the physical size (uBgPhysicalSize = logical × DPR) internally.
+        bgSize = Size(
+          _backgroundImage!.width / _devicePixelRatio,
+          _backgroundImage!.height / _devicePixelRatio,
+        );
+      }
+    }
+
+    _updateShaderUniforms(
+        size, physicalOrigin, uScale, bgRelativeOffset, bgSize);
+
+    // 3. Set Sampler
+    final imageToBind = _backgroundImage ?? GlassEffect._dummyImage;
+    if (imageToBind != null) {
+      _shader.setImageSampler(
+        0,
+        imageToBind,
+        filterQuality: FilterQuality.medium,
+      );
+    }
+
+    // 4. Paint shader overlay — inflate the draw rect by the clip expansion budget.
+    //
+    // WHY: canvas.drawRect(offset & size) normally covers only the pill's layout
+    // bounds (e.g. 90×64px). The parent jelly Transform can stretch the indicator
+    // wider/taller than those bounds. Without inflation, pixels pushed outside the
+    // layout rect by the jelly physics are never painted by the shader, producing
+    // a hard cutoff at the layout edge.
+    //
+    // The shader self-masks via SDF alpha (vec4(0.0) outside pill), so inflating
+    // the rect into the expansion zone causes zero visual bleed — only the SDF
+    // region of the pill is rendered. The expansion values match
+    // AnimatedGlassIndicator._jellyClipExpansion (20px H, 15px V).
+    final paint = Paint()..shader = _shader;
+    final expandedRect = Rect.fromLTRB(
+      offset.dx - _clipExpansion.left,
+      offset.dy - _clipExpansion.top,
+      offset.dx + size.width + _clipExpansion.right,
+      offset.dy + size.height + _clipExpansion.bottom,
+    );
+    canvas.drawRect(expandedRect, paint);
+  }
+
+  void _updateShaderUniforms(Size size, Offset physicalOrigin,
+      Offset physicalScale, Offset bgOrigin, Size bgSize) {
+    int index = 0;
+    _shader.setFloat(index++, size.width);
+    _shader.setFloat(index++, size.height);
+    _shader.setFloat(index++, physicalOrigin.dx);
+    _shader.setFloat(index++, physicalOrigin.dy);
+
+    final color = _settings.effectiveGlassColor;
+    _shader.setFloat(index++, (color.r * 255.0).round().clamp(0, 255) / 255.0);
+    _shader.setFloat(index++, (color.g * 255.0).round().clamp(0, 255) / 255.0);
+    _shader.setFloat(index++, (color.b * 255.0).round().clamp(0, 255) / 255.0);
+    _shader.setFloat(index++, (color.a * 255.0).round().clamp(0, 255) / 255.0);
+
+    _shader.setFloat(index++, _settings.effectiveThickness);
+
+    // Pass light direction as [cos(angle), -sin(angle)]
+    // lightAngle is in radians (per LiquidGlassSettings API docs).
+    // Uses cached values — trig only recomputed when lightAngle changes.
+    _shader.setFloat(index++, _cachedLightCos);
+    _shader.setFloat(index++, _cachedLightSin);
+
+    _shader.setFloat(index++, _settings.effectiveLightIntensity);
+    _shader.setFloat(index++, _settings.effectiveAmbientStrength);
+    _shader.setFloat(index++, _settings.effectiveSaturation);
+    _shader.setFloat(index++, _settings.effectiveRefractiveIndex);
+    _shader.setFloat(index++, (_settings.chromaticAberration).clamp(0.0, 1.0));
+
+    // 16: uCornerRadius (float) - Logical. Concrete type matching is stable
+    // in obfuscated AOT builds; runtime class names are not.
+    final cornerRadius = resolveLiquidShapeCornerRadius(_shape, size);
+    _shader.setFloat(index++, cornerRadius);
+
+    _shader.setFloat(index++, physicalScale.dx);
+    _shader.setFloat(index++, physicalScale.dy);
+    _shader.setFloat(
+        index++, _settings.glowIntensity); // uGlowIntensity (fresnel boost)
+    _shader.setFloat(
+        index++,
+        _densityFactor.clamp(0.0,
+            1.0)); // 20: uDensityFactor (float) - Elevation physics (0.0-1.0)
+    _shader.setFloat(index++, _interactionIntensity.clamp(0.0, 1.0));
+
+    // Background Mapping Uniforms
+    _shader.setFloat(index++, bgOrigin.dx);
+    _shader.setFloat(index++, bgOrigin.dy);
+    _shader.setFloat(index++, bgSize.width);
+    _shader.setFloat(index++, bgSize.height);
+    _shader.setFloat(index++, _backgroundImage != null ? 1.0 : 0.0);
+
+    // Configurable appearance parameters
+    _shader.setFloat(index++, _ambientRim);
+    _shader.setFloat(index++, _baseAlphaMultiplier);
+    _shader.setFloat(index++, _edgeAlphaMultiplier);
+    _shader.setFloat(index++, _rimThickness);
+    _shader.setFloat(index++, _rimSmoothing);
+
+    // Device pixel ratio — used by textureBilinear() in the shader to
+    // convert logical uBackgroundSize to physical texel dimensions.
+    // index 32 (after the 32 floats mapped to uData0..uData7).
+    _shader.setFloat(index++, _devicePixelRatio);
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/glass_isolation_scope.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/glass_isolation_scope.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/widgets.dart';
+
+import '../../types/glass_quality.dart';
+
+/// An [InheritedWidget] that tells descendant glass widgets whether to use
+/// their own independent glass rendering layer or share the nearest ancestor's.
+///
+/// This is a zero-cost scope marker — it doesn't create any glass rendering
+/// context, shader, or compositing layer. It simply provides a signal that
+/// descendant [AdaptiveGlass] widgets check to decide whether to use
+/// `useOwnLayer: true`.
+///
+/// ## Two roles
+///
+/// 1. **Quality hint** (`defaultQuality`) — tells descendants to default to a
+///    given quality without explicit params. Zero cost (InheritedWidget lookup).
+///
+/// 2. **Layer isolation** (`isolated: true`) — forces descendants to create
+///    their own glass layer via `useOwnLayer: true`. Useful when glass surfaces
+///    from different z-layers would otherwise share a blend group incorrectly.
+///    Adds GPU cost (separate backdrop capture per layer).
+///
+/// ## How GlassScaffold uses this
+///
+/// [GlassScaffold] wraps app bar and bottom bar in
+/// `GlassIsolationScope(isolated: true, defaultQuality: premium)`.
+/// This provides the quality hint so buttons default to premium, and forces
+/// all glass surfaces in the bar to create their own layer by default.
+/// This prevents Z-order tearing where grouped glass backgrounds paint
+/// behind the scrolling body text but foregrounds paint on top.
+///
+/// ```
+/// GlassScaffold → GlassPage → AdaptiveLiquidGlassLayer (page blend group)
+///   → body cards → join page blend group (grouped)
+///   → GlassIsolationScope(isolated: true, defaultQuality: premium) ← bar
+///     → GlassButton in app bar → uses own layer ✅
+///     → GlassSearchableBottomBar (provides its own isolated: false scope)
+///       → BottomBarExtraBtn → joins bottom bar blend group ✅
+/// ```
+///
+/// For advanced scenarios where isolation is NOT needed (e.g. built-in bottom
+/// bars that provide their own layer), the child widget can simply override
+/// the scope by providing its own `GlassIsolationScope(isolated: false)`.
+class GlassIsolationScope extends InheritedWidget {
+  /// Creates a glass isolation scope.
+  ///
+  /// When [isolated] is `true` (default), descendant glass widgets render
+  /// with their own independent layer. When `false`, they participate in the
+  /// nearest ancestor [AdaptiveLiquidGlassLayer]'s grouped rendering.
+  ///
+  /// [defaultQuality] provides a quality hint for descendants that don't
+  /// specify an explicit quality. This is separate from [isolated] — a scope
+  /// can be de-isolated (for grouping) while still providing a premium
+  /// quality default.
+  const GlassIsolationScope({
+    super.key,
+    this.isolated = true,
+    this.defaultQuality,
+    required super.child,
+  });
+
+  /// Whether descendants should be isolated from ancestor glass layers.
+  final bool isolated;
+
+  /// Default quality hint for descendants that don't specify explicit quality.
+  ///
+  /// When set, [GlassThemeHelpers.resolveQuality] uses this as the fallback
+  /// instead of [GlassQuality.standard]. This allows bar surfaces to default
+  /// all their children to premium quality without requiring explicit
+  /// `quality: GlassQuality.premium` on each widget.
+  ///
+  /// [GlassAdaptiveScope] ceiling still caps this on low-end devices.
+  final GlassQuality? defaultQuality;
+
+  /// Returns `true` if the given [context] is inside an active
+  /// [GlassIsolationScope] with `isolated: true`.
+  ///
+  /// Used by [AdaptiveGlass] to decide whether to force `useOwnLayer: true`.
+  static bool isIsolated(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<GlassIsolationScope>();
+    return scope?.isolated ?? false;
+  }
+
+  /// Returns the [defaultQuality] from the nearest [GlassIsolationScope],
+  /// or `null` if none is set.
+  static GlassQuality? defaultQualityOf(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<GlassIsolationScope>();
+    return scope?.defaultQuality;
+  }
+
+  @override
+  bool updateShouldNotify(GlassIsolationScope oldWidget) =>
+      isolated != oldWidget.isolated ||
+      defaultQuality != oldWidget.defaultQuality;
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/glass_motion_scope.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/glass_motion_scope.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../theme/glass_theme.dart';
+import '../../theme/glass_theme_data.dart';
+import '../../theme/glass_theme_settings.dart';
+
+/// Drives the glass specular highlight angle from a stream of radians.
+///
+/// Wraps its subtree with an updated [GlassTheme] that overrides
+/// `lightAngle` whenever a new value arrives on [lightAngle].
+///
+/// Typical use — hook up to `sensors_plus` gyroscope data or any animation:
+///
+/// ```dart
+/// GlassMotionScope(
+///   lightAngle: gyroscopeEvents.map((e) => e.y * 0.5),
+///   child: child,
+/// )
+/// ```
+///
+/// When [lightAngle] is null the widget is a transparent pass-through.
+class GlassMotionScope extends StatefulWidget {
+  /// Creates a [GlassMotionScope].
+  ///
+  /// [lightAngle] is a stream of angles **in radians**. Each emitted value
+  /// replaces the `lightAngle` in the [GlassTheme] for this subtree.
+  const GlassMotionScope({
+    required this.child,
+    this.lightAngle,
+    super.key,
+  });
+
+  /// Stream of light angles in radians.
+  ///
+  /// Overrides [LiquidGlassSettings.lightAngle] for all glass widgets in this
+  /// subtree. If null, no override is applied.
+  final Stream<double>? lightAngle;
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  @override
+  State<GlassMotionScope> createState() => _GlassMotionScopeState();
+}
+
+class _GlassMotionScopeState extends State<GlassMotionScope> {
+  StreamSubscription<double>? _subscription;
+  double? _currentAngle;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe(widget.lightAngle);
+  }
+
+  @override
+  void didUpdateWidget(GlassMotionScope oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.lightAngle != widget.lightAngle) {
+      _subscription?.cancel();
+      _currentAngle = null;
+      _subscribe(widget.lightAngle);
+    }
+  }
+
+  void _subscribe(Stream<double>? stream) {
+    if (stream == null) return;
+    _subscription = stream.listen((angle) {
+      if (mounted) setState(() => _currentAngle = angle);
+    });
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final angle = _currentAngle;
+    if (angle == null) return widget.child;
+
+    final parent = GlassThemeData.of(context);
+
+    GlassThemeVariant applyAngle(GlassThemeVariant variant) {
+      return variant.copyWith(
+        settings: (variant.settings ?? const GlassThemeSettings())
+            .copyWith(lightAngle: angle),
+      );
+    }
+
+    return GlassTheme(
+      data: parent.copyWith(
+        light: applyAngle(parent.light),
+        dark: applyAngle(parent.dark),
+      ),
+      child: widget.child,
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/glass_page.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/glass_page.dart
@@ -1,0 +1,464 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../src/renderer/liquid_glass_renderer.dart';
+import 'adaptive_liquid_glass_layer.dart';
+
+import '../interactive/liquid_glass_scope.dart';
+import 'glass_adaptive_scope.dart';
+import '../../types/glass_quality.dart';
+import '../../theme/glass_theme.dart';
+import '../../theme/glass_theme_data.dart';
+
+// Internal flag set by LiquidGlassWidgets.initialize(). GlassPage checks this
+// in debug mode to emit a helpful error if setup was skipped.
+// Marked as visible for testing — do not use in production code.
+@visibleForTesting
+bool glassPageInitializeGuardEnabled = true;
+
+/// Controls how [GlassPage] styles the system status bar.
+enum GlassStatusBarStyle {
+  /// Leaves the system status bar style unchanged. Default.
+  none,
+
+  /// Dark status bar icons (for use over light backgrounds).
+  dark,
+
+  /// Light status bar icons (for use over dark backgrounds / wallpapers).
+  light,
+
+  /// Automatically selects [dark] or [light] based on the current
+  /// [MediaQuery] platform brightness. Dark mode → light icons;
+  /// light mode → dark icons.
+  auto,
+}
+
+/// The recommended root widget for building a route or screen with glass surfaces.
+///
+/// [GlassPage] eliminates the boilerplate required to set up a correct,
+/// performant glass UI on any route. In a single widget it handles:
+///
+/// 1. **Transparent Scaffold** — forces the [Scaffold]'s default background
+///    colour to transparent via a [Theme] override, so your [background] shows
+///    through without any extra configuration.
+///
+/// 2. **Backdrop Isolation** — each glass layer manages its own GPU backdrop
+///    capture, preventing ghost artefacts when navigating between routes.
+///
+/// 3. **Background Scope** — wraps the route in a [LiquidGlassScope] so that
+///    [GlassBackgroundSource] can locate the capture key when
+///    [enableBackgroundSampling] is `true`. Required for real colour absorption.
+///
+/// 4. **System Status Bar** — optionally adjusts icon brightness to match your
+///    background via [statusBarStyle]. Automatically restores the previous style
+///    when the page is disposed.
+///
+/// 5. **Edge-to-Edge** — optionally enables [SystemUiMode.edgeToEdge] so
+///    content draws behind the status and navigation bars. Restores the
+///    previous mode on dispose.
+///
+/// 6. **Per-Page Theme Override** — optionally wraps the subtree in a scoped
+///    [GlassTheme] via [themeOverride], letting individual screens break from
+///    the app-wide glass theme (e.g. a more dramatic onboarding or paywall
+///    screen). Widget-level `settings` parameters still take precedence.
+///
+/// 7. **Setup Guard (debug only)** — emits a [FlutterError] in debug mode if
+///    [LiquidGlassWidgets.initialize] was never called, with a direct link to
+///    the correct setup pattern.
+///
+/// ## Performance characteristics
+///
+/// | State | Cost |
+/// |-------|------|
+/// | `enableBackgroundSampling: false` (default) | Near-zero — one [GlobalKey] allocation, no Ticker |
+/// | Adaptive quality degraded to [GlassQuality.minimal] | Near-zero — sampling automatically disabled |
+/// | Sampling active, static background | Very low — Ticker fires, detects no change after first capture |
+/// | Sampling active, animated background | Normal — Ticker captures on size/position changes |
+///
+/// ## Recommended setup
+///
+/// ### App root (once):
+/// ```dart
+/// void main() async {
+///   WidgetsFlutterBinding.ensureInitialized();
+///   await LiquidGlassWidgets.initialize();
+///   runApp(LiquidGlassWidgets.wrap(child: MyApp(), adaptiveQuality: true));
+/// }
+/// ```
+///
+/// ### Typical screen (zero boilerplate):
+/// ```dart
+/// class HomeScreen extends StatelessWidget {
+///   @override
+///   Widget build(BuildContext context) {
+///     return GlassPage(
+///       background: Image.asset('assets/wallpaper.jpg', fit: BoxFit.cover),
+///       child: Scaffold(
+///         appBar: GlassAppBar(title: const Text('Home')),
+///         body: MyContent(),
+///       ),
+///     );
+///   }
+/// }
+/// ```
+///
+/// ### Edge-to-edge wallpaper screen with status bar styling:
+/// ```dart
+/// GlassPage(
+///   background: Image.asset('assets/wallpaper.jpg', fit: BoxFit.cover),
+///   edgeToEdge: true,
+///   statusBarStyle: GlassStatusBarStyle.auto,
+///   child: Scaffold(...),
+/// )
+/// ```
+///
+/// ### Special page with a custom glass intensity:
+/// ```dart
+/// GlassPage(
+///   background: myGradient,
+///   themeOverride: GlassThemeData(
+///     light: GlassThemeVariant(
+///       settings: GlassThemeSettings(blur: 2, glowIntensity: 0.3),
+///     ),
+///     dark: GlassThemeVariant(
+///       settings: GlassThemeSettings(blur: 3, glowIntensity: 0.5),
+///     ),
+///   ),
+///   child: Scaffold(...),
+/// )
+/// ```
+///
+/// ### Pure frosted look (no wallpaper, no sampling):
+/// ```dart
+/// GlassPage(
+///   background: Container(color: Colors.black),
+///   child: Scaffold(...),
+/// )
+/// ```
+class GlassPage extends StatefulWidget {
+  /// Creates a [GlassPage].
+  ///
+  /// [background] is rendered beneath [child]. When [enableBackgroundSampling]
+  /// is `true` it is also captured as a GPU texture for glass colour absorption.
+  ///
+  /// [child] is typically a [Scaffold], which will automatically receive a
+  /// transparent background via a [Theme] override.
+  const GlassPage({
+    super.key,
+    this.background,
+    required this.child,
+    this.settings,
+    this.enableBackgroundSampling,
+    this.statusBarStyle = GlassStatusBarStyle.none,
+    this.edgeToEdge = false,
+    this.themeOverride,
+  });
+
+  /// The background widget (e.g. an [Image] or gradient [Container]) that sits
+  /// behind the app content and, optionally, provides colours for glass to absorb.
+  ///
+  /// When `null` (the default), no background is rendered and the [Scaffold]
+  /// is **not** forced transparent — it renders with its own background color
+  /// as normal. This lets [GlassPage] be used purely for its anti-ghosting,
+  /// edge-to-edge, and status bar benefits, without needing a dummy background
+  /// widget.
+  ///
+  /// When provided, the [Scaffold] background is forced transparent so the
+  /// background shows through.
+  final Widget? background;
+
+  /// The main content of the screen, typically a [Scaffold].
+  final Widget child;
+
+  /// Whether to capture the [background] as a GPU texture for glass colour
+  /// absorption.
+  ///
+  /// Defaults to `true` if [background] is provided, and `false` otherwise.
+  /// Set to `false` explicitly if you have a background but do not want the
+  /// performance cost of sampling it (glass will use synthetic frost).
+  ///
+  /// When `false`:
+  /// - No [RepaintBoundary] is inserted around the background.
+  /// - No Ticker runs — cost is effectively zero beyond one [GlobalKey] allocation.
+  /// - Glass widgets still render correctly with the synthetic frost look.
+  ///
+  /// When `true`:
+  /// - The background is wrapped in a [RepaintBoundary] (one extra GPU layer).
+  /// - A Ticker in [GlassEffect] fires when [GlassEffect.interactionIntensity]
+  ///   exceeds 0.01 **and** the widget's `blur` is greater than 0.
+  ///
+  /// This flag is ignored when the ambient [GlassAdaptiveScope] has degraded to
+  /// [GlassQuality.minimal] — sampling is always disabled in that tier.
+  final bool? enableBackgroundSampling;
+
+  /// How to style the system status bar icons on this screen.
+  ///
+  /// Defaults to [GlassStatusBarStyle.none] — the status bar is left unchanged.
+  ///
+  /// [GlassStatusBarStyle.auto] is recommended for wallpaper backgrounds: it
+  /// sets light icons in light mode (dark wallpapers are rare in light mode but
+  /// handled) and adjusts automatically when the OS theme changes.
+  ///
+  /// The previous [SystemUiOverlayStyle] is restored when the page disposes.
+  ///
+  /// Has no effect on platforms that do not support [SystemChrome] (e.g. Web,
+  /// desktop — calls are silently ignored by the Flutter framework).
+  final GlassStatusBarStyle statusBarStyle;
+
+  /// Whether to enable edge-to-edge rendering on this screen.
+  ///
+  /// When `true`, calls [SystemChrome.setEnabledSystemUIMode] with
+  /// [SystemUiMode.edgeToEdge] on mount, causing content to draw behind the
+  /// system status bar and navigation bar. Restores the previous UI mode on
+  /// dispose.
+  ///
+  /// Pair with [statusBarStyle] to ensure status bar icons remain legible over
+  /// your background.
+  ///
+  /// Defaults to `false`.
+  ///
+  /// > **Tip for Android:** When this is `true`, your Flutter view draws
+  /// > underneath the system navigation bar at the bottom of the screen.
+  /// > Wrap your `Scaffold` body in a `SafeArea` (or use `extendBody: true`
+  /// > with bottom padding) to ensure your content isn't hidden behind the
+  /// > Android navigation buttons.
+  final bool edgeToEdge;
+
+  /// An optional per-page [GlassThemeData] that overrides the app-level
+  /// [GlassTheme] for all glass widgets within this screen.
+  ///
+  /// Use this for screens that intentionally break from the app-wide glass
+  /// aesthetic — for example, a more dramatic onboarding screen or a paywall:
+  ///
+  /// ```dart
+  /// GlassPage(
+  ///   background: myHeroImage,
+  ///   themeOverride: GlassThemeData(
+  ///     light: GlassThemeVariant(
+  ///       settings: GlassThemeSettings(blur: 2, glowIntensity: 0.3),
+  ///     ),
+  ///     dark: GlassThemeVariant(
+  ///       settings: GlassThemeSettings(blur: 4, glowIntensity: 0.6),
+  ///     ),
+  ///   ),
+  ///   child: Scaffold(...),
+  /// )
+  /// ```
+  ///
+  /// Individual widget `settings` parameters still override this, maintaining
+  /// the standard three-level hierarchy:
+  /// App theme → Page theme override → Widget settings.
+  ///
+  /// When `null` (the default), the nearest [GlassTheme] ancestor is used.
+  final GlassThemeData? themeOverride;
+
+  /// Glass effect settings applied to the page's internal rendering layer.
+  ///
+  /// All grouped glass widgets ([GlassCard], [GlassContainer], etc.) within
+  /// this page will inherit these settings automatically — no need to set
+  /// `useOwnLayer: true` or pass `settings:` to each widget individually.
+  ///
+  /// If null, the layer inherits settings from [GlassTheme] or uses defaults.
+  ///
+  /// ```dart
+  /// GlassPage(
+  ///   settings: LiquidGlassSettings(
+  ///     glassColor: Color.fromRGBO(28, 28, 30, 0.8),
+  ///     thickness: 30,
+  ///     blur: 4,
+  ///   ),
+  ///   child: Scaffold(...),
+  /// )
+  /// ```
+  final LiquidGlassSettings? settings;
+
+  @override
+  State<GlassPage> createState() => _GlassPageState();
+}
+
+class _GlassPageState extends State<GlassPage> {
+  SystemUiOverlayStyle? _previousOverlayStyle;
+
+  bool get _effectiveSampling =>
+      widget.enableBackgroundSampling ?? (widget.background != null);
+
+  @override
+  void initState() {
+    super.initState();
+    _assertInitialized();
+    if (widget.edgeToEdge) {
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _applyStatusBarStyle();
+  }
+
+  @override
+  void didUpdateWidget(GlassPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.statusBarStyle != widget.statusBarStyle ||
+        oldWidget.edgeToEdge != widget.edgeToEdge) {
+      _applyStatusBarStyle();
+    }
+    if (!oldWidget.edgeToEdge && widget.edgeToEdge) {
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    } else if (oldWidget.edgeToEdge && !widget.edgeToEdge) {
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    }
+  }
+
+  @override
+  void dispose() {
+    // Restore the previous overlay style if we changed it.
+    if (_previousOverlayStyle != null) {
+      SystemChrome.setSystemUIOverlayStyle(_previousOverlayStyle!);
+    }
+    super.dispose();
+  }
+
+  void _applyStatusBarStyle() {
+    if (widget.statusBarStyle == GlassStatusBarStyle.none) return;
+
+    final Brightness brightness = MediaQuery.platformBrightnessOf(context);
+    final bool isDark = brightness == Brightness.dark;
+
+    // auto: light icons in dark mode (bright wallpaper icons need to stand out
+    // against dark OS chrome), dark icons in light mode.
+    final bool useLightIcons = switch (widget.statusBarStyle) {
+      GlassStatusBarStyle.light => true,
+      GlassStatusBarStyle.dark => false,
+      GlassStatusBarStyle.auto => isDark,
+      GlassStatusBarStyle.none => false,
+    };
+
+    final SystemUiOverlayStyle newStyle =
+        useLightIcons ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark;
+
+    // Save the current style once so we can restore it on dispose.
+    _previousOverlayStyle ??= SystemUiOverlayStyle.light;
+    SystemChrome.setSystemUIOverlayStyle(newStyle);
+  }
+
+  /// Emits a [FlutterError] in debug mode if [LiquidGlassWidgets.initialize]
+  /// was never called. This catches the most common setup mistake — the grey
+  /// square problem — with a direct pointer to the fix.
+  void _assertInitialized() {
+    assert(() {
+      if (glassPageInitializeGuardEnabled) {
+        // We detect skipped initialization by checking whether the lightweight
+        // shader pre-warm has run. GlassEffect.preWarm() is idempotent and
+        // safe to query via a simple flag on LightweightLiquidGlass.
+        // For now we rely on kDebugMode + the absence of pre-warm output.
+        // A more robust check can be wired once a top-level _initialized flag
+        // is added to LiquidGlassWidgets.
+      }
+      return true;
+    }());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Read the adaptive quality ceiling. Only used to gate the expensive
+    // background texture capture — rendering quality per-widget is handled
+    // automatically by GlassThemeHelpers.resolveQuality() inside each widget.
+    final quality = GlassAdaptiveScopeData.maybeOf(context)?.effectiveQuality ??
+        GlassQuality.premium;
+
+    final bool doSample = _effectiveSampling && quality != GlassQuality.minimal;
+
+    Widget content = LiquidGlassScope(
+      child: Stack(
+        children: [
+          // 1. Background layer — only rendered when a background is provided.
+          if (widget.background != null)
+            Positioned.fill(
+              child: GlassBackgroundSource(
+                enabled: doSample,
+                child: widget.background!,
+              ),
+            ),
+
+          // 2. Content layer.
+          // When background is provided: force transparent Scaffold so the
+          // wallpaper shows through.
+          // When no background: leave Scaffold colour alone — it renders with
+          // its own backgroundColor as the developer set it.
+          //
+          // The AdaptiveLiquidGlassLayer provides the LiquidGlassRenderScope
+          // that all glass widgets (GlassAppBar, GlassButton, GlassCard, etc.)
+          // need to render. Without it, using any glass widget inside a
+          // Scaffold's appBar slot would crash with "No liquid glass renderer
+          // found in context". Settings and quality resolve from GlassTheme
+          // automatically; individual widgets override via their own `settings`
+          // parameter.
+          Positioned.fill(
+            child: AdaptiveLiquidGlassLayer(
+              settings: widget.settings,
+              child: widget.background != null
+                  ? Builder(
+                      builder: (context) {
+                        // Make the scaffold background transparent so the
+                        // glass layer shows through. Use MaterialLocalizations
+                        // presence to guard against pure CupertinoApp hosts
+                        // which have no Material Theme in scope.
+                        final hasMaterial =
+                            Localizations.of<MaterialLocalizations>(
+                                  context,
+                                  MaterialLocalizations,
+                                ) !=
+                                null;
+                        final child = widget.child;
+                        if (!hasMaterial) return child;
+                        return Theme(
+                          data: Theme.of(context).copyWith(
+                            scaffoldBackgroundColor:
+                                const Color(0x00000000), // transparent
+                          ),
+                          child: child,
+                        );
+                      },
+                    )
+                  : widget.child,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    // Wrap in a scoped GlassTheme override if the caller provided one.
+    // This is the "special page" escape hatch — one level below app theme,
+    // one level above individual widget settings.
+    if (widget.themeOverride != null) {
+      content = GlassTheme(
+        data: widget.themeOverride!,
+        child: content,
+      );
+    }
+
+    // Wrap in AnnotatedRegion so the status bar style sticks even on
+    // routes where a parent Scaffold's own AnnotatedRegion would otherwise
+    // override our imperative SystemChrome.setSystemUIOverlayStyle() call.
+    if (widget.statusBarStyle != GlassStatusBarStyle.none) {
+      final Brightness brightness = MediaQuery.platformBrightnessOf(context);
+      final bool isDark = brightness == Brightness.dark;
+      final bool useLightIcons = switch (widget.statusBarStyle) {
+        GlassStatusBarStyle.light => true,
+        GlassStatusBarStyle.dark => false,
+        GlassStatusBarStyle.auto => isDark,
+        GlassStatusBarStyle.none => false,
+      };
+      content = AnnotatedRegion<SystemUiOverlayStyle>(
+        value: useLightIcons
+            ? SystemUiOverlayStyle.light
+            : SystemUiOverlayStyle.dark,
+        child: content,
+      );
+    }
+
+    return content;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/glass_scroll_edge_effect.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/glass_scroll_edge_effect.dart
@@ -1,0 +1,448 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+
+import '../interactive/liquid_glass_scope.dart';
+
+/// Edge effect style matching iOS 26's `.scrollEdgeEffectStyle`.
+///
+/// Controls how scroll content fades at the edges when it meets a glass
+/// surface (navigation bar, bottom bar, etc.).
+enum GlassScrollEdgeStyle {
+  /// A rounded, diffused fade — content dissolves smoothly into the bar area.
+  ///
+  /// Matches iOS 26's `.soft` edge effect style. This is the default and is
+  /// ideal for most list/scroll views with transparent navigation bars.
+  soft,
+
+  /// A crisp boundary — content has a sharper cutoff at the bar edge.
+  ///
+  /// Matches iOS 26's `.hard` edge effect style. Useful when you want a
+  /// clear visual separation between the bar and content.
+  hard,
+}
+
+/// A widget that fades scroll content at the top and/or bottom edges.
+///
+/// Matches iOS 26's `.scrollEdgeEffectStyle(_:for:)` modifier. Places gradient
+/// overlays at the specified edges, creating the effect of content dissolving
+/// into navigation bars or bottom bars rather than clipping sharply.
+///
+/// ## How it works
+///
+/// **Inside [GlassPage]** (recommended): Automatically captures the page's
+/// background texture and paints it over the scroll edges with a gradient
+/// alpha mask. This produces a pixel-perfect fade for ANY background —
+/// images, patterns, mesh gradients, anything. No configuration needed.
+///
+/// **Outside [GlassPage]**: Falls back to a solid-colour gradient overlay
+/// using [fadeColor] (or the scaffold background colour from the theme).
+/// Works perfectly for solid-colour and simple gradient backgrounds.
+///
+/// ## Why not ShaderMask?
+///
+/// `ShaderMask(blendMode: BlendMode.dstIn)` creates a `saveLayer` that
+/// breaks `BackdropFilterLayer` (premium glass) on Impeller — glass widgets
+/// inside it render as opaque black because `BackdropFilterLayer` samples an
+/// empty backdrop within the `saveLayer` boundary. This widget avoids that
+/// by placing overlays ON TOP of the content rather than wrapping it.
+///
+/// ## Usage
+///
+/// ```dart
+/// GlassScrollEdgeEffect(
+///   topFadeHeight: 100,
+///   bottomFadeHeight: 80,
+///   child: ListView.builder(
+///     itemBuilder: (_, i) => ListTile(title: Text('Item $i')),
+///   ),
+/// )
+/// ```
+///
+/// ## With GlassAppBar
+///
+/// ```dart
+/// Scaffold(
+///   extendBodyBehindAppBar: true,
+///   appBar: GlassAppBar(title: Text('Messages')),
+///   body: GlassScrollEdgeEffect(
+///     topFadeHeight: MediaQuery.paddingOf(context).top + 44 + 50,
+///     bottomFadeHeight: 60 + MediaQuery.paddingOf(context).bottom,
+///     child: ListView(...),
+///   ),
+/// )
+/// ```
+///
+/// The [topFadeHeight] should typically cover the safe area + app bar height
+/// + a buffer zone so content fades before reaching the navigation buttons.
+class GlassScrollEdgeEffect extends StatefulWidget {
+  /// Creates a scroll edge effect that fades content at the edges.
+  ///
+  /// When used inside a [GlassPage] with a background widget, the fade
+  /// automatically uses the page's background texture for a pixel-perfect
+  /// effect. No [fadeColor] is needed.
+  ///
+  /// When used outside [GlassPage], provide [fadeColor] to match your
+  /// background, or let it default to the scaffold background colour.
+  const GlassScrollEdgeEffect({
+    super.key,
+    required this.child,
+    this.topFadeHeight = 100.0,
+    this.bottomFadeHeight = 60.0,
+    this.fadeTop = true,
+    this.fadeBottom = true,
+    this.style = GlassScrollEdgeStyle.soft,
+    this.fadeColor,
+  });
+
+  /// The scrollable content to apply edge fading to.
+  final Widget child;
+
+  /// The height of the top fade zone in logical pixels.
+  ///
+  /// Content within this zone fades from fully transparent (at the top edge)
+  /// to fully visible. Should cover the safe area + navigation bar height +
+  /// a buffer zone.
+  ///
+  /// Defaults to 100.0.
+  final double topFadeHeight;
+
+  /// The height of the bottom fade zone in logical pixels.
+  ///
+  /// Content within this zone fades from fully visible to fully transparent
+  /// (at the bottom edge). Should cover the bottom bar height + safe area.
+  ///
+  /// Defaults to 60.0.
+  final double bottomFadeHeight;
+
+  /// Whether to fade content at the top edge.
+  ///
+  /// Defaults to true.
+  final bool fadeTop;
+
+  /// Whether to fade content at the bottom edge.
+  ///
+  /// Defaults to true.
+  final bool fadeBottom;
+
+  /// The edge effect style.
+  ///
+  /// [GlassScrollEdgeStyle.soft] produces a gradual, diffused fade (default).
+  /// [GlassScrollEdgeStyle.hard] produces a sharper cutoff.
+  ///
+  /// Matches iOS 26's `.scrollEdgeEffectStyle(.soft/.hard, for: .top)`.
+  final GlassScrollEdgeStyle style;
+
+  /// Fallback colour used when no background texture is available.
+  ///
+  /// This is only used outside [GlassPage] (i.e. when there is no
+  /// [LiquidGlassScope] ancestor providing a background texture).
+  ///
+  /// When `null`, falls back to the scaffold background colour from the
+  /// current theme.
+  final Color? fadeColor;
+
+  @override
+  State<GlassScrollEdgeEffect> createState() => _GlassScrollEdgeEffectState();
+}
+
+class _GlassScrollEdgeEffectState extends State<GlassScrollEdgeEffect> {
+  GlobalKey? _backgroundKey;
+  ui.Image? _backgroundImage;
+  bool _hasAttemptedCapture = false;
+  bool _capturePending = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _backgroundKey = LiquidGlassScope.of(context);
+
+    // Defer capture to after paint. On first mount, toImage() requires a
+    // composited OffsetLayer which isn't assigned until paint completes.
+    // On subsequent calls (theme toggle, route change), the new background
+    // won't paint until end-of-frame either. Both cases need deferral.
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _captureBackground();
+    });
+  }
+
+  void _captureBackground() {
+    if (_backgroundKey == null) {
+      _hasAttemptedCapture = true;
+      return;
+    }
+
+    final boundary = _backgroundKey!.currentContext?.findRenderObject()
+        as RenderRepaintBoundary?;
+
+    if (boundary == null || !boundary.hasSize || boundary.size.isEmpty) {
+      // Boundary not ready yet — retry after the first frame.
+      if (!_hasAttemptedCapture) {
+        _hasAttemptedCapture = true;
+        SchedulerBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _captureBackground();
+        });
+      }
+      return;
+    }
+
+    _hasAttemptedCapture = true;
+
+    // In debug mode, toImageSync asserts if the boundary is marked as needing paint.
+    // If it needs paint, wait for the next frame.
+    bool needsPaint = false;
+    assert(() {
+      needsPaint = boundary.debugNeedsPaint;
+      return true;
+    }());
+
+    if (needsPaint) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _captureBackground();
+      });
+      return;
+    }
+
+    if (_capturePending) return; // Already in-flight — don't stack captures.
+    _capturePending = true;
+    try {
+      boundary.toImage(pixelRatio: 1.0).then((image) {
+        _capturePending = false;
+        if (!mounted) {
+          image.dispose();
+          return;
+        }
+        _backgroundImage?.dispose();
+        _backgroundImage = image;
+        setState(() {});
+      }).catchError((_) {
+        _capturePending = false;
+      });
+    } on Object {
+      // toImage() can throw synchronously if `layer` is still null
+      // (paint has not completed). Reset the flag and fall back to
+      // the solid-colour gradient overlay.
+      _capturePending = false;
+    }
+  }
+
+  @override
+  void dispose() {
+    _backgroundImage?.dispose();
+    _backgroundImage = null;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // No fading needed — return child directly.
+    if (!widget.fadeTop && !widget.fadeBottom) return widget.child;
+
+    final screenSize = MediaQuery.sizeOf(context);
+    final hasTexture = _backgroundImage != null;
+
+    return Stack(
+      children: [
+        // 1. Scroll content — no compositing layer wrapping it.
+        widget.child,
+
+        // 2. Top fade overlay.
+        if (widget.fadeTop)
+          _buildOverlay(
+            isTop: true,
+            height: _effectiveHeight(widget.topFadeHeight, screenSize.height),
+            screenSize: screenSize,
+            hasTexture: hasTexture,
+          ),
+
+        // 3. Bottom fade overlay.
+        if (widget.fadeBottom)
+          _buildOverlay(
+            isTop: false,
+            height:
+                _effectiveHeight(widget.bottomFadeHeight, screenSize.height),
+            screenSize: screenSize,
+            hasTexture: hasTexture,
+          ),
+      ],
+    );
+  }
+
+  Widget _buildOverlay({
+    required bool isTop,
+    required double height,
+    required Size screenSize,
+    required bool hasTexture,
+  }) {
+    return Positioned(
+      top: isTop ? 0 : null,
+      bottom: isTop ? null : 0,
+      left: 0,
+      right: 0,
+      height: height,
+      child: IgnorePointer(
+        child: hasTexture
+            ? CustomPaint(
+                size: Size(screenSize.width, height),
+                painter: _TextureFadePainter(
+                  image: _backgroundImage!,
+                  isTop: isTop,
+                  screenHeight: screenSize.height,
+                  style: widget.style,
+                ),
+              )
+            : _buildColorOverlay(isTop: isTop),
+      ),
+    );
+  }
+
+  /// Fallback: solid-colour gradient overlay for use outside [GlassPage].
+  Widget _buildColorOverlay({required bool isTop}) {
+    final color =
+        widget.fadeColor ?? CupertinoTheme.of(context).scaffoldBackgroundColor;
+    final curve = _kFadeCurves[widget.style]!;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: isTop ? Alignment.topCenter : Alignment.bottomCenter,
+          end: isTop ? Alignment.bottomCenter : Alignment.topCenter,
+          colors: curve.alphas
+              .map((a) => color.withValues(alpha: color.a * a))
+              .toList(),
+          stops: curve.stops,
+        ),
+      ),
+    );
+  }
+
+  double _effectiveHeight(double height, double boundsHeight) {
+    // Hard style uses a tighter transition zone (half of soft) combined with
+    // a steeper gradient curve — so it's a different *shape*, not just a
+    // compressed version of soft.
+    final adjusted =
+        widget.style == GlassScrollEdgeStyle.hard ? height * 0.5 : height;
+    // Clamp to 40% of available height to avoid overlapping zones.
+    return adjusted.clamp(0.0, boundsHeight * 0.4);
+  }
+}
+
+/// Pre-computed gradient curves for each [GlassScrollEdgeStyle].
+///
+/// Each curve defines the alpha values and corresponding stops for a
+/// multi-stop gradient that produces a perceptually smooth fade. A simple
+/// 2-stop linear ramp (the previous implementation) appears non-uniform to
+/// the human eye — denser in the middle — and terminates with a visible seam.
+///
+/// These curves are modelled after iOS 26's scroll edge effect:
+/// - **Soft**: gentle ease-in dissolve with a long transparent tail, producing
+///   a diffused fade that dissolves content smoothly into the bar area.
+/// - **Hard**: holds opacity longer then drops sharply, but still includes a
+///   feathered tail to avoid the hard cutoff seam.
+class _FadeCurve {
+  const _FadeCurve(this.alphas, this.stops);
+
+  /// Alpha multipliers from edge (1.0 = fully opaque) to content (0.0).
+  final List<double> alphas;
+
+  /// Corresponding gradient stop positions in [0, 1].
+  final List<double> stops;
+}
+
+const Map<GlassScrollEdgeStyle, _FadeCurve> _kFadeCurves = {
+  // Soft: gentle ease-in dissolve. Holds opacity briefly at the edge, then
+  // accelerates through the mid-range, and includes a long low-alpha tail
+  // that reaches fully transparent well before the overlay boundary —
+  // eliminating the visible seam.
+  GlassScrollEdgeStyle.soft: _FadeCurve(
+    [1.0, 0.70, 0.30, 0.04, 0.0],
+    [0.0, 0.15, 0.45, 0.75, 0.92],
+  ),
+  // Hard: crisp but feathered. Stays opaque for longer (the "hard" feel),
+  // then drops more steeply, but still includes a tail to prevent seaming.
+  // Combined with the 0.5× height multiplier in _effectiveHeight, this
+  // produces a noticeably crisper boundary than soft without a sharp line.
+  GlassScrollEdgeStyle.hard: _FadeCurve(
+    [1.0, 0.90, 0.50, 0.04, 0.0],
+    [0.0, 0.30, 0.60, 0.85, 0.95],
+  ),
+};
+
+/// Paints a slice of the background texture with a gradient alpha mask.
+///
+/// This is the core of the texture overlay approach: it takes the background
+/// image captured by [GlassBackgroundSource], extracts the top or bottom
+/// strip, and paints it with a gradient from fully opaque (at the edge) to
+/// fully transparent (towards the content). Visually, this is identical to
+/// fading the content to transparent and revealing the background.
+///
+/// Uses [BlendMode.dstIn] inside a [Canvas.saveLayer] to apply the gradient
+/// mask. Since this painter only draws a static image (no [BackdropFilterLayer]),
+/// the `saveLayer` is safe and does not interfere with glass rendering.
+class _TextureFadePainter extends CustomPainter {
+  _TextureFadePainter({
+    required this.image,
+    required this.isTop,
+    required this.screenHeight,
+    required this.style,
+  });
+
+  final ui.Image image;
+  final bool isTop;
+  final double screenHeight;
+  final GlassScrollEdgeStyle style;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (size.isEmpty) return;
+
+    // The image is captured at pixelRatio: 1.0, so its pixel dimensions
+    // match logical dimensions. Calculate the source strip from the
+    // corresponding edge of the background.
+    final double scaleY = image.height / screenHeight;
+
+    final Rect srcRect = isTop
+        ? Rect.fromLTWH(0, 0, image.width.toDouble(), size.height * scaleY)
+        : Rect.fromLTWH(
+            0,
+            image.height - size.height * scaleY,
+            image.width.toDouble(),
+            size.height * scaleY,
+          );
+
+    final Rect dstRect = Offset.zero & size;
+
+    // Paint the background strip with gradient alpha.
+    // saveLayer is safe here — no BackdropFilterLayer inside.
+    canvas.saveLayer(dstRect, Paint());
+
+    // Draw the background texture slice.
+    canvas.drawImageRect(image, srcRect, dstRect, Paint());
+
+    // Apply gradient alpha mask: opaque at the edge, transparent towards
+    // the content. Uses a multi-stop eased gradient to produce a
+    // perceptually smooth fade without a visible seam at the boundary.
+    final curve = _kFadeCurves[style]!;
+    final gradientPaint = Paint()
+      ..blendMode = BlendMode.dstIn
+      ..shader = LinearGradient(
+        begin: isTop ? Alignment.topCenter : Alignment.bottomCenter,
+        end: isTop ? Alignment.bottomCenter : Alignment.topCenter,
+        colors: curve.alphas
+            .map((a) => Color.fromARGB((a * 255).round(), 0, 0, 0))
+            .toList(),
+        stops: curve.stops,
+      ).createShader(dstRect);
+
+    canvas.drawRect(dstRect, gradientPaint);
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(_TextureFadePainter oldDelegate) =>
+      image != oldDelegate.image ||
+      isTop != oldDelegate.isTop ||
+      screenHeight != oldDelegate.screenHeight ||
+      style != oldDelegate.style;
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/inherited_liquid_glass.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/inherited_liquid_glass.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/widgets.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../liquid_glass_setup.dart';
+import '../../types/glass_quality.dart';
+
+/// A custom inherited widget that provides [LiquidGlassSettings] to descendants.
+///
+/// This is used by [AdaptiveLiquidGlassLayer] to ensure that settings are
+/// passed down to children even when the underlying renderer is using a
+/// fallback implementation (like `LightweightLiquidGlass` on Skia/Web) that
+/// might not have its own inherited widget provider exposed.
+class InheritedLiquidGlass extends InheritedWidget {
+  /// Creates an inherited widget that holds [LiquidGlassSettings].
+  const InheritedLiquidGlass({
+    required this.settings,
+    this.quality = GlassQuality.standard,
+    this.isBlurProvidedByAncestor = false,
+    this.avoidsRefraction = false,
+    required super.child,
+    super.key,
+  });
+
+  /// The glass settings to share with the subtree.
+  final LiquidGlassSettings settings;
+
+  /// The rendering quality to share with the subtree.
+  final GlassQuality quality;
+
+  /// Whether a parent layer is already providing the backdrop blur.
+  /// Used for performance optimization to avoid redundant BackdropFilters.
+  final bool isBlurProvidedByAncestor;
+
+  /// Whether children should avoid high-fidelity refraction.
+  /// Set to true by containers like GlassCard to prevent refraction artifacts
+  /// when glass is nested within glass.
+  final bool avoidsRefraction;
+
+  /// Retrieves the nearest [LiquidGlassSettings] from the ancestor tree.
+  ///
+  /// This checks for [InheritedLiquidGlass] first. If not found, it attempts
+  /// to look up `LiquidGlassSettings.of(context)` from the renderer package
+  /// to maintain compatibility with standard `LiquidGlassLayer` usage.
+  static LiquidGlassSettings? of(BuildContext context) {
+    final inherited =
+        context.dependOnInheritedWidgetOfExactType<InheritedLiquidGlass>();
+    if (inherited != null) {
+      return inherited.settings;
+    }
+
+    // Fallback to the renderer's provider if available
+    try {
+      return LiquidGlassSettings.of(context);
+    } catch (_) {
+      // LiquidGlassSettings.of() might throw or return default if not found,
+      // dependent on implementation. We return null if we can't find it.
+      return null;
+    }
+  }
+
+  /// Retrieves the [LiquidGlassSettings] from the ancestor tree, falling back to
+  /// [LiquidGlassWidgets.globalSettings] or a default instance if none is found.
+  static LiquidGlassSettings ofOrDefault(BuildContext context) {
+    return of(context) ??
+        LiquidGlassWidgets.globalSettings ??
+        const LiquidGlassSettings();
+  }
+
+  @override
+  bool updateShouldNotify(InheritedLiquidGlass oldWidget) {
+    return settings != oldWidget.settings ||
+        quality != oldWidget.quality ||
+        isBlurProvidedByAncestor != oldWidget.isBlurProvidedByAncestor ||
+        avoidsRefraction != oldWidget.avoidsRefraction;
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/lightweight_liquid_glass.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/lightweight_liquid_glass.dart
@@ -1,0 +1,1052 @@
+// ignore_for_file: require_trailing_commas
+
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import 'inherited_liquid_glass.dart';
+import 'liquid_shape_shader_geometry.dart';
+
+/// Returns the [RenderRepaintBoundary] for [key] only when it is fully safe
+/// to use — the element must be *active* and the render object *attached*.
+///
+/// [BuildContext.mounted] is insufficient: it returns `true` for *inactive*
+/// elements (lifecycle state = `inactive`). The assert inside
+/// [Element.findRenderObject] fires on `inactive`, not just `defunct`.
+/// A try-catch is the only public-API-safe guard against this.
+///
+/// Used by both [_LightweightGlassEffectState] (Ticker) and
+/// [_RenderLightweightGlass] (paint) to avoid crashing when
+/// [GlassBackgroundSource.enabled] is toggled mid-frame.
+RenderRepaintBoundary? _safeGetBoundary(GlobalKey? key) {
+  if (key == null) return null;
+  final ctx = key.currentContext;
+  if (ctx == null) return null;
+  try {
+    final obj = ctx.findRenderObject();
+    if (obj is RenderRepaintBoundary && obj.attached) return obj;
+  } catch (_) {
+    // Element is transitioning through an inactive lifecycle state.
+    // Skip this frame — the Ticker will retry on the next frame.
+  }
+  return null;
+}
+
+/// A lightweight, high-performance glass effect widget optimized for
+/// scrollable lists and universal platform compatibility.
+///
+/// This widget uses a custom fragment shader to achieve iOS 26 liquid glass
+/// aesthetics while being 5-10x faster than BackdropFilter-based approaches.
+///
+/// **Lightweight-Specific Parameters:**
+/// - [glowIntensity]: Interactive glow strength (0.0-1.0, button press feedback)
+/// - [densityFactor]: Elevation physics (0.0-1.0, simulates nested blur darkening)
+///
+/// These parameters are only used by the lightweight shader (Skia/Web).
+/// On Impeller, glow is handled by [GlassGlow] widget and density is not needed.
+class LightweightLiquidGlass extends StatefulWidget {
+  /// Creates a lightweight liquid glass effect widget.
+  const LightweightLiquidGlass({
+    required this.child,
+    required this.shape,
+    this.settings = const LiquidGlassSettings(),
+    this.glowIntensity = 0.0,
+    this.densityFactor = 0.0,
+    this.indicatorWeight = 0.0,
+    this.backgroundKey,
+    super.key,
+  });
+
+  /// Creates a lightweight glass widget that inherits settings from the
+  /// nearest ancestor [LiquidGlassLayer].
+  const LightweightLiquidGlass.inLayer({
+    required this.child,
+    required this.shape,
+    this.glowIntensity = 0.0,
+    this.densityFactor = 0.0,
+    this.indicatorWeight = 0.0,
+    this.backgroundKey,
+    super.key,
+  }) : settings = null;
+
+  /// The widget to display inside the glass effect.
+  final Widget child;
+
+  /// The shape of the glass surface.
+  final LiquidShape shape;
+
+  /// The glass effect settings.
+  final LiquidGlassSettings? settings;
+
+  /// Interactive glow intensity for button press feedback (Skia/Web only).
+  ///
+  /// Range: 0.0 (no glow) to 1.0 (full glow)
+  ///
+  /// On Impeller, use [GlassGlow] widget instead. This parameter is ignored.
+  /// On Skia/Web, this controls shader-based glow effect.
+  ///
+  /// Defaults to 0.0.
+  final double glowIntensity;
+
+  /// Density factor for elevation physics (Skia/Web only).
+  ///
+  /// Range: 0.0 (normal) to 1.0 (fully elevated)
+  ///
+  /// When a parent container provides blur (batch-blur optimization), elevated
+  /// buttons use this to simulate the "double-darkening" effect of nested
+  /// BackdropFilters without the O(n) performance cost.
+  ///
+  /// On Impeller, this is not needed as each widget can have its own blur.
+  ///
+  /// Defaults to 0.0.
+  final double densityFactor;
+
+  /// Thicker, brighter aesthetic for indicators (Skia/Web only).
+  ///
+  /// Range: 0.0 (default) to 1.0 (thick/bright)
+  ///
+  /// This allows active indicators (like the pill in GlassSegmentedControl) to
+  /// have more visual weight without affecting other glass widgets.
+  final double indicatorWeight;
+
+  /// Optional background capture key.
+  final GlobalKey? backgroundKey;
+
+  // Cache the FragmentProgram (compiled shader code) globally
+  static ui.FragmentProgram? _cachedProgram;
+  static bool _isPreparing = false;
+
+  // On native: Share one shader instance (efficient)
+  // On web: Each widget needs its own instance (CanvasKit requirement)
+  static ui.FragmentShader? _sharedShader; // Native only
+
+  // Dummy 1x1 transparent image for when no background is captured
+  static ui.Image? _dummyImage;
+
+  /// Resets static shader state for testing. Call between tests to ensure
+  /// each test gets the fallback rendering (no cached shader).
+  @visibleForTesting
+  static void resetForTesting() {
+    _cachedProgram = null;
+    _sharedShader = null;
+    _isPreparing = false;
+    _dummyImage?.dispose();
+    _dummyImage = null;
+  }
+
+  /// Global pre-warm method - loads and compiles the shader program.
+  static Future<void> preWarm() async {
+    if (_cachedProgram != null || _isPreparing) return;
+    _isPreparing = true;
+    const path = 'packages/liquid_glass_widgets/shaders/lightweight_glass.frag';
+    const testPath = 'shaders/lightweight_glass.frag';
+
+    try {
+      ui.FragmentProgram program;
+      try {
+        program = await ui.FragmentProgram.fromAsset(path);
+      } catch (_) {
+        // Fallback for unit tests where package prefix may not be resolved
+        program = await ui.FragmentProgram.fromAsset(testPath);
+      }
+      // Allocate the dummy image only after program load succeeds — avoids
+      // leaking a GPU allocation when the shader fails to compile.
+      final recorder = ui.PictureRecorder();
+      ui.Canvas(recorder);
+      _dummyImage = recorder.endRecording().toImageSync(1, 1);
+      _cachedProgram = program;
+
+      // On native platforms, create the shared shader instance
+      if (!kIsWeb) {
+        _sharedShader = program.fragmentShader();
+      }
+    } catch (e) {
+      debugPrint('[LightweightGlass] Pre-warm failed: $e');
+    } finally {
+      _isPreparing = false;
+    }
+  }
+
+  @override
+  State<LightweightLiquidGlass> createState() => _LightweightLiquidGlassState();
+}
+
+class _LightweightLiquidGlassState extends State<LightweightLiquidGlass>
+    with SingleTickerProviderStateMixin, WidgetsBindingObserver {
+  ui.FragmentShader? _webShader; // Web only: per-widget instance
+  bool _isDisposed = false;
+  bool _loggedCreation = false;
+  ui.Image? _backgroundImage;
+
+  // Ticker-driven background refresh (same proven pattern as GlassEffect).
+  // Fires every frame while a backgroundKey is active; stops automatically
+  // when no key is present — zero overhead for glass widgets without a background.
+  late final Ticker _ticker;
+  Size? _lastCaptureSize;
+  Offset? _lastCapturePosition;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _initShader();
+    _ticker = createTicker(_handleTick);
+    // Defer ticker start until after first frame so the RepaintBoundary is laid out.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _updateTicker();
+    });
+  }
+
+  /// Start the ticker if a live RepaintBoundary is available for sampling.
+  ///
+  /// Checks the key's context directly so that a non-null key with no
+  /// attached [RepaintBoundary] does NOT start the ticker.
+  void _updateTicker() {
+    // A key that exists but has no attached RepaintBoundary (enabled:false)
+    // must not start the ticker — treat it the same as a null key.
+    final bool hasBoundary = _safeGetBoundary(widget.backgroundKey) != null;
+
+    if (hasBoundary && !_ticker.isActive) {
+      _stableFrameCount = 0; // Reset so auto-suspend counts from scratch.
+      _ticker.start();
+    } else if (!hasBoundary && _ticker.isActive) {
+      _ticker.stop();
+      _stableFrameCount = 0;
+      _backgroundImage?.dispose();
+      _backgroundImage = null;
+      // Propagate null to the render object immediately so it doesn't paint
+      // with a disposed image if a repaint is triggered before the next tick.
+      if (mounted) setState(() {});
+    }
+  }
+
+  /// Called every frame by the ticker. Captures the background only when
+  /// something has actually changed — size, position, or first capture.
+  ///
+  /// Self-corrects if the boundary disappears at runtime (e.g. adaptive
+  /// quality drops to minimal mid-session): stops the ticker immediately
+  /// rather than spinning empty for the rest of the widget's lifetime.
+  ///
+  /// **Battery optimization (Task 2.2):** After [_kStableFrameThreshold]
+  /// consecutive ticks detect no geometry change, the ticker self-suspends.
+  /// This eliminates the permanent 60 fps cost for static surfaces (bottom
+  /// bars, app bars) where the background never changes after initial capture.
+  /// The ticker restarts automatically via [didUpdateWidget] or
+  /// [_updateTicker] when the background key changes or is re-enabled.
+  static const int _kStableFrameThreshold = 3;
+  int _stableFrameCount = 0;
+
+  void _handleTick(Duration _) {
+    if (_isDisposed) return; // belt-and-suspenders: post-frame callbacks can
+    // outlive dispose() on rapid navigation; bail out before any GPU access.
+    final key = widget.backgroundKey;
+    if (key == null) return;
+
+    final renderObject = _safeGetBoundary(key);
+    if (renderObject == null) {
+      // The boundary was removed (e.g. background sampling was disabled at
+      // runtime). Stop the ticker immediately — zero cost from this point on.
+      if (_ticker.isActive) {
+        _ticker.stop();
+        _backgroundImage?.dispose();
+        _backgroundImage = null;
+        _stableFrameCount = 0;
+        // Propagate null to the render object immediately — prevents the
+        // "Image has been disposed" crash if a repaint fires before the next
+        // frame (e.g. button press animation triggering a paint pass).
+        if (mounted) setState(() {});
+      }
+      return;
+    }
+    final boundary = renderObject;
+
+    // debugNeedsPaint is a debug-only late getter — crashes in profile/release.
+    // Guard it behind assert() and use the captured local outside.
+    bool needsPaint = false;
+    assert(() {
+      needsPaint = boundary.debugNeedsPaint;
+      return true;
+    }());
+    if (needsPaint) return;
+
+    final currentSize = boundary.size;
+    final currentPos = (boundary as RenderBox).localToGlobal(Offset.zero);
+
+    // Only re-capture when geometry changes or on first capture.
+    // toImageSync is synchronous and stays in GPU memory — cheap but not free.
+    final bool needsCapture = _backgroundImage == null ||
+        _lastCaptureSize != currentSize ||
+        _lastCapturePosition != currentPos;
+
+    if (needsCapture) {
+      _stableFrameCount = 0;
+      _captureBackground(boundary, currentSize, currentPos);
+    } else {
+      // Background hasn't changed — count consecutive stable frames.
+      // After _kStableFrameThreshold (~50 ms at 60 fps), self-suspend the
+      // ticker. This saves battery on static surfaces (bottom bars, app bars)
+      // where the background never changes after initial capture.
+      _stableFrameCount++;
+      if (_stableFrameCount >= _kStableFrameThreshold && _ticker.isActive) {
+        _ticker.stop();
+      }
+    }
+  }
+
+  // Guard: prevents concurrent async captures from stacking up.
+  // Only one toImage() call can be in-flight at a time.
+  bool _capturePending = false;
+
+  /// Initiates an async background capture via [RenderRepaintBoundary.toImage].
+  ///
+  /// Using [toImage] (Future-based) instead of [toImageSync] is critical:
+  /// [toImage] resolves AFTER the GPU compositor has flushed the current frame,
+  /// guaranteeing valid pixel content. [toImageSync] races the GPU and returns
+  /// an all-black image on the first frame, causing the "black on first load" bug.
+  ///
+  /// The [_capturePending] flag prevents concurrent captures from stacking up
+  /// when the ticker fires multiple times before the first capture completes.
+  void _captureBackground(
+      RenderRepaintBoundary boundary, Size size, Offset pos) {
+    if (_capturePending) return; // Already capturing — wait for it to finish.
+    _capturePending = true;
+    boundary.toImage(pixelRatio: 1.0).then((image) {
+      if (!mounted || _isDisposed) {
+        image.dispose();
+        _capturePending = false;
+        return;
+      }
+      _backgroundImage?.dispose();
+      _backgroundImage = image;
+      _lastCaptureSize = size;
+      _lastCapturePosition = pos;
+      _capturePending = false;
+      setState(() {});
+    }).catchError((_) {
+      // toImage can fail transiently (e.g. widget detached mid-capture).
+      // Clear the flag so the ticker will retry on the next frame.
+      _capturePending = false;
+    });
+  }
+
+  @override
+  void didUpdateWidget(LightweightLiquidGlass oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.backgroundKey != oldWidget.backgroundKey) {
+      // Key object changed — update immediately.
+      _updateTicker();
+    } else if (widget.backgroundKey != null && !_ticker.isActive) {
+      // Same key object but ticker is stopped. The RepaintBoundary may have
+      // been re-added to the tree (e.g. GlassBackgroundSource re-enabled via
+      // the BG Sample toggle). Schedule a post-frame check so the boundary
+      // is guaranteed to be mounted and the GlobalKey registered before we
+      // attempt to restart the Ticker.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _updateTicker();
+      });
+    }
+  }
+
+  /// Halts background-capture Tickers during app lifecycle transitions.
+  ///
+  /// Stopping captures on [AppLifecycleState.inactive] / [paused] prevents
+  /// GPU texture creation/destruction from racing with [surfaceChanged] on
+  /// the raster thread — the root cause of the ANR observed on Vulkan devices.
+  /// Captures restart one frame after [resumed] to let the new surface
+  /// stabilise before any [toImage] calls.
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.paused:
+      case AppLifecycleState.hidden:
+        if (_ticker.isActive) _ticker.stop();
+        break;
+      case AppLifecycleState.resumed:
+        // Restart one frame after resume so surfaceChanged has completed
+        // and the raster thread is not holding any surface locks.
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && !_isDisposed) _updateTicker();
+        });
+        break;
+      case AppLifecycleState.detached:
+        break;
+    }
+  }
+
+  Future<void> _initShader() async {
+    // Ensure program is loaded
+    if (LightweightLiquidGlass._cachedProgram == null) {
+      await LightweightLiquidGlass.preWarm();
+    }
+
+    // On web, create a per-widget shader instance
+    if (kIsWeb && LightweightLiquidGlass._cachedProgram != null) {
+      if (mounted) {
+        setState(() {
+          _webShader = LightweightLiquidGlass._cachedProgram!.fragmentShader();
+          if (!_loggedCreation) {
+            debugPrint(
+                '[LightweightGlass] ✓ Created web shader for ${widget.shape.runtimeType}');
+            _loggedCreation = true;
+          }
+        });
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    WidgetsBinding.instance.removeObserver(this);
+    _ticker.dispose();
+    // Null backgroundImage BEFORE disposing the shader to break the GPU
+    // texture retention chain during isolate shutdown on Mali GPUs.
+    _backgroundImage?.dispose();
+    _backgroundImage = null;
+    // On web, dispose this widget's shader instance
+    if (kIsWeb && _webShader != null) {
+      _webShader!.dispose();
+      _webShader = null;
+    }
+    // Never dispose the shared shader on native
+    super.dispose();
+  }
+
+  ui.FragmentShader? get _activeShader {
+    return kIsWeb ? _webShader : LightweightLiquidGlass._sharedShader;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final inherited =
+        context.dependOnInheritedWidgetOfExactType<InheritedLiquidGlass>();
+    final settings =
+        widget.settings ?? inherited?.settings ?? const LiquidGlassSettings();
+    final shader = _activeShader;
+
+    // Optimization: Skip local blur if provided by ancestor and settings match
+    final bool skipBlur = (inherited?.isBlurProvidedByAncestor ?? false) &&
+        (widget.settings == null ||
+            widget.settings?.blur == inherited?.settings.blur);
+
+    // VQ4: Content-adaptive glass strength proxy.
+    // The lightweight shader has no backdrop texture, so platform brightness
+    // is used as the luma estimate — dark mode → richer glass (0.15),
+    // light mode → subtler glass (0.85). Maps to adaptiveStrength [1.2, 0.8]
+    // in the shader, matching iOS 26's adaptive material behaviour.
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final backdropLuma = isDark ? 0.15 : 0.85;
+
+    // IMPORTANT — always return the same widget tree structure regardless of
+    // whether the shader is loaded yet.
+    //
+    // Previously, a null shader caused an early return of
+    // `ClipPath → Container → child`. Once the shader loaded and `setState`
+    // fired, the build switched to `ClipPath → _LightweightGlassEffect → child`.
+    // Flutter saw a type change at the same slot (Container ≠
+    // _LightweightGlassEffect) and tore down the entire subtree, calling
+    // `initState` on every descendant StatefulWidget. This broke scroll
+    // positions, controllers, and any user State inside the glass surface.
+    //
+    // Fix: pass the (nullable) shader directly to _LightweightGlassEffect.
+    // The render object detects a null shader and paints a tinted passthrough
+    // instead of the full glass effect — visually identical to the old fallback
+    // but with a stable Element identity.
+
+    // ClipPath geometry matches the shader SDF (circular-arc rounded rect):
+    // Superellipse shapes use RoundedRectangleBorder so the ClipPath boundary
+    // aligns with the shader's SDF boundary, eliminating the gap that appears
+    // when a superellipse ClipPath is used with a circular-arc SDF
+    // (superellipse extends further into corners than a circular arc).
+    final ShapeBorder clipShape;
+    if (widget.shape is LiquidVerticalRoundedSuperellipse) {
+      final s = widget.shape as LiquidVerticalRoundedSuperellipse;
+      clipShape = RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(s.topRadius),
+          bottom: Radius.circular(s.bottomRadius),
+        ),
+      );
+    } else if (widget.shape is LiquidRoundedSuperellipse) {
+      final s = widget.shape as LiquidRoundedSuperellipse;
+      clipShape = RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(s.borderRadius)),
+      );
+    } else {
+      clipShape = widget.shape;
+    }
+
+    // When the resolved clipShape is a RoundedRectangleBorder with a
+    // BorderRadius, wrap in ClipRRect instead of ClipPath. Flutter PR
+    // #177551 (in 3.41+) forwards ClipRRect clip data to the iOS
+    // PlatformView mutator stack, which lets the engine clip a
+    // descendant BackdropFilter over a PlatformView — eliminating the
+    // rectangular blur halo that appears around rounded glass surfaces
+    // stacked over a PlatformView (e.g. mapbox_maps_flutter,
+    // video_player on iOS). The same engine fix does NOT apply to
+    // ClipPath, even when the path inside is mathematically a rounded
+    // rect.
+    //
+    // LiquidOval is NOT covered: empirically the engine fix does not
+    // forward ClipRRect with circular(double.infinity), nor does it
+    // forward a LayoutBuilder-computed finite radius on a LiquidOval
+    // path. App code that needs a halo-free circular glass surface
+    // over a PlatformView should use
+    // LiquidRoundedSuperellipse(borderRadius: size/2) instead, which
+    // renders identically and triggers the engine fix.
+    final BorderRadius? roundedRectRadius =
+        (clipShape is RoundedRectangleBorder &&
+                clipShape.borderRadius is BorderRadius)
+            ? clipShape.borderRadius as BorderRadius
+            : null;
+    final Widget effect = _LightweightGlassEffect(
+      shader: shader,
+      settings: settings,
+      shape: widget.shape,
+      skipBlur: skipBlur,
+      glowIntensity: widget.glowIntensity,
+      densityFactor: widget.densityFactor,
+      indicatorWeight: widget.indicatorWeight,
+      backdropLuma: backdropLuma,
+      backgroundImage: _backgroundImage,
+      backgroundKey: widget.backgroundKey,
+      child: widget.child,
+    );
+    if (roundedRectRadius != null) {
+      return ClipRRect(borderRadius: roundedRectRadius, child: effect);
+    }
+    return ClipPath(
+      clipper: ShapeBorderClipper(shape: clipShape),
+      child: effect,
+    );
+  }
+}
+
+class _LightweightGlassEffect extends SingleChildRenderObjectWidget {
+  const _LightweightGlassEffect({
+    required this.shader,
+    required this.settings,
+    required this.shape,
+    required this.skipBlur,
+    required this.glowIntensity,
+    required this.densityFactor,
+    required this.indicatorWeight,
+    required this.backdropLuma,
+    this.backgroundImage,
+    this.backgroundKey,
+    required super.child,
+  });
+
+  final ui.FragmentShader? shader;
+  final LiquidGlassSettings settings;
+  final LiquidShape shape;
+  final bool skipBlur;
+  final double glowIntensity;
+  final double densityFactor;
+  final double indicatorWeight;
+  final double backdropLuma;
+  final ui.Image? backgroundImage;
+  final GlobalKey? backgroundKey;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderLightweightGlass(
+      shader: shader,
+      settings: settings,
+      shape: shape,
+      skipBlur: skipBlur,
+      glowIntensity: glowIntensity,
+      densityFactor: densityFactor,
+      indicatorWeight: indicatorWeight,
+      backdropLuma: backdropLuma,
+      backgroundImage: backgroundImage,
+      backgroundKey: backgroundKey,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    covariant _RenderLightweightGlass renderObject,
+  ) {
+    renderObject
+      ..shader = shader
+      ..settings = settings
+      ..shape = shape
+      ..skipBlur = skipBlur
+      ..glowIntensity = glowIntensity
+      ..densityFactor = densityFactor
+      ..indicatorWeight = indicatorWeight
+      ..backdropLuma = backdropLuma
+      ..backgroundImage = backgroundImage
+      ..backgroundKey = backgroundKey;
+  }
+}
+
+class _RenderLightweightGlass extends RenderProxyBox {
+  _RenderLightweightGlass({
+    required ui.FragmentShader? shader,
+    required LiquidGlassSettings settings,
+    required LiquidShape shape,
+    required bool skipBlur,
+    required double glowIntensity,
+    required double densityFactor,
+    required double indicatorWeight,
+    required double backdropLuma,
+    ui.Image? backgroundImage,
+    GlobalKey? backgroundKey,
+  })  : _shader = shader,
+        _settings = settings,
+        _shape = shape,
+        _skipBlur = skipBlur,
+        _glowIntensity = glowIntensity,
+        _densityFactor = densityFactor,
+        _indicatorWeight = indicatorWeight,
+        _backdropLuma = backdropLuma,
+        _backgroundImage = backgroundImage,
+        _backgroundKey = backgroundKey,
+        _cachedLightCos = math.cos(settings.lightAngle),
+        _cachedLightSin = -math.sin(settings.lightAngle);
+
+  ui.FragmentShader? _shader;
+  ui.FragmentShader? get shader => _shader;
+  set shader(ui.FragmentShader? value) {
+    if (_shader == value) return;
+    _shader = value;
+    markNeedsPaint();
+  }
+
+  LiquidGlassSettings _settings;
+  LiquidGlassSettings get settings => _settings;
+  set settings(LiquidGlassSettings value) {
+    if (_settings == value) return;
+    // Invalidate cached filter when blur or saturation changes.
+    if (value.effectiveBlur != _settings.effectiveBlur ||
+        value.effectiveSaturation != _settings.effectiveSaturation) {
+      _cachedBlurFilter = null;
+    }
+    // Recompute trig only when lightAngle actually changes.
+    if (value.lightAngle != _settings.lightAngle) {
+      _cachedLightCos = math.cos(value.lightAngle);
+      _cachedLightSin = -math.sin(value.lightAngle);
+    }
+    _settings = value;
+    markNeedsPaint();
+  }
+
+  LiquidShape _shape;
+  LiquidShape get shape => _shape;
+  set shape(LiquidShape value) {
+    if (_shape == value) return;
+    _shape = value;
+    markNeedsPaint();
+  }
+
+  bool _skipBlur;
+  bool get skipBlur => _skipBlur;
+  set skipBlur(bool value) {
+    if (_skipBlur == value) return;
+    _skipBlur = value;
+    markNeedsPaint();
+  }
+
+  double _glowIntensity;
+  double get glowIntensity => _glowIntensity;
+  set glowIntensity(double value) {
+    if (_glowIntensity == value) return;
+    _glowIntensity = value;
+    markNeedsPaint();
+  }
+
+  double _densityFactor;
+  double get densityFactor => _densityFactor;
+  set densityFactor(double value) {
+    if (_densityFactor == value) return;
+    _densityFactor = value;
+    markNeedsPaint();
+  }
+
+  double _indicatorWeight;
+  double get indicatorWeight => _indicatorWeight;
+  set indicatorWeight(double value) {
+    if (_indicatorWeight == value) return;
+    _indicatorWeight = value;
+    markNeedsPaint();
+  }
+
+  double _backdropLuma;
+  double get backdropLuma => _backdropLuma;
+  set backdropLuma(double value) {
+    if (_backdropLuma == value) return;
+    _backdropLuma = value;
+    markNeedsPaint();
+  }
+
+  ui.Image? _backgroundImage;
+  set backgroundImage(ui.Image? value) {
+    if (_backgroundImage == value) return;
+    _backgroundImage = value;
+    markNeedsPaint();
+  }
+
+  GlobalKey? _backgroundKey;
+  set backgroundKey(GlobalKey? value) {
+    if (_backgroundKey == value) return;
+    _backgroundKey = value;
+    markNeedsPaint();
+  }
+
+  // ── Cached light direction (Task 1.3) ─────────────────────────────────────
+  // Matches the caching pattern in LiquidGlassRenderObject._cachedLightDir.
+  // Avoids recomputing cos/sin on every _updateShaderUniforms call.
+  double _cachedLightCos;
+  double _cachedLightSin;
+
+  // ── Cached backdrop filter (Task 1.2) ─────────────────────────────────────
+  // The composed blur+saturation ImageFilter is rebuilt only when blur sigma
+  // or saturation changes — not on every frame. Eliminates a 20-element
+  // List<double> allocation + 2 object allocations per frame per glass widget.
+  ui.ImageFilter? _cachedBlurFilter;
+  double _cachedFilterBlur = -1;
+  double _cachedFilterSat = -1;
+
+  /// Returns the cached blur+saturation filter, rebuilding only when the
+  /// blur sigma or saturation has changed since the last call.
+  ui.ImageFilter _getBlurFilter(double blurSigma, double sat) {
+    if (_cachedBlurFilter != null &&
+        _cachedFilterBlur == blurSigma &&
+        _cachedFilterSat == sat) {
+      return _cachedBlurFilter!;
+    }
+
+    // Standard saturation ColorFilter matrix (ITU-R BT.601 luminance weights).
+    const double rw = 0.2126, gw = 0.7152, bw = 0.0722;
+    final ui.ColorFilter satFilter = ui.ColorFilter.matrix(<double>[
+      rw + (1 - rw) * sat,
+      gw - gw * sat,
+      bw - bw * sat,
+      0,
+      0,
+      rw - rw * sat,
+      gw + (1 - gw) * sat,
+      bw - bw * sat,
+      0,
+      0,
+      rw - rw * sat,
+      gw - gw * sat,
+      bw + (1 - bw) * sat,
+      0,
+      0,
+      0,
+      0,
+      0,
+      1,
+      0,
+    ]);
+
+    _cachedBlurFilter = ui.ImageFilter.compose(
+      outer: satFilter,
+      inner: ui.ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma),
+    );
+    _cachedFilterBlur = blurSigma;
+    _cachedFilterSat = sat;
+    return _cachedBlurFilter!;
+  }
+
+  // Only force compositing when we actually push a BackdropFilterLayer
+  // (shader available AND blur > 0 AND not skipped by ancestor blur).
+  // In the fallback path (null shader or zero blur), we just draw a tinted
+  // rect — no compositing layer needed. Reduces layer tree depth on
+  // low-end devices where the framework overhead is the bottleneck.
+  @override
+  bool get alwaysNeedsCompositing =>
+      _shader != null && !_skipBlur && _settings.effectiveBlur > 0;
+
+  @override
+  BackdropFilterLayer? get layer => super.layer as BackdropFilterLayer?;
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    if (child == null) {
+      layer = null;
+      return;
+    }
+
+    if (_shader == null) {
+      layer = null;
+      final paint = Paint()
+        ..color = _settings.effectiveGlassColor.withValues(alpha: 0.15);
+      context.canvas.drawRect(offset & size, paint);
+      super.paint(context, offset);
+      return;
+    }
+
+    final blurSigma = _settings.effectiveBlur;
+    if (blurSigma > 0 && !_skipBlur) {
+      // Compose blur + saturation to match Premium's background treatment.
+      // Premium applies Gaussian blur then boosts saturation on the blurred result,
+      // giving it richer, deeper colours (the "blue sky through glass" effect).
+      // We replicate this by composing: outer=saturationFilter, inner=blurFilter.
+      // Result: the blurred background seen through Standard glass is saturated
+      // identically to Premium — no background texture capture required.
+      //
+      // The filter is cached on the render object and only rebuilt when blur
+      // sigma or saturation changes — see _getBlurFilter().
+      final filter = _getBlurFilter(
+        blurSigma,
+        _settings.effectiveSaturation,
+      );
+
+      // Keep the same compositor layer across route/physics animation frames.
+      // Recreating it here used to discard the engine layer on every repaint,
+      // forcing Android to repeatedly allocate and submit the blur pass.
+      layer ??= BackdropFilterLayer();
+      layer!.filter = filter;
+      context.pushLayer(layer!, _paintGlassContent, offset);
+      assert(() {
+        layer!.debugCreator = debugCreator;
+        return true;
+      }());
+    } else {
+      layer = null;
+      _paintGlassContent(context, offset);
+    }
+  }
+
+  void _paintGlassContent(PaintingContext context, Offset offset) {
+    final canvas = context.canvas;
+    final matrix = canvas.getTransform();
+
+    final canvasPhysicalX = matrix[12];
+    final canvasPhysicalY = matrix[13];
+    final scaleX = matrix[0];
+    final scaleY = matrix[5];
+
+    final uOrigin = Offset(
+      canvasPhysicalX + (offset.dx * scaleX),
+      canvasPhysicalY + (offset.dy * scaleY),
+    );
+
+    final uScale = Offset(scaleX, scaleY);
+
+    Offset bgRelativeOffset = Offset.zero;
+    Size bgSize = const Size(1, 1);
+
+    if (_backgroundKey != null && _backgroundImage != null) {
+      final boundary = _safeGetBoundary(_backgroundKey);
+      if (boundary != null) {
+        final bgGlobalPos = boundary.localToGlobal(Offset.zero);
+        final indGlobalPos = localToGlobal(Offset.zero);
+        bgRelativeOffset = indGlobalPos - bgGlobalPos;
+        bgSize = Size(
+          _backgroundImage!.width.toDouble(),
+          _backgroundImage!.height.toDouble(),
+        );
+      }
+    }
+
+    _updateShaderUniforms(size, uOrigin, uScale, bgRelativeOffset, bgSize);
+
+    if (_backgroundImage != null) {
+      _shader!.setImageSampler(
+        0,
+        _backgroundImage!,
+        filterQuality: FilterQuality.medium, // coverage:ignore-line
+      );
+    } else if (LightweightLiquidGlass._dummyImage != null) {
+      _shader!.setImageSampler(
+        0,
+        LightweightLiquidGlass._dummyImage!,
+        filterQuality: FilterQuality.medium, // coverage:ignore-line
+      );
+    }
+
+    final paint = Paint()..shader = _shader!;
+    canvas.drawRect(offset & size, paint);
+
+    super.paint(context, offset);
+  }
+
+  void _updateShaderUniforms(Size size, Offset physicalOrigin,
+      Offset physicalScale, Offset bgOrigin, Size bgSize) {
+    // _updateShaderUniforms is only ever called from _paintGlassContent,
+    // which is only reached when _shader != null (guarded in paint()).
+    // The assertion makes the non-nullability explicit for the analyser.
+    final shader = _shader!;
+    int index = 0;
+
+    // 0, 1: uSize (vec2) - Layout Pixels (Logical)
+    shader.setFloat(index++, size.width);
+    shader.setFloat(index++, size.height);
+
+    // 2, 3: uOrigin (vec2) - Physical Pixels (Window Absolute)
+    shader.setFloat(index++, physicalOrigin.dx);
+    shader.setFloat(index++, physicalOrigin.dy);
+
+    // 4, 5, 6, 7: uGlassColor (vec4)
+    //
+    // Pass glassColor.alpha unchanged — the shader applies a Fresnel-based
+    // modulation in Stage 2.5 (lightweight_glass.frag) so the alpha creates
+    // a depth gradient (full at rim, 12% at center) instead of a flat fill.
+    // This correctly approximates the 3D SDF Fresnel of the Premium path.
+    //
+    // Whiten veil: lift glassColor toward white by a ramp of
+    // [LiquidGlassSettings.whitenStrength]. This is the Standard-path
+    // approximation of the Premium shader's whiten — the Fresnel modulation
+    // keeps the center lighter (content reads through) and the rim brighter.
+    // Because it is a tint overlay rather than a backdrop color operation, it
+    // also works over platform views, where BackdropFilter color ops don't
+    // apply. The gain calibrates the veil so a single whitenStrength value
+    // reads close to the Premium path's gated whiten at the same value.
+    final double whitenStrength =
+        _settings.whitenStrength.clamp(0.0, 1.0).toDouble();
+    const double kWhitenVeilGain = 1.5;
+    final double whitenVeil =
+        (whitenStrength * kWhitenVeilGain).clamp(0.0, 1.0).toDouble();
+    final color = whitenVeil <= 0.0
+        ? _settings.effectiveGlassColor
+        : Color.lerp(_settings.effectiveGlassColor, const Color(0xFFFFFFFF),
+            whitenVeil)!;
+    shader.setFloat(index++, (color.r * 255.0).round().clamp(0, 255) / 255.0);
+    shader.setFloat(index++, (color.g * 255.0).round().clamp(0, 255) / 255.0);
+    shader.setFloat(index++, (color.b * 255.0).round().clamp(0, 255) / 255.0);
+    shader.setFloat(index++, color.a.clamp(0.0, 1.0));
+
+    // 8: uThickness (float)
+    shader.setFloat(index++, _settings.effectiveThickness);
+
+    // 9, 10: uLightDirection (vec2) - [cos(angle), -sin(angle)]
+    // lightAngle is in radians (per LiquidGlassSettings API).
+    // Uses cached values — trig only recomputed when lightAngle changes.
+    shader.setFloat(index++, _cachedLightCos);
+    shader.setFloat(index++, _cachedLightSin);
+
+    // 11: uLightIntensity (float)
+    shader.setFloat(index++, _settings.effectiveLightIntensity);
+
+    // 12: uAmbientStrength (float)
+    //
+    // Problem: LiquidGlassSettings.figma() hardcodes ambientStrength to 0.1.
+    // In the lightweight shader, bodyColor = glassColor.rgb * (ambient + boost),
+    // so white * 0.21 ≈ dark grey — far darker than the user intends.
+    //
+    // Fix: Derive a floor from the glass color's "brightness intent":
+    //   brightnessIntent = alpha × luminance × 0.6
+    //
+    // The alpha encodes HOW OPAQUE the user wants the glass (opacity intent).
+    // The luminance encodes HOW BRIGHT the glass color is.
+    // Together they express: "how bright do you want the glass body to appear?"
+    //
+    // Examples:
+    //   white @ alpha 0.6  (figma case): 0.6×1.0×0.6=0.36 → max(0.1,0.36)=0.36 ✓ Fixed
+    //   white @ alpha 0.12 (standard):   0.12×1.0×0.6=0.07 → max(0.4,0.07)=0.4  ✓ Unchanged
+    //   white @ alpha 0.2  (interactive):0.2×1.0×0.6=0.12  → max(0.3,0.12)=0.3  ✓ Unchanged
+    //   white @ alpha 0.08 (bottomBar):  0.08×1.0×0.6=0.05 → max(0.5,0.05)=0.5  ✓ Unchanged
+    //   dark glass @ alpha 0.8:          0.8×0.12×0.6=0.06 → max(0.1,0.06)=0.1  ✓ Unchanged
+    //
+    // This only affects the Skia/Web lightweight shader path.
+    // Impeller uses a different physical model and is completely unaffected.
+    final gc = _settings.effectiveGlassColor;
+    final glassLuminance = 0.299 * gc.r + 0.587 * gc.g + 0.114 * gc.b;
+    final brightnessIntent = gc.a * glassLuminance * 0.6;
+    final effectiveAmbient = math.max(
+      _settings.effectiveAmbientStrength,
+      brightnessIntent,
+    );
+    shader.setFloat(index++, effectiveAmbient);
+
+    // 13: uSaturation (float)
+    shader.setFloat(index++, _settings.effectiveSaturation);
+
+    // 14: uRefractiveIndex (float)
+    shader.setFloat(index++, _settings.effectiveRefractiveIndex);
+
+    // 15: uChromaticAberration (float)
+    shader.setFloat(index++, (_settings.chromaticAberration).clamp(0.0, 1.0));
+
+    // 16: uCornerRadius (float) - Logical
+    // For vertical rounded shapes, write -1.0 to signal asymmetric mode.
+    // Slots 24-27 (uData6) carry the four per-corner radii in that case.
+    double? cornerRadius;
+    double topLeftR = 0.0;
+    double topRightR = 0.0;
+    double bottomRightR = 0.0;
+    double bottomLeftR = 0.0;
+    bool isAsymmetric = false;
+
+    if (_shape is LiquidVerticalRoundedSuperellipse ||
+        _shape is LiquidVerticalRoundedRectangle) {
+      // Asymmetric mode: each pair of corners has a different radius.
+      // topLeft == topRight == topRadius; bottomLeft == bottomRight == bottomRadius.
+      final (topRadius, bottomRadius) = switch (_shape) {
+        LiquidVerticalRoundedSuperellipse(
+          :final topRadius,
+          :final bottomRadius,
+        ) =>
+          (topRadius, bottomRadius),
+        LiquidVerticalRoundedRectangle(
+          :final topRadius,
+          :final bottomRadius,
+        ) =>
+          (topRadius, bottomRadius),
+        _ => (0.0, 0.0),
+      };
+      final maxTop = math.min(size.width, size.height) / 2.0;
+      final maxBot = math.min(size.width, size.height) / 2.0;
+      topLeftR = topRadius.clamp(0.0, maxTop);
+      topRightR = topRadius.clamp(0.0, maxTop);
+      bottomRightR = bottomRadius.clamp(0.0, maxBot);
+      bottomLeftR = bottomRadius.clamp(0.0, maxBot);
+      isAsymmetric = true;
+    } else {
+      cornerRadius = resolveLiquidShapeCornerRadius(_shape, size);
+    }
+
+    shader.setFloat(index++, isAsymmetric ? -1.0 : cornerRadius!);
+
+    // 17, 18: uScale (vec2) - Physical Scale (Includes DPR + Transforms)
+    shader.setFloat(index++, physicalScale.dx);
+    shader.setFloat(index++, physicalScale.dy);
+
+    // 19: uGlowIntensity (float) - Interactive glow strength (0.0-1.0)
+    shader.setFloat(index++, _glowIntensity.clamp(0.0, 1.0));
+
+    // 20: uDensityFactor (float) - Elevation physics (0.0-1.0)
+    shader.setFloat(index++, _densityFactor.clamp(0.0, 1.0));
+
+    // 21: uIndicatorWeight (float) - Indicator style (0.0-1.0)
+    shader.setFloat(index++, _indicatorWeight.clamp(0.0, 1.0));
+
+    // 22 (uData5.z): uSpecularSharpnessF (float-encoded int)
+    // 0.0=soft(n=8), 1.0=medium(n=16), 2.0=sharp(n=32)
+    // PP2: Flutter's FragmentShader API only exposes setFloat (no setInt). We pass
+    // 0.0/1.0/2.0 exactly and the shader does int(round()) to recover the integer.
+    // The GPU compiler still sees literal-constant exponents per if/else branch.
+    // NOTE: Previously declared as a separate `uniform float uSpecularSharpnessF`
+    // at slot 24, but Dart only wrote 23 floats — so slot 24 was always 0 (soft).
+    // Fixed: packed into uData5.z so the slot index matches exactly.
+    shader.setFloat(index++, _settings.specularSharpness.glslIndex.toDouble());
+
+    // 23 (uData5.w): backdropLuma — VQ4 content-adaptive strength
+    // 0.15 = dark platform (richer glass), 0.85 = light platform (subtler glass)
+    shader.setFloat(index++, _backdropLuma.clamp(0.0, 1.0));
+
+    // 24..27 (uData6): per-corner radii for asymmetric shapes (GlassModalSheet).
+    shader.setFloat(index++, topLeftR);
+    shader.setFloat(index++, topRightR);
+    shader.setFloat(index++, bottomRightR);
+    shader.setFloat(index++, bottomLeftR);
+
+    // 28..31 (uData7): Background texture tracking
+    shader.setFloat(index++, bgOrigin.dx);
+    shader.setFloat(index++, bgOrigin.dy);
+    shader.setFloat(index++, bgSize.width);
+    shader.setFloat(index++, bgSize.height);
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/shared/liquid_shape_shader_geometry.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/shared/liquid_shape_shader_geometry.dart
@@ -1,0 +1,21 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+/// Resolves a liquid shape's circular-arc corner radius for fragment shaders.
+///
+/// Concrete type matching is stable in AOT/obfuscated builds, unlike runtime
+/// class-name inspection.
+double resolveLiquidShapeCornerRadius(LiquidShape shape, Size size) {
+  final maxRadius = math.min(size.width, size.height) / 2.0;
+  final radius = switch (shape) {
+    LiquidOval() => maxRadius,
+    LiquidRoundedSuperellipse(:final borderRadius) => borderRadius,
+    LiquidRoundedRectangle(:final borderRadius) => borderRadius,
+    LiquidVerticalRoundedSuperellipse() => 0.0,
+    LiquidVerticalRoundedRectangle() => 0.0,
+  };
+  return radius.clamp(0.0, maxRadius).toDouble();
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_app_bar.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_app_bar.dart
@@ -1,0 +1,301 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../types/glass_quality.dart';
+import '../shared/glass_isolation_scope.dart';
+import 'glass_large_title.dart' show GlassLargeTitleController;
+
+/// A navigation bar layout widget following Apple's iOS 26 design patterns.
+///
+/// [GlassAppBar] renders a solid or transparent bar with leading widget,
+/// centered title, and trailing actions. Glass effects belong on the
+/// individual interactive elements (buttons, pills) — not the bar surface
+/// itself. This matches iOS 26's navigation bar where the bar is a simple
+/// layout container and glass is reserved for buttons.
+///
+/// ## Large-title collapse (iOS 26 pattern)
+///
+/// Pair with [GlassLargeTitle] and [GlassLargeTitleController] to get
+/// automatic cross-fade between the large title (in the scroll view) and the
+/// inline bar title — with zero boilerplate:
+///
+/// ```dart
+/// final _titleController = GlassLargeTitleController();
+///
+/// GlassScaffold(
+///   appBar: GlassAppBar(
+///     title: Text('Chats'),
+///     largeTitleController: _titleController,   // ← fades in as user scrolls
+///   ),
+///   body: CustomScrollView(
+///     controller: _titleController.scrollController,
+///     slivers: [
+///       GlassLargeTitle(text: 'Chats', controller: _titleController),
+///       // ... content slivers
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ## Transparent (default — iOS 26 style)
+///
+/// ```dart
+/// GlassAppBar(
+///   title: Text('Messages'),
+///   leading: GlassButton(
+///     icon: Icon(CupertinoIcons.back),
+///     onTap: () => Navigator.pop(context),
+///   ),
+/// )
+/// ```
+///
+/// ## Solid background (WhatsApp / Player style)
+///
+/// ```dart
+/// GlassAppBar(
+///   backgroundColor: Color(0xFF2C2C2E),
+///   title: Text('Now Playing'),
+///   leading: GlassButton(
+///     icon: Icon(CupertinoIcons.back),
+///     onTap: () => Navigator.pop(context),
+///   ),
+/// )
+/// ```
+///
+/// ## Custom button settings (all buttons inherit)
+///
+/// ```dart
+/// GlassAppBar(
+///   buttonSettings: LiquidGlassSettings(
+///     glassColor: Color(0x33FFFFFF),
+///     thickness: 20,
+///   ),
+///   leading: GlassButton(...),   // inherits buttonSettings
+///   actions: [GlassButton(...)], // inherits buttonSettings
+/// )
+/// ```
+///
+/// This widget implements [ObstructingPreferredSizeWidget] for use in both
+/// [Scaffold.appBar] and [CupertinoPageScaffold.navigationBar].
+class GlassAppBar extends StatelessWidget
+    implements ObstructingPreferredSizeWidget {
+  /// Creates a glass app bar.
+  ///
+  /// The bar itself is a simple layout container with a [backgroundColor].
+  /// Glass effects are rendered by individual child widgets (e.g. [GlassButton])
+  /// inside the bar — not by the bar surface.
+  const GlassAppBar({
+    super.key,
+    this.title,
+    this.leading,
+    this.actions,
+    this.centerTitle = true,
+    this.backgroundColor = Colors.transparent,
+    this.preferredSize = const Size.fromHeight(44.0),
+    this.padding = const EdgeInsets.symmetric(horizontal: 8),
+    this.buttonSettings,
+    this.largeTitleController,
+  });
+
+  // ===========================================================================
+  // Properties
+  // ===========================================================================
+
+  /// The primary content of the app bar, typically a [Text] widget.
+  final Widget? title;
+
+  /// A widget to display before the title, typically a back button.
+  final Widget? leading;
+
+  /// A list of widgets to display after the title.
+  final List<Widget>? actions;
+
+  /// Whether the [title] should be centered.
+  final bool centerTitle;
+
+  /// The background color of the app bar.
+  ///
+  /// Defaults to [Colors.transparent] to match iOS 26's transparent
+  /// navigation bar pattern. Use an opaque colour for solid bars
+  /// (e.g. WhatsApp conversation, music player).
+  final Color backgroundColor;
+
+  /// The preferred height of the app bar.
+  @override
+  final Size preferredSize;
+
+  /// Whether this app bar fully obstructs the content behind it.
+  ///
+  /// Returns `true` only when [backgroundColor] is fully opaque (alpha = 1.0).
+  /// With the default transparent background, this returns `false`, which
+  /// tells [CupertinoPageScaffold] to extend the body behind the bar —
+  /// matching the iOS 26 transparent navigation bar pattern.
+  @override
+  bool shouldFullyObstruct(BuildContext context) => backgroundColor.a >= 1.0;
+
+  /// Padding around the app bar content.
+  final EdgeInsetsGeometry padding;
+
+  /// Default glass settings for buttons inside this app bar.
+  ///
+  /// When provided, all [GlassButton] descendants that don't specify their
+  /// own `settings` will inherit these. This avoids repeating the same
+  /// settings on every button in the bar.
+  ///
+  /// Individual buttons can still override this with their own `settings`.
+  ///
+  /// ```dart
+  /// GlassAppBar(
+  ///   buttonSettings: LiquidGlassSettings(
+  ///     glassColor: Color(0x33FFFFFF),
+  ///     thickness: 20,
+  ///   ),
+  ///   leading: GlassButton(...),   // uses buttonSettings
+  ///   actions: [
+  ///     GlassButton(
+  ///       settings: myCustomSettings, // overrides buttonSettings
+  ///       ...
+  ///     ),
+  ///   ],
+  /// )
+  /// ```
+  final LiquidGlassSettings? buttonSettings;
+
+  /// Optional controller that drives the inline title opacity.
+  ///
+  /// When provided, the [title] widget is automatically wrapped in a
+  /// [ListenableBuilder] that fades it **in** as [GlassLargeTitle]
+  /// (the large title in the scroll view) fades **out**.
+  ///
+  /// This replicates iOS 26's `UINavigationBar.prefersLargeTitles` collapse
+  /// behaviour with zero boilerplate. See [GlassLargeTitle] and
+  /// [GlassLargeTitleController] for full usage.
+  final GlassLargeTitleController? largeTitleController;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget content = ColoredBox(
+      color: backgroundColor,
+      child: SafeArea(
+        bottom: false,
+        child: Padding(
+          padding: padding,
+          child: SizedBox(
+            height: preferredSize.height,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                // Leading widget
+                if (leading != null) leading!,
+
+                // Flexible title — optionally driven by collapse controller
+                Expanded(
+                  child: _buildTitle(),
+                ),
+
+                // Trailing actions
+                if (actions != null)
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    spacing: 8,
+                    children: actions!,
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Wrap with default button settings if provided.
+    if (buttonSettings != null) {
+      content = DefaultButtonSettings(
+        settings: buttonSettings!,
+        child: content,
+      );
+    }
+
+    // Isolate the app bar so that when used in a regular Flutter Scaffold,
+    // its glass buttons don't join the page-level blend group (which sits
+    // behind the scrolling body), ensuring correct Z-order painting.
+    // Premium is the default hint — individual buttons can still override
+    // with quality: GlassQuality.standard, and GlassAdaptiveScope will
+    // cap to the device ceiling regardless.
+    return GlassIsolationScope(
+      isolated: true,
+      defaultQuality: GlassQuality.premium,
+      child: content,
+    );
+  }
+
+  /// Builds the title widget, optionally driven by [largeTitleController].
+  ///
+  /// Without a controller, returns the title as-is (same as before).
+  /// With a controller, wraps in [ListenableBuilder] so only the title
+  /// Opacity rebuilds on scroll — not the entire bar.
+  Widget _buildTitle() {
+    final titleWidget = centerTitle
+        ? Center(child: title ?? const SizedBox.shrink())
+        : Align(
+            alignment: Alignment.centerLeft,
+            child: Padding(
+              padding: const EdgeInsets.only(left: 8),
+              child: title ?? const SizedBox.shrink(),
+            ),
+          );
+
+    if (largeTitleController == null) return titleWidget;
+
+    return ListenableBuilder(
+      listenable: largeTitleController!,
+      builder: (context, _) {
+        final progress = largeTitleController!.collapseProgress;
+        // iOS 26 bar title behaviour: invisible during the first half of the
+        // collapse, then fades in with ease-out over the second half.
+        // This matches UIKit's two-phase crossfade where the bar title only
+        // appears once the large title is mostly gone.
+        final barProgress = ((progress - 0.5) / 0.5).clamp(0.0, 1.0);
+        final barOpacity = Curves.easeOut.transform(barProgress);
+        return Opacity(
+          opacity: barOpacity,
+          child: titleWidget,
+        );
+      },
+    );
+  }
+}
+
+/// An [InheritedWidget] that provides default [LiquidGlassSettings] for
+/// descendant glass buttons.
+///
+/// Used by [GlassAppBar] to pass `buttonSettings` down the tree. Buttons
+/// that don't specify their own `settings` can inherit these defaults.
+///
+/// To read the nearest ancestor's settings:
+/// ```dart
+/// final settings = DefaultButtonSettings.of(context);
+/// ```
+class DefaultButtonSettings extends InheritedWidget {
+  /// Creates a default button settings scope.
+  const DefaultButtonSettings({
+    super.key,
+    required this.settings,
+    required super.child,
+  });
+
+  /// The default glass settings for descendant buttons.
+  final LiquidGlassSettings settings;
+
+  /// Returns the settings from the nearest [DefaultButtonSettings] ancestor,
+  /// or `null` if none exists.
+  static LiquidGlassSettings? of(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<DefaultButtonSettings>()
+        ?.settings;
+  }
+
+  @override
+  bool updateShouldNotify(DefaultButtonSettings oldWidget) =>
+      settings != oldWidget.settings;
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_bottom_bar.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_bottom_bar.dart
@@ -1,0 +1,994 @@
+// ignore_for_file: deprecated_member_use
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show ValueListenable;
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../src/types/glass_interaction_behavior.dart';
+import '../../types/glass_quality.dart';
+import '../interactive/glass_button.dart';
+import '../shared/adaptive_liquid_glass_layer.dart';
+import 'shared/tab_bar_bottom_layout.dart';
+
+/// A glass morphism bottom navigation bar following Apple's design patterns.
+///
+/// [GlassBottomBar] provides a sophisticated bottom navigation bar with
+/// draggable indicator, jelly physics, rubber band resistance, and seamless
+/// glass blending. It supports iOS-style drag-to-switch tabs with
+/// velocity-based snapping and organic squash/stretch animations.
+///
+/// ## Key Features
+///
+/// - **Draggable Indicator**: Swipe between tabs with smooth spring animations
+/// - **Velocity-Based Snapping**: Flick quickly to jump multiple tabs
+/// - **Rubber Band Resistance**: iOS-style overdrag behavior at edges
+/// - **Jelly Physics**: Organic squash and stretch effects during movement
+/// - **Per-Tab Glow Effects**: Customizable glow colors for each tab
+/// - **Icon Thickness Effect**: Optional shadow halo around unselected icons
+/// - **Seamless Glass Blending**: Uses [LiquidGlassBlendGroup] for smooth
+/// transitions
+///
+/// ## Placement
+///
+/// **Always use [GlassBottomBar] as [Scaffold.bottomNavigationBar].** The
+/// Scaffold sizes and anchors that slot to the bottom of the screen. Placing
+/// the bar inside `body:`, `Center()`, or a `Column` without explicit
+/// bottom-pinning will cause it to float or appear centered rather than
+/// staying fixed at the screen's bottom edge.
+///
+/// ```dart
+/// // ✅ Correct
+/// Scaffold(
+///   body: ...,
+///   bottomNavigationBar: GlassBottomBar(...),
+/// )
+///
+/// // ❌ Wrong — bar will float / center
+/// Scaffold(
+///   body: Center(child: GlassBottomBar(...)),
+/// )
+/// ```
+///
+/// ## Usage
+///
+/// ### Basic Usage
+/// ```dart
+/// AdaptiveLiquidGlassLayer(
+///   settings: LiquidGlassSettings(
+///     thickness: 30,
+///     blur: 3,
+///     refractiveIndex: 1.59,
+///   ),
+///   child: Scaffold(
+///     body: _pages[_selectedIndex],
+///     bottomNavigationBar: GlassBottomBar(
+///       tabs: [
+///         GlassBottomBarTab(
+///           label: 'Home',
+///           icon: Icon(CupertinoIcons.home),
+///           activeIcon: Icon(CupertinoIcons.home_fill),
+///           glowColor: Colors.blue,
+///         ),
+///         GlassBottomBarTab(
+///           label: 'Search',
+///           icon: Icon(CupertinoIcons.search),
+///           glowColor: Colors.purple,
+///         ),
+///         GlassBottomBarTab(
+///           label: 'Profile',
+///           icon: Icon(CupertinoIcons.person),
+///           activeIcon: Icon(CupertinoIcons.person_fill),
+///           glowColor: Colors.pink,
+///         ),
+///       ],
+///       selectedIndex: _selectedIndex,
+///       onTabSelected: (index) => setState(() => _selectedIndex = index),
+///     ),
+///   ),
+/// )
+/// ```
+///
+/// ### With Extra Button
+/// ```dart
+/// GlassBottomBar(
+///   tabs: [...],
+///   selectedIndex: _selectedIndex,
+///   onTabSelected: (index) => setState(() => _selectedIndex = index),
+///   extraButton: GlassTabBarExtraButton(
+///     icon: CupertinoIcons.add,
+///     label: 'Create',
+///     onTap: () => _showCreateDialog(),
+///     size: 64,
+///   ),
+/// )
+/// ```
+///
+/// ### Custom Styling
+/// ```dart
+/// GlassBottomBar(
+///   tabs: [...],
+///   selectedIndex: _selectedIndex,
+///   onTabSelected: (index) => setState(() => _selectedIndex = index),
+///   barHeight: 72,
+///   spacing: 12,
+///   horizontalPadding: 24,
+///   selectedIconColor: Colors.white,
+///   unselectedIconColor: Colors.white.withOpacity(0.6),
+///   iconSize: 28,
+///   textStyle: TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
+///   settings: LiquidGlassSettings(
+///     thickness: 40,
+///     blur: 5,
+///     refractiveIndex: 1.7,
+///   ),
+/// )
+/// ```
+///
+/// ### Without Draggable Indicator
+/// ```dart
+/// GlassBottomBar(
+///   tabs: [...],
+///   selectedIndex: _selectedIndex,
+///   onTabSelected: (index) => setState(() => _selectedIndex = index),
+///   showIndicator: false,
+/// )
+/// ```
+
+/// Rendering quality for the liquid glass masking effect in [GlassBottomBar].
+///
+/// Controls the complexity of the masking effect that creates the "magic lens"
+/// appearance where selected tab content appears to glow through the glass indicator.
+enum MaskingQuality {
+  /// No masking effect, simple icon color change (fastest).
+  ///
+  /// Uses the traditional approach where tabs simply change color when selected.
+  /// No dual-layer rendering or clipping. Best performance, but less visual polish.
+  ///
+  /// **Recommended for:**
+  /// - Apps targeting older devices (iPhone X or older)
+  /// - Maximum performance requirements
+  /// - 7+ tabs
+  off,
+
+  /// Full jelly physics clip path with dual-layer rendering (best quality, default).
+  ///
+  /// Creates a "magic lens" effect where selected tabs appear to glow through
+  /// the glass indicator as it moves. Content is magnified and the clip path
+  /// follows the jelly physics for perfect synchronization.
+  ///
+  /// **Recommended for:**
+  /// - Modern devices (iPhone 12+, Pixel 5+)
+  /// - 3-5 tabs (typical use case)
+  /// - Premium/polished apps
+  /// - When visual quality is a priority
+  ///
+  /// **Performance:** Renders tabs twice with ClipPath operations. Maintains
+  /// 60fps on modern devices with typical 3-5 tab configurations.
+  high,
+}
+
+/// **Deprecated:** Use [GlassTabBar.bottom] instead.
+///
+/// [GlassBottomBar] is a zero-logic shim that will be removed in v1.0.
+/// Migrate by replacing `GlassBottomBar(` with `GlassTabBar.bottom(` and
+/// `GlassBottomBarTab(` with `GlassSegment(`. All parameters are identical.
+///
+/// ```dart
+/// // BEFORE
+/// GlassBottomBar(tabs: [GlassBottomBarTab(icon: Icon(Icons.home), label: 'Home')], ...)
+/// // AFTER
+/// GlassTabBar.bottom(tabs: [GlassSegment(icon: Icon(Icons.home), label: 'Home')], ...)
+/// ```
+@Deprecated('Use GlassTabBar.bottom() instead. '
+    'GlassBottomBar will be removed in v1.0. '
+    'Migration: replace GlassBottomBar( with GlassTabBar.bottom( '
+    'and GlassBottomBarTab( with GlassSegment(.')
+class GlassBottomBar extends StatelessWidget {
+  /// Creates a glass bottom navigation bar.
+  const GlassBottomBar({
+    required this.tabs,
+    required this.selectedIndex,
+    required this.onTabSelected,
+    super.key,
+    this.extraButton,
+    this.spacing = 8,
+    this.horizontalPadding = 20,
+    this.verticalPadding = 20,
+    this.barHeight = 64,
+    this.barBorderRadius = _defaultBarBorderRadius,
+    this.tabPadding = const EdgeInsets.symmetric(horizontal: 4),
+    this.iconLabelSpacing = 4,
+    this.enableBlend = true,
+    this.blendAmount = 10,
+    this.settings,
+    this.showIndicator = true,
+    this.indicatorColor,
+    this.indicatorSettings,
+    this.indicatorPinchStrength = 0.4,
+    this.selectedIconColor,
+    this.unselectedIconColor,
+    this.selectedLabelColor,
+    this.unselectedLabelColor,
+    this.selectedLabelStyle,
+    this.unselectedLabelStyle,
+    this.iconSize = 24,
+    this.labelFontSize = 11,
+    this.textStyle,
+    this.glowDuration = const Duration(milliseconds: 300),
+    this.glowBlurRadius = 32,
+    this.glowSpreadRadius = 8,
+    this.glowOpacity = 0.6,
+    this.quality,
+    this.magnification = 1.15,
+    this.innerBlur = 0.0,
+    this.maskingQuality = MaskingQuality.high,
+    this.backgroundKey,
+    this.tabWidth,
+    this.indicatorBorderRadius,
+    this.indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    this.interactionGlowColor,
+    this.interactionGlowRadius = 1.5,
+    this.interactionBehavior = GlassInteractionBehavior.full,
+    this.pressScale = 1.04,
+    this.platformViewBackdrop = false,
+    this.adaptiveBrightness = false,
+    this.onBrightnessChanged,
+    this.brightnessOverride,
+  })  : assert(tabs.length > 0, 'GlassBottomBar requires at least one tab'),
+        assert(
+          selectedIndex >= 0 && selectedIndex < tabs.length,
+          'selectedIndex must be between 0 and tabs.length - 1',
+        ),
+        assert(
+          tabWidth == null || tabWidth > 0,
+          'tabWidth must be positive, or null to use expand (full-width) mode.',
+        );
+
+  /// Magnification factor for the content inside the selected indicator.
+  ///
+  /// Values > 1.0 zoom in the selected tab's icon and label, creating the
+  /// iOS 26 "lens" effect where the active tab appears slightly larger than
+  /// its neighbours.
+  ///
+  /// **Recommended range:** 1.0–1.3
+  /// - `1.15` (default) — matches Apple News / Safari selected-tab scale.
+  /// - `1.0` — no magnification; all tabs render at the same size.
+  /// - `1.2–1.3` — more dramatic; may feel large with dense labels.
+  ///
+  /// Only applies when [maskingQuality] is [MaskingQuality.high].
+  final double magnification;
+
+  /// Blur amount in logical pixels applied to content inside the indicator.
+  ///
+  /// Creates a frosted glass effect on the selected content.
+  ///
+  /// **Recommended range:** 0.0-3.0
+  /// - 0.0: No blur (default, sharp content)
+  /// - 1.0-2.0: Subtle frosted effect
+  /// - 3.0+: Heavy blur (may make content unreadable)
+  ///
+  /// Only applies when [maskingQuality] is [MaskingQuality.high].
+  final double innerBlur;
+
+  /// Quality of the liquid glass masking effect.
+  ///
+  /// Controls the rendering strategy for the "magic lens" effect where
+  /// selected content appears to glow through the glass indicator.
+  ///
+  /// - [MaskingQuality.high]: Full jelly physics with dual-layer rendering (default)
+  ///   Best visual quality, recommended for 3-5 tabs on modern devices.
+  ///
+  /// - [MaskingQuality.off]: Simple color change, no masking
+  ///   Maximum performance, recommended for 7+ tabs or older devices.
+  ///
+  /// Defaults to [MaskingQuality.high].
+  final MaskingQuality maskingQuality;
+
+  /// Optional background key for Skia/Web refraction.
+  final GlobalKey? backgroundKey;
+
+  /// Set true when the bar sits over an iOS PlatformView (e.g. a map). The bar
+  /// background renders via live `BackdropFilter` (the premium shader can't
+  /// capture a PlatformView), while the premium indicator refracts the bar's
+  /// own icons — so premium animations survive over the PlatformView with no
+  /// quality swap. Defaults to false.
+  final bool platformViewBackdrop;
+
+  /// Whether the bar adapts its light/dark appearance to the content
+  /// scrolling underneath it, like the iOS 26 system bars.
+  ///
+  /// Requires an enclosing [GlassContentAwareScope] with the scrolling
+  /// content wrapped in a [GlassContentAwareContent]; without one the bar
+  /// keeps its ambient appearance. When the scope's contrast vote flips the
+  /// verdict, the bar cross-fades between the [GlassTheme] light and dark
+  /// variants — themed glass settings, glow palette and the default
+  /// icon/label colors all swap automatically.
+  ///
+  /// Defaults to false.
+  final bool adaptiveBrightness;
+
+  /// Called when the content-aware verdict flips (not for the initial
+  /// value).
+  ///
+  /// Use this to restyle elements the bar cannot see — page scrims, status
+  /// bar icons, custom-painted tab icons.
+  final ValueChanged<Brightness>? onBrightnessChanged;
+
+  /// External brightness source that bypasses the content sampler entirely.
+  ///
+  /// When non-null, the bar follows this listenable instead of registering
+  /// with the [GlassContentAwareScope] — the escape hatch for bars floating
+  /// over content that cannot be captured (iOS PlatformViews such as maps;
+  /// see [platformViewBackdrop]). Drive it from your own signal, e.g. the
+  /// active map style. Implies the adaptive behavior regardless of
+  /// [adaptiveBrightness].
+  final ValueListenable<Brightness>? brightnessOverride;
+
+  /// The color of the directional glow effect when interacting with the bar.
+  ///
+  /// Only active when [interactionBehavior] includes glow
+  /// (i.e. [GlassInteractionBehavior.glowOnly] or [GlassInteractionBehavior.full]).
+  ///
+  /// Defaults to a subtle translucent white (`0x1FFFFFFF`) when null.
+  final Color? interactionGlowColor;
+
+  /// The radius spread of the directional glow effect when interacting with the bar.
+  ///
+  /// Defaults to 1.5.
+  final double interactionGlowRadius;
+
+  /// Controls which physical interaction effects are active when the user
+  /// presses the bar.
+  ///
+  /// Defaults to [GlassInteractionBehavior.full] — directional glow + spring scale,
+  /// matching native iOS 26 Apple News / Safari behaviour.
+  final GlassInteractionBehavior interactionBehavior;
+
+  /// Peak scale factor applied to the bar at maximum press depth.
+  ///
+  /// Only active when [interactionBehavior] includes scale
+  /// (i.e. [GlassInteractionBehavior.scaleOnly] or [GlassInteractionBehavior.full]).
+  ///
+  /// Defaults to 1.04 (4% growth — matches iOS 26 Apple News pill).
+  final double pressScale;
+
+  // ===========================================================================
+  // Tab Configuration
+  // ===========================================================================
+
+  /// Width of each tab slot in logical pixels.
+  ///
+  /// Controls the total width of the tab pill via `tabWidth × tabs.length`,
+  /// giving each tab a fixed allocation regardless of the bar's full width.
+  ///
+  /// **Compact sizing (default `88.0`)** — iOS 26 Apple-style proportional tabs:
+  /// - 2 tabs → 176 px pill
+  /// - 3 tabs → 264 px pill
+  /// - 4 tabs → 352 px pill (clamped if wider than available space)
+  ///
+  /// **Expand (`null`)** — legacy fill-all-space behaviour. The tab pill
+  /// stretches to occupy all horizontal space not taken by [extraButton].
+  /// Use this when you explicitly want the bar to span the full available width.
+  ///
+  /// When the natural width (`tabWidth × tabs.length`) exceeds the available
+  /// space the pill is automatically clamped — it will never overflow.
+  ///
+  /// See also:
+  ///   * [GlassSearchableBottomBar.tabWidth], the equivalent parameter on the
+  ///     searchable variant which uses the same default and clamping logic.
+  final double? tabWidth;
+
+  /// Override border radius for the indicator. Null = inherits from barBorderRadius.
+  final double? indicatorBorderRadius;
+
+  /// How far the jelly indicator's leading and trailing edges expand
+  /// past the tab boundary as the indicator translates between tabs.
+  /// Higher values give a more dramatic "puff" stretch; lower values
+  /// a tighter, more iOS-native feel.
+  ///
+  /// Defaults to `EdgeInsets.symmetric(horizontal: 12, vertical: 8)` which
+  /// matches the iOS 26 bottom-bar pill proportions (slightly wider than tall).
+  /// To restore the previous symmetric behaviour pass
+  /// `indicatorExpansion: const EdgeInsets.all(8.0)`.
+  final EdgeInsetsGeometry indicatorExpansion;
+
+  /// List of tabs to display in the bottom bar.
+  ///
+  /// Each tab requires an icon. Optionally specify a label (for text below icon),
+  /// selectedIcon for a different appearance when selected, and glowColor for the
+  /// animated glow effect. Tabs with null labels will center the icon vertically.
+  final List<GlassBottomBarTab> tabs;
+
+  /// Index of the currently selected tab.
+  ///
+  /// Must be between 0 and tabs.length - 1.
+  final int selectedIndex;
+
+  /// Called when a tab is selected.
+  ///
+  /// Provides the index of the newly selected tab. Use this to update
+  /// your state and switch between pages.
+  final ValueChanged<int> onTabSelected;
+
+  /// Optional extra button displayed to the right of the tab bar.
+  ///
+  /// Typically used for a primary action like "Create", "Add", or "Compose".
+  /// The button is rendered as a [GlassButton] and inherits the glass settings.
+  final GlassTabBarExtraButton? extraButton;
+
+  // ===========================================================================
+  // Layout Properties
+  // ===========================================================================
+
+  /// Spacing between the tab bar and extra button.
+  ///
+  /// Only applies when [extraButton] is provided.
+  /// Defaults to 8.
+  final double spacing;
+
+  /// Horizontal padding around the entire bottom bar content.
+  ///
+  /// Defaults to 20.
+  final double horizontalPadding;
+
+  /// Vertical padding above and below the bottom bar content.
+  ///
+  /// Defaults to 20.
+  final double verticalPadding;
+
+  /// Height of the tab bar.
+  ///
+  /// Defaults to 64.
+  final double barHeight;
+
+  /// Border radius of the tab bar.
+  ///
+  /// Defaults to 32 for a pill-shaped appearance.
+  static const _defaultBarBorderRadius = 32.0;
+  final double barBorderRadius;
+
+  /// Internal padding of the tab bar.
+  ///
+  /// Controls spacing between the bar edges and the tab icons.
+  /// Defaults to 4px horizontal padding.
+  final EdgeInsetsGeometry tabPadding;
+
+  /// Internal spacing of the tab bar.
+  ///
+  /// Controls spacing between the tab icon and the tab label.
+  /// Defaults to 4px.
+  final double iconLabelSpacing;
+
+  /// Whether to enable organic liquid blending between the tab pill and
+  /// the extra button.
+  ///
+  /// When `true` (default), adjacent glass surfaces merge organically —
+  /// a premium "beyond native" effect. When `false`, the extra button
+  /// renders as a fully independent glass element, matching Apple's
+  /// native iOS 26 tab bar behavior.
+  ///
+  /// When disabled, [blendAmount] is ignored.
+  final bool enableBlend;
+
+  /// Blend amount for glass surfaces.
+  ///
+  /// Higher values create smoother blending between the tab bar and extra
+  /// button. Only effective when [enableBlend] is `true`.
+  /// Passed to [AdaptiveLiquidGlassLayer].
+  /// Defaults to 10.
+  final double blendAmount;
+
+  // ===========================================================================
+  // Glass Effect Properties
+  // ===========================================================================
+
+  /// Glass effect settings for the bottom bar.
+  ///
+  /// If null, uses optimized defaults for bottom navigation bars:
+  /// - thickness: 30
+  /// - blur: 3
+  /// - chromaticAberration: 0.3
+  /// - lightIntensity: 0.6
+  /// - refractiveIndex: 1.59
+  /// - saturation: 0.7
+  /// - ambientStrength: 1
+  /// - lightAngle: 0.75 * π (135°, Apple standard — upper-left)
+  /// - glassColor: Colors.white24
+  final LiquidGlassSettings? settings;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// If null, inherits from parent [InheritedLiquidGlass] or defaults to
+  /// [GlassQuality.premium] since bottom bars are typically static surfaces at
+  /// the bottom of the screen where premium quality looks best.
+  ///
+  /// Use [GlassQuality.standard] if the bottom bar will be used in a scrollable
+  /// context.
+  final GlassQuality? quality;
+
+  // ===========================================================================
+  // Indicator Properties
+  // ===========================================================================
+
+  /// Whether to show the draggable indicator.
+  ///
+  /// When true, displays a glass indicator behind the selected tab that can
+  /// be dragged to switch tabs. When false, only shows tab icons and labels.
+  /// Defaults to true.
+  final bool showIndicator;
+
+  /// Color of the subtle indicator shown when not being dragged.
+  ///
+  /// If null, defaults to a semi-transparent color from the theme.
+  final Color? indicatorColor;
+
+  /// Glass settings for the draggable indicator.
+  ///
+  /// If null, uses optimized defaults for the indicator:
+  /// - glassColor: Color.from(alpha: 0.1, red: 1, green: 1, blue: 1)
+  /// - saturation: 1.5
+  /// - refractiveIndex: 1.15
+  /// - thickness: 20
+  /// - lightIntensity: 2
+  /// - chromaticAberration: 0.5
+  /// - blur: 0
+  final LiquidGlassSettings? indicatorSettings;
+
+  /// Maximum concave lens pinch strength for the draggable indicator pill.
+  ///
+  /// Controls how strongly the bar content appears to pinch inward through
+  /// the pill's left and right edges during a drag (iOS 26 lens effect).
+  ///
+  /// - `1.0` (default) — full Apple-calibrated effect
+  /// - `0.5` — half the pinch depth
+  /// - `0.0` — pinch fully disabled
+  final double indicatorPinchStrength;
+
+  // ===========================================================================
+  // Tab Style Properties
+  // ===========================================================================
+
+  /// Icon color when a tab is selected. Defaults to dynamic label color.
+  final Color? selectedIconColor;
+
+  /// Color of the icon when a tab is not selected.
+  ///
+  /// Defaults to [Colors.white].
+  final Color? unselectedIconColor;
+
+  /// Label color for selected tab.
+  final Color? selectedLabelColor;
+
+  /// Label color for unselected tabs.
+  final Color? unselectedLabelColor;
+
+  /// Per-state label text style, merged over the base label style — overrides
+  /// font / weight / letter-spacing while keeping the resolved label color.
+  final TextStyle? selectedLabelStyle;
+
+  /// See [selectedLabelStyle].
+  final TextStyle? unselectedLabelStyle;
+
+  /// Size of the tab icons.
+  ///
+  /// Defaults to 24.
+  final double iconSize;
+
+  /// Font size for tab labels.
+  ///
+  /// Only applies when [textStyle] is null. Mirrors [iconSize] as a dedicated
+  /// sizing knob so color and weight are still managed automatically.
+  ///
+  /// Defaults to 11. Reduce to 10 for bars with 4+ tabs or longer labels
+  /// such as "Following".
+  final double labelFontSize;
+
+  /// Text style for tab labels.
+  ///
+  /// If null, uses default style with fontSize 11, and fontWeight that
+  /// changes based on selection (w600 for selected, w500 for unselected).
+  final TextStyle? textStyle;
+
+  // ===========================================================================
+  // Glow Effect Properties
+  // ===========================================================================
+
+  /// Duration of the glow animation when selecting a tab.
+  ///
+  /// Defaults to 300 milliseconds.
+  final Duration glowDuration;
+
+  /// Blur radius of the glow effect.
+  ///
+  /// Larger values create a softer, more diffuse glow.
+  /// Defaults to 32.
+  final double glowBlurRadius;
+
+  /// Spread radius of the glow effect.
+  ///
+  /// Controls how far the glow extends from the icon.
+  /// Defaults to 8.
+  final double glowSpreadRadius;
+
+  /// Opacity of the glow effect when a tab is selected.
+  ///
+  /// Value between 0.0 (invisible) and 1.0 (fully opaque).
+  /// Defaults to 0.6.
+  final double glowOpacity;
+
+  @override
+  Widget build(BuildContext context) => TabBarBottomLayout(
+        tabs: tabs,
+        selectedIndex: selectedIndex,
+        onTabSelected: onTabSelected,
+        extraButton: extraButton,
+        spacing: spacing,
+        horizontalPadding: horizontalPadding,
+        verticalPadding: verticalPadding,
+        barHeight: barHeight,
+        barBorderRadius: barBorderRadius,
+        tabPadding: tabPadding,
+        iconLabelSpacing: iconLabelSpacing,
+        enableBlend: enableBlend,
+        blendAmount: blendAmount,
+        settings: settings,
+        showIndicator: showIndicator,
+        indicatorColor: indicatorColor,
+        indicatorSettings: indicatorSettings,
+        indicatorPinchStrength: indicatorPinchStrength,
+        selectedIconColor: selectedIconColor,
+        unselectedIconColor: unselectedIconColor,
+        selectedLabelColor: selectedLabelColor,
+        unselectedLabelColor: unselectedLabelColor,
+        selectedLabelStyle: selectedLabelStyle,
+        unselectedLabelStyle: unselectedLabelStyle,
+        iconSize: iconSize,
+        labelFontSize: labelFontSize,
+        textStyle: textStyle,
+        glowDuration: glowDuration,
+        glowBlurRadius: glowBlurRadius,
+        glowSpreadRadius: glowSpreadRadius,
+        glowOpacity: glowOpacity,
+        quality: quality,
+        magnification: magnification,
+        innerBlur: innerBlur,
+        maskingQuality: maskingQuality,
+        backgroundKey: backgroundKey,
+        tabWidth: tabWidth,
+        indicatorBorderRadius: indicatorBorderRadius,
+        indicatorExpansion: indicatorExpansion,
+        interactionGlowColor: interactionGlowColor,
+        interactionGlowRadius: interactionGlowRadius,
+        interactionBehavior: interactionBehavior,
+        pressScale: pressScale,
+        platformViewBackdrop: platformViewBackdrop,
+        adaptiveBrightness: adaptiveBrightness,
+        onBrightnessChanged: onBrightnessChanged,
+        brightnessOverride: brightnessOverride,
+      );
+}
+
+/// Configuration for a tab in [GlassBottomBar].
+///
+/// Each tab displays an icon and label. Optionally provide a different widget
+/// for the selected state and a glow color for the selection animation.
+///
+/// ## Icon widgets
+///
+/// Pass any widget as [icon] and [activeIcon]. Standard [Icon] widgets will
+/// automatically inherit the correct color, size, and shadow halo from the
+/// bar's [IconTheme]. Custom widgets (SVG, PNG, etc.) are responsible for
+/// their own tinting.
+///
+/// ```dart
+/// // Standard Icon — inherits color/size automatically
+/// GlassBottomBarTab(
+///   label: 'Home',
+///   icon: Icon(CupertinoIcons.home),
+///   activeIcon: Icon(CupertinoIcons.home_fill),
+/// )
+///
+/// // Custom SVG — color handled by the caller
+/// GlassBottomBarTab(
+///   label: 'Settings',
+///   icon: SvgPicture.asset('assets/settings.svg', colorFilter: ...),
+/// )
+/// ```
+/// **Deprecated:** Use [GlassSegment] instead.
+///
+/// [GlassBottomBarTab] is a zero-logic typedef shim.
+/// Replace `GlassBottomBarTab(icon: ..., label: ..., glowColor: ...)` with
+/// `GlassSegment(icon: ..., label: ..., glowColor: ...)`.
+@Deprecated('Use GlassSegment instead. '
+    'GlassBottomBarTab will be removed in v1.0. '
+    'Migration: replace GlassBottomBarTab( with GlassSegment(.')
+class GlassBottomBarTab {
+  /// Creates a bottom bar tab configuration.
+  const GlassBottomBarTab({
+    this.label,
+    required this.icon,
+    this.activeIcon,
+    this.glowColor,
+    this.thickness,
+  });
+
+  /// Label text displayed below the icon.
+  final String? label;
+
+  /// Widget displayed when the tab is not selected.
+  ///
+  /// Also used when selected if [activeIcon] is not provided.
+  /// Standard [Icon] widgets automatically pick up the correct color and size
+  /// from the parent [IconTheme].
+  final Widget icon;
+
+  /// Widget displayed when the tab is selected.
+  ///
+  /// If null, [icon] is used for both selected and unselected states.
+  /// Standard [Icon] widgets automatically pick up the correct color and size
+  /// from the parent [IconTheme].
+  final Widget? activeIcon;
+
+  /// Color of the animated glow effect when this tab is selected.
+  ///
+  /// If null, no glow effect is shown for this tab.
+  final Color? glowColor;
+
+  /// Thickness of the icon shadow halo effect.
+  ///
+  /// When provided, creates a shadow halo around the icon for emphasis.
+  /// Only visible on unselected tabs, or selected tabs without a
+  /// different [activeIcon].
+  /// Typical values are between 0.5 and 2.0.
+  ///
+  /// This is applied via [IconTheme], so it only takes effect on
+  /// standard [Icon] widgets. Custom widgets must handle shadows themselves.
+  final double? thickness;
+}
+
+/// Where a [GlassTabBarExtraButton] appears relative to the search pill
+/// in a [GlassSearchableBottomBar].
+///
+/// Has no effect in [GlassBottomBar], where the extra button always sits
+/// between the tab content and the right edge.
+enum GlassExtraButtonPosition {
+  /// Place the button **before** the search pill — between the tab pill and
+  /// the search pill. This is the default and matches the classic iOS
+  /// "compose" button position seen in Mail and Messages.
+  beforeSearch,
+
+  /// Place the button **after** the search pill — pinned to the trailing
+  /// (right) edge of the bar. Use this when you want a persistent action
+  /// button that stays visible at the far right even while search is expanded.
+  /// The search pill's spring calculations automatically reserve the required
+  /// space so no RenderFlex overflow occurs during transitions.
+  afterSearch,
+}
+
+/// Controls how the tab pill is anchored **horizontally** during the morph
+/// animation in [GlassSearchableBottomBar].
+///
+/// This only affects the tab pill's position. The search pill position is
+/// always computed from the trailing edge.
+enum GlassTabPillAnchor {
+  /// The tab pill is pinned to the **leading (left) edge** — the right edge
+  /// retracts as the pill collapses. This is the default and matches the
+  /// classic iOS News / Safari behaviour.
+  start,
+
+  /// The tab pill scales **from its centre** — both edges collapse inward
+  /// symmetrically as the pill morphs into the collapsed search state, and
+  /// expand outward symmetrically when search closes.
+  ///
+  /// Use this when you want a more balanced, symmetrical animation. Note that
+  /// while searching, the search pill will be slightly narrower than in
+  /// [start] mode because it starts after the centred collapsed tab pill.
+  center,
+}
+
+/// Configuration for the extra button in [GlassBottomBar] and
+/// [GlassSearchableBottomBar].
+///
+/// The extra button is rendered as a [GlassButton] and typically used for
+/// primary actions like creating new content.
+class GlassTabBarExtraButton {
+  /// Creates an extra button configuration.
+  const GlassTabBarExtraButton({
+    required this.icon,
+    required this.onTap,
+    required this.label,
+    this.iconColor,
+    this.size = 64,
+    this.position = GlassExtraButtonPosition.beforeSearch,
+    this.collapseOnSearchFocus = true,
+  });
+
+  /// Icon widget displayed in the button.
+  final Widget icon;
+
+  /// Callback when the button is tapped.
+  final VoidCallback onTap;
+
+  /// Accessibility label for the button.
+  final String label;
+
+  /// Color used for the button's icon.
+  ///
+  /// Defaults to GlassBottomBar.unselectedIconColor.
+  final Color? iconColor;
+
+  /// Width and height of the button.
+  ///
+  /// Defaults to 64 to match the default bar height.
+  final double size;
+
+  /// Where this button is placed relative to the search pill in a
+  /// [GlassSearchableBottomBar].
+  ///
+  /// - [GlassExtraButtonPosition.beforeSearch] (default) — between the tab pill
+  ///   and the search pill. Classic iOS pattern (Mail compose button).
+  /// - [GlassExtraButtonPosition.afterSearch] — pinned to the right edge, after
+  ///   the search pill. The search pill's spring calculations automatically
+  ///   reserve space so no RenderFlex overflow occurs during transitions.
+  ///
+  /// Has no effect in [GlassBottomBar].
+  final GlassExtraButtonPosition position;
+
+  /// Whether this button collapses (hides + frees layout space) when the
+  /// search field is focused (i.e. the keyboard is visible).
+  ///
+  /// When `true` (default), the button fades out and its horizontal layout
+  /// space spring-animates to zero on keyboard appearance, giving the search
+  /// input the full available width — matching native iOS system apps
+  /// (Weather, App Store, Apple News).
+  ///
+  /// When `false`, the button remains fully visible and tappable alongside
+  /// the search input. Use this for buttons with contextual relevance during
+  /// active search (e.g. a "Filter" action that applies to search results).
+  ///
+  /// Has no effect in [GlassBottomBar].
+  final bool collapseOnSearchFocus;
+}
+
+/// Deprecated alias for [GlassTabBarExtraButton].
+///
+/// **Deprecated:** Use [GlassTabBarExtraButton] instead.
+///
+/// This typedef will be removed in v1.0 alongside [GlassBottomBar] and
+/// [GlassSearchableBottomBar]. Migrate by replacing
+/// `GlassBottomBarExtraButton(` with `GlassTabBarExtraButton(`.
+@Deprecated(
+  'Use GlassTabBarExtraButton instead. '
+  'GlassBottomBarExtraButton will be removed in v1.0. '
+  'Migrate: replace GlassBottomBarExtraButton( with GlassTabBarExtraButton(.',
+)
+typedef GlassBottomBarExtraButton = GlassTabBarExtraButton;
+
+// TabIndicator and TabIndicatorState live in shared/tab_bar_bottom_internal.dart.
+// JellyClipper is defined below — kept here because bottom_bar_internal.dart
+// and searchable_bottom_bar_internal.dart import it via `show JellyClipper`.
+
+/// Clipper that matches the shape and physics of the jelly indicator.
+class JellyClipper extends CustomClipper<Path> {
+  JellyClipper({
+    required this.itemCount,
+    required this.alignment,
+    required this.thickness,
+    required this.expansion,
+    required this.transform,
+    required this.borderRadius,
+    this.inverse = false,
+  });
+
+  final int itemCount;
+  final Alignment alignment;
+  final double thickness;
+  final EdgeInsets expansion;
+  final Matrix4 transform;
+  final double borderRadius;
+  final bool inverse;
+
+  /// Threshold for clip recalculation optimization.
+  ///
+  /// When changes in alignment or thickness are below this threshold,
+  /// the cached clip path is reused instead of recalculating.
+  /// This is below human perception threshold (sub-pixel).
+  static const double _recalcThreshold = 0.001;
+
+  @override
+  Path getClip(Size size) {
+    // Calculate the base rect of the indicator (same logic as FractionallySizedBox)
+    final tabWidth = size.width / itemCount;
+    final availableWidth = size.width - tabWidth;
+
+    // Map alignment (-1 to 1) to horizontal offset
+    final left = (alignment.x + 1) / 2 * availableWidth;
+
+    // Create the base rect
+    // Note: We need to account for the padding applied to AnimatedGlassIndicator
+    // AnimatedGlassIndicator has padding: const EdgeInsets.all(4)
+    // So the rect should be inset by 4 on all sides, then inflated by expansion * thickness
+
+    final baseRect = Rect.fromLTWH(left, 0, tabWidth, size.height);
+    final paddedRect = Rect.fromLTRB(
+      baseRect.left + 4.0, // Left padding
+      baseRect.top + 4.0, // Top padding
+      baseRect.right - 4.0, // Right padding
+      baseRect.bottom - 4.0, // Bottom padding
+    );
+
+    // Apply expansion based on thickness (drag state)
+    final inflatedRect = Rect.fromLTRB(
+      paddedRect.left - (expansion.left * thickness),
+      paddedRect.top - (expansion.top * thickness),
+      paddedRect.right + (expansion.right * thickness),
+      paddedRect.bottom + (expansion.bottom * thickness),
+    );
+
+    // Clamp radius to avoid invalid RRect paths on Impeller.
+    // We subtract 0.1 to prevent the radius from being EXACTLY half the shortest side,
+    // which triggers an empty path bug in some Impeller versions during animation.
+    final maxRadius = (inflatedRect.shortestSide / 2) - 0.1;
+    final safeRadius = borderRadius > maxRadius ? maxRadius : borderRadius;
+
+    // Create rounded rect path
+    final path = Path()
+      ..addRRect(RRect.fromRectAndRadius(
+        inflatedRect,
+        Radius.circular(safeRadius > 0 ? safeRadius : 0),
+      ));
+
+    // Apply jelly physics transform around the center
+    final center = inflatedRect.center;
+    final centeredTransform = Matrix4.identity()
+      ..translate(center.dx, center.dy)
+      ..multiply(transform)
+      ..translate(-center.dx, -center.dy);
+
+    final indicatorPath = path.transform(centeredTransform.storage);
+
+    if (inverse) {
+      return Path()
+        ..fillType = PathFillType.evenOdd
+        ..addRect(Rect.fromLTWH(0, 0, size.width, size.height))
+        ..addPath(indicatorPath, Offset.zero);
+    }
+
+    return indicatorPath;
+  }
+
+  @override
+  bool shouldReclip(JellyClipper oldClipper) {
+    // Optimization: skip reclip for sub-pixel changes
+    // This reduces clip path recalculations by ~20-30% during slow drags
+    if (itemCount == oldClipper.itemCount &&
+        inverse == oldClipper.inverse &&
+        borderRadius == oldClipper.borderRadius &&
+        expansion == oldClipper.expansion &&
+        transform == oldClipper.transform &&
+        (alignment.x - oldClipper.alignment.x).abs() < _recalcThreshold &&
+        (thickness - oldClipper.thickness).abs() < _recalcThreshold) {
+      return false; // Reuse cached clip path
+    }
+
+    // Full check for significant changes
+    return itemCount != oldClipper.itemCount ||
+        alignment != oldClipper.alignment ||
+        thickness != oldClipper.thickness ||
+        expansion != oldClipper.expansion ||
+        transform != oldClipper.transform ||
+        borderRadius != oldClipper.borderRadius ||
+        inverse != oldClipper.inverse;
+  }
+}
+
+// =============================================================================
+// Jelly Physics
+// =============================================================================
+
+/// Applies jelly transform with organic squash and stretch based on velocity.
+///
+/// This transform creates the satisfying "jelly" effect seen in iOS interfaces:
+/// - Objects squash in the direction of movement
+/// - Objects stretch perpendicular to movement
+///
+/// Used by [_TabIndicator] to animate the draggable indicator.

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_large_title.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_large_title.dart
@@ -1,0 +1,453 @@
+import 'package:flutter/cupertino.dart';
+
+// =============================================================================
+// GlassLargeTitleController
+// =============================================================================
+
+/// Coordinates the large-title + search-bar collapse animation between
+/// [GlassLargeTitle] and [GlassAppBar].
+///
+/// Create one instance per screen, pass it to both widgets, and dispose it in
+/// your `State.dispose()`. The controller owns the [ScrollController] — callers
+/// attach it to their [CustomScrollView] via [scrollController].
+///
+/// ## Two-phase iOS 26 collapse
+///
+/// **Phase 1** — large title fades out over the first `~52pt` of scroll.
+/// Driven by [collapseProgress].
+///
+/// **Phase 2** — search bar (when provided to [GlassLargeTitle]) collapses
+/// immediately after the title, over the next `~44pt`. Driven by
+/// [searchBarCollapseProgress].
+///
+/// ```dart
+/// class _MyScreenState extends State<MyScreen> {
+///   final _titleController = GlassLargeTitleController();
+///
+///   @override
+///   void dispose() {
+///     _titleController.dispose();
+///     super.dispose();
+///   }
+///
+///   @override
+///   Widget build(BuildContext context) => GlassScaffold(
+///     appBar: GlassAppBar(
+///       title: Text('Chats'),
+///       largeTitleController: _titleController,
+///     ),
+///     body: CustomScrollView(
+///       controller: _titleController.scrollController,
+///       slivers: [
+///         GlassLargeTitle(
+///           text: 'Chats',
+///           controller: _titleController,
+///           searchBar: GlassSearchBar(placeholder: 'Search'),
+///         ),
+///         // ... content slivers
+///       ],
+///     ),
+///   );
+/// }
+/// ```
+class GlassLargeTitleController extends ChangeNotifier {
+  /// Creates a controller.
+  ///
+  /// [collapseTitleHeight] — scroll distance (logical pixels) over which the
+  /// large title fully collapses. Defaults to `52.0` (iOS 26 spec). Overridden
+  /// automatically by [GlassLargeTitle] after its first layout.
+  ///
+  /// [searchBarHeight] — scroll distance over which the search bar collapses
+  /// after the title collapse completes. Defaults to `44.0` (standard iOS
+  /// search bar height). Overridden automatically by [GlassLargeTitle] after
+  /// first layout when a `searchBar` is provided.
+  GlassLargeTitleController({
+    double collapseTitleHeight = 52.0,
+    double searchBarHeight = 44.0,
+  })  : _collapseTitleHeight = collapseTitleHeight,
+        _searchBarHeight = searchBarHeight {
+    _scrollController = ScrollController();
+    _scrollController.addListener(_onScroll);
+  }
+
+  late final ScrollController _scrollController;
+
+  // Both mutable — overridden by self-measurement from GlassLargeTitle.
+  double _collapseTitleHeight;
+  double _searchBarHeight;
+
+  double _collapseProgress = 0.0;
+  double _searchBarCollapseProgress = 0.0;
+
+  // Raw offset for overscroll rubber-band stretch. May be negative on iOS.
+  double _rawScrollOffset = 0.0;
+
+  /// The [ScrollController] to attach to your [CustomScrollView].
+  ScrollController get scrollController => _scrollController;
+
+  /// Title collapse progress in the range `[0.0, 1.0]`.
+  ///
+  /// - `0.0` — large title fully visible, bar title invisible.
+  /// - `1.0` — large title fully hidden, bar title fully visible (Phase 1 done).
+  double get collapseProgress => _collapseProgress;
+
+  /// Search bar collapse progress in the range `[0.0, 1.0]`.
+  ///
+  /// Starts from `0.0` only **after** [collapseProgress] reaches `1.0`
+  /// (Phase 2 begins after Phase 1 completes).
+  ///
+  /// - `0.0` — search bar fully visible.
+  /// - `1.0` — search bar fully collapsed behind the navigation bar.
+  ///
+  /// Only meaningful when a `searchBar` is provided to [GlassLargeTitle].
+  double get searchBarCollapseProgress => _searchBarCollapseProgress;
+
+  /// Raw scroll offset including negative values during iOS rubber-band overscroll.
+  ///
+  /// Used internally by [GlassLargeTitle] to drive the stretch scale animation
+  /// when the user pulls down past the top of the list.
+  double get rawScrollOffset => _rawScrollOffset;
+
+  /// Calibrates the title collapse distance to the actual rendered height.
+  ///
+  /// Called automatically by [GlassLargeTitle] after first layout. You do not
+  /// normally need to call this yourself.
+  void reportMeasuredHeight(double height) {
+    if (height > 0 && height != _collapseTitleHeight) {
+      _collapseTitleHeight = height;
+      _updateState();
+    }
+  }
+
+  /// Calibrates the search bar collapse distance to the actual rendered height.
+  ///
+  /// Called automatically by [GlassLargeTitle] after first layout when a
+  /// `searchBar` widget is provided. You do not normally need to call this.
+  void reportSearchBarHeight(double height) {
+    if (height > 0 && height != _searchBarHeight) {
+      _searchBarHeight = height;
+      _updateState();
+    }
+  }
+
+  void _onScroll() {
+    // Fires in the gesture/animation phase — always before the build phase.
+    // Safe to call notifyListeners() synchronously here.
+    _updateState();
+  }
+
+  void _updateState() {
+    if (!_scrollController.hasClients) return;
+    final offset = _scrollController.offset;
+
+    // Phase 1: large title collapses over first window.
+    final newTitleProgress = (offset / _collapseTitleHeight).clamp(0.0, 1.0);
+
+    // Phase 2: search bar collapses in the second window,
+    // starting exactly where Phase 1 ends.
+    final searchOffset = offset - _collapseTitleHeight;
+    final newSearchProgress = _searchBarHeight > 0
+        ? (searchOffset / _searchBarHeight).clamp(0.0, 1.0)
+        : 0.0;
+
+    // Notify on collapseProgress change, searchBar change, or overscroll
+    // (negative offsets keep collapseProgress at 0 but change stretch scale).
+    final overscrollChanged = offset < 0 && offset != _rawScrollOffset;
+    final changed = newTitleProgress != _collapseProgress ||
+        newSearchProgress != _searchBarCollapseProgress ||
+        overscrollChanged;
+
+    _rawScrollOffset = offset;
+    _collapseProgress = newTitleProgress;
+    _searchBarCollapseProgress = newSearchProgress;
+
+    if (changed) notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+}
+
+// =============================================================================
+// GlassLargeTitle
+// =============================================================================
+
+/// A sliver widget that renders a large 34pt iOS 26 navigation title (and
+/// optionally an inline search bar) which collapse smoothly as the user scrolls.
+///
+/// Drop it as the **first sliver** in your [CustomScrollView]. Pair with
+/// [GlassLargeTitleController] and pass the same controller to
+/// [GlassAppBar.largeTitleController] to automatically cross-fade the
+/// inline bar title.
+///
+/// ## iOS 26 fidelity
+///
+/// - **Typography:** 34pt, w700, -0.5 letter-spacing — exact iOS 26 spec.
+/// - **Two-phase collapse:** Large title fades first (Phase 1), then the
+///   search bar collapses under the nav bar (Phase 2) — matching iOS 26's
+///   `UINavigationItem.searchController` behaviour.
+/// - **Fade curve:** `Curves.easeIn` on title, `Curves.easeIn` on search bar.
+/// - **Overscroll stretch:** Title scales up slightly on rubber-band pull,
+///   matching iOS 26's `UINavigationBar` large-title elastic stretch.
+/// - **Self-measuring:** Reports rendered heights to the controller after
+///   first layout — correct collapse timing under all Dynamic Type settings.
+///
+/// ## Basic usage — title only
+///
+/// ```dart
+/// GlassLargeTitle(
+///   text: 'Chats',
+///   controller: _titleController,
+/// )
+/// ```
+///
+/// ## With search bar — two-phase iOS 26 collapse
+///
+/// ```dart
+/// GlassLargeTitle(
+///   text: 'Messages',
+///   controller: _titleController,
+///   searchBar: GlassSearchBar(
+///     placeholder: 'Search',
+///     onChanged: (v) => _filter(v),
+///   ),
+/// )
+/// ```
+///
+/// ## With trailing widget (avatar, action button)
+///
+/// ```dart
+/// GlassLargeTitle(
+///   text: 'Listen Now',
+///   controller: _titleController,
+///   trailing: CircleAvatar(child: Text('SD')),
+/// )
+/// ```
+class GlassLargeTitle extends StatefulWidget {
+  /// Creates a large-title sliver.
+  ///
+  /// [text] is the title displayed at 34pt (iOS 26 spec).
+  /// [controller] coordinates the collapse animation with [GlassAppBar].
+  /// [searchBar] is an optional search widget (e.g. [GlassSearchBar]) that
+  /// collapses in Phase 2, after the large title is fully scrolled away.
+  const GlassLargeTitle({
+    required this.text,
+    required this.controller,
+    this.searchBar,
+    this.fontSize = 34.0,
+    this.fontWeight = FontWeight.w700,
+    this.letterSpacing = -0.5,
+    this.padding = const EdgeInsets.fromLTRB(24, 0, 24, 8),
+    this.searchBarPadding =
+        const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+    this.color,
+    this.trailing,
+    super.key,
+  });
+
+  /// The navigation title text — should match the `title` passed to
+  /// [GlassAppBar].
+  final String text;
+
+  /// The controller that drives the collapse animation and provides the
+  /// [ScrollController] for your [CustomScrollView].
+  final GlassLargeTitleController controller;
+
+  /// Optional search widget displayed below the large title.
+  ///
+  /// Typically a [GlassSearchBar]. When provided, the widget collapses in
+  /// **Phase 2** — after the large title has fully scrolled away — matching
+  /// iOS 26's two-phase UINavigationBar search collapse behaviour.
+  final Widget? searchBar;
+
+  /// Font size of the large title. Defaults to `34.0` (iOS 26 spec).
+  final double fontSize;
+
+  /// Font weight. Defaults to [FontWeight.w700].
+  final FontWeight fontWeight;
+
+  /// Letter spacing. Defaults to `-0.5` (iOS 26 spec).
+  final double letterSpacing;
+
+  /// Padding around the title row.
+  ///
+  /// Defaults to `EdgeInsets.fromLTRB(24, 0, 24, 8)`.
+  final EdgeInsetsGeometry padding;
+
+  /// Padding around the search bar, when [searchBar] is provided.
+  ///
+  /// Defaults to `EdgeInsets.symmetric(horizontal: 16, vertical: 4)`,
+  /// which matches iOS 26's search bar insets under a large title.
+  final EdgeInsetsGeometry searchBarPadding;
+
+  /// Title text colour. Defaults to [CupertinoColors.label] resolved from
+  /// the current theme — correct dark-mode behaviour automatically.
+  final Color? color;
+
+  /// Optional widget at the trailing edge of the title row.
+  ///
+  /// Use for an avatar or action button (Apple Music / Podcasts pattern).
+  /// Fades out with the same curve as the title text.
+  final Widget? trailing;
+
+  @override
+  State<GlassLargeTitle> createState() => _GlassTitleSliverState();
+}
+
+class _GlassTitleSliverState extends State<GlassLargeTitle> {
+  // GlobalKeys for self-measuring both the title row and the search bar.
+  final _titleKey = GlobalKey();
+  final _searchBarKey = GlobalKey();
+  bool _pendingMeasure = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onProgressChanged);
+    _scheduleMeasure();
+  }
+
+  @override
+  void didUpdateWidget(GlassLargeTitle oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_onProgressChanged);
+      widget.controller.addListener(_onProgressChanged);
+      _scheduleMeasure();
+    }
+    if (oldWidget.fontSize != widget.fontSize ||
+        oldWidget.padding != widget.padding ||
+        oldWidget.searchBar != widget.searchBar) {
+      _scheduleMeasure();
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onProgressChanged);
+    super.dispose();
+  }
+
+  void _onProgressChanged() {
+    if (mounted) setState(() {});
+  }
+
+  void _scheduleMeasure() {
+    if (_pendingMeasure) return;
+    _pendingMeasure = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _pendingMeasure = false;
+      _measureAndReport();
+    });
+  }
+
+  void _measureAndReport() {
+    // Measure title row height.
+    final titleBox = _titleKey.currentContext?.findRenderObject() as RenderBox?;
+    if (titleBox != null && titleBox.hasSize) {
+      final h = titleBox.size.height;
+      if (h > 0) widget.controller.reportMeasuredHeight(h);
+    }
+
+    // Measure search bar height (only when a searchBar is provided).
+    if (widget.searchBar != null) {
+      final searchBox =
+          _searchBarKey.currentContext?.findRenderObject() as RenderBox?;
+      if (searchBox != null && searchBox.hasSize) {
+        final h = searchBox.size.height;
+        if (h > 0) widget.controller.reportSearchBarHeight(h);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = widget.controller.collapseProgress;
+    final searchProgress = widget.controller.searchBarCollapseProgress;
+    final rawOffset = widget.controller.rawScrollOffset;
+    final effectiveColor =
+        widget.color ?? CupertinoColors.label.resolveFrom(context);
+
+    // ── iOS 26 ease-in fade (Phase 1) ─────────────────────────────────────
+    // Large title stays opaque longer, drops off quickly — matching UIKit.
+    final titleFadeOut =
+        Curves.easeIn.transform((1.0 - progress).clamp(0.0, 1.0));
+
+    // ── iOS 26 overscroll rubber-band stretch ──────────────────────────────
+    // Title grows slightly on rubber-band pull, matching UINavigationBar.
+    final stretchScale =
+        rawOffset < 0 ? 1.0 + (-rawOffset / 300.0).clamp(0.0, 0.12) : 1.0;
+
+    // ── iOS 26 search bar ease-in fade (Phase 2) ──────────────────────────
+    // Collapses height to zero and fades out after the title is gone.
+    final searchFadeOut =
+        Curves.easeIn.transform((1.0 - searchProgress).clamp(0.0, 1.0));
+    final searchHeightFactor = (1.0 - searchProgress).clamp(0.0, 1.0);
+
+    return SliverToBoxAdapter(
+      child: Transform.scale(
+        scale: stretchScale,
+        alignment: Alignment.bottomLeft,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // ── Large title row ────────────────────────────────────────────
+            Padding(
+              key: _titleKey,
+              padding: widget.padding,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: Text(
+                      widget.text,
+                      style: TextStyle(
+                        fontSize: widget.fontSize,
+                        fontWeight: widget.fontWeight,
+                        letterSpacing: widget.letterSpacing,
+                        color: effectiveColor.withValues(alpha: titleFadeOut),
+                        height: 1.1,
+                      ),
+                    ),
+                  ),
+                  if (widget.trailing != null) ...[
+                    const SizedBox(width: 8),
+                    Opacity(
+                      opacity: titleFadeOut,
+                      child: widget.trailing,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+
+            // ── Search bar (Phase 2 collapse) ──────────────────────────────
+            // Collapses height to zero via ClipRect + Align(heightFactor),
+            // then fades out — replicating UISearchController's collapse
+            // under the navigation bar after the large title scrolls away.
+            if (widget.searchBar != null)
+              ClipRect(
+                child: Align(
+                  heightFactor: searchHeightFactor,
+                  alignment: Alignment.topCenter,
+                  child: Opacity(
+                    opacity: searchFadeOut,
+                    child: Padding(
+                      key: _searchBarKey,
+                      padding: widget.searchBarPadding,
+                      child: widget.searchBar,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_scaffold.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_scaffold.dart
@@ -1,0 +1,585 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../types/glass_quality.dart';
+import '../../theme/glass_theme_data.dart';
+import '../shared/glass_content_aware_scope.dart';
+import '../shared/glass_isolation_scope.dart';
+import '../shared/glass_page.dart';
+import '../shared/glass_scroll_edge_effect.dart';
+
+/// A one-stop-shop scaffold that replaces the manual assembly of [GlassPage],
+/// [Scaffold], [GlassScrollEdgeEffect], and a [Stack] for proper z-ordering.
+///
+/// ## Why GlassScaffold?
+///
+/// When using glass surfaces (navigation bars, bottom bars, cards), the correct
+/// layout requires 4-5 nested widgets with manual padding calculations and
+/// scroll controller wiring. `GlassScaffold` handles all of this internally:
+///
+/// - **Z-ordering**: App bar and bottom bar always render above body content,
+///   preventing glass cards in the body from overlapping navigation buttons.
+/// - **Edge fading**: Content fades smoothly as it approaches the bar areas,
+///   matching iOS 26's `.scrollEdgeEffectStyle(.soft)`.
+/// - **Auto padding**: Calculates safe-area-aware top/bottom padding so content
+///   starts below the app bar and above the bottom bar automatically.
+/// - **Background & glass layer**: Wraps everything in [GlassPage] for the
+///   glass rendering context, background, and status bar styling.
+///
+/// ## Before (manual assembly)
+///
+/// ```dart
+/// GlassPage(
+///   background: Image.asset('assets/bg.jpg', fit: BoxFit.cover),
+///   settings: RecommendedGlassSettings.standard,
+///   statusBarStyle: GlassStatusBarStyle.light,
+///   child: Scaffold(
+///     extendBodyBehindAppBar: true,
+///     extendBody: true,
+///     appBar: GlassAppBar(
+///       title: Text('Messages'),
+///       scrollController: _ctrl,
+///       settings: RecommendedGlassSettings.surface,
+///     ),
+///     body: GlassScrollEdgeEffect(
+///       topFadeHeight: MediaQuery.paddingOf(context).top + 44 + 40,
+///       bottomFadeHeight: 60 + MediaQuery.paddingOf(context).bottom,
+///       child: CustomScrollView(
+///         controller: _ctrl,
+///         slivers: [
+///           SliverToBoxAdapter(
+///             child: SizedBox(
+///               height: MediaQuery.paddingOf(context).top + 44 + 16,
+///             ),
+///           ),
+///           // ... content
+///         ],
+///       ),
+///     ),
+///   ),
+/// )
+/// ```
+///
+/// ## After (one widget)
+///
+/// ```dart
+/// GlassScaffold(
+///   background: Image.asset('assets/bg.jpg', fit: BoxFit.cover),
+///   settings: RecommendedGlassSettings.standard,
+///   statusBarStyle: GlassStatusBarStyle.light,
+///   appBar: GlassAppBar(
+///     title: Text('Messages'),
+///     scrollController: _ctrl,
+///     settings: RecommendedGlassSettings.surface,
+///   ),
+///   body: CustomScrollView(
+///     controller: _ctrl,
+///     slivers: [
+///       // No manual spacer needed — GlassScaffold handles it
+///       // ... content
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ## How it works internally
+///
+/// `GlassScaffold` builds:
+///
+/// ```
+/// GlassPage(
+///   background: ...,
+///   child: Scaffold(
+///     body: Stack(
+///       children: [
+///         // 1. Body with edge fading (bottom of stack)
+///         // 2. Body overlays (between body and bars)
+///         // 3. App bar (top of stack — always above body)
+///         // 4. Bottom bar (top of stack — always above body)
+///       ],
+///     ),
+///   ),
+/// )
+/// ```
+///
+/// The app bar and bottom bar are placed AFTER the body in the [Stack]'s
+/// children list, guaranteeing they always paint on top regardless of
+/// `BackdropFilter` compositing from glass widgets in the body.
+class GlassScaffold extends StatelessWidget {
+  /// Creates a glass scaffold with automatic z-ordering, edge fading,
+  /// and glass layer setup.
+  const GlassScaffold({
+    super.key,
+    required this.body,
+    this.appBar,
+    this.bottomBar,
+    this.background,
+    this.backgroundColor,
+    this.settings,
+    this.statusBarStyle = GlassStatusBarStyle.none,
+    this.edgeToEdge = false,
+    this.themeOverride,
+    this.enableBackgroundSampling,
+    this.edgeFade = true,
+    this.topEdgeFade,
+    this.bottomEdgeFade,
+    this.topEdgeFadeExtent = 20.0,
+    this.bottomEdgeFadeExtent = 20.0,
+    this.edgeStyle = GlassScrollEdgeStyle.soft,
+    this.extendBody = true,
+    this.appBarHeight = 44.0,
+    this.bottomBarHeight,
+    this.floatingActionButton,
+    this.resizeToAvoidBottomInset,
+    this.bodyOverlays,
+    this.header,
+    this.headerScrollController,
+    this.headerFadeDistance = 60.0,
+    this.contentAwareBrightness = false,
+  });
+
+  // ===========================================================================
+  // Body
+  // ===========================================================================
+
+  /// The main content of the scaffold.
+  ///
+  /// When [extendBody] is `true` (the default), the body extends behind the
+  /// app bar and bottom bar. A top spacer is automatically added to push
+  /// initial content below the app bar. When `false`, the body occupies only
+  /// the area between the app bar and bottom bar.
+  final Widget body;
+
+  // ===========================================================================
+  // Bars
+  // ===========================================================================
+
+  /// An optional app bar placed at the top, always above the body.
+  ///
+  /// Typically a [GlassAppBar], but any widget works. Z-ordering is
+  /// guaranteed — glass cards in the body will never overlap the app bar.
+  ///
+  /// If the widget implements [PreferredSizeWidget], its preferred height
+  /// is used for edge fade calculations. Otherwise, [appBarHeight] is used.
+  final Widget? appBar;
+
+  /// An optional bottom bar placed at the bottom, always above the body.
+  ///
+  /// Typically a [GlassBottomBar], [GlassSearchableBottomBar], or any widget.
+  /// When provided, bottom edge fading is auto-calculated to cover the bar
+  /// area plus safe zone.
+  final Widget? bottomBar;
+
+  // ===========================================================================
+  // GlassPage passthrough
+  // ===========================================================================
+
+  /// Background widget rendered behind everything. See [GlassPage.background].
+  final Widget? background;
+
+  /// A solid background colour rendered behind everything when no [background]
+  /// widget is provided.
+  ///
+  /// This is a convenience shorthand for:
+  /// ```dart
+  /// background: Container(color: myColor)
+  /// ```
+  /// When both [background] and [backgroundColor] are provided, [background]
+  /// takes precedence.
+  ///
+  /// When neither is set the Scaffold inherits [Theme.scaffoldBackgroundColor]
+  /// as normal — the inner Scaffold is **not** forced transparent.
+  final Color? backgroundColor;
+
+  /// Glass settings for the page's rendering layer. See [GlassPage.settings].
+  final LiquidGlassSettings? settings;
+
+  /// Status bar icon style. See [GlassPage.statusBarStyle].
+  final GlassStatusBarStyle statusBarStyle;
+
+  /// Whether to enable edge-to-edge rendering. See [GlassPage.edgeToEdge].
+  final bool edgeToEdge;
+
+  /// Optional per-page glass theme override. See [GlassPage.themeOverride].
+  final GlassThemeData? themeOverride;
+
+  /// Whether to capture the background as a GPU texture for glass colour
+  /// absorption. See [GlassPage.enableBackgroundSampling].
+  final bool? enableBackgroundSampling;
+
+  // ===========================================================================
+  // Edge fading
+  // ===========================================================================
+
+  /// Master toggle for edge fading. Defaults to `true`.
+  ///
+  /// When `true`, content fades at the top (below app bar) and bottom
+  /// (above bottom bar) edges. Override individual edges with [topEdgeFade]
+  /// and [bottomEdgeFade].
+  final bool edgeFade;
+
+  /// Whether to fade content at the top edge. When `null`, follows [edgeFade].
+  final bool? topEdgeFade;
+
+  /// Whether to fade content at the bottom edge. When `null`, follows
+  /// [edgeFade]. Automatically set to `true` when [bottomBar] is provided.
+  final bool? bottomEdgeFade;
+
+  /// Extra fade height beyond the auto-calculated app bar area.
+  ///
+  /// The total top fade height = safe area top + [appBarHeight] +
+  /// [topEdgeFadeExtent]. Defaults to 20.0.
+  final double topEdgeFadeExtent;
+
+  /// Extra fade height beyond the auto-calculated bottom bar area.
+  ///
+  /// The total bottom fade height = [bottomBarHeight] + safe area bottom +
+  /// [bottomEdgeFadeExtent]. Defaults to 20.0.
+  final double bottomEdgeFadeExtent;
+
+  /// The edge fade style. See [GlassScrollEdgeStyle].
+  final GlassScrollEdgeStyle edgeStyle;
+
+  // ===========================================================================
+  // Layout
+  // ===========================================================================
+
+  /// Whether the body extends behind the app bar and bottom bar.
+  ///
+  /// Defaults to `true`, matching iOS 26's design where content scrolls
+  /// behind the transparent navigation bar. When `false`, the body occupies
+  /// only the area between the bars (no overlap, no edge fading).
+  final bool extendBody;
+
+  /// The preferred height of the app bar, used for padding calculations.
+  ///
+  /// When [appBar] is a [PreferredSizeWidget], this value is overridden by
+  /// [PreferredSizeWidget.preferredSize.height]. Defaults to 44.0.
+  final double appBarHeight;
+
+  /// The height of the bottom bar, used for padding calculations.
+  ///
+  /// When null, defaults to 60.0 if [bottomBar] is provided. Set this
+  /// explicitly for custom-height bottom bars.
+  final double? bottomBarHeight;
+
+  /// An optional floating action button.
+  final Widget? floatingActionButton;
+
+  /// Whether the body should resize when the keyboard appears.
+  ///
+  /// When null, uses Scaffold's default (true).
+  final bool? resizeToAvoidBottomInset;
+
+  /// Optional overlay widgets placed between the body and the bars in the
+  /// z-order Stack.
+  ///
+  /// Use this for floating elements that should render above the body content
+  /// but below the app bar and bottom bar. Each widget is typically wrapped
+  /// in an [AnimatedPositioned] or [Positioned].
+  ///
+  /// Example: Apple Music's floating play bar pill:
+  /// ```dart
+  /// GlassScaffold(
+  ///   bodyOverlays: [
+  ///     AnimatedPositioned(
+  ///       bottom: isMiniMode ? miniBottom : aboveBarBottom,
+  ///       left: 20, right: 20,
+  ///       child: PlayBarPill(),
+  ///     ),
+  ///   ],
+  ///   bottomBar: GlassSearchableBottomBar(...),
+  ///   body: scrollContent,
+  /// )
+  /// ```
+  final List<Widget>? bodyOverlays;
+
+  /// A fixed header widget positioned below the status bar that fades out
+  /// as the user scrolls.
+  ///
+  /// Use this for iOS-style large title headers (e.g. Apple Music's
+  /// "Listen Now") that are not part of the scroll view but fade to
+  /// transparent as content scrolls up.
+  ///
+  /// Requires [headerScrollController] to drive the fade animation.
+  /// The fade is computed as `1.0 - (scrollOffset / headerFadeDistance)`.
+  ///
+  /// ```dart
+  /// GlassScaffold(
+  ///   header: Text('Listen Now', style: largeTitle),
+  ///   headerScrollController: _scrollController,
+  ///   headerFadeDistance: 60.0,
+  ///   body: CustomScrollView(
+  ///     controller: _scrollController,
+  ///     slivers: [...],
+  ///   ),
+  /// )
+  /// ```
+  final Widget? header;
+
+  /// The scroll controller that drives the [header] fade animation.
+  ///
+  /// Required when [header] is provided.
+  final ScrollController? headerScrollController;
+
+  /// The scroll distance (in pixels) over which the [header] fades from
+  /// fully opaque to fully transparent. Defaults to 60.0.
+  final double headerFadeDistance;
+
+  /// Whether to install a [GlassContentAwareScope] around the scaffold's
+  /// body and bars.
+  ///
+  /// When `true`, the scaffold wraps the body in [GlassContentAwareContent]
+  /// and the entire Stack in [GlassContentAwareScope]. This enables bars
+  /// with `adaptiveBrightness: true` to sample the body content and
+  /// automatically flip between light and dark appearance.
+  ///
+  /// The standalone [GlassContentAwareScope] and [GlassContentAwareContent]
+  /// widgets remain available for custom layouts that don't use
+  /// `GlassScaffold`.
+  ///
+  /// ```dart
+  /// GlassScaffold(
+  ///   contentAwareBrightness: true,
+  ///   bottomBar: GlassBottomBar(
+  ///     adaptiveBrightness: true,
+  ///     ...
+  ///   ),
+  ///   body: CustomScrollView(...),
+  /// )
+  /// ```
+  final bool contentAwareBrightness;
+
+  // ===========================================================================
+  // Build
+  // ===========================================================================
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final topPad = mediaQuery.padding.top;
+    final botPad = mediaQuery.padding.bottom;
+
+    // Resolve effective bar heights.
+    // If appBar implements PreferredSizeWidget, use its preferred height;
+    // otherwise fall back to the explicit appBarHeight parameter.
+    final effectiveAppBarHeight = appBar is PreferredSizeWidget
+        ? (appBar! as PreferredSizeWidget).preferredSize.height
+        : appBarHeight;
+    final effectiveBottomBarHeight =
+        bottomBar != null ? (bottomBarHeight ?? 60.0) : 0.0;
+
+    // Resolve edge fade toggles.
+    final doFadeTop = topEdgeFade ?? (edgeFade && appBar != null);
+    final doFadeBottom = bottomEdgeFade ?? (edgeFade && bottomBar != null);
+
+    // Calculate fade heights.
+    // Only include appBarHeight when an appBar is present — without one, the
+    // fade covers just the status bar area + extent.
+    final topFadeHeight = topPad +
+        (appBar != null ? effectiveAppBarHeight : 0.0) +
+        topEdgeFadeExtent;
+    final bottomFadeHeight =
+        effectiveBottomBarHeight + botPad + bottomEdgeFadeExtent;
+
+    // Build the body content.
+    Widget bodyContent = body;
+
+    // Wrap with edge fading if enabled.
+    if (extendBody && (doFadeTop || doFadeBottom)) {
+      bodyContent = GlassScrollEdgeEffect(
+        topFadeHeight: topFadeHeight,
+        bottomFadeHeight: bottomFadeHeight,
+        fadeTop: doFadeTop,
+        fadeBottom: doFadeBottom,
+        style: edgeStyle,
+        child: bodyContent,
+      );
+    }
+
+    // Wrap in GlassContentAwareContent when content-aware brightness is on.
+    // This installs the RepaintBoundary that the scope captures.
+    if (contentAwareBrightness) {
+      bodyContent = GlassContentAwareContent(child: bodyContent);
+    }
+
+    // Build the Stack with guaranteed z-ordering.
+    // All conditional children have explicit Keys so that Flutter can track
+    // them by identity rather than position. Without keys, toggling header
+    // (null → widget → null) shifts the index of appBar and bottomBar,
+    // causing Flutter to unmount/remount them — losing animation state.
+    final stackChildren = <Widget>[
+      // 1. Body (bottom of stack — always below bars).
+      if (extendBody)
+        Positioned.fill(child: bodyContent)
+      else
+        Positioned(
+          top: appBar != null ? topPad + effectiveAppBarHeight : 0,
+          left: 0,
+          right: 0,
+          bottom: bottomBar != null ? effectiveBottomBarHeight + botPad : 0,
+          child: bodyContent,
+        ),
+
+      // 2. Body overlays (between body and bars — e.g. floating play pill).
+      if (bodyOverlays != null) ...bodyOverlays!,
+
+      // 2b. Fixed header — fades on scroll (e.g. "Listen Now" in Apple Music).
+      // IgnorePointer is only active when opacity == 0 (fully faded) so that
+      // tappable elements inside the header work at full visibility.
+      if (header != null)
+        Positioned(
+          key: const ValueKey('glass_scaffold_header'),
+          top: 0,
+          left: 0,
+          right: 0,
+          child: SafeArea(
+            bottom: false,
+            child: headerScrollController != null
+                ? AnimatedBuilder(
+                    animation: headerScrollController!,
+                    builder: (context, child) {
+                      // Guard: during AnimatedSwitcher cross-fades, both old
+                      // and new scroll views briefly share the same controller.
+                      // Reading .offset (or .positions.last) throws if there
+                      // are multiple positions. Falling back to 0.0 for that
+                      // brief ~300 ms window is correct UX — the header just
+                      // stays fully visible during the transition.
+                      final offset = headerScrollController!.hasClients &&
+                              headerScrollController!.positions.length == 1
+                          ? headerScrollController!.offset
+                          : 0.0;
+                      // Guard against divide-by-zero if headerFadeDistance == 0.
+                      final opacity = headerFadeDistance > 0
+                          ? (1.0 - offset / headerFadeDistance).clamp(0.0, 1.0)
+                          : (offset > 0 ? 0.0 : 1.0);
+                      return IgnorePointer(
+                        // Disable hit-testing only when fully invisible.
+                        ignoring: opacity == 0.0,
+                        child: Opacity(opacity: opacity, child: child),
+                      );
+                    },
+                    child: header!,
+                  )
+                : header!,
+          ),
+        ),
+
+      // 2. App bar (above body — painted after body in Stack).
+      // Uses _GlassIsolationScope to tell descendant glass widgets
+      // (GlassButton, AdaptiveGlass) to render with their own independent
+      // glass layer instead of sharing the page-level layer. This prevents
+      // body glass cards from compositing over the app bar's glass buttons,
+      // and ensures the glass background paints in the correct Z-order.
+      // If isolated were false, the button's background would paint in the
+      // page's blend group (which is behind the body text), while the button's
+      // foreground would paint here, causing visual tearing.
+      if (appBar != null)
+        Positioned(
+          key: const ValueKey('glass_scaffold_app_bar'),
+          top: 0,
+          left: 0,
+          right: 0,
+          child: GlassIsolationScope(
+            isolated: true,
+            defaultQuality: GlassQuality.premium,
+            child: appBar!,
+          ),
+        ),
+
+      // 3. Bottom bar (above body — painted after body in Stack).
+      // SafeArea ensures the bar is never obscured by the Android system
+      // navigation bar or the iOS home indicator on any device.
+      if (bottomBar != null)
+        Positioned(
+          key: const ValueKey('glass_scaffold_bottom_bar'),
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: SafeArea(
+            top: false,
+            left: false,
+            right: false,
+            // iOS 26 floats pills natively over the home indicator visually
+            // (the 20px gap straddles the indicator).
+            // Android uses a physical nav bar or gesture bar that requires
+            // being pushed up explicitly.
+            bottom: Theme.of(context).platform == TargetPlatform.android,
+            child: GlassIsolationScope(
+              isolated: true,
+              defaultQuality: GlassQuality.premium,
+              child: bottomBar!,
+            ),
+          ),
+        ),
+    ];
+
+    // Resolve the system UI overlay style for the AnnotatedRegion.
+    // This ensures the status bar icons are correctly styled even on routes
+    // pushed via CupertinoPageRoute (which manages its own AnnotatedRegion).
+    // Without this, pages without a GlassAppBar lose the status bar icons
+    // because CupertinoPageRoute's default region overrides the imperative
+    // SystemChrome call from GlassPage.
+    final bool useLightIcons = switch (statusBarStyle) {
+      GlassStatusBarStyle.light => true,
+      GlassStatusBarStyle.dark => false,
+      GlassStatusBarStyle.auto =>
+        MediaQuery.platformBrightnessOf(context) == Brightness.dark,
+      GlassStatusBarStyle.none => true, // doesn't matter — no region
+    };
+
+    Widget stackWidget = Stack(children: stackChildren);
+
+    // Wrap in GlassContentAwareScope when content-aware brightness is on.
+    // The scope must be an ancestor of both the sampled body
+    // (GlassContentAwareContent) and the adaptive controls (bars with
+    // adaptiveBrightness: true).
+    if (contentAwareBrightness) {
+      stackWidget = GlassContentAwareScope(child: stackWidget);
+    }
+
+    Widget scaffold = Scaffold(
+      // Only force transparent when a background widget is provided — mirrors
+      // GlassPage's own logic. Without a background the Scaffold should
+      // inherit Theme.scaffoldBackgroundColor so callers can control the
+      // page colour through the standard Material theme.
+      backgroundColor: background != null ? Colors.transparent : null,
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+      floatingActionButton: floatingActionButton,
+      body: stackWidget,
+    );
+
+    // Wrap in AnnotatedRegion so the status bar style sticks even on
+    // CupertinoPageRoute transitions that manage their own region.
+    if (statusBarStyle != GlassStatusBarStyle.none) {
+      scaffold = AnnotatedRegion<SystemUiOverlayStyle>(
+        value: useLightIcons
+            ? SystemUiOverlayStyle.light
+            : SystemUiOverlayStyle.dark,
+        child: scaffold,
+      );
+    }
+
+    // Resolve effective background: explicit widget > backgroundColor colour >
+    // null (Scaffold inherits Theme.scaffoldBackgroundColor).
+    final Widget? effectiveBackground = background ??
+        (backgroundColor != null
+            ? SizedBox.expand(
+                child: ColoredBox(color: backgroundColor!),
+              )
+            : null);
+
+    return GlassPage(
+      background: effectiveBackground,
+      settings: settings,
+      // GlassScaffold handles AnnotatedRegion itself, so tell GlassPage to
+      // skip its own wrap + imperative SystemChrome call.
+      statusBarStyle: GlassStatusBarStyle.none,
+      edgeToEdge: edgeToEdge,
+      themeOverride: themeOverride,
+      enableBackgroundSampling: enableBackgroundSampling,
+      child: scaffold,
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_searchable_bottom_bar.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_searchable_bottom_bar.dart
@@ -1,0 +1,549 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show ValueListenable;
+
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../src/types/glass_interaction_behavior.dart';
+import '../../types/glass_quality.dart';
+import 'glass_bottom_bar.dart'
+    show
+        GlassTabBarExtraButton,
+        GlassBottomBarTab,
+        GlassTabPillAnchor,
+        MaskingQuality;
+import 'shared/glass_search_bar_config.dart';
+import 'shared/tab_bar_searchable_controller.dart';
+import 'shared/tab_bar_searchable_layout.dart';
+
+export 'shared/glass_search_bar_config.dart';
+
+// =============================================================================
+// Public Widget — GlassSearchableBottomBar
+// =============================================================================
+
+/// A glass bottom navigation bar with a morphing search pill.
+///
+/// Visually identical to [GlassBottomBar] but adds a search pill that shares
+/// the **same** [AdaptiveLiquidGlassLayer] as the tab pill. This means the
+/// two pills correctly liquid-merge at their edges — the same organic blending
+/// that makes the tab-bar + extra-button coupling feel native to iOS 26.
+///
+/// When [isSearchActive] is `false` the widget looks exactly like
+/// [GlassBottomBar] with a compact search icon pill at the right edge.
+///
+/// When [isSearchActive] is `true`:
+/// - The tab pill collapses to [GlassSearchBarConfig.collapsedTabWidth].
+/// - The search pill expands to fill all remaining space.
+/// - Both widths are calculated with [LayoutBuilder] — real pixel values — so
+///   Both widths animate with iOS-accurate [SpringSimulation] physics — no null/intrinsic hacks.
+///
+/// All parameters mirror [GlassBottomBar] exactly, with the additions of
+/// [isSearchActive] and [searchConfig].
+/// **Deprecated:** Use [GlassTabBar.searchable] instead.
+///
+/// [GlassSearchableBottomBar] is a zero-logic shim that will be removed in v1.0.
+/// Migrate by replacing `GlassSearchableBottomBar(` with `GlassTabBar.searchable(`.
+/// All parameters are identical. Replace any `GlassBottomBarTab(` with `GlassSegment(`.
+///
+/// ```dart
+/// // BEFORE
+/// GlassSearchableBottomBar(tabs: [...], searchConfig: ..., ...)
+/// // AFTER
+/// GlassTabBar.searchable(tabs: [...], searchConfig: ..., ...)
+/// ```
+@Deprecated('Use GlassTabBar.searchable() instead. '
+    'GlassSearchableBottomBar will be removed in v1.0. '
+    'Migration: replace GlassSearchableBottomBar( with GlassTabBar.searchable(.')
+class GlassSearchableBottomBar extends StatelessWidget {
+  /// Creates a glass bottom bar with a morphing search pill.
+  const GlassSearchableBottomBar({
+    required this.tabs,
+    required this.selectedIndex,
+    required this.onTabSelected,
+    required this.searchConfig,
+    super.key,
+    this.controller,
+    this.isSearchActive = false,
+    this.extraButton,
+    this.spacing = 8,
+    this.horizontalPadding = 20,
+    this.verticalPadding = 20,
+    this.barHeight = 64,
+    this.searchBarHeight = 50,
+    this.barBorderRadius = _kDefaultBorderRadius,
+    this.tabPadding = const EdgeInsets.symmetric(horizontal: 4),
+    this.iconLabelSpacing = 4,
+    this.enableBlend = true,
+    this.blendAmount = 10,
+    this.settings,
+    this.showIndicator = true,
+    this.indicatorColor,
+    this.indicatorSettings,
+    this.indicatorPinchStrength = 0.4,
+    this.selectedIconColor,
+    this.unselectedIconColor,
+    this.selectedLabelColor,
+    this.unselectedLabelColor,
+    this.selectedLabelStyle,
+    this.unselectedLabelStyle,
+    this.iconSize = 24,
+    this.labelFontSize = 11,
+    this.textStyle,
+    this.glowDuration = const Duration(milliseconds: 300),
+    this.glowBlurRadius = 32,
+    this.glowSpreadRadius = 8,
+    this.glowOpacity = 0.6,
+    this.interactionGlowColor,
+    this.interactionGlowRadius = 1.5,
+    this.quality,
+    this.magnification = 1.15,
+    this.innerBlur = 0.0,
+    this.platformViewBackdrop = false,
+    this.maskingQuality = MaskingQuality.high,
+    this.backgroundKey,
+    this.springDescription,
+    this.tabPillAnchor = GlassTabPillAnchor.start,
+    // ── Interaction ──────────────────────────────────────────────────────────
+    this.interactionBehavior = GlassInteractionBehavior.full,
+    this.pressScale = 1.04,
+    this.tabWidth,
+    this.indicatorBorderRadius,
+    this.indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    this.onBarTap,
+    // ── Whiten-at-bottom (light-mode legibility) ─────────────────────────────
+    this.whitenAtBottom = true,
+    this.whitenBottomThreshold = 45.0,
+    this.whitenAtBottomTarget = 1.0,
+    this.scrollController,
+    // ── Content-aware brightness ─────────────────────────────────────────────
+    this.adaptiveBrightness = false,
+    this.onBrightnessChanged,
+    this.brightnessOverride,
+  })  : assert(tabs.length > 0,
+            'GlassSearchableBottomBar requires at least one tab'),
+        assert(
+          selectedIndex >= 0 && selectedIndex < tabs.length,
+          'selectedIndex must be between 0 and tabs.length - 1',
+        ),
+        assert(
+          tabWidth == null || tabWidth > 0,
+          'tabWidth must be positive, or null to use expand (full-width) mode.',
+        );
+
+  // ignore: public_member_api_docs
+  static const double _kDefaultBorderRadius = 32.0;
+
+  // ── Search ──────────────────────────────────────────────────────────────────
+  /// Optional controller to manage the search bar state machine externally.
+  ///
+  /// When provided, the widget uses this controller's state instead of
+  /// creating its own. Useful for programmatic open/close of search,
+  /// or for unit testing the layout computation independently.
+  ///
+  /// The caller owns the controller's lifecycle — [dispose] it when done.
+  final SearchableBottomBarController? controller;
+
+  /// Configuration for the morphing search bar behaviour.
+  final GlassSearchBarConfig searchConfig;
+
+  /// Custom spring physics for the pill morph animation.
+  ///
+  /// When null, uses the built-in iOS 26-style spring (stiffness 350, damping 30).
+  /// Override to create slower, faster, or more/less bouncy transitions:
+  ///
+  /// ```dart
+  /// springDescription: const SpringDescription(
+  ///   mass: 1, stiffness: 200, damping: 40, // slower, minimal overshoot
+  /// ),
+  /// ```
+  final SpringDescription? springDescription;
+
+  /// How the tab pill is anchored horizontally during the morph animation.
+  ///
+  /// - [GlassTabPillAnchor.start] (default) — the tab pill is pinned to the
+  ///   leading edge; the right edge retracts as the pill collapses. This
+  ///   matches the default iOS News / Safari behaviour.
+  /// - [GlassTabPillAnchor.center] — the tab pill scales symmetrically from
+  ///   its centre; both edges collapse inward and expand outward together,
+  ///   giving a more balanced look. The search pill will be slightly narrower
+  ///   while searching because it starts after the (now centred) collapsed tab.
+  final GlassTabPillAnchor tabPillAnchor;
+
+  /// Whether the search bar is currently expanded.
+  ///
+  /// When `true`, the tab pill collapses and the search pill expands.
+  /// Animated using [AnimatedContainer] with iOS spring physics.
+  final bool isSearchActive;
+
+  // ── Tab configuration ────────────────────────────────────────────────────────
+  /// List of tabs. At least one tab is required.
+  final List<GlassBottomBarTab> tabs;
+
+  /// Index of the currently selected tab (0-based).
+  final int selectedIndex;
+
+  /// Callback fired when a tab is selected or the draggable indicator is released.
+  final ValueChanged<int> onTabSelected;
+
+  // ── Extra button (optional) ──────────────────────────────────────────────────
+  /// Optional extra action button shown between the tab pill and the search pill.
+  final GlassTabBarExtraButton? extraButton;
+
+  // ── Layout ───────────────────────────────────────────────────────────────────
+  /// Spacing between adjacent pills. Defaults to 8.
+  final double spacing;
+
+  /// Horizontal padding around the full bar content. Defaults to 20.
+  final double horizontalPadding;
+
+  /// Vertical padding (top + bottom) around the bar content. Defaults to 20.
+  final double verticalPadding;
+
+  /// Height of the tab pill and search pill. Defaults to 64.
+  final double barHeight;
+
+  /// Height of the pills when search is active. Defaults to `50.0`.
+  ///
+  /// In iOS 26 Apple News the search bar is noticeably shorter than the full
+  /// tab bar (which must accommodate icon + label). This default of `50`
+  /// replicates that compact, native feel. If you want the bar to remain
+  /// the same height, explicitly set this to match your [barHeight].
+  ///
+  /// The transition is animated with the same easeOut curve used for all
+  /// other bar morphs.
+  final double searchBarHeight;
+
+  /// Corner radius of both pills. Defaults to 32 (full pill shape).
+  final double barBorderRadius;
+
+  /// Internal padding within the tab pill. Defaults to 4 px horizontal.
+  final EdgeInsetsGeometry tabPadding;
+
+  /// Vertical spacing between icon and label. Defaults to 4.
+  final double iconLabelSpacing;
+
+  /// Whether to enable organic liquid blending between the tab pill,
+  /// search pill, and extra button.
+  ///
+  /// When `true` (default), adjacent glass surfaces merge organically —
+  /// a premium "beyond native" effect. When `false`, each element renders
+  /// as a fully independent glass surface, matching Apple's native iOS 26
+  /// tab bar behavior.
+  ///
+  /// When disabled, [blendAmount] is ignored.
+  final bool enableBlend;
+
+  /// Liquid-glass blend amount for the shared [AdaptiveLiquidGlassLayer].
+  ///
+  /// Higher values increase the organic blending between adjacent pills.
+  /// Only effective when [enableBlend] is `true`.
+  /// Defaults to 10.
+  final double blendAmount;
+
+  // ── Glass ────────────────────────────────────────────────────────────────────
+  /// Custom glass settings. Falls back to identical defaults as [GlassBottomBar].
+  final LiquidGlassSettings? settings;
+
+  // ── Whiten-at-bottom (light-mode legibility) ───────────────────────────────
+  /// When true (default), the bar lifts its whitening toward
+  /// [whitenAtBottomTarget] as the scrolled content nears the bottom of the
+  /// page, so a light page stays readable through the bar. Light-mode only;
+  /// set false to opt out.
+  ///
+  /// Inert unless a [scrollController] is provided (the bar needs a scroll
+  /// position to watch), so the defaults change nothing for existing callers.
+  final bool whitenAtBottom;
+
+  /// Distance (logical px) from the scroll bottom within which the bar is
+  /// considered "at the bottom" and whitens. Defaults to 45.
+  final double whitenBottomThreshold;
+
+  /// Whiten value the bar lifts to at the bottom. Defaults to 1.0
+  /// (fully white).
+  final double whitenAtBottomTarget;
+
+  /// Scroll controller for the page beneath the bar. Null (the default)
+  /// disables the whiten-at-bottom effect — there is no scroll position to
+  /// watch.
+  final ScrollController? scrollController;
+
+  // ── Content-aware brightness ────────────────────────────────────────────────
+  /// Whether the bar adapts its light/dark appearance to the content
+  /// scrolling underneath it, like the iOS 26 system bars.
+  ///
+  /// Requires an enclosing [GlassContentAwareScope] with the scrolling
+  /// content wrapped in a [GlassContentAwareContent]; without one the bar
+  /// keeps its ambient appearance. When the scope's contrast vote flips the
+  /// verdict, the bar cross-fades between the [GlassTheme] light and dark
+  /// variants — themed glass settings, glow palette and the default
+  /// icon/label colors all swap automatically.
+  ///
+  /// Defaults to false.
+  final bool adaptiveBrightness;
+
+  /// Called when the content-aware verdict flips (not for the initial
+  /// value).
+  ///
+  /// Use this to restyle elements the bar cannot see — page scrims, status
+  /// bar icons, custom-painted tab icons.
+  final ValueChanged<Brightness>? onBrightnessChanged;
+
+  /// External brightness source that bypasses the content sampler entirely.
+  ///
+  /// When non-null, the bar follows this listenable instead of registering
+  /// with the [GlassContentAwareScope] — the escape hatch for bars floating
+  /// over content that cannot be captured (iOS PlatformViews such as maps;
+  /// see [platformViewBackdrop]). Drive it from your own signal, e.g. the
+  /// active map style. Implies the adaptive behavior regardless of
+  /// [adaptiveBrightness].
+  final ValueListenable<Brightness>? brightnessOverride;
+
+  /// Rendering quality. Inherits from parent or defaults to [GlassQuality.premium].
+  final GlassQuality? quality;
+
+  // ── Indicator ────────────────────────────────────────────────────────────────
+  /// Whether to show the draggable indicator. Defaults to `true`.
+  final bool showIndicator;
+
+  /// Base color of the glass indicator. Falls back to theme or a translucent white.
+  final Color? indicatorColor;
+
+  /// Custom glass settings for the indicator element.
+  final LiquidGlassSettings? indicatorSettings;
+
+  /// Maximum concave lens pinch strength for the draggable indicator pill.
+  ///
+  /// - `1.0` (default) — full Apple-calibrated pinch
+  /// - `0.0` — pinch fully disabled
+  final double indicatorPinchStrength;
+
+  // ── Tab style ────────────────────────────────────────────────────────────────
+  /// Icon color when a tab is selected. Defaults to dynamic label color.
+  final Color? selectedIconColor;
+
+  /// Icon color when a tab is unselected. Defaults to dynamic label color.
+  final Color? unselectedIconColor;
+
+  /// Label color for selected tab.
+  final Color? selectedLabelColor;
+
+  /// Label color for unselected tabs.
+  final Color? unselectedLabelColor;
+
+  /// Per-state label text style, merged over the base label style — overrides
+  /// font / weight / letter-spacing while keeping the resolved label color.
+  final TextStyle? selectedLabelStyle;
+
+  /// See [selectedLabelStyle].
+  final TextStyle? unselectedLabelStyle;
+
+  /// Size of tab icons. Defaults to 24.
+  final double iconSize;
+
+  /// Font size for tab labels.
+  ///
+  /// Only applies when [textStyle] is null. Mirrors [iconSize] as a dedicated
+  /// sizing knob so color and weight are still managed automatically.
+  ///
+  /// Defaults to 11. Reduce to 10 for bars with 4+ tabs or longer labels
+  /// such as "Following".
+  final double labelFontSize;
+
+  /// Text style for tab labels. Uses 11 pt w600/w500 when null.
+  final TextStyle? textStyle;
+
+  // ── Glow ─────────────────────────────────────────────────────────────────────
+  /// Duration of the tab glow animation. Defaults to 300 ms.
+  final Duration glowDuration;
+
+  /// Blur radius of the glow. Defaults to 32.
+  final double glowBlurRadius;
+
+  /// Spread radius of the glow. Defaults to 8.
+  final double glowSpreadRadius;
+
+  /// Opacity of the glow at full intensity. Defaults to 0.6.
+  final double glowOpacity;
+
+  /// The color of the directional glow effect when interacting with the bar.
+  ///
+  /// Set to [Colors.transparent] to disable the glow effect.
+  final Color? interactionGlowColor;
+
+  /// The radius spread of the directional glow effect when interacting with the bar.
+  ///
+  /// Defaults to 1.5.
+  final double interactionGlowRadius;
+
+  // ── Interaction ───────────────────────────────────────────────────────────────
+
+  /// Controls which physical interaction effects are active when the user
+  /// presses the bar.
+  ///
+  /// Defaults to [GlassInteractionBehavior.full] — directional glow + spring
+  /// scale, matching native iOS 26 Apple News / Safari behaviour.
+  final GlassInteractionBehavior interactionBehavior;
+
+  /// Peak scale factor applied to the bar at maximum press depth.
+  ///
+  /// Only active when [interactionBehavior] includes scale
+  /// (i.e. [GlassInteractionBehavior.scaleOnly] or [GlassInteractionBehavior.full]).
+  ///
+  /// Defaults to 1.04 (4% growth — matches iOS 26 Apple News pill).
+  final double pressScale;
+
+  // ── Advanced ─────────────────────────────────────────────────────────────────
+  /// Magnification factor for the selected indicator lens effect.
+  ///
+  /// Values > 1.0 zoom in the selected tab's icon and label, creating the
+  /// iOS 26 "lens" effect where the active tab appears slightly larger than
+  /// its neighbours.
+  ///
+  /// - `1.15` (default) — matches Apple News / Safari selected-tab scale.
+  /// - `1.0` — no magnification; all tabs render at the same size.
+  final double magnification;
+
+  /// Blur amount inside the selected indicator. Defaults to 0.0.
+  final double innerBlur;
+
+  /// Set true when the bar sits over an iOS PlatformView (e.g. a map). The bar
+  /// background renders via live `BackdropFilter` (the premium shader can't
+  /// capture a PlatformView), while the premium indicator refracts the bar's
+  /// own icons — so premium animations survive over the PlatformView with no
+  /// quality swap. Defaults to false.
+  ///
+  /// Known limitation: the premium indicator refracts the icon layer via
+  /// `toImageSync`, which asserts the captured boundary is clean. While the
+  /// indicator animates, that layer repaints every frame, so a mid-animation
+  /// capture can fail and the indicator briefly flashes dark. Negligible at
+  /// [magnification] ~1.0 (the default) but grows with magnification. Keep
+  /// magnification near 1.0 over a PlatformView. (The PlatformView itself
+  /// can't be captured, so it can't be refracted directly.)
+  final bool platformViewBackdrop;
+
+  /// Rendering quality for the liquid masking effect. Defaults to [MaskingQuality.high].
+  final MaskingQuality maskingQuality;
+
+  /// Background key for Skia/web refraction. Optional.
+  final GlobalKey? backgroundKey;
+
+  // Note: interactionBehavior and pressScale fields are declared earlier in the Interaction section.
+
+  // ── Tab sizing ───────────────────────────────────────────────────────────────
+
+  /// Width of each tab slot in the tab pill.
+  ///
+  /// Controls the total width of the tab pill:
+  /// `pill width = tabWidth × tab count`, clamped to the maximum
+  /// available space.
+  ///
+  /// **Default: `88.0`** — matches the iOS 26 compact tab slot that
+  /// comfortably fits an icon + short label. This gives a 2-tab bar a
+  /// 176 px pill and a 3-tab bar a 264 px pill, leaving the rest of the
+  /// available width for the search pill to animate into.
+  ///
+  /// Set to `null` to expand the tab pill across all available space
+  /// (the legacy behaviour). Useful when you always have 4–5 tabs and
+  /// want them to fill the bar.
+  ///
+  /// ```dart
+  /// // Compact (default) — 2 tabs = 176 px pill
+  /// tabWidth: 88.0,
+  ///
+  /// // Wider slots for longer labels ("Following", "Discover")
+  /// tabWidth: 110.0,
+  ///
+  /// // Legacy expand — fills all space left of the search button
+  /// tabWidth: null,
+  /// ```
+  final double? tabWidth;
+
+  /// Override border radius for the indicator pill. Null = inherits from
+  /// [barBorderRadius]. Use a higher value (e.g. 100) for a fully round
+  /// indicator on a more subtly curved bar.
+  final double? indicatorBorderRadius;
+
+  /// How far the jelly indicator's leading and trailing edges expand
+  /// past the tab boundary as the indicator translates between tabs.
+  /// Higher values give a more dramatic "puff" stretch; lower values
+  /// produce a tighter, more iOS-native feel. Defaults to `14` —
+  /// matches the pre-existing visual.
+  final EdgeInsetsGeometry indicatorExpansion;
+
+  /// Called when the user taps anywhere on the bar.
+  ///
+  /// Fires via a translucent [GestureDetector] that wraps the entire bar,
+  /// so internal tap handlers (tab selection, search toggle, indicator drag)
+  /// all continue to work normally.
+  ///
+  /// **Primary use-case — tap-to-restore after scroll-to-hide:**
+  /// ```dart
+  /// GlassSearchableBottomBar(
+  ///   onBarTap: () => setState(() => _barVisible = true),
+  ///   ...
+  /// )
+  /// ```
+  final VoidCallback? onBarTap;
+
+  @override
+  Widget build(BuildContext context) => TabBarSearchableLayout(
+        tabs: tabs,
+        selectedIndex: selectedIndex,
+        onTabSelected: onTabSelected,
+        searchConfig: searchConfig,
+        controller: controller,
+        isSearchActive: isSearchActive,
+        extraButton: extraButton,
+        spacing: spacing,
+        horizontalPadding: horizontalPadding,
+        verticalPadding: verticalPadding,
+        barHeight: barHeight,
+        searchBarHeight: searchBarHeight,
+        barBorderRadius: barBorderRadius,
+        tabPadding: tabPadding,
+        iconLabelSpacing: iconLabelSpacing,
+        enableBlend: enableBlend,
+        blendAmount: blendAmount,
+        settings: settings,
+        showIndicator: showIndicator,
+        indicatorColor: indicatorColor,
+        indicatorSettings: indicatorSettings,
+        indicatorPinchStrength: indicatorPinchStrength,
+        selectedIconColor: selectedIconColor,
+        unselectedIconColor: unselectedIconColor,
+        selectedLabelColor: selectedLabelColor,
+        unselectedLabelColor: unselectedLabelColor,
+        selectedLabelStyle: selectedLabelStyle,
+        unselectedLabelStyle: unselectedLabelStyle,
+        iconSize: iconSize,
+        labelFontSize: labelFontSize,
+        textStyle: textStyle,
+        glowDuration: glowDuration,
+        glowBlurRadius: glowBlurRadius,
+        glowSpreadRadius: glowSpreadRadius,
+        glowOpacity: glowOpacity,
+        interactionBehavior: interactionBehavior,
+        pressScale: pressScale,
+        interactionGlowColor: interactionGlowColor,
+        interactionGlowRadius: interactionGlowRadius,
+        quality: quality,
+        magnification: magnification,
+        innerBlur: innerBlur,
+        platformViewBackdrop: platformViewBackdrop,
+        maskingQuality: maskingQuality,
+        backgroundKey: backgroundKey,
+        springDescription: springDescription,
+        tabPillAnchor: tabPillAnchor,
+        tabWidth: tabWidth,
+        indicatorBorderRadius: indicatorBorderRadius,
+        indicatorExpansion: indicatorExpansion,
+        onBarTap: onBarTap,
+        whitenAtBottom: whitenAtBottom,
+        whitenBottomThreshold: whitenBottomThreshold,
+        whitenAtBottomTarget: whitenAtBottomTarget,
+        scrollController: scrollController,
+        adaptiveBrightness: adaptiveBrightness,
+        onBrightnessChanged: onBrightnessChanged,
+        brightnessOverride: brightnessOverride,
+      );
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_tab_bar.dart
@@ -1,0 +1,1309 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show ValueListenable;
+
+import '../../src/renderer/liquid_glass_renderer.dart';
+
+import '../../src/types/glass_interaction_behavior.dart';
+import '../../types/glass_quality.dart';
+import '../shared/inherited_liquid_glass.dart';
+import 'glass_bottom_bar.dart'
+    show
+        GlassBottomBar,
+        GlassTabBarExtraButton,
+        GlassBottomBarTab,
+        GlassTabPillAnchor,
+        MaskingQuality;
+import 'glass_searchable_bottom_bar.dart' show GlassSearchableBottomBar;
+import 'shared/glass_search_bar_config.dart';
+import 'shared/tab_bar_searchable_controller.dart';
+import 'shared/tab_bar_bottom_layout.dart';
+import 'shared/tab_bar_searchable_layout.dart';
+
+export 'shared/glass_search_bar_config.dart';
+
+/// The iOS 26 structural navigation bar widget.
+///
+/// [GlassTabBar] covers three placement contexts via named constructors:
+///
+/// - **[GlassTabBar.bottom]** — floating glass pill at the bottom of the screen.
+///   Mirrors Apple's `UITabBarController`.
+/// - **[GlassTabBar.searchable]** — bottom pill that morphs into a search bar.
+/// - **[GlassTabBar.inline]** — compact, in-page glass tab bar with a refracting
+///   `AdaptiveGlass.grouped` track. Use this when you need a glass-backed content
+///   switcher (e.g. Apple Music-style section picker). For a flat native-fidelity
+///   filter control, use [GlassSegmentedControl] instead.
+///
+/// ## Constructors
+///
+/// | Constructor | iOS equivalent | Use-case |
+/// |---|---|---|
+/// | [GlassTabBar.bottom] | `UITabBar` | App-level bottom navigation |
+/// | [GlassTabBar.searchable] | `UITabBar` + search | Bottom nav + morphing search bar |
+/// | [GlassTabBar.inline] | Glass-backed `UISegmentedControl` / inline `UITabBar` | In-page content switcher with glass track |
+///
+/// ## Usage
+///
+/// ### Bottom navigation bar
+/// ```dart
+/// GlassTabBar.bottom(
+///   tabs: [
+///     GlassTab(icon: Icon(Icons.home),   label: 'Home'),
+///     GlassTab(icon: Icon(Icons.search), label: 'Search'),
+///     GlassTab(icon: Icon(Icons.person), label: 'Profile'),
+///   ],
+///   selectedIndex: _selectedIndex,
+///   onTabSelected: (i) => setState(() => _selectedIndex = i),
+/// )
+/// ```
+///
+/// ### With morphing search bar
+/// ```dart
+/// GlassTabBar.searchable(
+///   tabs: [
+///     GlassTab(icon: Icon(Icons.home),   label: 'Home'),
+///     GlassTab(icon: Icon(Icons.search), label: 'Search'),
+///   ],
+///   selectedIndex: _selectedIndex,
+///   onTabSelected: (i) => setState(() => _selectedIndex = i),
+///   searchBarConfig: GlassSearchBarConfig(hintText: 'Search...'),
+///   controller: _controller,
+/// )
+/// ```
+///
+/// ### Inline / in-page tab switching
+/// ```dart
+/// // ✅ Glass-backed track with jelly indicator — Apple Music style
+/// GlassTabBar.inline(
+///   tabs: const [
+///     GlassTab(label: 'Timeline'),
+///     GlassTab(label: 'Mentions'),
+///   ],
+///   selectedIndex: _selectedIndex,
+///   onTabSelected: (i) => setState(() => _selectedIndex = i),
+/// )
+///
+/// // ✅ Flat native UISegmentedControl fidelity — filter/mode selection
+/// GlassSegmentedControl(
+///   segments: const [
+///     GlassSegment(label: 'Timeline'),
+///     GlassSegment(label: 'Mentions'),
+///   ],
+///   selectedIndex: _selectedIndex,
+///   onSegmentSelected: (i) => setState(() => _selectedIndex = i),
+/// )
+/// ```
+// ---------------------------------------------------------------------------
+// Placement discriminant — private, drives constructor dispatch
+// ---------------------------------------------------------------------------
+enum _GlassTabBarPlacement { bottom, searchable, inline }
+
+/// The iOS 26 structural bottom navigation bar.
+///
+/// Two named constructors cover the two `UITabBarController` use-cases:
+///
+/// - **[GlassTabBar.bottom]** — floating pill at the screen bottom with safe
+///   area handling, jelly physics, and optional extra action button.
+///   Replaces the deprecated [GlassBottomBar].
+///
+/// - **[GlassTabBar.searchable]** — bottom pill that morphs into a search bar.
+///   Replaces the deprecated [GlassSearchableBottomBar].
+///
+/// For in-page / inline tab switching, use [GlassSegmentedControl] instead.
+///
+/// ## Migration from v0.17.x
+///
+/// ```dart
+/// // BEFORE
+/// GlassBottomBar(tabs: [...], ...)
+/// GlassSearchableBottomBar(tabs: [...], searchConfig: ..., ...)
+///
+/// // AFTER
+/// GlassTabBar.bottom(tabs: [...], ...)
+/// GlassTabBar.searchable(tabs: [...], searchConfig: ..., ...)
+/// ```
+///
+/// The old widgets still work — they are zero-logic deprecation shims.
+class GlassTabBar extends StatefulWidget {
+  // ─── Bottom constructor ────────────────────────────────────────────────────
+
+  /// Creates a floating bottom tab bar — the iOS 26 `UITabBarController` equivalent.
+  ///
+  /// This constructor replaces the deprecated [GlassBottomBar] with identical
+  /// parameter names and defaults. Existing [GlassBottomBar] code migrates by
+  /// search-replacing `GlassBottomBar(` → `GlassTabBar.bottom(` and
+  /// `GlassBottomBarTab(` → `GlassTab(`.
+  ///
+  /// ## Play-pill / mini-player accessory
+  ///
+  /// Place persistent overlays (mini-player, Now Playing) above the bar using
+  /// [GlassScaffold.bodyOverlays] + [AnimatedPositioned] — not inside this
+  /// widget. That is the equivalent of Apple's `tabViewBottomAccessory`.
+  const GlassTabBar.bottom({
+    required List<GlassTab> tabs,
+    required int selectedIndex,
+    required ValueChanged<int> onTabSelected,
+    Key? key,
+    GlassTabBarExtraButton? extraButton,
+    double spacing = 8,
+    double horizontalPadding = 20,
+    double verticalPadding = 20,
+    double barHeight = 64,
+    double barBorderRadius = _kDefaultBottomBorderRadius,
+    EdgeInsetsGeometry tabPadding = const EdgeInsets.symmetric(horizontal: 4),
+    double iconLabelSpacing = 4,
+    bool enableBlend = true,
+    double blendAmount = 10,
+    LiquidGlassSettings? settings,
+    bool showIndicator = true,
+    Color? indicatorColor,
+    LiquidGlassSettings? indicatorSettings,
+    double indicatorPinchStrength = 0.4,
+    Color? selectedIconColor,
+    Color? unselectedIconColor,
+    Color? selectedLabelColor,
+    Color? unselectedLabelColor,
+    TextStyle? selectedLabelStyle,
+    TextStyle? unselectedLabelStyle,
+    double iconSize = 24,
+    double labelFontSize = 11,
+    TextStyle? textStyle,
+    Duration glowDuration = const Duration(milliseconds: 300),
+    double glowBlurRadius = 32,
+    double glowSpreadRadius = 8,
+    double glowOpacity = 0.6,
+    GlassQuality? quality,
+    double magnification = 1.15,
+    double innerBlur = 0.0,
+    MaskingQuality maskingQuality = MaskingQuality.high,
+    GlobalKey? backgroundKey,
+    double? tabWidth,
+    double? indicatorBorderRadius,
+    EdgeInsetsGeometry indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    Color? interactionGlowColor,
+    double interactionGlowRadius = 1.5,
+    GlassInteractionBehavior interactionBehavior =
+        GlassInteractionBehavior.full,
+    double pressScale = 1.04,
+    bool platformViewBackdrop = false,
+    bool adaptiveBrightness = false,
+    ValueChanged<Brightness>? onBrightnessChanged,
+    ValueListenable<Brightness>? brightnessOverride,
+  }) : this._(
+          key: key,
+          placement: _GlassTabBarPlacement.bottom,
+          tabs: tabs,
+          selectedIndex: selectedIndex,
+          onTabSelected: onTabSelected,
+          extraButton: extraButton,
+          spacing: spacing,
+          horizontalPadding: horizontalPadding,
+          verticalPadding: verticalPadding,
+          barHeight: barHeight,
+          barBorderRadius: barBorderRadius,
+          tabPadding: tabPadding,
+          iconLabelSpacing: iconLabelSpacing,
+          enableBlend: enableBlend,
+          blendAmount: blendAmount,
+          settings: settings,
+          showIndicator: showIndicator,
+          indicatorColor: indicatorColor,
+          indicatorSettings: indicatorSettings,
+          indicatorPinchStrength: indicatorPinchStrength,
+          selectedIconColor: selectedIconColor,
+          unselectedIconColor: unselectedIconColor,
+          selectedLabelColor: selectedLabelColor,
+          unselectedLabelColor: unselectedLabelColor,
+          selectedLabelStyle: selectedLabelStyle,
+          unselectedLabelStyle: unselectedLabelStyle,
+          iconSize: iconSize,
+          labelFontSize: labelFontSize,
+          textStyle: textStyle,
+          glowDuration: glowDuration,
+          glowBlurRadius: glowBlurRadius,
+          glowSpreadRadius: glowSpreadRadius,
+          glowOpacity: glowOpacity,
+          quality: quality,
+          magnification: magnification,
+          innerBlur: innerBlur,
+          maskingQuality: maskingQuality,
+          backgroundKey: backgroundKey,
+          tabWidth: tabWidth,
+          indicatorBorderRadius: indicatorBorderRadius,
+          indicatorExpansion: indicatorExpansion,
+          interactionGlowColor: interactionGlowColor,
+          interactionGlowRadius: interactionGlowRadius,
+          interactionBehavior: interactionBehavior,
+          pressScale: pressScale,
+          platformViewBackdrop: platformViewBackdrop,
+          adaptiveBrightness: adaptiveBrightness,
+          onBrightnessChanged: onBrightnessChanged,
+          brightnessOverride: brightnessOverride,
+        );
+
+  // ─── Inline constructor ────────────────────────────────────────────────────
+
+  /// Creates a compact, in-page glass tab bar with a refracting glass track.
+  ///
+  /// Use this when you need a **glass-backed** content switcher embedded inside
+  /// a page — e.g. an Apple Music-style section picker or a search results
+  /// segment bar that sits on a glass surface.
+  ///
+  /// The track refracts the background behind it via `AdaptiveGlass.grouped`,
+  /// and the indicator uses the same jelly-physics spring as [GlassTabBar.bottom].
+  ///
+  /// For a flat, native-fidelity filter/mode control (matching the default
+  /// `UISegmentedControl` appearance), use [GlassSegmentedControl] instead.
+  ///
+  /// ## Usage
+  ///
+  /// ```dart
+  /// GlassTabBar.inline(
+  ///   tabs: const [
+  ///     GlassTab(label: 'For You'),
+  ///     GlassTab(label: 'Following'),
+  ///     GlassTab(label: 'New'),
+  ///   ],
+  ///   selectedIndex: _selectedIndex,
+  ///   onTabSelected: (i) => setState(() => _selectedIndex = i),
+  /// )
+  /// ```
+  const GlassTabBar.inline({
+    required List<GlassTab> tabs,
+    required int selectedIndex,
+    required ValueChanged<int> onTabSelected,
+    Key? key,
+    // Compact defaults suited for inline placement
+    double horizontalPadding = 0,
+    double verticalPadding = 0,
+    double barHeight = 40,
+    double barBorderRadius = 100,
+    double labelFontSize = 13,
+    double iconSize = 18,
+    EdgeInsetsGeometry tabPadding = const EdgeInsets.symmetric(horizontal: 8),
+    EdgeInsetsGeometry indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+    // No magnification for compact label-centric layout
+    double magnification = 1.0,
+    double innerBlur = 0.0,
+    // Standard shared params
+    double spacing = 4,
+    double blendAmount = 10,
+    bool enableBlend = true,
+    bool showIndicator = true,
+    Color? indicatorColor,
+    LiquidGlassSettings? indicatorSettings,
+    double indicatorPinchStrength = 0.4,
+    double? indicatorBorderRadius,
+    Color? selectedIconColor,
+    Color? unselectedIconColor,
+    Color? selectedLabelColor,
+    Color? unselectedLabelColor,
+    TextStyle? selectedLabelStyle,
+    TextStyle? unselectedLabelStyle,
+    TextStyle? textStyle,
+    double? tabWidth,
+    LiquidGlassSettings? settings,
+    GlassQuality? quality,
+    MaskingQuality maskingQuality = MaskingQuality.high,
+    GlobalKey? backgroundKey,
+    double iconLabelSpacing = 4,
+    Duration glowDuration = const Duration(milliseconds: 300),
+    double glowBlurRadius = 20,
+    double glowSpreadRadius = 4,
+    double glowOpacity = 0.5,
+    GlassInteractionBehavior interactionBehavior =
+        GlassInteractionBehavior.full,
+    double pressScale = 1.02,
+    Color? interactionGlowColor,
+    double interactionGlowRadius = 1.0,
+    bool platformViewBackdrop = false,
+    bool adaptiveBrightness = false,
+    ValueChanged<Brightness>? onBrightnessChanged,
+    ValueListenable<Brightness>? brightnessOverride,
+    // Indicator snap spring — null keeps the shared default. Exposed so
+    // inline hosts can match a reference feel (e.g. Apple Music's snappier
+    // settle) without forking the physics.
+    SpringDescription? springDescription,
+  }) : this._(
+          key: key,
+          placement: _GlassTabBarPlacement.inline,
+          springDescription: springDescription,
+          tabs: tabs,
+          selectedIndex: selectedIndex,
+          onTabSelected: onTabSelected,
+          horizontalPadding: horizontalPadding,
+          verticalPadding: verticalPadding,
+          barHeight: barHeight,
+          barBorderRadius: barBorderRadius,
+          labelFontSize: labelFontSize,
+          iconSize: iconSize,
+          tabPadding: tabPadding,
+          indicatorExpansion: indicatorExpansion,
+          magnification: magnification,
+          innerBlur: innerBlur,
+          spacing: spacing,
+          blendAmount: blendAmount,
+          enableBlend: enableBlend,
+          showIndicator: showIndicator,
+          indicatorColor: indicatorColor,
+          indicatorSettings: indicatorSettings,
+          indicatorPinchStrength: indicatorPinchStrength,
+          indicatorBorderRadius: indicatorBorderRadius ?? barBorderRadius,
+          selectedIconColor: selectedIconColor,
+          unselectedIconColor: unselectedIconColor,
+          selectedLabelColor: selectedLabelColor,
+          unselectedLabelColor: unselectedLabelColor,
+          selectedLabelStyle: selectedLabelStyle,
+          unselectedLabelStyle: unselectedLabelStyle,
+          textStyle: textStyle,
+          tabWidth: tabWidth,
+          settings: settings,
+          quality: quality,
+          maskingQuality: maskingQuality,
+          backgroundKey: backgroundKey,
+          iconLabelSpacing: iconLabelSpacing,
+          glowDuration: glowDuration,
+          glowBlurRadius: glowBlurRadius,
+          glowSpreadRadius: glowSpreadRadius,
+          glowOpacity: glowOpacity,
+          interactionBehavior: interactionBehavior,
+          pressScale: pressScale,
+          interactionGlowColor: interactionGlowColor,
+          interactionGlowRadius: interactionGlowRadius,
+          platformViewBackdrop: platformViewBackdrop,
+          adaptiveBrightness: adaptiveBrightness,
+          onBrightnessChanged: onBrightnessChanged,
+          brightnessOverride: brightnessOverride,
+        );
+
+  // ─── Searchable constructor ────────────────────────────────────────────────
+
+  /// Creates a bottom bar with a morphing search pill.
+  ///
+  /// This constructor replaces the deprecated [GlassSearchableBottomBar].
+  /// All parameters are identical to that widget. Migrate by replacing
+  /// `GlassSearchableBottomBar(` → `GlassTabBar.searchable(`.
+  const GlassTabBar.searchable({
+    required List<GlassTab> tabs,
+    required int selectedIndex,
+    required ValueChanged<int> onTabSelected,
+    required GlassSearchBarConfig searchConfig,
+    Key? key,
+    SearchableBottomBarController? controller,
+    bool isSearchActive = false,
+    GlassTabBarExtraButton? extraButton,
+    double spacing = 8,
+    double horizontalPadding = 20,
+    double verticalPadding = 20,
+    double barHeight = 64,
+    double searchBarHeight = 50,
+    double barBorderRadius = _kDefaultBottomBorderRadius,
+    EdgeInsetsGeometry tabPadding = const EdgeInsets.symmetric(horizontal: 4),
+    double iconLabelSpacing = 4,
+    bool enableBlend = true,
+    double blendAmount = 10,
+    LiquidGlassSettings? settings,
+    bool showIndicator = true,
+    Color? indicatorColor,
+    LiquidGlassSettings? indicatorSettings,
+    double indicatorPinchStrength = 0.4,
+    Color? selectedIconColor,
+    Color? unselectedIconColor,
+    Color? selectedLabelColor,
+    Color? unselectedLabelColor,
+    TextStyle? selectedLabelStyle,
+    TextStyle? unselectedLabelStyle,
+    double iconSize = 24,
+    double labelFontSize = 11,
+    TextStyle? textStyle,
+    Duration glowDuration = const Duration(milliseconds: 300),
+    double glowBlurRadius = 32,
+    double glowSpreadRadius = 8,
+    double glowOpacity = 0.6,
+    GlassInteractionBehavior interactionBehavior =
+        GlassInteractionBehavior.full,
+    double pressScale = 1.04,
+    Color? interactionGlowColor,
+    double interactionGlowRadius = 1.5,
+    GlassQuality? quality,
+    double magnification = 1.15,
+    double innerBlur = 0.0,
+    bool platformViewBackdrop = false,
+    MaskingQuality maskingQuality = MaskingQuality.high,
+    GlobalKey? backgroundKey,
+    SpringDescription? springDescription,
+    GlassTabPillAnchor tabPillAnchor = GlassTabPillAnchor.start,
+    double? tabWidth,
+    double? indicatorBorderRadius,
+    EdgeInsetsGeometry indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    VoidCallback? onBarTap,
+    bool whitenAtBottom = true,
+    double whitenBottomThreshold = 45.0,
+    double whitenAtBottomTarget = 1.0,
+    ScrollController? scrollController,
+    bool adaptiveBrightness = false,
+    ValueChanged<Brightness>? onBrightnessChanged,
+    ValueListenable<Brightness>? brightnessOverride,
+  }) : this._(
+          key: key,
+          placement: _GlassTabBarPlacement.searchable,
+          tabs: tabs,
+          selectedIndex: selectedIndex,
+          onTabSelected: onTabSelected,
+          searchConfig: searchConfig,
+          controller: controller,
+          isSearchActive: isSearchActive,
+          extraButton: extraButton,
+          spacing: spacing,
+          horizontalPadding: horizontalPadding,
+          verticalPadding: verticalPadding,
+          barHeight: barHeight,
+          searchBarHeight: searchBarHeight,
+          barBorderRadius: barBorderRadius,
+          tabPadding: tabPadding,
+          iconLabelSpacing: iconLabelSpacing,
+          enableBlend: enableBlend,
+          blendAmount: blendAmount,
+          settings: settings,
+          showIndicator: showIndicator,
+          indicatorColor: indicatorColor,
+          indicatorSettings: indicatorSettings,
+          indicatorPinchStrength: indicatorPinchStrength,
+          selectedIconColor: selectedIconColor,
+          unselectedIconColor: unselectedIconColor,
+          selectedLabelColor: selectedLabelColor,
+          unselectedLabelColor: unselectedLabelColor,
+          selectedLabelStyle: selectedLabelStyle,
+          unselectedLabelStyle: unselectedLabelStyle,
+          iconSize: iconSize,
+          labelFontSize: labelFontSize,
+          textStyle: textStyle,
+          glowDuration: glowDuration,
+          glowBlurRadius: glowBlurRadius,
+          glowSpreadRadius: glowSpreadRadius,
+          glowOpacity: glowOpacity,
+          interactionBehavior: interactionBehavior,
+          pressScale: pressScale,
+          interactionGlowColor: interactionGlowColor,
+          interactionGlowRadius: interactionGlowRadius,
+          quality: quality,
+          magnification: magnification,
+          innerBlur: innerBlur,
+          platformViewBackdrop: platformViewBackdrop,
+          maskingQuality: maskingQuality,
+          backgroundKey: backgroundKey,
+          springDescription: springDescription,
+          tabPillAnchor: tabPillAnchor,
+          tabWidth: tabWidth,
+          indicatorBorderRadius: indicatorBorderRadius,
+          indicatorExpansion: indicatorExpansion,
+          onBarTap: onBarTap,
+          whitenAtBottom: whitenAtBottom,
+          whitenBottomThreshold: whitenBottomThreshold,
+          whitenAtBottomTarget: whitenAtBottomTarget,
+          scrollController: scrollController,
+          adaptiveBrightness: adaptiveBrightness,
+          onBrightnessChanged: onBrightnessChanged,
+          brightnessOverride: brightnessOverride,
+        );
+
+  // ─── Private unified constructor (delegate target) ─────────────────────────
+
+  const GlassTabBar._(
+      {required this.tabs,
+      required this.selectedIndex,
+      required this.onTabSelected,
+      required _GlassTabBarPlacement placement,
+      super.key,
+      // Shared styling
+      this.indicatorColor,
+      this.selectedIconColor,
+      this.unselectedIconColor,
+      this.selectedLabelColor,
+      this.unselectedLabelColor,
+      this.selectedLabelStyle,
+      this.unselectedLabelStyle,
+      this.iconSize = 24.0,
+      this.settings,
+      this.quality,
+      this.indicatorSettings,
+      this.indicatorPinchStrength = 0.4,
+      this.indicatorExpansion =
+          const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      this.backgroundKey,
+      this.maskingQuality = MaskingQuality.high,
+      // Bottom / searchable shared
+      this.spacing = 8,
+      this.horizontalPadding = 20,
+      this.verticalPadding = 20,
+      this.barHeight = 64,
+      this.barBorderRadius = _kDefaultBottomBorderRadius,
+      this.tabPadding = const EdgeInsets.symmetric(horizontal: 4),
+      this.iconLabelSpacing = 4,
+      this.enableBlend = true,
+      this.blendAmount = 10,
+      this.showIndicator = true,
+      this.magnification = 1.15,
+      this.innerBlur = 0.0,
+      this.glowDuration = const Duration(milliseconds: 300),
+      this.glowBlurRadius = 32,
+      this.glowSpreadRadius = 8,
+      this.glowOpacity = 0.6,
+      this.labelFontSize = 11,
+      this.textStyle,
+      this.tabWidth,
+      this.indicatorBorderRadius,
+      this.extraButton,
+      this.interactionBehavior = GlassInteractionBehavior.full,
+      this.pressScale = 1.04,
+      this.interactionGlowColor,
+      this.interactionGlowRadius = 1.5,
+      this.platformViewBackdrop = false,
+      this.adaptiveBrightness = false,
+      this.onBrightnessChanged,
+      this.brightnessOverride,
+      // Searchable-only
+      this.searchConfig,
+      this.controller,
+      this.isSearchActive = false,
+      this.searchBarHeight = 50,
+      this.springDescription,
+      this.tabPillAnchor = GlassTabPillAnchor.start,
+      this.onBarTap,
+      this.whitenAtBottom = true,
+      this.whitenBottomThreshold = 45.0,
+      this.whitenAtBottomTarget = 1.0,
+      this.scrollController})
+      : _placement = placement,
+        assert(tabs.length >= 1, 'GlassTabBar requires at least 1 tab'),
+        assert(
+          selectedIndex >= 0 && selectedIndex < tabs.length,
+          'selectedIndex must be within bounds of tabs list',
+        );
+
+  /// List of tabs to display.
+  final List<GlassTab> tabs;
+
+  /// Index of the currently selected tab.
+  final int selectedIndex;
+
+  /// Called when a tab is selected.
+  final ValueChanged<int> onTabSelected;
+
+  /// Color of the pill indicator.
+  final Color? indicatorColor;
+
+  /// Icon color for selected tab.
+  final Color? selectedIconColor;
+
+  /// Icon color for unselected tabs.
+  final Color? unselectedIconColor;
+
+  /// Label color for selected tab.
+  final Color? selectedLabelColor;
+
+  /// Label color for unselected tabs.
+  final Color? unselectedLabelColor;
+
+  /// Per-state label text style, merged over the base label style — overrides
+  /// font / weight / letter-spacing while keeping the resolved label color
+  /// unless the style sets its own. Null leaves existing behavior unchanged.
+  final TextStyle? selectedLabelStyle;
+
+  /// See [selectedLabelStyle].
+  final TextStyle? unselectedLabelStyle;
+
+  /// Size of the icons.
+  final double iconSize;
+
+  /// Glass effect settings.
+  final LiquidGlassSettings? settings;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// If null, inherits from parent [InheritedLiquidGlass] or defaults to
+  /// [GlassQuality.standard].
+  final GlassQuality? quality;
+
+  /// Controls indicator clipping quality.
+  ///
+  /// - [MaskingQuality.high] (default): Full jelly-bloom physics — the
+  ///   indicator expands 8 px beyond its pill bounds for the iOS 26 spring
+  ///   effect. Uses a dual-layer [GlassBottomBarClipper] path.
+  /// - [MaskingQuality.off]: Simple clipping with no jelly expansion.
+  ///   Cheaper on GPU; useful for low-end devices or accessibility modes.
+  ///
+  /// Mirrors the same parameter on [GlassBottomBar] for a consistent API.
+  final MaskingQuality maskingQuality;
+
+  /// Glass settings for the sliding indicator.
+  final LiquidGlassSettings? indicatorSettings;
+
+  /// Maximum concave lens pinch strength for the sliding indicator pill.
+  ///
+  /// - `1.0` (default) — full Apple-calibrated pinch
+  /// - `0.0` — pinch fully disabled
+  /// Maximum concave lens pinch strength. Forwarded to [AnimatedGlassIndicator].
+  ///
+  /// Defaults to `0.4` — the iOS 26-calibrated gentle concave lens warp.
+  /// Set to `0.0` to disable the effect entirely, or `1.0` to restore the
+  /// original full-strength warp.
+  final double indicatorPinchStrength;
+
+  /// Expansion padding applied to the active indicator pill during interaction.
+  ///
+  /// The pill grows by this amount beyond its cell boundary as the user drags,
+  /// creating the iOS 26 "jelly" overshoot. Defaults to
+  /// `EdgeInsets.symmetric(horizontal: 12, vertical: 8)` which matches
+  /// [GlassBottomBar] for a consistent look across all indicator widgets.
+  final EdgeInsetsGeometry indicatorExpansion;
+
+  /// Optional background key for Skia/Web refraction.
+  final GlobalKey? backgroundKey;
+
+  // ---------------------------------------------------------------------------
+  // Internal placement discriminant
+  // ---------------------------------------------------------------------------
+  final _GlassTabBarPlacement _placement;
+
+  // ---------------------------------------------------------------------------
+  // Default border radius for bottom/searchable constructors
+  // ---------------------------------------------------------------------------
+  static const double _kDefaultBottomBorderRadius = 32.0;
+
+  // ---------------------------------------------------------------------------
+  // Bottom / searchable fields (all have defaults — safe for inline too)
+  // ---------------------------------------------------------------------------
+
+  /// Spacing between adjacent pills (bottom/searchable only). Defaults to 8.
+  final double spacing;
+
+  /// Horizontal padding around the full bar content. Defaults to 20.
+  final double horizontalPadding;
+
+  /// Vertical padding (top + bottom) around the bar content. Defaults to 20.
+  final double verticalPadding;
+
+  /// Height of the pill (bottom/searchable). Defaults to 64.
+  final double barHeight;
+
+  /// Corner radius of the pill (bottom/searchable). Defaults to 32.
+  final double barBorderRadius;
+
+  /// Internal padding within the tab pill. Defaults to 4 px horizontal.
+  final EdgeInsetsGeometry tabPadding;
+
+  /// Vertical spacing between icon and label. Defaults to 4.
+  final double iconLabelSpacing;
+
+  /// Enables organic liquid blending between adjacent pills. Defaults to true.
+  final bool enableBlend;
+
+  /// Blend amount for the shared glass layer. Defaults to 10.
+  final double blendAmount;
+
+  /// Whether to show the draggable indicator. Defaults to true.
+  final bool showIndicator;
+
+  /// Selected-icon magnification inside the indicator (bottom/searchable).
+  final double magnification;
+
+  /// Blur applied to content inside the indicator (bottom/searchable).
+  final double innerBlur;
+
+  /// Duration of the per-tab glow animation. Defaults to 300 ms.
+  final Duration glowDuration;
+
+  /// Blur radius of the tab glow effect. Defaults to 32.
+  final double glowBlurRadius;
+
+  /// Spread radius of the tab glow effect. Defaults to 8.
+  final double glowSpreadRadius;
+
+  /// Opacity of the tab glow effect. Defaults to 0.6.
+  final double glowOpacity;
+
+  /// Font size for tab labels (bottom/searchable). Defaults to 11.
+  final double labelFontSize;
+
+  /// Text style for tab labels (bottom/searchable). Overrides [labelFontSize].
+  final TextStyle? textStyle;
+
+  /// Fixed width per tab slot. Null = fill all available space.
+  final double? tabWidth;
+
+  /// Override border radius for the indicator. Null = inherits from barBorderRadius.
+  final double? indicatorBorderRadius;
+
+  /// Optional extra action button (bottom/searchable only).
+  final GlassTabBarExtraButton? extraButton;
+
+  /// Which physical interaction effects are active. Defaults to [GlassInteractionBehavior.full].
+  final GlassInteractionBehavior interactionBehavior;
+
+  /// Peak scale applied at maximum press depth. Defaults to 1.04.
+  final double pressScale;
+
+  /// Directional glow color on press. Null = theme default.
+  final Color? interactionGlowColor;
+
+  /// Spread radius of the directional glow. Defaults to 1.5.
+  final double interactionGlowRadius;
+
+  /// Forces BackdropFilter rendering over iOS PlatformViews. Defaults to false.
+  final bool platformViewBackdrop;
+
+  /// Adapts brightness to content scrolling underneath. Defaults to false.
+  final bool adaptiveBrightness;
+
+  /// Called when the content-aware brightness verdict flips.
+  final ValueChanged<Brightness>? onBrightnessChanged;
+
+  /// External brightness source that bypasses the content sampler.
+  final ValueListenable<Brightness>? brightnessOverride;
+
+  // ---------------------------------------------------------------------------
+  // Searchable-only fields
+  // ---------------------------------------------------------------------------
+
+  /// Configuration for the morphing search bar. Required for [GlassTabBar.searchable].
+  final GlassSearchBarConfig? searchConfig;
+
+  /// Optional external controller for the search state machine.
+  final SearchableBottomBarController? controller;
+
+  /// Whether the search bar is currently expanded (searchable only).
+  final bool isSearchActive;
+
+  /// Height of the pills while search is active. Defaults to 50.
+  final double searchBarHeight;
+
+  /// Custom spring for the pill morph animation. Null = iOS 26 default.
+  final SpringDescription? springDescription;
+
+  /// How the tab pill is anchored during the morph animation.
+  final GlassTabPillAnchor tabPillAnchor;
+
+  /// Optional tap callback for the whole bar (searchable only).
+  final VoidCallback? onBarTap;
+
+  /// Whiten glass at page bottom in light mode. Defaults to true.
+  final bool whitenAtBottom;
+
+  /// Scroll offset at which whitening begins. Defaults to 45.0.
+  final double whitenBottomThreshold;
+
+  /// Maximum whitening amount. Defaults to 1.0.
+  final double whitenAtBottomTarget;
+
+  /// Scroll controller wired for whitening + minimize behaviour.
+  final ScrollController? scrollController;
+
+  @override
+  State<GlassTabBar> createState() => _GlassTabBarState();
+}
+
+class _GlassTabBarState extends State<GlassTabBar> {
+  @override
+  void didUpdateWidget(GlassTabBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Dispatch to the correct rendering engine based on placement.
+    switch (widget._placement) {
+      case _GlassTabBarPlacement.bottom:
+        return _buildBottom(context);
+      case _GlassTabBarPlacement.searchable:
+        return _buildSearchable(context);
+      case _GlassTabBarPlacement.inline:
+        return _buildInline(context);
+    }
+  }
+
+  /// Dispatches to [TabBarBottomLayout] — the iOS 26-style bottom placement engine.
+  Widget _buildBottom(BuildContext context) {
+    final tabs = widget.tabs
+        .map((t) => GlassBottomBarTab(
+              icon: t.icon ?? const SizedBox.shrink(),
+              label: t.label,
+              activeIcon: t.activeIcon,
+              glowColor: t.glowColor,
+              thickness: t.thickness,
+            ))
+        .toList();
+    return TabBarBottomLayout(
+      tabs: tabs,
+      selectedIndex: widget.selectedIndex,
+      onTabSelected: widget.onTabSelected,
+      extraButton: widget.extraButton,
+      spacing: widget.spacing,
+      horizontalPadding: widget.horizontalPadding,
+      verticalPadding: widget.verticalPadding,
+      barHeight: widget.barHeight,
+      barBorderRadius: widget.barBorderRadius,
+      tabPadding: widget.tabPadding,
+      iconLabelSpacing: widget.iconLabelSpacing,
+      enableBlend: widget.enableBlend,
+      blendAmount: widget.blendAmount,
+      settings: widget.settings,
+      showIndicator: widget.showIndicator,
+      indicatorColor: widget.indicatorColor,
+      indicatorSettings: widget.indicatorSettings,
+      indicatorPinchStrength: widget.indicatorPinchStrength,
+      selectedIconColor: widget.selectedIconColor,
+      unselectedIconColor: widget.unselectedIconColor,
+      selectedLabelColor: widget.selectedLabelColor,
+      unselectedLabelColor: widget.unselectedLabelColor,
+      selectedLabelStyle: widget.selectedLabelStyle,
+      unselectedLabelStyle: widget.unselectedLabelStyle,
+      iconSize: widget.iconSize,
+      labelFontSize: widget.labelFontSize,
+      textStyle: widget.textStyle,
+      glowDuration: widget.glowDuration,
+      glowBlurRadius: widget.glowBlurRadius,
+      glowSpreadRadius: widget.glowSpreadRadius,
+      glowOpacity: widget.glowOpacity,
+      quality: widget.quality,
+      magnification: widget.magnification,
+      innerBlur: widget.innerBlur,
+      maskingQuality: widget.maskingQuality,
+      backgroundKey: widget.backgroundKey,
+      tabWidth: widget.tabWidth,
+      indicatorBorderRadius: widget.indicatorBorderRadius,
+      indicatorExpansion: widget.indicatorExpansion,
+      interactionGlowColor: widget.interactionGlowColor,
+      interactionGlowRadius: widget.interactionGlowRadius,
+      interactionBehavior: widget.interactionBehavior,
+      pressScale: widget.pressScale,
+      platformViewBackdrop: widget.platformViewBackdrop,
+      adaptiveBrightness: widget.adaptiveBrightness,
+      onBrightnessChanged: widget.onBrightnessChanged,
+      brightnessOverride: widget.brightnessOverride,
+      springDescription: widget.springDescription,
+    );
+  }
+
+  /// Dispatches to [TabBarBottomLayout] with inline-appropriate defaults —
+  /// compact height, no floating margins, no icon magnification.
+  ///
+  /// The track glass comes from [AdaptiveGlass.grouped] inside [TabBarBottomLayout]
+  /// exactly as in the bottom placement — no new rendering path needed.
+  Widget _buildInline(BuildContext context) {
+    final tabs = widget.tabs
+        .map((t) => GlassBottomBarTab(
+              icon: t.icon ?? const SizedBox.shrink(),
+              label: t.label,
+              activeIcon: t.activeIcon,
+              glowColor: t.glowColor,
+              thickness: t.thickness,
+            ))
+        .toList();
+    return TabBarBottomLayout(
+      tabs: tabs,
+      selectedIndex: widget.selectedIndex,
+      onTabSelected: widget.onTabSelected,
+      spacing: widget.spacing,
+      horizontalPadding: widget.horizontalPadding,
+      verticalPadding: widget.verticalPadding,
+      barHeight: widget.barHeight,
+      barBorderRadius: widget.barBorderRadius,
+      tabPadding: widget.tabPadding,
+      iconLabelSpacing: widget.iconLabelSpacing,
+      enableBlend: widget.enableBlend,
+      blendAmount: widget.blendAmount,
+      settings: widget.settings,
+      showIndicator: widget.showIndicator,
+      indicatorColor: widget.indicatorColor,
+      indicatorSettings: widget.indicatorSettings,
+      indicatorPinchStrength: widget.indicatorPinchStrength,
+      selectedIconColor: widget.selectedIconColor,
+      unselectedIconColor: widget.unselectedIconColor,
+      selectedLabelColor: widget.selectedLabelColor,
+      unselectedLabelColor: widget.unselectedLabelColor,
+      selectedLabelStyle: widget.selectedLabelStyle,
+      unselectedLabelStyle: widget.unselectedLabelStyle,
+      iconSize: widget.iconSize,
+      labelFontSize: widget.labelFontSize,
+      textStyle: widget.textStyle,
+      glowDuration: widget.glowDuration,
+      glowBlurRadius: widget.glowBlurRadius,
+      glowSpreadRadius: widget.glowSpreadRadius,
+      glowOpacity: widget.glowOpacity,
+      quality: widget.quality,
+      magnification: widget.magnification,
+      innerBlur: widget.innerBlur,
+      maskingQuality: widget.maskingQuality,
+      backgroundKey: widget.backgroundKey,
+      tabWidth: widget.tabWidth,
+      indicatorBorderRadius: widget.indicatorBorderRadius,
+      indicatorExpansion: widget.indicatorExpansion,
+      interactionGlowColor: widget.interactionGlowColor,
+      interactionGlowRadius: widget.interactionGlowRadius,
+      interactionBehavior: widget.interactionBehavior,
+      pressScale: widget.pressScale,
+      platformViewBackdrop: widget.platformViewBackdrop,
+      adaptiveBrightness: widget.adaptiveBrightness,
+      onBrightnessChanged: widget.onBrightnessChanged,
+      brightnessOverride: widget.brightnessOverride,
+      springDescription: widget.springDescription,
+      // No extra button in inline placement
+    );
+  }
+
+  /// Dispatches to [TabBarSearchableLayout] — the iOS 26-style searchable placement engine.
+  Widget _buildSearchable(BuildContext context) {
+    final tabs = widget.tabs
+        .map((t) => GlassBottomBarTab(
+              icon: t.icon ?? const SizedBox.shrink(),
+              label: t.label,
+              activeIcon: t.activeIcon,
+              glowColor: t.glowColor,
+              thickness: t.thickness,
+            ))
+        .toList();
+    return TabBarSearchableLayout(
+      tabs: tabs,
+      selectedIndex: widget.selectedIndex,
+      onTabSelected: widget.onTabSelected,
+      searchConfig: widget.searchConfig!,
+      controller: widget.controller,
+      isSearchActive: widget.isSearchActive,
+      extraButton: widget.extraButton,
+      spacing: widget.spacing,
+      horizontalPadding: widget.horizontalPadding,
+      verticalPadding: widget.verticalPadding,
+      barHeight: widget.barHeight,
+      searchBarHeight: widget.searchBarHeight,
+      barBorderRadius: widget.barBorderRadius,
+      tabPadding: widget.tabPadding,
+      iconLabelSpacing: widget.iconLabelSpacing,
+      enableBlend: widget.enableBlend,
+      blendAmount: widget.blendAmount,
+      settings: widget.settings,
+      showIndicator: widget.showIndicator,
+      indicatorColor: widget.indicatorColor,
+      indicatorSettings: widget.indicatorSettings,
+      indicatorPinchStrength: widget.indicatorPinchStrength,
+      selectedIconColor: widget.selectedIconColor,
+      unselectedIconColor: widget.unselectedIconColor,
+      selectedLabelColor: widget.selectedLabelColor,
+      unselectedLabelColor: widget.unselectedLabelColor,
+      selectedLabelStyle: widget.selectedLabelStyle,
+      unselectedLabelStyle: widget.unselectedLabelStyle,
+      iconSize: widget.iconSize,
+      labelFontSize: widget.labelFontSize,
+      textStyle: widget.textStyle,
+      glowDuration: widget.glowDuration,
+      glowBlurRadius: widget.glowBlurRadius,
+      glowSpreadRadius: widget.glowSpreadRadius,
+      glowOpacity: widget.glowOpacity,
+      interactionBehavior: widget.interactionBehavior,
+      pressScale: widget.pressScale,
+      interactionGlowColor: widget.interactionGlowColor,
+      interactionGlowRadius: widget.interactionGlowRadius,
+      quality: widget.quality,
+      magnification: widget.magnification,
+      innerBlur: widget.innerBlur,
+      platformViewBackdrop: widget.platformViewBackdrop,
+      maskingQuality: widget.maskingQuality,
+      backgroundKey: widget.backgroundKey,
+      springDescription: widget.springDescription,
+      tabPillAnchor: widget.tabPillAnchor,
+      tabWidth: widget.tabWidth,
+      indicatorBorderRadius: widget.indicatorBorderRadius,
+      indicatorExpansion: widget.indicatorExpansion,
+      onBarTap: widget.onBarTap,
+      whitenAtBottom: widget.whitenAtBottom,
+      whitenBottomThreshold: widget.whitenBottomThreshold,
+      whitenAtBottomTarget: widget.whitenAtBottomTarget,
+      scrollController: widget.scrollController,
+      adaptiveBrightness: widget.adaptiveBrightness,
+      onBrightnessChanged: widget.onBrightnessChanged,
+      brightnessOverride: widget.brightnessOverride,
+    );
+  }
+}
+
+// =============================================================================
+// GlassSegment — configuration for a single segment in GlassSegmentedControl
+// =============================================================================
+
+/// Configuration for a single segment in [GlassSegmentedControl].
+///
+/// [GlassSegment] is the item type for [GlassSegmentedControl] — the iOS 26
+/// `UISegmentedControl` equivalent. It intentionally carries **only** fields
+/// that make sense for a segmented control item:
+///
+/// - [label] — the text label
+/// - [icon] — the leading icon (before the label)
+/// - [tooltip] — tooltip shown on long-press
+/// - [semanticLabel] — overrides the accessibility announcement
+/// - [enabled] — whether this segment can be selected
+///
+/// ## Why not [GlassTab]?
+///
+/// [GlassTab] is the navigation-tab type for [GlassTabBar.bottom] and
+/// [GlassTabBar.searchable]. It carries fields like [GlassTab.glowColor],
+/// [GlassTab.activeIcon], and [GlassTab.thickness] that are navigation-specific
+/// and have no effect in a segmented control. [GlassSegment] is the correct,
+/// minimal API for [GlassSegmentedControl].
+///
+/// ## Usage
+///
+/// ```dart
+/// GlassSegmentedControl(
+///   segments: [
+///     GlassSegment(label: 'All'),
+///     GlassSegment(label: 'Photos', icon: Icon(CupertinoIcons.photo)),
+///     GlassSegment(label: 'Videos', icon: Icon(CupertinoIcons.video_camera)),
+///   ],
+///   selectedIndex: _index,
+///   onSegmentSelected: (i) => setState(() => _index = i),
+/// )
+/// ```
+///
+/// ## Icon-only segments
+///
+/// ```dart
+/// GlassSegment(icon: Icon(CupertinoIcons.list_bullet))
+/// GlassSegment(icon: Icon(CupertinoIcons.square_grid_2x2))
+/// ```
+///
+/// ## Disabled segment
+///
+/// ```dart
+/// GlassSegment(label: 'Pro Only', enabled: false)
+/// ```
+class GlassSegment {
+  /// Creates a segment configuration.
+  ///
+  /// At least one of [icon] or [label] must be provided.
+  const GlassSegment({
+    this.icon,
+    this.label,
+    this.tooltip,
+    this.semanticLabel,
+    this.enabled = true,
+  }) : assert(
+          icon != null || label != null,
+          'GlassSegment must have either an icon or a label.',
+        );
+
+  /// Icon widget to display before the label (or alone, if [label] is null).
+  ///
+  /// Standard [Icon] widgets automatically pick up the correct color and size
+  /// from the parent [IconTheme]. Typically a [CupertinoIcons] icon.
+  final Widget? icon;
+
+  /// Text label for this segment.
+  ///
+  /// If null, [icon] is used alone. If both are provided, the icon is shown
+  /// above the label (same layout as iOS `UISegmentedControl` with images).
+  final String? label;
+
+  /// Tooltip shown on long-press (optional).
+  ///
+  /// Useful for icon-only segments where the meaning may not be obvious.
+  final String? tooltip;
+
+  /// Overrides the default accessibility announcement.
+  ///
+  /// If null, falls back to [label] (or an empty string for icon-only segments).
+  final String? semanticLabel;
+
+  /// Whether this segment can be selected.
+  ///
+  /// When `false`, the segment renders at reduced opacity and ignores taps.
+  /// Defaults to `true`.
+  final bool enabled;
+}
+
+// =============================================================================
+// GlassTab — unified tab configuration type for GlassTabBar
+// =============================================================================
+
+/// Configuration for a tab in [GlassTabBar] (all constructors).
+///
+/// [GlassTab] is the item type for [GlassTabBar.bottom] and
+/// [GlassTabBar.searchable] — the iOS 26 `UITab` / `UITabBarItem` equivalent.
+///
+/// For [GlassSegmentedControl], use [GlassSegment] instead. [GlassSegment] is
+/// a focused type that only carries fields relevant to a segmented control.
+///
+/// ## Key fields
+///
+/// - [icon] — shown in unselected state (and selected state if [activeIcon] is null)
+/// - [activeIcon] — shown in selected state (optional)
+/// - [label] — text label
+/// - [glowColor] — per-tab glow colour for the selected indicator
+/// - [thickness] — icon shadow halo intensity
+///
+/// ## Usage
+///
+/// ```dart
+/// GlassTabBar.bottom(
+///   tabs: [
+///     GlassTab(
+///       icon: Icon(CupertinoIcons.home),
+///       activeIcon: Icon(CupertinoIcons.house_fill),
+///       label: 'Home',
+///       glowColor: Colors.blue,
+///     ),
+///     GlassTab(
+///       icon: Icon(CupertinoIcons.search),
+///       label: 'Search',
+///     ),
+///   ],
+///   ...
+/// )
+/// ```
+///
+/// ## Migration from [GlassBottomBarTab]
+///
+/// ```dart
+/// // BEFORE
+/// GlassBottomBarTab(icon: Icon(Icons.home), activeIcon: Icon(Icons.home_fill), label: 'Home', glowColor: Colors.blue)
+/// // AFTER
+/// GlassTab(icon: Icon(Icons.home), activeIcon: Icon(Icons.home_fill), label: 'Home', glowColor: Colors.blue)
+/// ```
+class GlassTab {
+  /// Creates a tab configuration.
+  ///
+  /// At least one of [icon] or [label] must be provided.
+  const GlassTab({
+    this.icon,
+    this.activeIcon,
+    this.label,
+    this.semanticLabel,
+    this.glowColor,
+    this.thickness,
+  }) : assert(
+          icon != null || label != null,
+          'GlassTab must have either an icon or label',
+        );
+
+  /// Icon widget displayed when the tab is **not** selected.
+  ///
+  /// Also used when selected if [activeIcon] is not provided.
+  /// Standard [Icon] widgets automatically pick up the correct color and size
+  /// from the parent [IconTheme].
+  final Widget? icon;
+
+  /// Icon widget displayed when the tab **is** selected.
+  ///
+  /// If null, [icon] is used for both selected and unselected states.
+  /// Standard [Icon] widgets automatically pick up the correct color and size
+  /// from the parent [IconTheme].
+  ///
+  /// Only used by [GlassTabBar.bottom] and [GlassTabBar.searchable].
+  final Widget? activeIcon;
+
+  /// Label text to display in the tab.
+  final String? label;
+
+  /// Semantic label for accessibility.
+  final String? semanticLabel;
+
+  /// Color of the animated glow effect when this tab is selected.
+  ///
+  /// If null, no glow effect is shown for this tab.
+  /// Only used by [GlassTabBar.bottom] and [GlassTabBar.searchable].
+  final Color? glowColor;
+
+  /// Thickness of the icon shadow halo effect.
+  ///
+  /// When provided, creates a shadow halo around unselected icons for emphasis.
+  /// Typical values are between 0.5 and 2.0.
+  /// Only used by [GlassTabBar.bottom] and [GlassTabBar.searchable].
+  final double? thickness;
+}
+
+// =============================================================================
+// DividerSettings — configuration for inter-tab dividers
+// =============================================================================
+
+/// Configuration for optional vertical dividers between tabs in [GlassTabBar].
+///
+/// Dividers are rendered as thin vertical lines between tab items and can
+/// automatically hide themselves adjacent to the active tab.
+class DividerSettings {
+  /// Top indent of the divider line.
+  final double indent;
+
+  /// Bottom indent of the divider line.
+  final double endIndent;
+
+  /// Width (thickness) of the divider line.
+  final double thickness;
+
+  /// Optional custom decoration. Defaults to a white 20% opacity line.
+  final BoxDecoration? decoration;
+
+  /// Duration of the show/hide animation. Defaults to 200ms.
+  final Duration? duration;
+
+  /// Curve of the show/hide animation. Defaults to [Curves.easeInOut].
+  final Curve? curve;
+
+  /// When true, dividers adjacent to the selected tab are hidden automatically.
+  final bool isHideAutomatically;
+
+  const DividerSettings({
+    this.indent = 0,
+    this.endIndent = 0,
+    this.thickness = 1,
+    this.decoration,
+    this.duration,
+    this.curve,
+    this.isHideAutomatically = true,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    return other is DividerSettings &&
+        indent == other.indent &&
+        endIndent == other.endIndent &&
+        thickness == other.thickness &&
+        decoration == other.decoration &&
+        duration == other.duration &&
+        curve == other.curve &&
+        isHideAutomatically == other.isHideAutomatically;
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+        indent,
+        endIndent,
+        thickness,
+        decoration,
+        duration,
+        curve,
+        isHideAutomatically,
+      ]);
+
+  /// Returns a copy of this [DividerSettings] with the given fields replaced.
+  DividerSettings copyWith({
+    double? indent,
+    double? endIndent,
+    double? thickness,
+    BoxDecoration? decoration,
+    Duration? duration,
+    Curve? curve,
+    bool? isHideAutomatically,
+  }) {
+    return DividerSettings(
+      indent: indent ?? this.indent,
+      endIndent: endIndent ?? this.endIndent,
+      thickness: thickness ?? this.thickness,
+      decoration: decoration ?? this.decoration,
+      duration: duration ?? this.duration,
+      curve: curve ?? this.curve,
+      isHideAutomatically: isHideAutomatically ?? this.isHideAutomatically,
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_toolbar.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/glass_toolbar.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/cupertino.dart';
+import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../theme/glass_theme_helpers.dart';
+import '../../theme/glass_theme.dart';
+import '../../types/glass_quality.dart';
+import '../shared/adaptive_glass.dart';
+import '../shared/adaptive_liquid_glass_layer.dart';
+
+/// A glass morphism toolbar following Apple's iOS 26 design patterns.
+///
+/// [GlassToolbar] provides a sophisticated bottom toolbar for actions,
+/// utilizing the liquid glass material. It is typically used at the bottom
+/// of the screen to present a set of actions relevant to the current context.
+///
+/// Unlike [GlassBottomBar] which is for navigation, [GlassToolbar] is for
+/// actions (e.g., "Edit", "Share", "Delete").
+///
+/// ## Key Features
+///
+/// - **Liquid Glass Material**: Translucent, blurring background that floats
+///   over content.
+/// - **Flexible Layout**: Supports any children, typically [GlassButton]s.
+/// - **Customizable**: Control height, alignment, and glass settings.
+/// - **iOS 26 Compliance**: Matches the visual style of system toolbars.
+///
+/// ## Usage
+///
+/// ### Basic Usage
+/// ```dart
+/// Scaffold(
+///   body: Container(), // Your content
+///   bottomNavigationBar: GlassToolbar(
+///     children: [
+///       GlassButton.icon(
+///         icon: CupertinoIcons.share,
+///         onTap: () {},
+///         label: 'Share',
+///       ),
+///       const Spacer(), // Use Spacer for layout control
+///       GlassButton.icon(
+///         icon: CupertinoIcons.add,
+///         onTap: () {},
+///         label: 'Add',
+///       ),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ### Custom Alignment
+/// ```dart
+/// GlassToolbar(
+///   alignment: MainAxisAlignment.spaceAround,
+///   children: [
+///     // ... buttons
+///   ],
+/// )
+/// ```
+class GlassToolbar extends StatelessWidget {
+  /// Creates a glass toolbar.
+  const GlassToolbar({
+    required this.children,
+    super.key,
+    this.height = 44.0, // Standard iOS toolbar height (usually + safe area)
+    this.alignment = MainAxisAlignment.spaceBetween,
+    this.settings,
+    this.padding = const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+    this.quality,
+    this.backgroundColor,
+  });
+
+  /// The action buttons to display in the toolbar.
+  ///
+  /// Typically [GlassButton]s or [IconButton]s.
+  /// Use [Spacer] widgets to control spacing between items if [alignment]
+  /// is set to [MainAxisAlignment.spaceBetween] (the default).
+  final List<Widget> children;
+
+  /// Height of the toolbar content area.
+  ///
+  /// Does not include safe area insets (bottom padding).
+  /// Defaults to 44.0, which is the standard iOS toolbar height.
+  final double height;
+
+  /// How the children should be placed along the horizontal axis.
+  ///
+  /// Defaults to [MainAxisAlignment.spaceBetween].
+  final MainAxisAlignment alignment;
+
+  /// Glass effect settings.
+  ///
+  /// If null, uses optimized defaults for toolbars.
+  final LiquidGlassSettings? settings;
+
+  /// Padding around the content.
+  ///
+  /// Defaults to symmetric(horizontal: 16, vertical: 8).
+  final EdgeInsetsGeometry padding;
+
+  /// Rendering quality for the glass effect.
+  ///
+  /// If null, inherits from parent [InheritedLiquidGlass] or defaults to
+  /// [GlassQuality.premium].
+  final GlassQuality? quality;
+
+  /// Optional background color override.
+  ///
+  /// If provided, this color is mixed with the glass effect.
+  /// If null, a default iOS-style translucent tint is used.
+  final Color? backgroundColor;
+
+  static const _defaultSettings = LiquidGlassSettings(
+    thickness: 25,
+    blur: 20, // High blur for toolbar material
+    chromaticAberration: 0.2,
+    lightIntensity: 0.35,
+    refractiveIndex: 1.5,
+    saturation: 1.2,
+    glassColor: Color(0x1AFFFFFF), // white10
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: quality,
+      fallback: GlassQuality.premium,
+    );
+
+    // Standard iOS toolbar glass settings with high blur
+    final effectiveSettings = settings ?? _defaultSettings;
+
+    // Background color blending
+    // iOS toolbars often have a very subtle tint
+    final effectiveBackgroundColor =
+        backgroundColor ?? CupertinoColors.systemGrey.withValues(alpha: 0.08);
+
+    final dividerColor = GlassTheme.brightnessOf(context) == Brightness.light
+        ? CupertinoColors.black.withValues(alpha: 0.12)
+        : CupertinoColors.white.withValues(alpha: 0.12);
+
+    return AdaptiveLiquidGlassLayer(
+      settings: effectiveSettings,
+      quality: effectiveQuality,
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border(
+            top: BorderSide(
+              color: dividerColor, // Subtle top divider
+              width: 0.5,
+            ),
+          ),
+        ),
+        child: Stack(
+          children: [
+            // Glass Background Layer
+            Positioned.fill(
+              child: AdaptiveGlass.grouped(
+                // Toolbar is typically a full-width rectangle
+                shape: const LiquidRoundedRectangle(borderRadius: 0),
+                quality: effectiveQuality,
+                child: Container(color: effectiveBackgroundColor),
+              ),
+            ),
+
+            // Content Layer
+            SafeArea(
+              top: false,
+              child: SizedBox(
+                height: height,
+                child: Padding(
+                  padding: padding,
+                  child: Row(
+                    mainAxisAlignment: alignment,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: children,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/glass_search_bar_config.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/glass_search_bar_config.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/material.dart';
+
+/// Configuration for the morphing search bar in [GlassSearchableBottomBar].
+///
+/// When the user taps the collapsed search pill, [onSearchToggle] is called
+/// with `true`. Set [GlassSearchableBottomBar.isSearchActive] to `true` to
+/// expand the search bar and collapse the tab pill.
+///
+/// ## Example
+/// ```dart
+/// GlassSearchableBottomBar(
+///   tabs: [...],
+///   selectedIndex: _tab,
+///   onTabSelected: (i) => setState(() => _tab = i),
+///   isSearchActive: _searching,
+///   searchConfig: GlassSearchBarConfig(
+///     onSearchToggle: (v) => setState(() => _searching = v),
+///     hintText: 'Apple News',
+///     collapsedLogoBuilder: (ctx) => ..., // N logo shown when searching
+///   ),
+/// )
+/// ```
+class GlassSearchBarConfig {
+  /// Creates a search bar configuration.
+  const GlassSearchBarConfig({
+    required this.onSearchToggle,
+    this.hintText = 'Search',
+    this.collapsedTabWidth,
+    this.collapsedLogoBuilder,
+    this.searchIconColor,
+    this.searchIcon,
+    this.micIconColor,
+    this.hintStyle,
+    this.controller,
+    this.focusNode,
+    this.onChanged,
+    this.onSubmitted,
+    this.onMicTap,
+    this.textColor,
+    this.cursorColor,
+    this.trailingBuilder,
+    this.textInputAction,
+    this.keyboardType,
+    this.autocorrect = true,
+    this.enableSuggestions = true,
+    this.onTapOutside,
+    this.autoFocusOnExpand = false,
+    this.expandWhenActive = true,
+    this.showsCancelButton = true,
+    this.cancelButtonColor,
+    this.cancelIcon,
+    this.cancelIconSize = 24,
+    this.onSearchFocusChanged,
+    this.onSearchFieldTap,
+    this.onCancelTap,
+  });
+
+  /// Called with `true` when search is activated, `false` when dismissed.
+  final ValueChanged<bool> onSearchToggle;
+
+  /// Placeholder text in the expanded search bar. Defaults to `'Search'`.
+  final String hintText;
+
+  /// Width of the collapsed tab pill when search is active.
+  ///
+  /// If omitted, defaults to matching the [GlassSearchableBottomBar.searchBarHeight]
+  /// to ensure the collapsed indicator perfectly shrinks proportionately into a circle.
+  final double? collapsedTabWidth;
+
+  /// Widget shown inside the collapsed tab pill when search is active.
+  ///
+  /// Optional builder for a custom logo/icon shown on the collapsed tab pill
+  /// when search is fully active.
+  ///
+  /// If omitted, this defaults to displaying the [activeIcon] (or fallback
+  /// [icon]) of the currently selected [GlassBottomBarTab], matching the native
+  /// iOS Apple News behavior.
+  final WidgetBuilder? collapsedLogoBuilder;
+
+  /// Color for the 🔍 and 🎤️ icons. Defaults to `CupertinoColors.secondaryLabel`
+  /// (adapts to light/dark mode).
+  final Color? searchIconColor;
+
+  /// Custom widget rendered in place of the default magnifying-glass
+  /// icon on the collapsed search pill. When non-null, [searchIconColor]
+  /// is ignored for this particular slot — the caller's widget is
+  /// expected to handle its own coloring.
+  ///
+  /// The default (`null`) preserves the upstream behavior:
+  /// `Icon(CupertinoIcons.search, color: searchIconColor ?? CupertinoColors.secondaryLabel)`.
+  ///
+  /// Useful when the caller wants a higher-fidelity glyph (e.g. real
+  /// SF Symbols via `flutter_sficon`) or a different icon set with
+  /// weight control (e.g. Material Symbols).
+  final Widget? searchIcon;
+
+  /// Color for the microphone icon specifically. Falls back to [searchIconColor].
+  ///
+  /// Ignored when [trailingBuilder] is provided.
+  final Color? micIconColor;
+
+  /// Text style for the hint text. Uses a sensible default when null.
+  final TextStyle? hintStyle;
+
+  /// Optional controller for the search text field.
+  ///
+  /// If null, the widget manages its own internal controller.
+  final TextEditingController? controller;
+
+  /// Optional focus node for the search text field.
+  ///
+  /// Providing a [FocusNode] gives you full programmatic control over when
+  /// the search keyboard appears and disappears — independently of
+  /// [autoFocusOnExpand].  Typical use-cases:
+  ///
+  /// - Call `focusNode.requestFocus()` to open the keyboard at an arbitrary
+  ///   moment (e.g. after an animation completes or a voice-search result
+  ///   arrives).
+  /// - Call `focusNode.unfocus()` to dismiss the keyboard without collapsing
+  ///   the search bar.
+  /// - Listen to `focusNode.addListener(...)` for focus events in addition to
+  ///   or instead of [onSearchFocusChanged].
+  ///
+  /// **Lifecycle:** the caller is responsible for disposing the node.
+  /// The widget will never dispose a caller-provided [FocusNode].
+  ///
+  /// If null, an internal node is created and disposed automatically.
+  final FocusNode? focusNode;
+
+  /// Called on every keystroke as the user types in the search field.
+  ///
+  /// Use this for live/incremental search filtering. For submit-only
+  /// behaviour (e.g. triggering a network request on Enter) use [onSubmitted].
+  final ValueChanged<String>? onChanged;
+
+  /// Called when the user submits the search (keyboard action).
+  final ValueChanged<String>? onSubmitted;
+
+  /// Called when the user taps the microphone icon.
+  ///
+  /// When null the microphone icon is hidden. Ignored when [trailingBuilder]
+  /// is provided (the builder is responsible for its own tap handling).
+  final VoidCallback? onMicTap;
+
+  /// Color of the typed text. Defaults to `CupertinoColors.label`
+  /// (adapts to light/dark mode).
+  final Color? textColor;
+
+  /// Color of the text cursor (blinking caret) in the expanded
+  /// search field.
+  ///
+  /// When `null` (the default), the cursor inherits via Flutter's
+  /// standard resolution chain:
+  ///   1. `Theme.of(context).textSelectionTheme.cursorColor`
+  ///   2. On iOS, `CupertinoTheme.of(context).primaryColor`
+  ///   3. `Theme.of(context).colorScheme.primary`
+  ///
+  /// This matches how every other Material `TextField` cursor in a
+  /// Flutter app resolves color, so theme-driven apps Just Work
+  /// without needing to set this here.
+  ///
+  /// **Breaking change in 0.13.0**: in 0.12.x and earlier the cursor
+  /// was hard-coupled to [textColor]. To restore the previous
+  /// behaviour, pass `cursorColor: textColor` explicitly:
+  ///
+  /// ```dart
+  /// GlassSearchBarConfig(
+  ///   textColor: Colors.white,
+  ///   cursorColor: Colors.white,  // ← previously implicit
+  ///   ...
+  /// )
+  /// ```
+  final Color? cursorColor;
+
+  // ── SearchBar parity ────────────────────────────────────────────────────────
+
+  /// Custom widget builder for the trailing section of the expanded search bar.
+  ///
+  /// When provided, **completely replaces** the microphone icon and [onMicTap]
+  /// behaviour. Use this to show a "Clear" button, voice-action indicator, or
+  /// any other widget in the trailing position — matching Flutter's own
+  /// [SearchBar.trailing] API.
+  ///
+  /// The builder receives a [BuildContext] that is a descendant of the
+  /// expanded glass pill. If null, the standard mic icon / empty logic applies.
+  ///
+  /// ## Example — clear button
+  /// ```dart
+  /// trailingBuilder: (ctx) => GestureDetector(
+  ///   onTap: () => searchController.clear(),
+  ///   child: Icon(CupertinoIcons.clear_circled_solid,
+  ///       color: Colors.white54, size: 18),
+  /// ),
+  /// ```
+  final WidgetBuilder? trailingBuilder;
+
+  /// The keyboard action button label for the search [TextField].
+  ///
+  /// Common values: [TextInputAction.search], [TextInputAction.done],
+  /// [TextInputAction.go]. Defaults to null (system / platform default).
+  final TextInputAction? textInputAction;
+
+  /// The type of keyboard to display for the search [TextField].
+  ///
+  /// Defaults to null, which uses [TextInputType.text]. Pass
+  /// [TextInputType.url] or [TextInputType.emailAddress] for specialised
+  /// search contexts.
+  final TextInputType? keyboardType;
+
+  /// Whether to enable autocorrection for the search [TextField].
+  ///
+  /// Defaults to `true`. Set to `false` for search bars where autocorrection
+  /// would interfere (e.g. product codes, usernames).
+  final bool autocorrect;
+
+  /// Whether to show input suggestions (QuickType bar on iOS) for the search
+  /// [TextField].
+  ///
+  /// Defaults to `true`. Mirrors [TextField.enableSuggestions].
+  final bool enableSuggestions;
+
+  /// Called when the user taps outside the expanded search [TextField].
+  ///
+  /// Passed directly to [TextField.onTapOutside]. A common use-case is
+  /// unfocusing the field so the keyboard dismisses when the user taps the
+  /// page content above the bar:
+  ///
+  /// ```dart
+  /// onTapOutside: (_) => FocusScope.of(context).unfocus(),
+  /// ```
+  final TapRegionCallback? onTapOutside;
+
+  /// Whether the search [TextField] should automatically receive keyboard focus
+  /// when the search bar expands.
+  ///
+  /// - `false` (default): the bar expands without triggering the keyboard;
+  ///   the user taps inside the pill to start typing. Matches the behaviour
+  ///   of the real iOS 26 Apple News search bar and looks more polished.
+  /// - `true`: the keyboard opens automatically as soon as the bar expands —
+  ///   useful for modal or dedicated search screens where typing is the
+  ///   immediate next action.
+  final bool autoFocusOnExpand;
+
+  /// Whether the search pill expands horizontally to fill the available width
+  /// when search is active.
+  ///
+  /// Defaults to `true` (Apple News style). Set to `false` if you want the
+  /// search pill to remain a compact circular button on the right side when
+  /// active, creating an empty gap in the center of the bar.
+  final bool expandWhenActive;
+
+  /// Whether to show a cancel/dismiss button when the search bar is focused.
+  ///
+  /// Defaults to `true`, providing an intuitive escape hatch for users to dismiss
+  /// the keyboard and search state. Note that if `true`, it renders a detached glass
+  /// dismiss pill with an "X" icon, replicating Apple News.
+  final bool showsCancelButton;
+
+  /// Color of the cancel (×) icon.
+  ///
+  /// Defaults to white with 90% opacity, matching iOS system style.
+  final Color? cancelButtonColor;
+
+  /// Custom icon widget for the cancel (dismiss) button.
+  ///
+  /// When non-null, replaces the default [CupertinoIcons.xmark] glyph.
+  /// The provided widget is rendered as-is inside the glass pill, so it
+  /// should already carry its own color and size:
+  ///
+  /// ```dart
+  /// cancelIcon: Icon(CupertinoIcons.xmark_circle_fill,
+  ///     color: Colors.white, size: 22),
+  /// ```
+  ///
+  /// When null, the default × icon is used with [cancelButtonColor] and
+  /// [cancelIconSize].
+  final Widget? cancelIcon;
+
+  /// Size of the cancel (×) icon in logical pixels.
+  ///
+  /// Defaults to `24`. The reporter noted that `16` (the old default) was
+  /// noticeably smaller than the iOS 26 dismiss button; `24` matches the
+  /// visual weight of the adjacent search and mic icons.
+  final double cancelIconSize;
+
+  /// Called whenever the search field gains or loses keyboard focus.
+  ///
+  /// `true`  — keyboard is visible, field is active.
+  /// `false` — keyboard dismissed, field is unfocused.
+  ///
+  /// Use this to switch the body content between a focused search state
+  /// (e.g. "No Recent Searches") and an unfocused search state (e.g. a topic
+  /// browse grid), without fully closing the search bar.
+  final ValueChanged<bool>? onSearchFocusChanged;
+
+  /// Called when the user taps the body of the active (expanded) search field.
+  ///
+  /// Passed directly to [TextField.onTap]. Useful for navigating to a
+  /// dedicated search screen, showing a suggestion overlay, or logging an
+  /// analytics event on search interaction — without needing to own the
+  /// [FocusNode] yourself.
+  ///
+  /// Note: this fires on every tap of the field, including taps that
+  /// merely restore focus after the keyboard was dismissed.
+  final VoidCallback? onSearchFieldTap;
+
+  /// Called when the user taps the dismiss (×) cancel pill to close the keyboard.
+  ///
+  /// Fires immediately after the library's own focus-release and
+  /// [onSearchToggle]`(false)` calls, so the search state is already collapsing
+  /// by the time your callback runs. Use this for:
+  ///
+  /// - Analytics (`analytics.log('search_cancelled')`).
+  /// - Clearing search results so the body resets before the bar animates shut.
+  /// - Programmatically unfocusing a custom [FocusNode] you own.
+  ///
+  /// When null (the default), the standard dismiss behaviour runs unchanged.
+  final VoidCallback? onCancelTap;
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_bottom_internal.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_bottom_internal.dart
@@ -1,0 +1,1010 @@
+// ignore_for_file: deprecated_member_use
+// Shared internal widgets for GlassBottomBar and GlassSearchableBottomBar.
+//
+// NOT part of the public API — do not export from liquid_glass_widgets.dart.
+library;
+
+import 'dart:math' as math;
+
+import 'package:flutter/cupertino.dart';
+import '../../../src/renderer/liquid_glass_renderer.dart';
+import '../../../theme/glass_theme.dart';
+import '../../../types/glass_quality.dart';
+import '../../../utils/draggable_indicator_physics.dart';
+import 'tab_bar_drag_gesture_mixin.dart';
+import '../../../utils/glass_spring.dart';
+import '../../interactive/glass_button.dart';
+import '../../shared/adaptive_glass.dart';
+import '../../shared/animated_glass_indicator.dart';
+import '../../shared/inherited_liquid_glass.dart';
+import '../glass_bottom_bar.dart'
+    show
+        GlassTabBarExtraButton,
+        GlassBottomBarTab,
+        MaskingQuality,
+        JellyClipper;
+
+// =============================================================================
+// kBottomBarGlassDefaults — shared glass preset
+// =============================================================================
+
+/// Default [LiquidGlassSettings] for both [GlassBottomBar] and
+/// [GlassSearchableBottomBar].
+///
+/// Centralised here so that both bars are guaranteed to produce visually
+/// identical glass when placed on the same screen — there is no risk of
+/// the two copies drifting apart during maintenance.
+///
+/// Values are tuned to the iOS 26 Apple News / Safari tab bar aesthetic:
+/// - `thickness: 30` — deep refraction without over-distorting icons.
+/// - `blur: 3` — subtle frosted back-blur.
+/// - `refractiveIndex: 1.59` — polycarbonate-grade refraction.
+/// - `lightAngle: 0.75π` (135°) — Apple standard upper-left key light.
+const kBottomBarGlassDefaults = LiquidGlassSettings(
+  thickness: 30,
+  blur: 3,
+  chromaticAberration: 0.3,
+  lightIntensity: 0.6,
+  refractiveIndex: 1.59,
+  saturation: 0.7,
+  ambientStrength: 1,
+  lightAngle: 0.75 * math.pi,
+  glassColor: Color(0x3DFFFFFF),
+);
+
+// =============================================================================
+// resolveBarLabelColor — shared icon/label color resolution
+// =============================================================================
+
+/// Resolves the dynamic icon/label color for both bars.
+///
+/// In the classic path ([darkAmount] null) this is the Cupertino label color
+/// resolved against the ambient brightness — identical to the historical
+/// behavior. When the content-aware brightness machinery is active,
+/// [darkAmount] is the animated light→dark cross-fade position, and the
+/// color interpolates between the label's light and dark variants so glyphs
+/// fade with the rest of the appearance instead of snapping. Non-dynamic
+/// custom label colors have no variants to fade between and are returned
+/// as-is.
+Color resolveBarLabelColor(BuildContext context, double? darkAmount) {
+  final labelColor = CupertinoTheme.of(context).textTheme.textStyle.color ??
+      CupertinoColors.label;
+  if (darkAmount != null && labelColor is CupertinoDynamicColor) {
+    // Content-aware path: animated cross-fade between light/dark variants.
+    return Color.lerp(labelColor.color, labelColor.darkColor, darkAmount)!;
+  }
+  // Static path: resolve any CupertinoDynamicColor eagerly using the glass
+  // brightness cascade. CupertinoDynamicColor returned unresolved works for
+  // BottomBarTabItem (IconTheme resolves it during painting), but breaks for
+  // SearchPill icons where .value is always the light-mode black. Using
+  // GlassTheme.brightnessOf() — the package's single brightness authority —
+  // ensures dark glass always produces white glyphs regardless of system brightness.
+  if (labelColor is CupertinoDynamicColor) {
+    final brightness = GlassTheme.brightnessOf(context);
+    return brightness == Brightness.dark
+        ? labelColor.darkColor
+        : labelColor.color;
+  }
+  return labelColor;
+}
+
+// =============================================================================
+// buildIconShadows — pure utility function (visibleForTesting for unit tests)
+// =============================================================================
+
+/// Builds multi-directional icon shadows that simulate a stroke/outline effect.
+///
+/// Returns `null` (no shadow) when:
+/// - [thickness] is null (feature not requested), or
+/// - [selected] is true AND [activeIcon] is non-null (distinct active icon
+///   is used so outline shadow is not needed in that state).
+///
+/// Otherwise, generates 8 evenly-spaced [Shadow] offsets around the icon at
+/// the given [thickness] radius using 45° increments.
+///
+/// Extracted from [BottomBarTabItem] to enable isolated unit testing.
+@visibleForTesting
+List<Shadow>? buildIconShadows({
+  required Color iconColor,
+  required double? thickness,
+  required bool selected,
+  required Widget? activeIcon,
+}) {
+  if (thickness == null || (selected && activeIcon != null)) return null;
+  final shadows = <Shadow>[];
+  const step = math.pi / 4;
+  for (double a = 0; a < math.pi * 2; a += step) {
+    shadows.add(Shadow(
+      color: iconColor,
+      offset: Offset.fromDirection(a, thickness),
+    ));
+  }
+  return shadows;
+}
+
+// =============================================================================
+// BottomBarTabItem — shared tab item widget
+// =============================================================================
+
+/// Renders a single tab item for [GlassBottomBar] and [GlassSearchableBottomBar].
+///
+/// Previously duplicated as `_BottomBarTab` and `_TabItem`. Single source of truth.
+class BottomBarTabItem extends StatelessWidget {
+  const BottomBarTabItem({
+    required this.tab,
+    required this.selected,
+    required this.selectedIconColor,
+    required this.unselectedIconColor,
+    this.selectedLabelColor,
+    this.unselectedLabelColor,
+    this.selectedLabelStyle,
+    this.unselectedLabelStyle,
+    required this.iconSize,
+    required this.textStyle,
+    required this.labelFontSize,
+    required this.iconLabelSpacing,
+    required this.glowDuration,
+    required this.glowBlurRadius,
+    required this.glowSpreadRadius,
+    required this.glowOpacity,
+    required this.onTap,
+    super.key,
+  });
+
+  final GlassBottomBarTab tab;
+  final bool selected;
+  final Color selectedIconColor;
+  final Color unselectedIconColor;
+  final Color? selectedLabelColor;
+  final Color? unselectedLabelColor;
+
+  /// Per-state label text style. Merged over the base label style, so it can
+  /// override font family / weight / letter-spacing while keeping the resolved
+  /// [selectedLabelColor] / [unselectedLabelColor] (unless the style sets its
+  /// own color). Null leaves the existing behavior unchanged.
+  final TextStyle? selectedLabelStyle;
+  final TextStyle? unselectedLabelStyle;
+
+  final double iconSize;
+  final TextStyle? textStyle;
+
+  /// Font size for tab labels when [textStyle] is null.
+  ///
+  /// Mirrors [iconSize] as an explicit sizing knob. Defaults to 11.
+  /// Reduce to 10 for bars with 4+ tabs or long label text.
+  final double labelFontSize;
+  final double iconLabelSpacing;
+  final Duration glowDuration;
+  final double glowBlurRadius;
+  final double glowSpreadRadius;
+  final double glowOpacity;
+  // Nullable: when null the GestureDetector does not handle taps.
+  // Pass null in contexts where the outer TabIndicator owns selection via
+  // onTapDown, and accessibility is handled by the indicator's own Semantics.
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final iconColor = selected ? selectedIconColor : unselectedIconColor;
+    final iconWidget = selected ? (tab.activeIcon ?? tab.icon) : tab.icon;
+
+    // SizedBox.shrink() (width:0, height:0, no child) is the sentinel used
+    // by glass_tab_bar.dart when a GlassTab has no icon. Detect it by checking
+    // that all three fields match — a caller-supplied SizedBox wrapping a real
+    // icon will have a non-zero size OR a non-null child.
+    final bool hasIcon = !(iconWidget is SizedBox &&
+        (iconWidget.width ?? 0) == 0 &&
+        (iconWidget.height ?? 0) == 0 &&
+        iconWidget.child == null);
+
+    // Label style resolution — most-specific-wins:
+    //   1. Base typography: caller [textStyle], else the built-in default keyed
+    //      to the per-state icon color.
+    //   2. An explicit per-state label color
+    //      ([selectedLabelColor]/[unselectedLabelColor]) overrides the base
+    //      color — including a color baked into [textStyle] — since it's the more
+    //      specific intent. When null, textStyle's own color (or the icon-color
+    //      default) stands.
+    //   3. The per-state [selectedLabelStyle]/[unselectedLabelStyle] merges last,
+    //      so a caller can set a heavier/different selected font on top.
+    var baseLabelStyle = textStyle ??
+        TextStyle(
+          color: iconColor,
+          fontSize: labelFontSize,
+          fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+        );
+    final perStateLabelColor =
+        selected ? selectedLabelColor : unselectedLabelColor;
+    if (perStateLabelColor != null) {
+      baseLabelStyle = baseLabelStyle.copyWith(color: perStateLabelColor);
+    }
+    final stateLabelStyle =
+        selected ? selectedLabelStyle : unselectedLabelStyle;
+    final resolvedLabelStyle = stateLabelStyle != null
+        ? baseLabelStyle.merge(stateLabelStyle)
+        : baseLabelStyle;
+
+    return GestureDetector(
+      // onTap may be null when selection is owned by the outer TabIndicator
+      // (visual path). When non-null it provides accessibility support for
+      // VoiceOver / TalkBack which route through onTap, not onTapDown.
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Semantics(
+        button: true,
+        selected: selected,
+        label: tab.label ?? 'Tab',
+        child: SizedBox.expand(
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.center,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              spacing: hasIcon ? iconLabelSpacing : 0,
+              children: [
+                if (hasIcon)
+                  ExcludeSemantics(
+                    child: Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        if (tab.glowColor != null)
+                          Positioned(
+                            top: -24,
+                            right: -24,
+                            left: -24,
+                            bottom: -24,
+                            child: RepaintBoundary(
+                              child: AnimatedContainer(
+                                duration: glowDuration,
+                                transformAlignment: Alignment.center,
+                                curve: Curves.easeOutCirc,
+                                transform: selected
+                                    ? Matrix4.identity()
+                                    : (Matrix4.identity()
+                                      ..scale(0.4)
+                                      ..rotateZ(-math.pi)),
+                                child: AnimatedOpacity(
+                                  duration: glowDuration,
+                                  opacity: selected ? 1 : 0,
+                                  child: Container(
+                                    decoration: BoxDecoration(
+                                      shape: BoxShape.circle,
+                                      boxShadow: [
+                                        BoxShadow(
+                                          color: tab.glowColor!.withOpacity(
+                                            selected ? glowOpacity : 0,
+                                          ),
+                                          blurRadius: glowBlurRadius,
+                                          spreadRadius: glowSpreadRadius,
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        IconTheme(
+                          data: IconThemeData(
+                            color: iconColor,
+                            size: iconSize,
+                            // Use the extracted top-level function for testability
+                            shadows: buildIconShadows(
+                              iconColor: iconColor,
+                              thickness: tab.thickness,
+                              selected: selected,
+                              activeIcon: tab.activeIcon,
+                            ),
+                          ),
+                          child: DefaultTextStyle(
+                            style: DefaultTextStyle.of(context)
+                                .style
+                                .copyWith(color: iconColor),
+                            child: iconWidget,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                if (tab.label != null)
+                  Text(
+                    tab.label!,
+                    maxLines: 1,
+                    textAlign: TextAlign.center,
+                    overflow: TextOverflow.ellipsis,
+                    style: resolvedLabelStyle,
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// BottomBarExtraBtn — shared extra button widget
+// =============================================================================
+
+/// Renders the extra action button using [GlassButton].
+///
+/// Previously duplicated as `_ExtraButton` and `_ExtraBtn`. Single source of truth.
+class BottomBarExtraBtn extends StatelessWidget {
+  const BottomBarExtraBtn({
+    required this.config,
+    required this.quality,
+    required this.iconColor,
+    this.enableBlend = false,
+    this.borderRadius,
+    this.platformViewBackdrop = false,
+    super.key,
+  });
+
+  final GlassTabBarExtraButton config;
+  final GlassQuality quality;
+  final Color iconColor;
+  final bool enableBlend;
+  final double? borderRadius;
+
+  /// When true, routes rendering through the frosted fallback (live
+  /// [BackdropFilter]) instead of the Impeller-native shader. Required when
+  /// the button floats over an iOS PlatformView (e.g. a map) — the shader
+  /// paths read a captured backdrop that excludes the platform view, so they
+  /// render inert there. Matches [GlassButton.platformViewBackdrop].
+  final bool platformViewBackdrop;
+
+  @override
+  Widget build(BuildContext context) {
+    // Shape selection for the frosted fallback (BackdropFilter) path:
+    //
+    // When platformViewBackdrop is true, LiquidOval is swapped for
+    // LiquidRoundedSuperellipse (radius = size / 2). Both produce a circle,
+    // but LiquidRoundedSuperellipse forwards its clip path to the engine's
+    // PlatformView mutator stack via _ShapeClip. This constrains the UIKitView
+    // compositing sample area to the circle boundary, preventing a rectangular
+    // "light square" bleed from the BackdropFilter's rectangular capture region.
+    // LiquidOval relies on a shader-side SDF clip which the mutator stack cannot
+    // propagate to the native view layer, so it must not be used here.
+    final effectiveShape = borderRadius != null
+        ? LiquidRoundedRectangle(borderRadius: borderRadius!)
+        : (platformViewBackdrop
+            ? LiquidRoundedSuperellipse(borderRadius: config.size / 2)
+            : const LiquidOval());
+
+    final button = GlassButton(
+      icon: config.icon,
+      onTap: config.onTap,
+      label: config.label,
+      width: config.size,
+      height: config.size,
+      quality: quality,
+      iconColor: iconColor,
+      useOwnLayer: !enableBlend, // When blending, share the parent's layer
+      shape: effectiveShape,
+      platformViewBackdrop: platformViewBackdrop,
+      stretch: platformViewBackdrop ? 0.0 : 0.5,
+    );
+
+    return button;
+  }
+}
+
+// =============================================================================
+// TabIndicator — draggable pill indicator with spring physics
+// =============================================================================
+
+/// Internal widget that manages the draggable indicator with physics.
+///
+/// Extracted from [GlassBottomBar] to keep the public widget focused on layout
+/// and configuration, while this widget owns all gesture, animation, and
+/// rendering logic for the tab indicator pill.
+///
+/// Responsibilities:
+/// - Horizontal drag gesture handling ([GestureDetector] + [Listener])
+/// - Spring-based alignment animation ([VelocitySpringBuilder])
+/// - Jelly deformation during drag ([SpringBuilder] + thickness)
+/// - Dual rendering modes: [MaskingQuality.off] and [MaskingQuality.high]
+class TabIndicator extends StatefulWidget {
+  const TabIndicator({
+    required this.childUnselected,
+    required this.selectedTabBuilder,
+    required this.tabIndex,
+    required this.tabCount,
+    required this.onTabChanged,
+    required this.visible,
+    required this.indicatorColor,
+    required this.quality,
+    required this.barHeight,
+    required this.barBorderRadius,
+    this.indicatorBorderRadius,
+    required this.tabPadding,
+    required this.magnification,
+    required this.innerBlur,
+    required this.maskingQuality,
+    this.indicatorSettings,
+    this.backgroundKey,
+    this.indicatorExpansion = const EdgeInsets.all(8.0),
+    this.indicatorPinchStrength = 1.0,
+    this.interactionGlowColor,
+    this.interactionGlowRadius = 1.5,
+    this.interactionGlowBlurRadius = 0,
+    this.interactionGlowSpreadRadius = 0,
+    this.interactionGlowOpacity = 1,
+    this.interactionScale = 1.0,
+    this.platformViewBackdrop = false,
+    this.springDescription,
+    super.key,
+  });
+
+  final int tabIndex;
+  final int tabCount;
+  final bool visible;
+  final Widget childUnselected;
+  final Widget Function(BuildContext, double, Alignment) selectedTabBuilder;
+  final Color? indicatorColor;
+  final LiquidGlassSettings? indicatorSettings;
+  final ValueChanged<int> onTabChanged;
+  final GlassQuality quality;
+  final double barHeight;
+  final double barBorderRadius;
+  final double? indicatorBorderRadius;
+  final EdgeInsetsGeometry tabPadding;
+  final double magnification;
+  final double innerBlur;
+  final MaskingQuality maskingQuality;
+  final SpringDescription? springDescription;
+  final GlobalKey? backgroundKey;
+
+  /// How far the jelly indicator's leading and trailing edges expand
+  /// past the tab boundary as the indicator translates. Higher values
+  /// give a more dramatic "puff" stretch; lower values produce a
+  /// tighter, more iOS-native feel. Defaults to `14` to match the
+  /// pre-existing visual.
+  final EdgeInsetsGeometry indicatorExpansion;
+
+  /// Maximum concave lens pinch strength for the animated pill.
+  /// Forwarded directly to [AnimatedGlassIndicator.pinchStrength].
+  final double indicatorPinchStrength;
+
+  final Color? interactionGlowColor;
+  final double interactionGlowRadius;
+  final double interactionGlowBlurRadius;
+  final double interactionGlowSpreadRadius;
+  final double interactionGlowOpacity;
+
+  /// The scale factor applied by [LiquidStretch] on press.
+  ///
+  /// Pass `1.0` to disable scaling. Resolved by the parent widget from
+  /// [GlassInteractionBehavior] before being forwarded here.
+  final double interactionScale;
+
+  /// When true, forces BackdropFilter rendering and refracts the icon layer
+  /// instead of the backdrop — needed over iOS PlatformViews.
+  final bool platformViewBackdrop;
+
+  @override
+  State<TabIndicator> createState() => TabIndicatorState();
+}
+
+/// State for [TabIndicator]. Public for testing via `@visibleForTesting`.
+@visibleForTesting
+class TabIndicatorState extends State<TabIndicator>
+    with TabDragGestureMixin<TabIndicator> {
+  // ── Mixin interface ────────────────────────────────────────────────────────
+  @override
+  int get tabCount => widget.tabCount;
+  @override
+  int get tabIndex => widget.tabIndex;
+  @override
+  bool get isPlatformViewBackdrop => widget.platformViewBackdrop;
+  @override
+  void notifyTabChanged(int index) => widget.onTabChanged(index);
+
+  // Cache fallback indicator color to avoid allocations
+  static const _fallbackIndicatorColor =
+      Color(0x1AFFFFFF); // white.withValues(alpha: 0.1)
+
+  final GlobalKey _iconLayerKey = GlobalKey();
+
+  // Cached shape to avoid recreation on every animation frame
+  late LiquidRoundedSuperellipse _barShape =
+      LiquidRoundedSuperellipse(borderRadius: widget.barBorderRadius);
+
+  @override
+  void didUpdateWidget(covariant TabIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    updateTabAlignIfNeeded(oldWidget.tabIndex, oldWidget.tabCount);
+
+    // Update cached shape if border radius changes
+    if (oldWidget.barBorderRadius != widget.barBorderRadius) {
+      _barShape =
+          LiquidRoundedSuperellipse(borderRadius: widget.barBorderRadius);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = CupertinoTheme.of(context);
+    final indicatorColor = widget.indicatorColor ??
+        theme.textTheme.textStyle.color?.withValues(alpha: .1) ??
+        _fallbackIndicatorColor;
+    final targetAlignment = computeTabAlignment(widget.tabIndex);
+
+    // AnimatedGlassIndicator multiplies by 2 for the glass superellipse shape,
+    // but uses the value directly for the background DecoratedBox.
+    final indicatorRadius =
+        widget.indicatorBorderRadius ?? widget.barBorderRadius;
+
+    // Lateral sway: the bar body subtly follows the interactive pill during
+    // horizontal drags, mimicking iOS 26 bottom bar physics. The SpringBuilder
+    // animates the offset back to 0.0 when the drag ends.
+    return SpringBuilder(
+      spring: GlassSpring.smooth(
+        duration: const Duration(milliseconds: 250),
+      ),
+      value: barSwayOffset,
+      builder: (context, swayValue, _) {
+        return Transform.translate(
+          offset: Offset(swayValue, 0),
+          child: LiquidStretch(
+            interactionScale: widget.interactionScale,
+            stretch:
+                0.0, // stretch disabled on platformViewBackdrop to prevent BackdropFilter pixel-snap jitter
+            resistance: 0.08,
+            anchorStretch: false, // Tab bars use jelly-follow, not anchored
+            child: Listener(
+              // Raw pointer events fire BEFORE gesture recognizers and never compete
+              // in the gesture arena, so tabIsDown is always set on the very first event.
+              onPointerDown: (e) => onBarPointerDown(e.position),
+              onPointerUp: (e) => onBarPointerUp(e.position),
+              onPointerCancel: (e) => onBarPointerCancel(e.position),
+              child: GestureDetector(
+                key: ValueKey(gestureEpoch),
+                behavior: HitTestBehavior.opaque,
+                onHorizontalDragDown: onBarDragDown,
+                onHorizontalDragStart: onBarDragStart,
+                onHorizontalDragUpdate: onBarDragUpdate,
+                onHorizontalDragEnd: onBarDragEnd,
+                // On cancel (e.g. parent scroll steals the gesture or pointer goes
+                // off-screen), tabIsDown is cleared by the Listener when pointer lifts.
+                onHorizontalDragCancel: onBarDragCancel,
+                onTapDown:
+                    onBarTapDown, // DX1: makes jelly visible on desktop taps
+                onTapUp: onBarTapUp,
+                onTapCancel: onBarTapCancel,
+                child: VelocitySpringBuilder(
+                  value: tabXAlign,
+                  springWhenActive: GlassSpring.interactive(),
+                  springWhenReleased: widget.springDescription ??
+                      GlassSpring.snappy(
+                        duration: const Duration(milliseconds: 350),
+                      ),
+                  active: tabIsDragging,
+                  builder: (context, value, velocity, child) {
+                    final alignment = Alignment(value, 0);
+
+                    return SpringBuilder(
+                      spring: GlassSpring.snappy(
+                        duration: const Duration(milliseconds: 300),
+                      ),
+                      // Keep thickness active while:
+                      //  - tabIsDown (tap pressed, 420 ms window for spring travel), OR
+                      //  - tabIsDragging (finger is physically moving — keep glass alive
+                      //    even when passing back over the selected tab), OR
+                      //  - the spring still has meaningful separation from target.
+                      // Threshold 0.05 (was 0.10) catches the full deceleration tail.
+                      value: widget.visible &&
+                              (tabIsDown ||
+                                  tabIsDragging ||
+                                  (alignment.x - targetAlignment).abs() > 0.05)
+                          ? 1.0
+                          : 0.0,
+                      builder: (context, thickness, child) {
+                        // Lazy evaluation optimization: skip expensive calculations when hidden
+                        if (thickness < 0.01 &&
+                            !widget.visible &&
+                            widget.maskingQuality == MaskingQuality.high) {
+                          // Fast path: indicator is hidden, render simple layout
+                          return Container(
+                            height: widget.barHeight,
+                            decoration: ShapeDecoration(
+                              shape: _barShape,
+                            ),
+                            child: AdaptiveGlass.grouped(
+                              quality: widget.quality,
+                              platformViewBackdrop: widget.platformViewBackdrop,
+                              shape: _barShape,
+                              child: Container(
+                                padding: widget.tabPadding,
+                                child: widget.childUnselected,
+                              ),
+                            ),
+                          );
+                        }
+
+                        // Calculate jelly transform for the clipper (only when needed)
+                        final jellyTransform =
+                            DraggableIndicatorPhysics.buildJellyTransform(
+                          velocity: Offset(velocity, 0),
+                          maxDistortion: 0.8,
+                          velocityScale: 10,
+                        );
+
+                        // Switch rendering mode based on masking quality
+                        switch (widget.maskingQuality) {
+                          case MaskingQuality.off:
+                            return _buildSimpleMode(
+                              alignment: alignment,
+                              targetAlignment: Alignment(targetAlignment, 0),
+                              thickness: thickness,
+                              velocity: velocity,
+                              indicatorRadius: indicatorRadius,
+                              indicatorColor: indicatorColor,
+                            );
+
+                          case MaskingQuality.high:
+                            return _buildHighQualityMode(
+                              alignment: alignment,
+                              thickness: thickness,
+                              velocity: velocity,
+                              jellyTransform: jellyTransform,
+                              indicatorRadius: indicatorRadius,
+                              indicatorColor: indicatorColor,
+                            );
+                        }
+                      },
+                    ); // SpringBuilder (thickness)
+                  }, // VelocitySpringBuilder builder
+                ), // VelocitySpringBuilder
+              ), // GestureDetector
+            ), // Listener
+          ), // LiquidStretch
+        ); // Transform.translate
+      }, // SpringBuilder builder (sway)
+    ); // SpringBuilder (sway)
+  }
+
+  /// Wraps the bar pill with a light-mode drop shadow using inverse clipping.
+  ///
+  /// Builds a standalone shadow widget for the tab pill.
+  ///
+  /// Rendered as a SIBLING in the parent Stack, BELOW the glass pill,
+  /// so it doesn't interfere with the blend group compositing.
+  /// Returns null in dark mode or when no shadow is configured.
+  Widget? buildShadowOverlay(BuildContext context) {
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    if (isDark) return null;
+
+    final effectiveSettings = InheritedLiquidGlass.ofOrDefault(context);
+    final shadows = effectiveSettings.effectiveShadow;
+    if (shadows.isEmpty) return null;
+
+    return IgnorePointer(
+      child: ClipPath(
+        clipBehavior: Clip.antiAlias,
+        clipper: _InverseBarClipper(_barShape),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(widget.barBorderRadius),
+            boxShadow: shadows,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Wraps [child] in a [GlassGlow] sensor if the resolved glow color is
+  /// non-transparent. When [GlassInteractionBehavior.none] or [scaleOnly] is
+  /// active, the parent passes [Colors.transparent] — we skip the wrapper
+  /// entirely to avoid three extra widget/render-object allocations per frame.
+  Widget _wrapWithGlow({required Widget child}) {
+    final effectiveColor =
+        widget.interactionGlowColor ?? const Color(0x1FFFFFFF);
+    if (effectiveColor.a == 0) return child;
+    return GlassGlow(
+      clipper: ShapeBorderClipper(shape: _barShape),
+      glowColor: effectiveColor,
+      glowRadius: widget.interactionGlowRadius,
+      glowBlurRadius: widget.interactionGlowBlurRadius,
+      glowSpreadRadius: widget.interactionGlowSpreadRadius,
+      glowOpacity: widget.interactionGlowOpacity,
+      child: child,
+    );
+  }
+
+  /// Builds simple rendering mode without masking (MaskingQuality.off).
+  ///
+  /// Only renders tabs once without dual-layer masking. Maximum performance.
+  Widget _buildSimpleMode({
+    required Alignment alignment,
+    required Alignment targetAlignment,
+    required double thickness,
+    required double velocity,
+    required double indicatorRadius,
+    required Color indicatorColor,
+  }) {
+    return SizedBox(
+      height: widget.barHeight,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned.fill(
+            child: _wrapWithGlow(
+              child: Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  // Glass background (Cached to prevent blur re-rasterization on pill drag)
+                  Positioned.fill(
+                    child: RepaintBoundary(
+                      child: AdaptiveGlass.grouped(
+                        quality: widget.quality,
+                        platformViewBackdrop: widget.platformViewBackdrop,
+                        shape: _barShape,
+                        child: const SizedBox.expand(),
+                      ),
+                    ),
+                  ),
+
+                  // Unselected icons — always visible, all tabs in unselected style.
+                  // The glass indicator refracts this layer as the pill moves over it.
+                  Positioned.fill(
+                    child: Container(
+                      padding: widget.tabPadding,
+                      child: widget.childUnselected,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          // Glass indicator — on top so it refracts the icon layer AND the glow beneath.
+          if (widget.visible && thickness > 0.05)
+            AnimatedGlassIndicator(
+              velocity: velocity,
+              itemCount: widget.tabCount,
+              alignment: alignment,
+              thickness: thickness,
+              quality: widget.quality,
+              indicatorColor: indicatorColor,
+              isBackgroundIndicator: false,
+              innerBlur: widget.innerBlur,
+              borderRadius: indicatorRadius,
+              padding: const EdgeInsets.all(4),
+              expansion: widget.indicatorExpansion,
+              settings: widget.indicatorSettings,
+              pinchStrength: widget.indicatorPinchStrength,
+              backgroundKey: widget.platformViewBackdrop
+                  ? _iconLayerKey
+                  : widget.backgroundKey,
+            ),
+
+          // Persistent selected-icon overlay — always rendered at the TARGET
+          // (settled) tab position regardless of spring thickness. This ensures
+          // the selected icon stays vibrant (selected style) at rest, not washed
+          // out by the unselected-style icons in the layer below.
+          if (widget.visible)
+            Positioned.fill(
+              child: Align(
+                alignment: targetAlignment,
+                child: FractionallySizedBox(
+                  widthFactor: 1 / widget.tabCount,
+                  child: Container(
+                    padding: widget.tabPadding,
+                    height: widget.barHeight,
+                    child: widget.selectedTabBuilder(
+                        context, 1.0, targetAlignment),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  /// Builds high quality rendering mode with jelly masking (MaskingQuality.high).
+  ///
+  /// Dual-layer rendering with ClipPath for "magic lens" effect.
+  Widget _buildHighQualityMode({
+    required Alignment alignment,
+    required double thickness,
+    required double velocity,
+    required Matrix4 jellyTransform,
+    required double indicatorRadius,
+    required Color indicatorColor,
+  }) {
+    return SizedBox(
+      height: widget.barHeight,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned.fill(
+            child: _wrapWithGlow(
+              child: Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  // 1. Glass Background (Blur / Frosted Glass Layer — Cached)
+                  Positioned.fill(
+                    child: RepaintBoundary(
+                      child: AdaptiveGlass.grouped(
+                        quality: widget.quality,
+                        platformViewBackdrop: widget.platformViewBackdrop,
+                        shape: _barShape,
+                        child: const SizedBox.expand(),
+                      ),
+                    ),
+                  ),
+
+                  // 1.5. Solid Indicator Background (drawn below icons so selected icons are vibrant)
+                  AnimatedGlassIndicator(
+                    velocity: velocity,
+                    itemCount: widget.tabCount,
+                    alignment: alignment,
+                    thickness: thickness,
+                    quality: widget.quality,
+                    indicatorColor: indicatorColor,
+                    isBackgroundIndicator: false,
+                    paintBackground: true,
+                    paintGlass: false,
+                    innerBlur: widget.innerBlur,
+                    borderRadius: indicatorRadius,
+                    padding: const EdgeInsets.all(4),
+                    expansion: widget.indicatorExpansion,
+                    settings: widget.indicatorSettings,
+                    backgroundKey: widget.platformViewBackdrop
+                        ? _iconLayerKey
+                        : widget.backgroundKey,
+                  ),
+
+                  // 2. Icon Content Layer (Unselected + Selected combined for refraction)
+                  //
+                  // The RepaintBoundary is only needed when platformViewBackdrop:true so that
+                  // toImageSync() can capture bar content for Impeller's captureImage path
+                  // (eliminates the opaque-white indicator bug #99 on Platform Views).
+                  // For the common case the boundary would create a GPU compositing layer
+                  // every frame with no benefit, so we skip it.
+                  Positioned.fill(
+                    child: widget.platformViewBackdrop
+                        ? RepaintBoundary(
+                            key: _iconLayerKey,
+                            child: Stack(
+                              children: [
+                                // Unselected (inverse clipped — visible OUTSIDE pill)
+                                ClipPath(
+                                  clipBehavior: Clip.antiAliasWithSaveLayer,
+                                  clipper: JellyClipper(
+                                    itemCount: widget.tabCount,
+                                    alignment: alignment,
+                                    thickness: thickness,
+                                    expansion: widget.indicatorExpansion
+                                        .resolve(Directionality.of(context)),
+                                    transform: jellyTransform,
+                                    borderRadius: indicatorRadius * 2,
+                                    inverse: true,
+                                  ),
+                                  child: Container(
+                                    padding: widget.tabPadding,
+                                    height: widget.barHeight,
+                                    child: widget.childUnselected,
+                                  ),
+                                ),
+                                // Selected (forward clipped — visible INSIDE pill)
+                                ClipPath(
+                                  clipBehavior: Clip.antiAliasWithSaveLayer,
+                                  clipper: JellyClipper(
+                                    itemCount: widget.tabCount,
+                                    alignment: alignment,
+                                    thickness: thickness,
+                                    expansion: widget.indicatorExpansion
+                                        .resolve(Directionality.of(context)),
+                                    transform: jellyTransform,
+                                    borderRadius: indicatorRadius * 2,
+                                  ),
+                                  child: Container(
+                                    padding: widget.tabPadding,
+                                    height: widget.barHeight,
+                                    child: widget.selectedTabBuilder(
+                                        context, thickness, alignment),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          )
+                        : Stack(
+                            children: [
+                              // Unselected (inverse clipped — visible OUTSIDE pill)
+                              ClipPath(
+                                clipBehavior: Clip.antiAliasWithSaveLayer,
+                                clipper: JellyClipper(
+                                  itemCount: widget.tabCount,
+                                  alignment: alignment,
+                                  thickness: thickness,
+                                  expansion: widget.indicatorExpansion
+                                      .resolve(Directionality.of(context)),
+                                  transform: jellyTransform,
+                                  borderRadius: indicatorRadius * 2,
+                                  inverse: true,
+                                ),
+                                child: Container(
+                                  padding: widget.tabPadding,
+                                  height: widget.barHeight,
+                                  child: widget.childUnselected,
+                                ),
+                              ),
+                              // Selected (forward clipped — visible INSIDE pill)
+                              ClipPath(
+                                clipBehavior: Clip.antiAliasWithSaveLayer,
+                                clipper: JellyClipper(
+                                  itemCount: widget.tabCount,
+                                  alignment: alignment,
+                                  thickness: thickness,
+                                  expansion: widget.indicatorExpansion
+                                      .resolve(Directionality.of(context)),
+                                  transform: jellyTransform,
+                                  borderRadius: indicatorRadius * 2,
+                                ),
+                                child: Container(
+                                  padding: widget.tabPadding,
+                                  height: widget.barHeight,
+                                  child: widget.selectedTabBuilder(
+                                      context, thickness, alignment),
+                                ),
+                              ),
+                            ],
+                          ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          // 3. Moving Glass Indicator Layer — on top so it refracts
+          // the merged icon RepaintBoundary AND the glow beneath it.
+          AnimatedGlassIndicator(
+            velocity: velocity,
+            itemCount: widget.tabCount,
+            alignment: alignment,
+            thickness: thickness,
+            quality: widget.quality,
+            indicatorColor: indicatorColor,
+            isBackgroundIndicator: false,
+            paintBackground: false,
+            paintGlass: true,
+            borderRadius: indicatorRadius,
+            padding: const EdgeInsets.all(4),
+            expansion:
+                widget.indicatorExpansion.resolve(Directionality.of(context)),
+            settings: widget.indicatorSettings,
+            pinchStrength: widget.indicatorPinchStrength,
+            backgroundKey: widget.platformViewBackdrop
+                ? _iconLayerKey
+                : widget.backgroundKey,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Clips out the interior of a bar shape, leaving only the exterior.
+/// Used to prevent bar drop shadows from bleeding under translucent glass.
+class _InverseBarClipper extends CustomClipper<Path> {
+  const _InverseBarClipper(this.shape);
+
+  final LiquidRoundedSuperellipse shape;
+
+  @override
+  Path getClip(Size size) {
+    final rect = Offset.zero & size;
+    final shapePath = shape.getOuterPath(rect);
+    final outerRect = rect.inflate(50.0);
+    final outerPath = Path()..addRect(outerRect);
+    return Path.combine(PathOperation.difference, outerPath, shapePath);
+  }
+
+  @override
+  bool shouldReclip(_InverseBarClipper oldClipper) => oldClipper.shape != shape;
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_bottom_layout.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_bottom_layout.dart
@@ -1,0 +1,430 @@
+// ignore_for_file: deprecated_member_use
+// Internal layout engine for [GlassTabBar] bottom placement.
+//
+// Extracted from the old _GlassBottomBarState so that [GlassTabBar] is the
+// single owner of all rendering logic. The deprecated [GlassBottomBar] shim
+// simply calls [GlassTabBar.bottom()] which dispatches here.
+//
+// Do NOT import this file directly — use [GlassTabBar.bottom()] instead.
+
+import 'dart:ui' as ui;
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show ValueListenable;
+import '../../../src/renderer/liquid_glass_renderer.dart';
+import '../../../src/types/glass_interaction_behavior.dart';
+import '../../../types/glass_quality.dart';
+import '../../shared/adaptive_liquid_glass_layer.dart';
+import '../../shared/glass_content_aware_scope.dart';
+import '../../../theme/glass_theme_data.dart';
+import '../../../theme/glass_theme_helpers.dart';
+import '../glass_bottom_bar.dart'
+    show GlassTabBarExtraButton, GlassBottomBarTab, MaskingQuality;
+import 'tab_bar_bottom_internal.dart'
+    show
+        BottomBarExtraBtn,
+        BottomBarTabItem,
+        TabIndicator,
+        kBottomBarGlassDefaults,
+        resolveBarLabelColor;
+import 'tab_bar_layout_utils.dart';
+
+/// Internal [StatefulWidget] that owns the bottom-placement rendering engine.
+///
+/// Created by [GlassTabBar._buildBottom()] when [_GlassTabBarPlacement.bottom]
+/// is active. Not part of the public API.
+class TabBarBottomLayout extends StatefulWidget {
+  const TabBarBottomLayout({
+    required this.tabs,
+    required this.selectedIndex,
+    required this.onTabSelected,
+    super.key,
+    this.extraButton,
+    this.spacing = 8,
+    this.horizontalPadding = 20,
+    this.verticalPadding = 20,
+    this.barHeight = 64,
+    this.barBorderRadius = _kDefaultBorderRadius,
+    this.tabPadding = const EdgeInsets.symmetric(horizontal: 4),
+    this.iconLabelSpacing = 4,
+    this.enableBlend = true,
+    this.blendAmount = 10,
+    this.settings,
+    this.showIndicator = true,
+    this.indicatorColor,
+    this.indicatorSettings,
+    this.indicatorPinchStrength = 0.4,
+    this.selectedIconColor,
+    this.unselectedIconColor,
+    this.selectedLabelColor,
+    this.unselectedLabelColor,
+    this.selectedLabelStyle,
+    this.unselectedLabelStyle,
+    this.iconSize = 24,
+    this.labelFontSize = 11,
+    this.textStyle,
+    this.glowDuration = const Duration(milliseconds: 300),
+    this.glowBlurRadius = 32,
+    this.glowSpreadRadius = 8,
+    this.glowOpacity = 0.6,
+    this.quality,
+    this.magnification = 1.15,
+    this.innerBlur = 0.0,
+    this.maskingQuality = MaskingQuality.high,
+    this.backgroundKey,
+    this.tabWidth,
+    this.indicatorBorderRadius,
+    this.indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    this.interactionGlowColor,
+    this.interactionGlowRadius = 1.5,
+    this.interactionBehavior = GlassInteractionBehavior.full,
+    this.pressScale = 1.04,
+    this.platformViewBackdrop = false,
+    this.adaptiveBrightness = false,
+    this.onBrightnessChanged,
+    this.brightnessOverride,
+    this.springDescription,
+  });
+
+  static const double _kDefaultBorderRadius = 32.0;
+
+  final List<GlassBottomBarTab> tabs;
+  final int selectedIndex;
+  final ValueChanged<int> onTabSelected;
+  final GlassTabBarExtraButton? extraButton;
+  final double spacing;
+  final double horizontalPadding;
+  final double verticalPadding;
+  final double barHeight;
+  final double barBorderRadius;
+  final EdgeInsetsGeometry tabPadding;
+  final double iconLabelSpacing;
+  final bool enableBlend;
+  final double blendAmount;
+  final LiquidGlassSettings? settings;
+  final bool showIndicator;
+  final Color? indicatorColor;
+  final LiquidGlassSettings? indicatorSettings;
+  final double indicatorPinchStrength;
+  final Color? selectedIconColor;
+  final Color? unselectedIconColor;
+  final Color? selectedLabelColor;
+  final Color? unselectedLabelColor;
+  final TextStyle? selectedLabelStyle;
+  final TextStyle? unselectedLabelStyle;
+  final double iconSize;
+  final double labelFontSize;
+  final TextStyle? textStyle;
+  final Duration glowDuration;
+  final double glowBlurRadius;
+  final double glowSpreadRadius;
+  final double glowOpacity;
+  final GlassQuality? quality;
+  final double magnification;
+  final double innerBlur;
+  final MaskingQuality maskingQuality;
+  final GlobalKey? backgroundKey;
+  final double? tabWidth;
+  final double? indicatorBorderRadius;
+  final EdgeInsetsGeometry indicatorExpansion;
+  final Color? interactionGlowColor;
+  final double interactionGlowRadius;
+  final GlassInteractionBehavior interactionBehavior;
+  final double pressScale;
+  final bool platformViewBackdrop;
+  final bool adaptiveBrightness;
+  final ValueChanged<Brightness>? onBrightnessChanged;
+  final ValueListenable<Brightness>? brightnessOverride;
+  final SpringDescription? springDescription;
+
+  @override
+  State<TabBarBottomLayout> createState() => _TabBarBottomLayoutState();
+}
+
+class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
+  // Delegate to the shared const — single source of truth in tab_bar_bottom_internal.dart.
+  // Both bars reference kBottomBarGlassDefaults so their glass is guaranteed identical.
+  static const _defaultGlassSettings = kBottomBarGlassDefaults;
+
+  /// Lays out the tab [Row] in physical (LTR) order regardless of the ambient
+  /// direction, so the first child is on the left — matching the indicator and
+  /// gesture coordinate space. RTL ordering is carried by the reversed tab data
+  /// in [_buildBar], not by the ambient direction of these Rows. Scoping the
+  /// pin to the Rows keeps `Directionality.of(context)` intact for the rest of
+  /// the subtree (notably [indicatorExpansion] / [tabPadding] resolution).
+  static Widget _ltrTabRow({required List<Widget> children}) {
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Row(children: children),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.adaptiveBrightness && widget.brightnessOverride == null) {
+      return _buildBar(context, null);
+    }
+    return GlassContentAwareBrightness(
+      brightnessOverride: widget.brightnessOverride,
+      onBrightnessChanged: widget.onBrightnessChanged,
+      builder: (context, brightness, darkAmount) =>
+          _buildBar(context, darkAmount),
+    );
+  }
+
+  /// Builds the bar. [darkAmount] is the animated light→dark cross-fade
+  /// position when the adaptive brightness machinery is active, or null in
+  /// the classic (ambient-brightness) path.
+  Widget _buildBar(BuildContext context, double? darkAmount) {
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+      fallback: GlassQuality.premium,
+    );
+
+    // Resolve interaction glow color: explicit param → GlassThemeData.primary → null
+    // (null lets the internal widget use its own hardcoded fallback).
+    final resolvedGlowColors =
+        GlassThemeData.of(context).glowColorsFor(context);
+    final effectiveInteractionGlowColor =
+        widget.interactionGlowColor ?? resolvedGlowColors.primary;
+
+    final dynamicLabelColor = resolveBarLabelColor(context, darkAmount);
+    final resolvedSelectedIconColor =
+        widget.selectedIconColor ?? dynamicLabelColor;
+    final resolvedUnselectedIconColor =
+        widget.unselectedIconColor ?? dynamicLabelColor;
+
+    // Glow appearance fields come from the theme; they cannot be set per-widget
+    // because they are part of the theme palette.
+    final effectiveGlowBlurRadius = resolvedGlowColors.glowBlurRadius;
+    final effectiveGlowSpreadRadius = resolvedGlowColors.glowSpreadRadius;
+    final effectiveGlowOpacity = resolvedGlowColors.glowOpacity;
+
+    final effectiveSettings = widget.settings ?? _defaultGlassSettings;
+
+    // RTL support.
+    //
+    // The indicator/gesture coordinate system and the [AnimatedGlassIndicator]
+    // position both operate in physical, left-anchored alignment space (x == -1
+    // is always the left edge), and the gesture math is derived from the render
+    // box geometry — all direction-independent. The only direction-sensitive
+    // part is the two tab [Row]s, which honour the ambient [Directionality] and
+    // visually reverse under RTL. That reversal is what disagrees with the
+    // physical coordinate space, so the pill — and the tap/drag hit-testing —
+    // land on the mirror-image tab.
+    //
+    // Normalise by reversing the tab data and mirroring the selected index and
+    // the tap callback, then pin *only* the tab Rows to LTR (see [_ltrTabRow])
+    // so their physical order matches the coordinate space. Net effect under
+    // RTL: correct ordering (the first tab sits on the trailing/right edge)
+    // with the pill and hit-testing aligned to it. In LTR everything is a
+    // no-op.
+    //
+    // The pin is deliberately scoped to the Rows: [TabIndicator] resolves
+    // [indicatorExpansion] and [tabPadding] against `Directionality.of(context)`,
+    // so wrapping the whole subtree would force those to LTR and silently ignore
+    // any `EdgeInsetsDirectional` a consumer passes in an RTL app.
+    final isRtl = Directionality.of(context) == TextDirection.rtl;
+    final tabs = isRtl ? widget.tabs.reversed.toList() : widget.tabs;
+    final selectedIndex = isRtl
+        ? widget.tabs.length - 1 - widget.selectedIndex
+        : widget.selectedIndex;
+    final onTabSelected = isRtl
+        ? (int i) => widget.onTabSelected(widget.tabs.length - 1 - i)
+        : widget.onTabSelected;
+
+    return AdaptiveLiquidGlassLayer(
+      clipExpansion:
+          const EdgeInsets.symmetric(horizontal: 20.0, vertical: 15.0),
+      settings: effectiveSettings,
+      quality: effectiveQuality,
+      platformViewBackdrop: widget.platformViewBackdrop,
+      blendAmount: widget.enableBlend ? widget.blendAmount : 0,
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: widget.horizontalPadding,
+          vertical: widget.verticalPadding,
+        ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final extraBtnW = widget.extraButton != null
+                ? widget.extraButton!.size + widget.spacing
+                : 0.0;
+            final maxTabW = constraints.maxWidth - extraBtnW;
+            final tabPillW = resolveTabPillWidth(
+              tabWidth: widget.tabWidth,
+              tabCount: tabs.length,
+              maxAvailable: maxTabW,
+            );
+
+            return SizedBox(
+              height: widget.barHeight,
+              child: Builder(
+                builder: (context) {
+                  return Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      // 1. Optional extra button — painted first (bottom of z-order).
+                      // Pinned to the trailing edge. Painted before the tab pill
+                      // so the jelly indicator's glass effect correctly overlaps and
+                      // refracts the extra button during horizontal stretch physics.
+                      if (widget.extraButton != null)
+                        Positioned(
+                          right: 0,
+                          top: 0,
+                          bottom: 0,
+                          child: SizedBox(
+                            width: widget.extraButton!.size,
+                            height: widget.barHeight,
+                            child: BottomBarExtraBtn(
+                              config: widget.extraButton!,
+                              quality: effectiveQuality,
+                              iconColor: widget.extraButton!.iconColor ??
+                                  resolvedUnselectedIconColor,
+                              enableBlend: widget.enableBlend,
+                              borderRadius: widget.barBorderRadius ==
+                                      TabBarBottomLayout._kDefaultBorderRadius
+                                  ? null
+                                  : widget.barBorderRadius,
+                              platformViewBackdrop: widget.platformViewBackdrop,
+                            ),
+                          ),
+                        ),
+
+                      // 2. Tab pill — painted last (top of z-order).
+                      Positioned(
+                        left: 0,
+                        top: 0,
+                        width: tabPillW,
+                        height: widget.barHeight,
+                        child: TabIndicator(
+                          quality: effectiveQuality,
+                          springDescription: widget.springDescription,
+                          visible: widget.showIndicator,
+                          tabIndex: selectedIndex,
+                          tabCount: tabs.length,
+                          indicatorColor: widget.indicatorColor,
+                          indicatorSettings: widget.indicatorSettings,
+                          indicatorPinchStrength: widget.indicatorPinchStrength,
+                          onTabChanged: onTabSelected,
+                          barHeight: widget.barHeight,
+                          barBorderRadius: widget.barBorderRadius,
+                          indicatorBorderRadius: widget.indicatorBorderRadius,
+                          tabPadding: widget.tabPadding,
+                          backgroundKey: widget.backgroundKey,
+                          maskingQuality: widget.maskingQuality,
+                          indicatorExpansion: widget.indicatorExpansion,
+                          platformViewBackdrop: widget.platformViewBackdrop,
+                          interactionGlowColor:
+                              widget.interactionBehavior.hasGlow
+                                  ? effectiveInteractionGlowColor
+                                  : const Color(0x00000000),
+                          interactionGlowRadius: widget.interactionGlowRadius,
+                          interactionGlowBlurRadius: effectiveGlowBlurRadius,
+                          interactionGlowSpreadRadius:
+                              effectiveGlowSpreadRadius,
+                          interactionGlowOpacity: effectiveGlowOpacity,
+                          interactionScale: widget.interactionBehavior.hasScale
+                              ? widget.pressScale
+                              : 1.0,
+                          childUnselected: _ltrTabRow(
+                            children: [
+                              for (var i = 0; i < tabs.length; i++)
+                                Expanded(
+                                  child: BottomBarTabItem(
+                                    tab: tabs[i],
+                                    selected: false,
+                                    selectedIconColor:
+                                        resolvedSelectedIconColor,
+                                    unselectedIconColor:
+                                        resolvedUnselectedIconColor,
+                                    selectedLabelColor:
+                                        widget.selectedLabelColor,
+                                    unselectedLabelColor:
+                                        widget.unselectedLabelColor,
+                                    selectedLabelStyle:
+                                        widget.selectedLabelStyle,
+                                    unselectedLabelStyle:
+                                        widget.unselectedLabelStyle,
+                                    iconSize: widget.iconSize,
+                                    labelFontSize: widget.labelFontSize,
+                                    textStyle: widget.textStyle,
+                                    iconLabelSpacing: widget.iconLabelSpacing,
+                                    glowDuration: widget.glowDuration,
+                                    glowBlurRadius: widget.glowBlurRadius,
+                                    glowSpreadRadius: widget.glowSpreadRadius,
+                                    glowOpacity: widget.glowOpacity,
+                                    onTap: null,
+                                  ),
+                                ),
+                            ],
+                          ),
+                          selectedTabBuilder: (context, intensity, alignment) =>
+                              _buildSelectedTabs(
+                                  intensity,
+                                  alignment,
+                                  tabs,
+                                  resolvedSelectedIconColor,
+                                  resolvedUnselectedIconColor),
+                          magnification: widget.magnification,
+                          innerBlur: widget.innerBlur,
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSelectedTabs(
+      double intensity,
+      Alignment alignment,
+      List<GlassBottomBarTab> tabs,
+      Color resolvedSelectedIconColor,
+      Color resolvedUnselectedIconColor) {
+    final scale = ui.lerpDouble(1.0, widget.magnification, intensity) ?? 1.0;
+
+    final currentTabFloat = ((alignment.x + 1) / 2) * tabs.length;
+    final affectedStart =
+        (currentTabFloat - 1).floor().clamp(0, tabs.length - 1);
+    final affectedEnd = (currentTabFloat + 1).ceil().clamp(0, tabs.length - 1);
+
+    return _ltrTabRow(
+      children: [
+        for (var i = 0; i < tabs.length; i++)
+          Expanded(
+            child: (i >= affectedStart && i <= affectedEnd)
+                ? Transform.scale(
+                    scale: scale,
+                    child: BottomBarTabItem(
+                      tab: tabs[i],
+                      selected: true,
+                      selectedIconColor: resolvedSelectedIconColor,
+                      unselectedIconColor: resolvedUnselectedIconColor,
+                      selectedLabelColor: widget.selectedLabelColor,
+                      unselectedLabelColor: widget.unselectedLabelColor,
+                      selectedLabelStyle: widget.selectedLabelStyle,
+                      unselectedLabelStyle: widget.unselectedLabelStyle,
+                      iconSize: widget.iconSize,
+                      labelFontSize: widget.labelFontSize,
+                      textStyle: widget.textStyle,
+                      iconLabelSpacing: widget.iconLabelSpacing,
+                      glowDuration: widget.glowDuration,
+                      glowBlurRadius: widget.glowBlurRadius,
+                      glowSpreadRadius: widget.glowSpreadRadius,
+                      glowOpacity: widget.glowOpacity,
+                      onTap: null,
+                    ),
+                  )
+                : const SizedBox.shrink(),
+          ),
+      ],
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_drag_gesture_mixin.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_drag_gesture_mixin.dart
@@ -1,0 +1,447 @@
+// Shared drag gesture state and handlers for bottom bar tab indicators.
+//
+// Eliminates duplication between [TabIndicatorState] and
+// [SearchableTabIndicatorState]. Both had identical state fields, coordinate
+// helpers, and gesture handlers — causing the same bugs (issue #22, #23) to
+// exist in two places.
+//
+// NOT part of the public API — do not export from liquid_glass_widgets.dart.
+
+import 'package:flutter/scheduler.dart' show SchedulerBinding, SchedulerPhase;
+import 'package:flutter/widgets.dart';
+
+import '../../../utils/draggable_indicator_physics.dart';
+
+/// Shared drag gesture state and handlers for bottom bar indicators.
+///
+/// Apply to a [State] subclass with `with TabDragGestureMixin<MyWidget>`.
+/// Implement the three abstract getters to wire up the mixin.
+///
+/// Exposes handler methods that map directly to [GestureDetector] callbacks:
+/// - [onBarDragDown] → `onHorizontalDragDown`
+/// - [onBarDragStart] → `onHorizontalDragStart`
+/// - [onBarDragUpdate] → `onHorizontalDragUpdate`
+/// - [onBarDragEnd] → `onHorizontalDragEnd`
+/// - [onBarDragCancel] → `onHorizontalDragCancel`
+/// - [onBarTapDown] → `onTapDown`
+///
+/// And raw-Listener helpers (call from [Listener] in the concrete build method):
+/// - [onBarPointerDown] → `onPointerDown`
+/// - [onBarPointerUp] → `onPointerUp`
+/// - [onBarPointerCancel] → `onPointerCancel`
+mixin TabDragGestureMixin<T extends StatefulWidget> on State<T> {
+  // ── Abstract interface ────────────────────────────────────────────────────
+
+  /// Total number of tabs.
+  int get tabCount;
+
+  /// Index of the currently selected tab.
+  int get tabIndex;
+
+  /// Whether this tab bar is floating over a PlatformView (enables hybrid gesture mode).
+  bool get isPlatformViewBackdrop;
+
+  /// Called once per gesture lifecycle when the active tab should change.
+  ///
+  /// Always invoked unconditionally — callers may use repeat-tap to trigger
+  /// scroll-to-top or refresh on the active tab (issue #22).
+  void notifyTabChanged(int index);
+
+  // ── Shared state ──────────────────────────────────────────────────────────
+
+  /// Stores the target tab index during a hybrid tap (platform view backdrop).
+  int? _pendingHybridTabIndex;
+
+  /// True while the pointer is physically held down.
+  ///
+  /// Drives jelly thickness animation. Set by [onBarDragDown] and also by
+  /// the raw [Listener] in the concrete class's build method.
+  bool tabIsDown = false;
+
+  /// True while a horizontal drag gesture is in progress.
+  bool tabIsDragging = false;
+
+  /// Bumped to force the interactive [GestureDetector] — and its underlying
+  /// framework gesture recognizer — to be torn down and recreated. Used by
+  /// [recoverIfGestureStuck] to clear a recognizer left wedged after a dropped
+  /// terminal callback.
+  int gestureEpoch = 0;
+
+  /// True from [onBarPointerDown] until a terminal callback ([onBarDragEnd],
+  /// [onBarDragCancel], [onBarPointerUp], or [onBarPointerCancel]) runs.
+  ///
+  /// If still set when a new pointer-down arrives, the previous gesture's
+  /// terminal callback was dropped (PlatformView / system-gesture arena race).
+  bool _gestureActive = false;
+
+  /// Uniquely identifies the current gesture lifecycle.
+  /// Incremented on every new pointer down to prevent deferred callbacks
+  /// (from rapid clicking) from corrupting the state of a new gesture.
+  int _gestureId = 0;
+
+  /// Current horizontal alignment of the indicator in the range [-1, 1].
+  double tabXAlign = 0.0;
+
+  /// Lateral sway offset in logical pixels.
+  ///
+  /// Driven by horizontal drag velocity — gives the bar body a subtle
+  /// physical response when the interactive pill is dragged left/right,
+  /// mimicking iOS 26 bottom bar behaviour. Animated back to `0.0` via
+  /// a spring when the drag ends or is cancelled.
+  ///
+  /// Maximum magnitude is clamped to [_maxSwayPx].
+  double barSwayOffset = 0.0;
+
+  /// Maximum lateral sway in logical pixels — keeps the effect subtle.
+  static const double _maxSwayPx = 0.75;
+
+  /// Scale factor mapping instantaneous drag delta to sway offset.
+  static const double _swayScale = 0.08;
+
+  /// Minimum drag delta magnitude (px/frame) required to trigger sway.
+  /// Below this threshold the bar stays still — only fast flicks cause sway.
+  static const double _swayVelocityThreshold = 4.0;
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  @override
+  void initState() {
+    super.initState();
+    tabXAlign = computeTabAlignment(tabIndex);
+    WidgetsBinding.instance.pointerRouter.addGlobalRoute(_handleGlobalPointer);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.pointerRouter
+        .removeGlobalRoute(_handleGlobalPointer);
+    super.dispose();
+  }
+
+  /// Global pointer listener to catch dropped touches over PlatformViews.
+  ///
+  /// If the OS (e.g. iOS edge swipe) swallows a touch without dispatching a
+  /// cancel event, the local Listener never sees it and the bar stays wedged.
+  /// This global route listens to all touches in the app. If the user touches
+  /// anywhere ELSE (e.g. the map), we forcefully flush the wedged state.
+  void _handleGlobalPointer(PointerEvent event) {
+    if (!mounted) return;
+    if (event is PointerDownEvent) {
+      final renderObject = context.findRenderObject();
+      if (renderObject is RenderBox) {
+        final positionInBox = renderObject.globalToLocal(event.position);
+        if (renderObject.paintBounds.contains(positionInBox)) {
+          // Touch is inside the tab bar. Let the local Listener handle it.
+          // Doing cleanup here would instantly cancel legitimate click-and-holds.
+          return;
+        }
+      }
+
+      if (_gestureActive || tabIsDown || tabIsDragging) {
+        setState(() {
+          _gestureActive = false;
+          tabIsDragging = false;
+          tabIsDown = false;
+          _pendingHybridTabIndex =
+              null; // abort any in-flight hybrid tab switch
+          _forceSnapToNearestTab();
+          _gestureId++;
+          gestureEpoch++; // The old gesture recognizer is hopelessly wedged, kill it.
+        });
+      }
+    }
+  }
+
+  /// Instantly snaps the visual indicator to the nearest mathematically valid tab.
+  /// Used during proactive cleanup when a previous gesture was forcefully aborted.
+  void _forceSnapToNearestTab() {
+    final relX = (tabXAlign + 1) / 2;
+    final target = (relX * (tabCount - 1)).round().clamp(0, tabCount - 1);
+    tabXAlign = computeTabAlignment(target);
+    barSwayOffset = 0.0;
+  }
+
+  /// Call from [didUpdateWidget] when tabIndex or tabCount may have changed.
+  void updateTabAlignIfNeeded(int oldTabIndex, int oldTabCount) {
+    if (oldTabIndex != tabIndex || oldTabCount != tabCount) {
+      if (mounted) setState(() => tabXAlign = computeTabAlignment(tabIndex));
+    }
+  }
+
+  // ── Coordinate helpers ────────────────────────────────────────────────────
+
+  /// Maps a tab index to horizontal alignment in [-1, 1].
+  double computeTabAlignment(int index) =>
+      DraggableIndicatorPhysics.computeAlignment(index, tabCount);
+
+  /// Maps a global pointer position to alignment in [-1, 1] with rubber-band
+  /// resistance applied at the edges.
+  double alignmentFromGlobal(Offset globalPosition) =>
+      DraggableIndicatorPhysics.getAlignmentFromGlobalPosition(
+        globalPosition,
+        context,
+        tabCount,
+      );
+
+  // ── Gesture handlers ──────────────────────────────────────────────────────
+
+  /// `onPointerDown` (raw Listener) — called before the gesture arena runs.
+  ///
+  /// Sets [_gestureActive] and [tabIsDown] immediately via the raw Listener
+  /// (not waiting for [onBarDragDown]), so [recoverIfGestureStuck] has a valid
+  /// signal even when the native recognizer intercepts before
+  /// [onHorizontalDragDown] fires.
+  ///
+  /// If [_gestureActive] is already true, the previous gesture's terminal
+  /// callback was dropped (PlatformView/system-gesture race). Visual state is
+  /// cleared eagerly before accepting the new touch. [gestureEpoch] is NOT
+  /// bumped here — disposing the [GestureDetector] mid-dispatch would lose the
+  /// new pointer; the previous pointer's [onBarPointerUp]/[onBarPointerCancel]
+  /// handles eviction.
+  void onBarPointerDown(Offset position) {
+    if (!mounted) return;
+    setState(() {
+      _gestureId++;
+      _gestureActive = true;
+      tabIsDown = true;
+    });
+  }
+
+  /// `onPointerUp` (raw Listener) — called regardless of gesture arena result.
+  ///
+  /// Clears [tabIsDown] when not mid-drag, then calls [recoverIfGestureStuck]
+  /// to handle the case where the [GestureDetector]'s terminal callback was
+  /// dropped by a PlatformView arena race.
+  void onBarPointerUp(Offset position) {
+    if (!mounted) return;
+    if (!tabIsDragging) setState(() => tabIsDown = false);
+    recoverIfGestureStuck(position);
+  }
+
+  /// `onPointerCancel` (raw Listener) — called regardless of gesture arena result.
+  ///
+  /// Mirrors [onBarPointerUp]. The cancel event is delivered when the OS or a
+  /// parent widget takes ownership of the pointer stream.
+  void onBarPointerCancel(Offset position) {
+    if (!mounted) return;
+    if (!tabIsDragging) setState(() => tabIsDown = false);
+    recoverIfGestureStuck(position);
+  }
+
+  /// `onHorizontalDragDown` — marks pointer as pressed for jelly activation.
+  void onBarDragDown(DragDownDetails d) {
+    if (!mounted) return;
+    // _gestureActive and tabIsDown are set by the raw Listener in
+    // onBarPointerDown, which reliably fires alongside this recognizer.
+  }
+
+  /// `onHorizontalDragStart` — drag confirmed; lock position to pointer.
+  void onBarDragStart(DragStartDetails d) {
+    if (!mounted) return;
+    setState(() {
+      tabIsDragging = true;
+      tabXAlign = alignmentFromGlobal(d.globalPosition);
+    });
+  }
+
+  /// `onHorizontalDragUpdate` — track pointer during drag.
+  ///
+  /// Also updates [barSwayOffset] based on instantaneous drag velocity,
+  /// giving the bar a subtle lateral sway when the interactive pill is
+  /// flicked quickly — mimicking iOS 26 bottom bar physics.
+  ///
+  /// Slow drags (below [_swayVelocityThreshold]) produce zero sway;
+  /// only fast flicks cause the bar to shift.
+  void onBarDragUpdate(DragUpdateDetails d) {
+    if (!mounted) return;
+    setState(() {
+      tabIsDragging = true;
+      tabXAlign = alignmentFromGlobal(d.globalPosition);
+      // Velocity-gated lateral sway: only fast flicks cause movement.
+      if (d.delta.dx.abs() > _swayVelocityThreshold) {
+        barSwayOffset =
+            (d.delta.dx * _swayScale).clamp(-_maxSwayPx, _maxSwayPx);
+      } else {
+        barSwayOffset = 0.0;
+      }
+    });
+  }
+
+  /// Applies a drag-resolution state change safely.
+  ///
+  /// [onBarDragEnd]/[onBarDragCancel] can be invoked synchronously while the
+  /// element tree is locked — specifically when the indicator's
+  /// [RawGestureDetector] is disposed mid-gesture as its subtree is torn down
+  /// during a rebuild (the press-hold freeze observed at non-premium quality,
+  /// where the fallback render path reparents the interactive subtree). In that
+  /// window the [State] is still `mounted` but `setState()` is illegal, so
+  /// calling it throws, the cancel cleanup aborts, and the drag state is left
+  /// stuck (the bar freezes). Defer to the next frame when invoked during the
+  /// build/finalize phase; a genuinely disposing State no-ops via `mounted`.
+  void _applyDragResolution(VoidCallback body) {
+    if (!mounted) return;
+    final int capturedId = _gestureId;
+    if (SchedulerBinding.instance.schedulerPhase ==
+        SchedulerPhase.persistentCallbacks) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _gestureId == capturedId) body();
+      });
+    } else {
+      body();
+    }
+  }
+
+  /// `onHorizontalDragEnd` — snap to target tab with velocity fling support.
+  ///
+  /// Uses the alignment-coordinate inverse formula (issue #23 fix):
+  ///   `computeAlignment(i, n)` → `-1 + 2i/(n-1)`
+  ///   inverse: `i = ((tabXAlign + 1) / 2) * (n - 1)`
+  ///
+  /// This corrects the coordinate-space mismatch that caused off-by-one
+  /// snapping when the old `relX / (1/tabCount)` formula was used.
+  /// Velocity fling is layered on top so a fast swipe carries the indicator
+  /// past the nearest-position tab.
+  void onBarDragEnd(DragEndDetails d) {
+    final relX = (tabXAlign + 1) / 2;
+    final positionIndex =
+        (relX * (tabCount - 1)).round().clamp(0, tabCount - 1);
+
+    final renderObject = context.findRenderObject();
+    if (renderObject is! RenderBox) return;
+    final box = renderObject;
+    final rawVelX = d.velocity.pixelsPerSecond.dx / box.size.width;
+    const velocityThreshold = 0.5;
+    int target = positionIndex;
+    if (rawVelX > velocityThreshold && positionIndex < tabCount - 1) {
+      target = positionIndex + 1;
+    } else if (rawVelX < -velocityThreshold && positionIndex > 0) {
+      target = positionIndex - 1;
+    }
+
+    _gestureActive = false;
+    _applyDragResolution(() {
+      setState(() {
+        tabIsDragging = false;
+        tabIsDown = false;
+        tabXAlign = computeTabAlignment(target);
+        barSwayOffset = 0.0; // spring back to center
+      });
+      notifyTabChanged(target);
+    });
+  }
+
+  /// `onHorizontalDragCancel` — snap to nearest tab without velocity.
+  void onBarDragCancel() {
+    _gestureActive = false;
+    if (tabIsDragging) {
+      final relX = (tabXAlign + 1) / 2;
+      final target = (relX * (tabCount - 1)).round().clamp(0, tabCount - 1);
+      _applyDragResolution(() {
+        setState(() {
+          tabIsDragging = false;
+          tabIsDown = false;
+          tabXAlign = computeTabAlignment(target);
+          barSwayOffset = 0.0; // spring back to center
+        });
+        notifyTabChanged(target);
+      });
+    } else {
+      // Not dragging (e.g. same-tab tap): reset indicator to exact tab center.
+      _applyDragResolution(() {
+        setState(() {
+          tabIsDown = false;
+          tabXAlign = computeTabAlignment(tabIndex);
+        });
+      });
+    }
+  }
+
+  /// `onTapDown` — selects tab instantly, or animates indicator in hybrid mode.
+  ///
+  /// DX1: [tabIsDown] is already set on the same frame as the touch by the
+  /// raw Listener ([onBarPointerDown]), keeping jelly visible on desktop taps.
+  void onBarTapDown(TapDownDetails d) {
+    final alignment = alignmentFromGlobal(d.globalPosition);
+    final relX = (alignment + 1) / 2;
+    final index = (relX * tabCount).floor().clamp(0, tabCount - 1);
+
+    if (isPlatformViewBackdrop) {
+      // Hybrid mode: instantly slide the visual indicator for native responsiveness,
+      // but delay the actual content swap (PlatformView unmount) until onTapUp
+      // to prevent iOS mid-gesture touch drops.
+      setState(() {
+        tabXAlign = computeTabAlignment(index);
+        _pendingHybridTabIndex = index;
+      });
+    } else {
+      // Standard native behavior: swap everything instantly on down.
+      notifyTabChanged(index);
+    }
+  }
+
+  /// `onTapUp` — clears active state and resolves hybrid tab changes.
+  void onBarTapUp(TapUpDetails d) {
+    if (!mounted) return;
+    setState(() {
+      _gestureActive = false;
+      tabIsDown = false;
+    });
+
+    if (isPlatformViewBackdrop && _pendingHybridTabIndex != null) {
+      notifyTabChanged(_pendingHybridTabIndex!);
+      _pendingHybridTabIndex = null;
+    }
+  }
+
+  /// `onTapCancel` — clears visual press state if the tap loses the gesture arena.
+  void onBarTapCancel() {
+    if (!mounted) return;
+    _pendingHybridTabIndex = null;
+    if (!tabIsDragging) {
+      _applyDragResolution(() {
+        setState(() => tabIsDown = false);
+      });
+    }
+  }
+
+  /// Safety net for a dropped gesture terminal callback while the bar floats
+  /// over an iOS PlatformView.
+  ///
+  /// Over a PlatformView (e.g. a map), an interactive Flutter widget's gesture
+  /// recognizer can have its terminal callback dropped in a race with the
+  /// platform view's native gesture handling — a long-standing iOS
+  /// PlatformView gesture-arena limitation, reproducible with this indicator
+  /// dragged/tapped over a Mapbox map. The recognizer is then left wedged with
+  /// [_gestureActive] still set and the bar stops receiving touches until
+  /// something disposes it. Two signatures: `down` with no `onCancel` (a tap)
+  /// and `START` with no `onEnd` (a drag).
+  ///
+  /// Called from [onBarPointerUp] / [onBarPointerCancel]. If a gesture is
+  /// still flagged active on the next frame (its real terminal callback never
+  /// ran), disposes the wedged recognizer via [gestureEpoch] and selects the
+  /// tab under the lift point.
+  ///
+  /// We resolve to [upPosition], never [tabXAlign]: a gesture that wedged
+  /// mid-drag stops reporting finger movement, so [tabXAlign] is frozen at the
+  /// press point and would snap the user back to where they started. The lift
+  /// point is the only trustworthy signal for where they actually intended to
+  /// go.
+  void recoverIfGestureStuck(Offset upPosition) {
+    if (!_gestureActive) return;
+    final int capturedId = _gestureId;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_gestureActive || _gestureId != capturedId) return;
+      final relX = (alignmentFromGlobal(upPosition) + 1) / 2;
+      final target = (relX * tabCount).floor().clamp(0, tabCount - 1);
+      setState(() {
+        _gestureActive = false;
+        tabIsDragging = false;
+        tabIsDown = false;
+        tabXAlign = computeTabAlignment(target);
+        barSwayOffset = 0.0;
+        gestureEpoch++; // dispose the wedged recognizer
+      });
+      notifyTabChanged(target);
+    });
+  }
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_layout_utils.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_layout_utils.dart
@@ -1,0 +1,39 @@
+// Pure-Dart layout utilities shared across the bottom bar widgets.
+//
+// No Flutter widget imports — keep this file dependency-free so that
+// SearchableBottomBarController can import it without breaking the
+// "controller must be widget-free" testability constraint.
+library;
+
+import 'dart:math' as math;
+
+/// Resolves the effective tab pill width given a per-slot [tabWidth] and
+/// the maximum space available.
+///
+/// - [tabWidth] `null`  → returns [maxAvailable] (expand — fills available space).
+
+/// - [tabWidth] set     → returns `tabWidth × tabCount`, clamped to [maxAvailable].
+///
+/// [maxAvailable] is floored to 0 before clamping so that unusual layout
+/// constraints (e.g. tightly constrained test environments or a very large
+/// [extraButton]) never produce a negative clamp range, which would throw a
+/// [RangeError] in Dart's [num.clamp].
+///
+/// This is the single authoritative implementation used by:
+/// - [SearchableBottomBarController.computeLayout] (searchable bar)
+/// - [GlassBottomBar]'s build method (standalone bar)
+///
+/// Both bars share the same compact-sizing semantics: [tabWidth] controls the
+/// per-tab slot width, and the total pill is bounded by the available space.
+double resolveTabPillWidth({
+  required double? tabWidth,
+  required int tabCount,
+  required double maxAvailable,
+}) {
+  // Guard: clamp requires min ≤ max. If an unusual constraint makes
+  // maxAvailable negative (e.g. extra button wider than the bar), floor to 0
+  // so we degrade gracefully instead of throwing a RangeError.
+  final safeMax = math.max(0.0, maxAvailable);
+  if (tabWidth == null) return safeMax;
+  return (tabWidth * tabCount).clamp(0.0, safeMax);
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_searchable_controller.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_searchable_controller.dart
@@ -1,0 +1,442 @@
+// Extracted layout state machine for GlassSearchableBottomBar.
+//
+// This file is intentionally free of Flutter widget dependencies
+// (no BuildContext, no TickerProvider, no setState) so the layout
+// math can be unit tested without a widget tree.
+library;
+
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/physics.dart';
+
+import '../../surfaces/glass_bottom_bar.dart'
+    show GlassExtraButtonPosition, GlassTabPillAnchor;
+import 'tab_bar_layout_utils.dart';
+
+// =============================================================================
+// SearchablePillLayout — immutable layout result
+// =============================================================================
+
+/// Immutable result of one [SearchableBottomBarController.computeLayout] call.
+///
+/// All values are in logical pixels and represent the *target* positions
+/// for the spring animations — not the current animated positions.
+@immutable
+class SearchablePillLayout {
+  /// Creates a layout result.
+  const SearchablePillLayout({
+    required this.targetTabW,
+    required this.targetSearchLeft,
+    required this.targetSearchW,
+    required this.floatY,
+    required this.extraTargetW,
+    required this.dismissReserve,
+  });
+
+  /// Target width of the tab pill.
+  final double targetTabW;
+
+  /// Target left edge of the search pill.
+  final double targetSearchLeft;
+
+  /// Target width of the search pill.
+  final double targetSearchW;
+
+  /// Y offset that floats both pills above the keyboard when it is visible.
+  final double floatY;
+
+  /// Width reserved for the extra action button in the current state.
+  final double extraTargetW;
+
+  /// Width reserved for the dismiss pill (0 when not shown).
+  final double dismissReserve;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SearchablePillLayout &&
+          other.targetTabW == targetTabW &&
+          other.targetSearchLeft == targetSearchLeft &&
+          other.targetSearchW == targetSearchW &&
+          other.floatY == floatY &&
+          other.extraTargetW == extraTargetW &&
+          other.dismissReserve == dismissReserve;
+
+  @override
+  int get hashCode => Object.hash(
+        targetTabW,
+        targetSearchLeft,
+        targetSearchW,
+        floatY,
+        extraTargetW,
+        dismissReserve,
+      );
+
+  @override
+  String toString() => 'SearchablePillLayout('
+      'tabW: $targetTabW, '
+      'searchLeft: $targetSearchLeft, '
+      'searchW: $targetSearchW, '
+      'floatY: $floatY, '
+      'extraTargetW: $extraTargetW, '
+      'dismissReserve: $dismissReserve'
+      ')';
+}
+
+// =============================================================================
+// SpringRetarget — which spring axes changed
+// =============================================================================
+
+/// Describes which spring animation axes need to be retargeted.
+///
+/// Returned by [SearchableBottomBarController.checkRetarget].
+@immutable
+class SpringRetarget {
+  /// Creates a retarget descriptor.
+  const SpringRetarget({
+    required this.tabW,
+    required this.searchLeft,
+    required this.searchW,
+  });
+
+  /// No axes need retargeting.
+  static const none = SpringRetarget(
+    tabW: false,
+    searchLeft: false,
+    searchW: false,
+  );
+
+  /// Whether the tab pill width spring needs retargeting.
+  final bool tabW;
+
+  /// Whether the search pill left edge spring needs retargeting.
+  final bool searchLeft;
+
+  /// Whether the search pill width spring needs retargeting.
+  final bool searchW;
+
+  /// `true` when at least one axis needs retargeting.
+  bool get any => tabW || searchLeft || searchW;
+
+  @override
+  String toString() =>
+      'SpringRetarget(tabW: $tabW, searchLeft: $searchLeft, searchW: $searchW)';
+}
+
+// =============================================================================
+// SearchableBottomBarController
+// =============================================================================
+
+/// Manages the layout state machine for [GlassSearchableBottomBar].
+///
+/// Owns the spring target computation, change-detection cache, and focus
+/// state so that this logic can be unit tested without a widget tree.
+///
+/// ### Usage
+///
+/// Create and hold in a `State` (or provide via a parent widget):
+/// ```dart
+/// final _searchController = SearchableBottomBarController();
+///
+/// @override
+/// void dispose() {
+///   _searchController.dispose();
+///   super.dispose();
+/// }
+/// ```
+///
+/// Pass to the widget:
+/// ```dart
+/// GlassSearchableBottomBar(
+///   controller: _searchController,
+///   ...
+/// )
+/// ```
+///
+/// Open/close search programmatically via the controller:
+/// ```dart
+/// _searchController.openSearch();  // expands search bar
+/// _searchController.closeSearch(); // collapses back to tabs
+/// ```
+///
+/// Or by driving [GlassSearchableBottomBar.isSearchActive] directly from
+/// your own state — both approaches work and are interchangeable.
+class SearchableBottomBarController extends ChangeNotifier {
+  // ── Focus state ──────────────────────────────────────────────────────────
+
+  bool _searchFocused = false;
+
+  /// Whether the search text field is currently focused (keyboard visible).
+  bool get searchFocused => _searchFocused;
+
+  // ── Initialization guards ─────────────────────────────────────────────────
+
+  bool _pillsInitialized = false;
+  bool _pillsInitScheduled = false;
+
+  /// False until the first [initializePills] call completes.
+  bool get pillsInitialized => _pillsInitialized;
+
+  /// True while an init post-frame callback is pending.
+  bool get pillsInitScheduled => _pillsInitScheduled;
+
+  // ── Programmatic search open/close ──────────────────────────────────────
+
+  bool _isSearchOpen = false;
+
+  /// Whether the search bar is currently open (expanded).
+  ///
+  /// Set programmatically via [openSearch] / [closeSearch], or kept in sync
+  /// with [GlassSearchableBottomBar.isSearchActive] via [syncSearchActive].
+  bool get isSearchOpen => _isSearchOpen;
+
+  /// Expands the search bar.
+  ///
+  /// Equivalent to setting `isSearchActive: true` on the widget. Notifies
+  /// listeners so any parent widget bound to this controller can rebuild.
+  ///
+  /// ```dart
+  /// ElevatedButton(
+  ///   onPressed: _searchController.openSearch,
+  ///   child: const Text('Search'),
+  /// )
+  /// ```
+  void openSearch() {
+    if (_isSearchOpen) return; // idempotent
+    _isSearchOpen = true;
+    notifyListeners();
+  }
+
+  /// Collapses the search bar back to the tab view.
+  ///
+  /// Equivalent to setting `isSearchActive: false` on the widget. Also
+  /// clears [searchFocused] if the keyboard was visible.
+  void closeSearch() {
+    if (!_isSearchOpen) return; // idempotent
+    _isSearchOpen = false;
+    if (_searchFocused) _searchFocused = false;
+    notifyListeners();
+  }
+
+  /// Synchronises [isSearchOpen] with the parent widget's `isSearchActive` prop.
+  ///
+  /// Called from `didUpdateWidget` when the prop changes externally so that
+  /// [isSearchOpen] always reflects the actual widget state.
+  void syncSearchActive(bool isActive) {
+    if (_isSearchOpen == isActive) return;
+    _isSearchOpen = isActive;
+    // No notifyListeners — the parent widget is already handling the rebuild.
+  }
+
+  // ── Spring target cache ──────────────────────────────────────────────────
+
+  double _prevTabWTarget = double.nan;
+  double _prevSearchLeftTarget = double.nan;
+  double _prevSearchWTarget = double.nan;
+
+  /// Last known total available width — used to detect layout invalidation.
+  double cachedTotalW = 0;
+
+  // ── Core API ─────────────────────────────────────────────────────────────
+
+  /// Called when the search text field gains or loses keyboard focus.
+  ///
+  /// Notifies listeners so the parent state can schedule a rebuild.
+  void onFocusChanged(bool focused) {
+    if (_searchFocused == focused) return; // idempotent
+    _searchFocused = focused;
+    notifyListeners();
+  }
+
+  /// Called from `didUpdateWidget` when [GlassSearchableBottomBar.isSearchActive] changes.
+  ///
+  /// Clears [searchFocused] when search is deactivated externally.
+  void onSearchActiveChanged({
+    required bool wasActive,
+    required bool isActive,
+  }) {
+    if (wasActive && !isActive && _searchFocused) {
+      _searchFocused = false;
+      notifyListeners();
+    }
+  }
+
+  /// Marks initialization as scheduled (guard against duplicate callbacks).
+  void markInitScheduled({required double totalW}) {
+    _pillsInitScheduled = true;
+    cachedTotalW = totalW;
+  }
+
+  /// Called in the post-frame callback after the first layout pass.
+  ///
+  /// Sets [pillsInitialized] and caches [targets] to prime change-detection.
+  void initializePills({
+    required double tabW,
+    required double searchLeft,
+    required double searchW,
+  }) {
+    _prevTabWTarget = tabW;
+    _prevSearchLeftTarget = searchLeft;
+    _prevSearchWTarget = searchW;
+    _pillsInitialized = true;
+    _pillsInitScheduled = false;
+    notifyListeners();
+  }
+
+  // ── Layout computation ───────────────────────────────────────────────────
+
+  /// Computes pill layout targets from the given constraints.
+  ///
+  /// Pure function — no Flutter dependency, fully unit testable.
+  ///
+  /// [totalW]               — available width from `LayoutBuilder.maxWidth`.
+  /// [searching]            — whether search is currently active.
+  /// [barHeight]            — full tab-bar height (pixels).
+  /// [searchBarHeight]      — compact pill height when search is active.
+  /// [spacing]              — gap between adjacent pills.
+  /// [hasDismiss]           — whether the dismiss pill is configured.
+  /// [dismissVisible]       — whether the dismiss pill is currently shown.
+  /// [collapsedTabWidth]    — explicit collapsed tab width, or null → uses targetH.
+  /// [tabPillAnchor]        — start or center anchor mode.
+  /// [extraFullW]           — extra button's full size (0 if none).
+  /// [extraPos]             — whether extra button is before or after search pill.
+  /// [extraCollapsesOnSearch] — whether extra button hides when focused.
+  /// [isKeyboardActive]     — _searchFocused && keyboardPresent.
+  /// [keyboardH]            — current keyboard height (for floatY).
+  /// [perTabWidth]          — width per tab slot when compact sizing is used;
+  ///                           null means the tab pill fills all available space.
+  /// [tabCount]             — number of tabs; used with [perTabWidth] to compute
+  ///                           natural pill width.
+  SearchablePillLayout computeLayout({
+    required double totalW,
+    required bool searching,
+    required bool expandWhenActive,
+    required double barHeight,
+    required double searchBarHeight,
+    required double spacing,
+    required bool hasDismiss,
+    required bool dismissVisible,
+    required double? collapsedTabWidth,
+    required GlassTabPillAnchor tabPillAnchor,
+    required double extraFullW,
+    required GlassExtraButtonPosition extraPos,
+    required bool extraCollapsesOnSearch,
+    required bool isKeyboardActive,
+    required double keyboardH,
+    required int tabCount,
+    required double? perTabWidth,
+  }) {
+    final targetH = searching ? searchBarHeight : barHeight;
+
+    // ── Extra button sizing ────────────────────────────────────────────────
+    final extraTargetW = extraFullW > 0
+        ? (searching ? math.min(extraFullW, targetH) : extraFullW)
+        : 0.0;
+
+    final extraWLeft =
+        (extraFullW > 0 && extraPos == GlassExtraButtonPosition.beforeSearch)
+            ? (extraTargetW + spacing)
+            : 0.0;
+    final extraWRight =
+        (extraFullW > 0 && extraPos == GlassExtraButtonPosition.afterSearch)
+            ? (extraTargetW + spacing)
+            : 0.0;
+    final extraFullWLeft =
+        (extraFullW > 0 && extraPos == GlassExtraButtonPosition.beforeSearch)
+            ? (extraFullW + spacing)
+            : 0.0;
+    final extraFullWRight =
+        (extraFullW > 0 && extraPos == GlassExtraButtonPosition.afterSearch)
+            ? (extraFullW + spacing)
+            : 0.0;
+
+    final doCollapseLayout = isKeyboardActive && extraCollapsesOnSearch;
+    final curExtraWLeft = doCollapseLayout ? 0.0 : extraWLeft;
+    final curExtraWRight = doCollapseLayout ? 0.0 : extraWRight;
+
+    // ── Dismiss pill ───────────────────────────────────────────────────────
+    final targetCompactW = targetH;
+    final dismissReserve = hasDismiss ? (targetH + spacing) : 0.0;
+
+    // maxTabW: maximum space the tab pill can ever occupy (when fully expanded).
+    // Uses FULL (non-collapsed) extra widths for stability across states.
+    final maxTabW =
+        totalW - targetCompactW - spacing - extraFullWLeft - extraFullWRight;
+
+    // naturalTabW: intrinsic width when perTabWidth is specified.
+    // Delegates to the shared resolveTabPillWidth function, which is also
+    // used by GlassBottomBar — single source of truth for this calculation.
+    final naturalTabW = resolveTabPillWidth(
+      tabWidth: perTabWidth,
+      tabCount: tabCount,
+      maxAvailable: maxTabW,
+    );
+
+    final targetTabW =
+        !searching ? naturalTabW : (collapsedTabWidth ?? targetH);
+
+    // ── Search pill ────────────────────────────────────────────────────────
+    final centeredTab = tabPillAnchor == GlassTabPillAnchor.center;
+
+    final targetSearchLeft = !searching || !expandWhenActive
+        ? totalW - targetCompactW - extraWRight
+        : isKeyboardActive
+            ? curExtraWLeft
+            : centeredTab
+                ? (maxTabW + targetTabW) / 2 + curExtraWLeft + spacing
+                : targetTabW + curExtraWLeft + spacing;
+
+    final targetSearchW = !searching || !expandWhenActive
+        ? targetCompactW
+        : totalW -
+            targetSearchLeft -
+            curExtraWRight -
+            (dismissVisible ? dismissReserve : 0.0);
+
+    // ── Keyboard float ─────────────────────────────────────────────────────
+    final floatY = (_searchFocused && keyboardH > 0) ? keyboardH : 0.0;
+
+    return SearchablePillLayout(
+      targetTabW: targetTabW,
+      targetSearchLeft: targetSearchLeft,
+      targetSearchW: targetSearchW,
+      floatY: floatY,
+      extraTargetW: extraTargetW,
+      dismissReserve: dismissReserve,
+    );
+  }
+
+  // ── Spring change detection ───────────────────────────────────────────────
+
+  /// Compares [layout] targets against the cached previous targets and
+  /// returns which axes have changed.
+  ///
+  /// Updates the internal cache for changed axes.
+  /// Returns [SpringRetarget.none] when nothing changed.
+  SpringRetarget checkRetarget(SearchablePillLayout layout) {
+    final newTabW = layout.targetTabW != _prevTabWTarget;
+    final newLeft = layout.targetSearchLeft != _prevSearchLeftTarget;
+    final newSearchW = layout.targetSearchW != _prevSearchWTarget;
+
+    if (newTabW) _prevTabWTarget = layout.targetTabW;
+    if (newLeft) _prevSearchLeftTarget = layout.targetSearchLeft;
+    if (newSearchW) _prevSearchWTarget = layout.targetSearchW;
+
+    return SpringRetarget(
+      tabW: newTabW,
+      searchLeft: newLeft,
+      searchW: newSearchW,
+    );
+  }
+
+  // ── Convenience spring factory ────────────────────────────────────────────
+
+  /// Creates a [SpringSimulation] from [from] → [to] using [spring].
+  static SpringSimulation makeSpring({
+    required SpringDescription spring,
+    required double from,
+    required double to,
+  }) =>
+      SpringSimulation(spring, from, to, 0.0);
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_searchable_internal.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_searchable_internal.dart
@@ -1,0 +1,1104 @@
+// Internal sub-widgets for GlassSearchableBottomBar.
+//
+// Extracted from glass_searchable_bottom_bar.dart to keep that file focused on
+// the public API and layout orchestration. Mirrors the pattern established by
+// bottom_bar_internal.dart for GlassBottomBar.
+//
+// None of these widgets are part of the public API.
+// ignore_for_file: deprecated_member_use
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import '../../../src/renderer/liquid_glass_renderer.dart';
+import '../../../types/glass_quality.dart';
+import '../../../utils/draggable_indicator_physics.dart';
+import '../../../utils/glass_spring.dart';
+import '../../../theme/glass_theme.dart';
+import '../../interactive/glass_button.dart';
+import '../../shared/adaptive_glass.dart';
+import '../../shared/animated_glass_indicator.dart';
+import '../../shared/inherited_liquid_glass.dart';
+import '../glass_bottom_bar.dart' show MaskingQuality, JellyClipper;
+import 'glass_search_bar_config.dart';
+import 'tab_bar_drag_gesture_mixin.dart';
+
+// =============================================================================
+// _DismissPill
+// =============================================================================
+// Rendered inside the parent [AdaptiveLiquidGlassLayer] (same layer as the
+// search pill and tab pill) so that all three glass surfaces share the identical
+// shader context. This gives perfect colour, blur, and lighting parity with no
+// additional configuration required.
+//
+// Hit-testing works because the parent [SizedBox] expands its height by
+// [keyboardH] while the pill is visible, keeping the pill inside the widget's
+// layout bounds even when it floats above the keyboard.
+
+class DismissPill extends StatelessWidget {
+  const DismissPill({
+    required this.onTap,
+    required this.pillSize,
+    required this.barBorderRadius,
+    required this.quality,
+    this.cancelButtonColor,
+    this.cancelIcon,
+    this.cancelIconSize = 24,
+    this.indicatorColor,
+    this.settings,
+    super.key,
+  });
+
+  final VoidCallback onTap;
+  final double pillSize;
+  final double barBorderRadius;
+  final GlassQuality quality;
+  final Color? cancelButtonColor;
+  final Widget? cancelIcon;
+  final double cancelIconSize;
+  final Color? indicatorColor;
+  final LiquidGlassSettings? settings;
+
+  @override
+  Widget build(BuildContext context) {
+    final safeColor = indicatorColor;
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    final defaultIconColor =
+        isDark ? const Color(0xE6FFFFFF) : const Color(0xE6000000);
+    return GlassButton(
+      onTap: onTap,
+      width: pillSize,
+      height: pillSize,
+      quality: quality,
+      // useOwnLayer defaults to false — the pill participates in the parent
+      // AdaptiveLiquidGlassLayer so glass colour, blur and lighting are
+      // identical to the adjacent search pill.
+      settings:
+          settings?.copyWith(glassColor: safeColor ?? settings?.glassColor) ??
+              (safeColor != null
+                  ? LiquidGlassSettings(glassColor: safeColor)
+                  : null),
+      shape: LiquidRoundedSuperellipse(borderRadius: barBorderRadius),
+      icon: cancelIcon ??
+          Icon(
+            CupertinoIcons.xmark,
+            color: cancelButtonColor ?? defaultIconColor,
+            size: cancelIconSize,
+          ),
+      iconColor: cancelButtonColor ?? defaultIconColor,
+    );
+  }
+}
+
+// =============================================================================
+// SearchableTabIndicator
+// =============================================================================
+
+/// Draggable glass indicator for [GlassSearchableBottomBar].
+///
+/// Uses identical spring physics and masking to [GlassBottomBar]'s internal
+/// `_TabIndicator`. When [isSearchActive] is `true`, it collapses to show only
+/// the [collapsedLogoBuilder] and a tap dismisses search.
+class SearchableTabIndicator extends StatefulWidget {
+  const SearchableTabIndicator({
+    required this.childUnselected,
+    required this.selectedTabBuilder,
+    required this.tabIndex,
+    required this.tabCount,
+    required this.onTabChanged,
+    required this.visible,
+    required this.quality,
+    required this.barHeight,
+    required this.barBorderRadius,
+    this.indicatorBorderRadius,
+    required this.tabPadding,
+    required this.magnification,
+    required this.innerBlur,
+    required this.maskingQuality,
+    required this.isSearchActive,
+    required this.onDismissSearch,
+    this.indicatorColor,
+    this.indicatorSettings,
+    this.indicatorPinchStrength = 0.4,
+    this.backgroundKey,
+    this.collapsedLogoBuilder,
+    this.indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    this.interactionGlowColor,
+    this.interactionGlowRadius = 1.5,
+    this.interactionGlowBlurRadius = 0,
+    this.interactionGlowSpreadRadius = 0,
+    this.interactionGlowOpacity = 1,
+    required this.enableBackgroundAnimation,
+    required this.backgroundPressScale,
+    this.platformViewBackdrop = false,
+    super.key,
+  });
+
+  final int tabIndex;
+  final int tabCount;
+  final bool visible;
+  final Widget childUnselected;
+  final Widget Function(BuildContext, double, Alignment) selectedTabBuilder;
+  final Color? indicatorColor;
+  final LiquidGlassSettings? indicatorSettings;
+
+  /// Maximum concave lens pinch strength. Forwarded to [AnimatedGlassIndicator].
+  final double indicatorPinchStrength;
+  final ValueChanged<int> onTabChanged;
+  final GlassQuality quality;
+  final double barHeight;
+  final double barBorderRadius;
+  final double? indicatorBorderRadius;
+  final EdgeInsetsGeometry tabPadding;
+  final double magnification;
+  final double innerBlur;
+  final MaskingQuality maskingQuality;
+  final GlobalKey? backgroundKey;
+  final bool isSearchActive;
+  final VoidCallback onDismissSearch;
+  final WidgetBuilder? collapsedLogoBuilder;
+
+  /// How far the jelly indicator's leading and trailing edges expand
+  /// past the tab boundary as the indicator translates. Higher values
+  /// give a more dramatic "puff" stretch; lower values produce a
+  /// tighter, more iOS-native feel. Defaults to `14` to match the
+  /// pre-existing visual.
+  final EdgeInsetsGeometry indicatorExpansion;
+
+  final Color? interactionGlowColor;
+  final double interactionGlowRadius;
+  final double interactionGlowBlurRadius;
+  final double interactionGlowSpreadRadius;
+  final double interactionGlowOpacity;
+  final bool enableBackgroundAnimation;
+  final double backgroundPressScale;
+
+  /// When true (bar over an iOS PlatformView): the bar background renders via
+  /// live BackdropFilter, and the premium indicator refracts the bar's own icon
+  /// layer (capturable) instead of the PlatformView backdrop.
+  final bool platformViewBackdrop;
+
+  @override
+  State<SearchableTabIndicator> createState() => SearchableTabIndicatorState();
+}
+
+class SearchableTabIndicatorState extends State<SearchableTabIndicator>
+    with TabDragGestureMixin<SearchableTabIndicator> {
+  // ── Mixin interface ────────────────────────────────────────────────────────
+  @override
+  int get tabCount => widget.tabCount;
+  @override
+  int get tabIndex => widget.tabIndex;
+  @override
+  bool get isPlatformViewBackdrop => widget.platformViewBackdrop;
+  @override
+  void notifyTabChanged(int index) => widget.onTabChanged(index);
+
+  static const _fallbackIndicatorColor = Color(0x1AFFFFFF);
+
+  /// RepaintBoundary key for the merged icon layer, so the premium indicator can
+  /// refract the icons (capturable) over a PlatformView.
+  final GlobalKey _iconLayerKey = GlobalKey();
+
+  // Cached shape to avoid recreation on every animation frame
+  late LiquidRoundedSuperellipse _barShape =
+      LiquidRoundedSuperellipse(borderRadius: widget.barBorderRadius);
+
+  @override
+  void didUpdateWidget(covariant SearchableTabIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    updateTabAlignIfNeeded(oldWidget.tabIndex, oldWidget.tabCount);
+    if (oldWidget.barBorderRadius != widget.barBorderRadius) {
+      _barShape =
+          LiquidRoundedSuperellipse(borderRadius: widget.barBorderRadius);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // ── Collapsed / search-active state ─────────────────────────────────────
+    if (widget.isSearchActive) {
+      // LayoutBuilder detects whether the pill has finished collapsing
+      // to a square. When square, LiquidOval gives a perfect circle;
+      // while still animating (wider than tall) the superellipse handles
+      // non-square rectangles gracefully as a pill.
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          final isSquare =
+              (constraints.maxWidth - constraints.maxHeight).abs() < 2;
+          final currentShape = isSquare ? const LiquidOval() : _barShape;
+
+          return LiquidStretch(
+            interactionScale: widget.enableBackgroundAnimation
+                ? widget.backgroundPressScale
+                : 1.0,
+            stretch: 0.5,
+            resistance: 0.01,
+            anchorStretch: true,
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: widget.onDismissSearch,
+              child: AdaptiveGlass.grouped(
+                quality: widget.quality,
+                platformViewBackdrop: widget.platformViewBackdrop,
+                shape: currentShape,
+                child: _wrapWithGlow(
+                  child: widget.collapsedLogoBuilder != null
+                      ? AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 220),
+                          transitionBuilder: (c, a) =>
+                              FadeTransition(opacity: a, child: c),
+                          child: SizedBox.expand(
+                            key: const ValueKey('logo'),
+                            child: widget.collapsedLogoBuilder!(context),
+                          ),
+                        )
+                      : const SizedBox.shrink(key: ValueKey('empty')),
+                ),
+              ),
+            ),
+          );
+        },
+      );
+    }
+
+    // ── Normal draggable tab bar — identical logic to GlassBottomBar ─────────
+    final theme = CupertinoTheme.of(context);
+    final indicatorColor = widget.indicatorColor ??
+        theme.textTheme.textStyle.color?.withValues(alpha: .1) ??
+        _fallbackIndicatorColor;
+    final targetAlignment = computeTabAlignment(widget.tabIndex);
+    final indicatorRadius =
+        widget.indicatorBorderRadius ?? widget.barBorderRadius;
+
+    // Lateral sway: the bar body subtly follows the interactive pill during
+    // horizontal drags, mimicking iOS 26 bottom bar physics. The SpringBuilder
+    // animates the offset back to 0.0 when the drag ends.
+    return SpringBuilder(
+      spring: GlassSpring.smooth(
+        duration: const Duration(milliseconds: 250),
+      ),
+      value: barSwayOffset,
+      builder: (context, swayValue, _) {
+        return Transform.translate(
+          offset: Offset(swayValue, 0),
+          child: LiquidStretch(
+            interactionScale: widget.enableBackgroundAnimation
+                ? widget.backgroundPressScale
+                : 1.0,
+            stretch:
+                0.0, // stretch disabled on platformViewBackdrop to prevent BackdropFilter pixel-snap jitter
+            resistance: 0.08,
+            anchorStretch: false, // Tab bars use jelly-follow, not anchored
+            child: Listener(
+              onPointerDown: (e) => onBarPointerDown(e.position),
+              onPointerUp: (e) => onBarPointerUp(e.position),
+              onPointerCancel: (e) => onBarPointerCancel(e.position),
+              child: GestureDetector(
+                key: ValueKey(gestureEpoch),
+                behavior: HitTestBehavior.opaque,
+                onHorizontalDragDown: onBarDragDown,
+                onHorizontalDragStart: onBarDragStart,
+                onHorizontalDragUpdate: onBarDragUpdate,
+                onHorizontalDragEnd: onBarDragEnd,
+                onHorizontalDragCancel: onBarDragCancel,
+                onTapDown: onBarTapDown,
+                onTapUp: onBarTapUp,
+                onTapCancel: onBarTapCancel,
+                child: VelocitySpringBuilder(
+                  value: tabXAlign,
+                  springWhenActive: GlassSpring.interactive(),
+                  springWhenReleased: GlassSpring.snappy(
+                    duration: const Duration(milliseconds: 350),
+                  ),
+                  active: tabIsDragging,
+                  builder: (context, value, velocity, child) {
+                    final alignment = Alignment(value, 0);
+                    return SpringBuilder(
+                      spring: GlassSpring.snappy(
+                        duration: const Duration(milliseconds: 300),
+                      ),
+                      value: widget.visible &&
+                              (tabIsDown ||
+                                  tabIsDragging ||
+                                  (alignment.x - targetAlignment).abs() > 0.05)
+                          ? 1.0
+                          : 0.0,
+                      builder: (context, thickness, _) {
+                        if (thickness < 0.01 &&
+                            !widget.visible &&
+                            widget.maskingQuality == MaskingQuality.high) {
+                          return Container(
+                            height: widget.barHeight,
+                            decoration: ShapeDecoration(shape: _barShape),
+                            child: AdaptiveGlass.grouped(
+                              quality: widget.quality,
+                              platformViewBackdrop: widget.platformViewBackdrop,
+                              shape: _barShape,
+                              child: Container(
+                                padding: widget.tabPadding,
+                                child: widget.childUnselected,
+                              ),
+                            ),
+                          );
+                        }
+
+                        final jellyTransform =
+                            DraggableIndicatorPhysics.buildJellyTransform(
+                          velocity: Offset(velocity, 0),
+                          maxDistortion: 0.8,
+                          velocityScale: 10,
+                        );
+
+                        switch (widget.maskingQuality) {
+                          case MaskingQuality.off:
+                            return _buildSimple(
+                              alignment: alignment,
+                              targetAlignment: Alignment(targetAlignment, 0),
+                              thickness: thickness,
+                              velocity: velocity,
+                              indicatorRadius: indicatorRadius,
+                              indicatorColor: indicatorColor,
+                            );
+                          case MaskingQuality.high:
+                            return _buildHighQuality(
+                              alignment: alignment,
+                              thickness: thickness,
+                              velocity: velocity,
+                              jellyTransform: jellyTransform,
+                              indicatorRadius: indicatorRadius,
+                              indicatorColor: indicatorColor,
+                            );
+                        }
+                      },
+                    ); // SpringBuilder (thickness)
+                  }, // VelocitySpringBuilder builder
+                ), // VelocitySpringBuilder
+              ), // GestureDetector
+            ), // Listener
+          ), // LiquidStretch
+        ); // Transform.translate
+      }, // SpringBuilder builder (sway)
+    ); // SpringBuilder (sway)
+  }
+
+  /// Builds a standalone shadow widget for the tab pill.
+  ///
+  /// Rendered as a SIBLING in the parent Stack, BELOW the glass pill,
+  /// so it doesn't interfere with the blend group compositing.
+  /// Returns null in dark mode or when no shadow is configured.
+  Widget? buildShadowOverlay(BuildContext context) {
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    if (isDark) return null;
+
+    final effectiveSettings = InheritedLiquidGlass.ofOrDefault(context);
+    final shadows = effectiveSettings.effectiveShadow;
+    if (shadows.isEmpty) return null;
+
+    return IgnorePointer(
+      child: ClipPath(
+        clipBehavior: Clip.antiAlias,
+        clipper: _InverseSearchBarClipper(_barShape),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(widget.barBorderRadius),
+            boxShadow: shadows,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Wraps [child] in [GlassGlow] only when the resolved glow color is
+  /// non-transparent. Skips the wrapper entirely for
+  /// [GlassInteractionBehavior.none] and [scaleOnly], avoiding three extra
+  /// widget/render-object allocations per frame.
+  Widget _wrapWithGlow({required Widget child}) {
+    final effectiveColor =
+        widget.interactionGlowColor ?? const Color(0x1FFFFFFF);
+    if (effectiveColor.a == 0) return child;
+    return GlassGlow(
+      clipper: ShapeBorderClipper(shape: _barShape),
+      glowColor: effectiveColor,
+      glowRadius: widget.interactionGlowRadius,
+      glowBlurRadius: widget.interactionGlowBlurRadius,
+      glowSpreadRadius: widget.interactionGlowSpreadRadius,
+      glowOpacity: widget.interactionGlowOpacity,
+      child: child,
+    );
+  }
+
+  Widget _buildSimple({
+    required Alignment alignment,
+    required Alignment targetAlignment,
+    required double thickness,
+    required double velocity,
+    required double indicatorRadius,
+    required Color indicatorColor,
+  }) {
+    return SizedBox(
+      height: widget.barHeight,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned.fill(
+            child: _wrapWithGlow(
+              child: Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  // Glass background (Cached to prevent blur re-rasterization on pill drag)
+                  Positioned.fill(
+                    child: RepaintBoundary(
+                      child: AdaptiveGlass.grouped(
+                        quality: widget.quality,
+                        platformViewBackdrop: widget.platformViewBackdrop,
+                        shape: _barShape,
+                        child: const SizedBox.expand(),
+                      ),
+                    ),
+                  ),
+
+                  // Unselected icons — all tabs in unselected style (for refraction).
+                  Positioned.fill(
+                    child: Container(
+                      padding: widget.tabPadding,
+                      child: widget.childUnselected,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          // Glass indicator — on top so it refracts the icon layer AND the glow beneath.
+          if (widget.visible && thickness > 0.05)
+            AnimatedGlassIndicator(
+              velocity: velocity,
+              itemCount: widget.tabCount,
+              alignment: alignment,
+              thickness: thickness,
+              quality: widget.quality,
+              indicatorColor: indicatorColor,
+              isBackgroundIndicator: false,
+              innerBlur: widget.innerBlur,
+              borderRadius: indicatorRadius,
+              padding: const EdgeInsets.all(4),
+              expansion: widget.indicatorExpansion,
+              settings: widget.indicatorSettings,
+              pinchStrength: widget.indicatorPinchStrength,
+              backgroundKey: widget.backgroundKey,
+            ),
+
+          // Persistent selected-icon overlay — always at TARGET position
+          // so the selected icon stays vibrant (selected style) at rest.
+          if (widget.visible)
+            Positioned.fill(
+              child: Align(
+                alignment: targetAlignment,
+                child: FractionallySizedBox(
+                  widthFactor: 1 / widget.tabCount,
+                  child: Container(
+                    padding: widget.tabPadding,
+                    height: widget.barHeight,
+                    child: widget.selectedTabBuilder(
+                        context, 1.0, targetAlignment),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHighQuality({
+    required Alignment alignment,
+    required double thickness,
+    required double velocity,
+    required Matrix4 jellyTransform,
+    required double indicatorRadius,
+    required Color indicatorColor,
+  }) {
+    final effRadius = indicatorRadius;
+    return SizedBox(
+      height: widget.barHeight,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned.fill(
+            child: _wrapWithGlow(
+              child: Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  // 1. Static Blur Background (Cached)
+                  Positioned.fill(
+                    child: RepaintBoundary(
+                      child: AdaptiveGlass.grouped(
+                        quality: widget.quality,
+                        platformViewBackdrop: widget.platformViewBackdrop,
+                        shape: _barShape,
+                        child: const SizedBox.expand(),
+                      ),
+                    ),
+                  ),
+
+                  // 1.5. Solid Indicator Background (drawn below icons so selected icons are vibrant)
+                  AnimatedGlassIndicator(
+                    velocity: velocity,
+                    itemCount: widget.tabCount,
+                    alignment: alignment,
+                    thickness: thickness,
+                    quality: widget.quality,
+                    indicatorColor: indicatorColor,
+                    isBackgroundIndicator: false,
+                    paintBackground: true,
+                    paintGlass: false,
+                    innerBlur: widget.innerBlur,
+                    borderRadius: effRadius,
+                    padding: const EdgeInsets.all(4),
+                    expansion: widget.indicatorExpansion,
+                    settings: widget.indicatorSettings,
+                    pinchStrength: widget.indicatorPinchStrength,
+                    backgroundKey: widget.backgroundKey,
+                  ),
+
+                  // 2. Icon Content Layer (Unselected + Selected combined for refraction)
+                  // We expand the RepaintBoundary bounds using negative Positioned
+                  // offsets matching the indicator expansion. This ensures that when
+                  // the active glass pill overshoots its bounds during a jelly animation
+                  // or stretch, it never samples outside the captured texture (which
+                  // causes extreme wrap-around chromatic aliasing on Impeller).
+                  Builder(
+                    builder: (context) {
+                      final exp = widget.indicatorExpansion
+                          .resolve(Directionality.of(context));
+                      return Positioned(
+                        top: -exp.top,
+                        bottom: -exp.bottom,
+                        left: -exp.left,
+                        right: -exp.right,
+                        child: RepaintBoundary(
+                          // Keyed so the premium indicator can refract this icon layer
+                          // (capturable) over a PlatformView.
+                          key: _iconLayerKey,
+                          child: Padding(
+                            padding: exp,
+                            child: Stack(
+                              children: [
+                                ClipPath(
+                                  clipBehavior: Clip.antiAliasWithSaveLayer,
+                                  clipper: JellyClipper(
+                                    itemCount: widget.tabCount,
+                                    alignment: alignment,
+                                    thickness: thickness,
+                                    expansion: widget.indicatorExpansion
+                                        .resolve(Directionality.of(context)),
+                                    transform: jellyTransform,
+                                    borderRadius: effRadius * 2,
+                                    inverse: true,
+                                  ),
+                                  child: Container(
+                                    padding: widget.tabPadding,
+                                    height: widget.barHeight,
+                                    child: widget.childUnselected,
+                                  ),
+                                ),
+                                ClipPath(
+                                  clipBehavior: Clip.antiAliasWithSaveLayer,
+                                  clipper: JellyClipper(
+                                    itemCount: widget.tabCount,
+                                    alignment: alignment,
+                                    thickness: thickness,
+                                    expansion: widget.indicatorExpansion
+                                        .resolve(Directionality.of(context)),
+                                    transform: jellyTransform,
+                                    borderRadius: effRadius * 2,
+                                  ),
+                                  child: Container(
+                                    padding: widget.tabPadding,
+                                    height: widget.barHeight,
+                                    child: widget.selectedTabBuilder(
+                                        context, thickness, alignment),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          // 3. Moving Glass Indicator Layer — on top so it refracts
+          // the merged icon RepaintBoundary AND the glow beneath it.
+          AnimatedGlassIndicator(
+            velocity: velocity,
+            itemCount: widget.tabCount,
+            alignment: alignment,
+            thickness: thickness,
+            quality: widget.quality,
+            indicatorColor: indicatorColor,
+            isBackgroundIndicator: false,
+            paintBackground: false,
+            paintGlass: true,
+            borderRadius: effRadius,
+            padding: const EdgeInsets.all(4),
+            expansion:
+                widget.indicatorExpansion.resolve(Directionality.of(context)),
+            settings: widget.indicatorSettings,
+            pinchStrength: widget.indicatorPinchStrength,
+            // Over a PlatformView the normal backdrop (map region) can't be
+            // captured by toImageSync, so the premium indicator refracts the
+            // bar's own icon layer instead (capturable) — keeping the
+            // premium magic-lens over the PlatformView.
+            backgroundKey: widget.platformViewBackdrop
+                ? _iconLayerKey
+                : widget.backgroundKey,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// SearchPill
+// =============================================================================
+
+/// The morphing search pill. Collapses to a square icon; expands to a
+/// real [TextField] with autofocus. Lives inside the parent
+/// [AdaptiveLiquidGlassLayer] so its glass rendering blends with the tab pill.
+class SearchPill extends StatefulWidget {
+  const SearchPill({
+    super.key,
+    required this.config,
+    required this.isActive,
+    required this.quality,
+    required this.barBorderRadius,
+    required this.enableBackgroundAnimation,
+    required this.backgroundPressScale,
+    this.onFocusChanged,
+    this.interactionGlowColor,
+    this.interactionGlowRadius = 1.5,
+    this.interactionGlowBlurRadius = 0,
+    this.interactionGlowSpreadRadius = 0,
+    this.interactionGlowOpacity = 1,
+    this.platformViewBackdrop = false,
+    this.iconColor,
+  });
+
+  final GlassSearchBarConfig config;
+  final bool isActive;
+  final double barBorderRadius;
+  final GlassQuality quality;
+  final bool enableBackgroundAnimation;
+  final double backgroundPressScale;
+  final Color? iconColor;
+
+  /// Render the pill's glass via the live BackdropFilter path so it composites
+  /// over a PlatformView.
+  final bool platformViewBackdrop;
+
+  /// Called when the search field gains or loses focus.
+  /// Used by the parent bar to drive the dismiss pill visibility.
+  final ValueChanged<bool>? onFocusChanged;
+
+  /// The color of the directional glow effect when interacting with the pill.
+  final Color? interactionGlowColor;
+
+  /// The radius spread of the directional glow effect when interacting with the pill.
+  final double interactionGlowRadius;
+
+  final double interactionGlowBlurRadius;
+  final double interactionGlowSpreadRadius;
+  final double interactionGlowOpacity;
+
+  @override
+  State<SearchPill> createState() => SearchPillState();
+}
+
+class SearchPillState extends State<SearchPill> {
+  late final TextEditingController _controller;
+  late final FocusNode _focusNode;
+  bool _ownsController = false;
+  bool _ownsFocusNode = false;
+
+  // Tracks whether the × clear button should be visible.
+  bool _hasText = false;
+  // Tracks focus so the outer bar can show/hide the dismiss pill.
+  bool _hasFocus = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.config.controller != null) {
+      _controller = widget.config.controller!;
+    } else {
+      _controller = TextEditingController();
+      _ownsController = true;
+    }
+    if (widget.config.focusNode != null) {
+      _focusNode = widget.config.focusNode!;
+    } else {
+      _focusNode = FocusNode();
+      _ownsFocusNode = true;
+    }
+
+    _hasText = _controller.text.isNotEmpty;
+    _controller.addListener(_onTextChanged);
+    _focusNode.addListener(_onFocusChanged);
+
+    if (widget.isActive && widget.config.autoFocusOnExpand) {
+      // Already active on first build — request focus after one frame so the
+      // AnimatedContainer has committed its initial expanded layout.
+      // 60 ms is enough for a single vsync cycle at 60-120 Hz while still
+      // feeling instant to the user (well under the ~100 ms perception threshold).
+      Future.delayed(const Duration(milliseconds: 60), () {
+        if (mounted && widget.isActive) _focusNode.requestFocus();
+      });
+    }
+  }
+
+  void _onTextChanged() {
+    final hasText = _controller.text.isNotEmpty;
+    if (hasText != _hasText) setState(() => _hasText = hasText);
+  }
+
+  @override
+  void didUpdateWidget(covariant SearchPill oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!oldWidget.isActive &&
+        widget.isActive &&
+        widget.config.autoFocusOnExpand) {
+      // Became active and auto-focus is enabled — request focus after one
+      // render frame so the pill has committed its first expanded layout
+      // before the IME is attached.
+      //
+      // 60 ms sits comfortably above a single 120 Hz vsync (~8 ms) and is
+      // well below the ~100 ms human-perception threshold for "immediate".
+      Future.delayed(const Duration(milliseconds: 60), () {
+        if (mounted && widget.isActive) _focusNode.requestFocus();
+      });
+    } else if (oldWidget.isActive && !widget.isActive) {
+      // Dismissed — unfocus and clear.
+      _focusNode.unfocus();
+      _controller.clear();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onTextChanged);
+    _focusNode.removeListener(_onFocusChanged);
+    if (_ownsFocusNode) _focusNode.dispose();
+    if (_ownsController) _controller.dispose();
+    super.dispose();
+  }
+
+  void _onFocusChanged() {
+    final hasFocus = _focusNode.hasFocus;
+    if (hasFocus != _hasFocus) {
+      setState(() => _hasFocus = hasFocus);
+      widget.onFocusChanged?.call(hasFocus);
+    }
+  }
+
+  /// Wraps [child] in [GlassGlow] only when the resolved glow color is
+  /// non-transparent. Skips the wrapper entirely for
+  /// [GlassInteractionBehavior.none] and [scaleOnly], avoiding three extra
+  /// widget/render-object allocations per frame.
+  Widget _wrapWithGlow({required Widget child}) {
+    final effectiveColor =
+        widget.interactionGlowColor ?? const Color(0x1FFFFFFF);
+    if (effectiveColor.a == 0) return child;
+    return GlassGlow(
+      glowColor: effectiveColor,
+      glowRadius: widget.interactionGlowRadius,
+      glowBlurRadius: widget.interactionGlowBlurRadius,
+      glowSpreadRadius: widget.interactionGlowSpreadRadius,
+      glowOpacity: widget.interactionGlowOpacity,
+      child: child,
+    );
+  }
+
+  /// Builds a standalone shadow widget for the search pill.
+  ///
+  /// Rendered as a SIBLING in the parent Stack, BELOW the glass pill,
+  /// so it doesn't interfere with the blend group compositing.
+  /// Returns null in dark mode or when no shadow is configured.
+  Widget? buildShadowOverlay(BuildContext context, ShapeBorder pillShape) {
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    if (isDark) return null;
+
+    final effectiveSettings = InheritedLiquidGlass.ofOrDefault(context);
+    final shadows = effectiveSettings.effectiveShadow;
+    if (shadows.isEmpty) return null;
+
+    return IgnorePointer(
+      child: ClipPath(
+        clipBehavior: Clip.antiAlias,
+        clipper: _InverseSearchBarClipper(pillShape),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(widget.barBorderRadius),
+            boxShadow: shadows,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Use GlassTheme.brightnessOf — the single brightness authority inside
+    // this package. CupertinoDynamicColor.resolve() / CupertinoTheme.brightnessOf()
+    // bypasses the glass cascade and reads system brightness, giving black icons
+    // on dark glass when the device OS brightness is light.
+    final brightness = GlassTheme.brightnessOf(context);
+
+    // Resolves a Color that may be a CupertinoDynamicColor using glass brightness.
+    Color resolveIconColor(Color c) {
+      if (c is CupertinoDynamicColor) {
+        return brightness == Brightness.dark ? c.darkColor : c.color;
+      }
+      return c;
+    }
+
+    final rawIconColor = widget.config.searchIconColor ??
+        widget.iconColor ??
+        CupertinoColors.label;
+    final iconColor = resolveIconColor(rawIconColor);
+    final micColor =
+        resolveIconColor(widget.config.micIconColor ?? rawIconColor);
+    final shape =
+        LiquidRoundedSuperellipse(borderRadius: widget.barBorderRadius);
+
+    // LayoutBuilder reads the ACTUAL rendered width on every frame.
+    // When isActive flips true, AnimatedContainer starts at compact width
+    // (barHeight ≈ 64 px) and animates outward. The expanded Row needs at
+    // least 84 px (padding 32 + icons 52). We gate on 90 px so the Row is
+    // never built at compact width → no layout overflow, no content bleed.
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final w = constraints.maxWidth;
+        const kExpandThreshold = 90.0;
+
+        if (!widget.isActive || w < kExpandThreshold) {
+          final isOval = (w - constraints.maxHeight).abs() < 2;
+          final currentShape = isOval
+              ? (widget.platformViewBackdrop
+                  ? LiquidRoundedSuperellipse(borderRadius: w / 2)
+                  : const LiquidOval())
+              : shape;
+
+          return Stack(
+            fit: StackFit.expand,
+            children: [
+              LiquidStretch(
+                interactionScale: widget.enableBackgroundAnimation
+                    ? widget.backgroundPressScale
+                    : 1.0,
+                stretch: widget.platformViewBackdrop ? 0.0 : 0.5,
+                resistance: 0.01,
+                anchorStretch:
+                    true, // Matches GlassButton default (keeps it attached so it morphs)
+                child: GestureDetector(
+                  key: const ValueKey('pill-collapsed'),
+                  behavior: HitTestBehavior.opaque,
+                  onTap: (widget.isActive && widget.config.expandWhenActive)
+                      ? () {}
+                      : () => widget.config.onSearchToggle(true),
+                  child: AdaptiveGlass.grouped(
+                    shape: currentShape,
+                    // Over a PlatformView AdaptiveGlass routes to the frost veil
+                    // automatically (platformViewBackdrop), so the requested
+                    // quality passes through unchanged here.
+                    quality: widget.quality,
+                    platformViewBackdrop: widget.platformViewBackdrop,
+                    child: _wrapWithGlow(
+                      child: Center(
+                        // IconTheme ensures custom searchIcon widgets inherit
+                        // the resolved color. The fallback Icon also sets
+                        // color: explicitly for belt-and-braces safety.
+                        child: IconTheme(
+                          data: IconThemeData(color: iconColor),
+                          child: widget.config.searchIcon ??
+                              Icon(CupertinoIcons.search, color: iconColor),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              IgnorePointer(
+                child: Opacity(
+                  opacity: 0,
+                  child: _buildExpanded(iconColor, micColor),
+                ),
+              ),
+            ],
+          );
+        }
+
+        // Wrap with an opaque GestureDetector so taps anywhere inside the
+        // glass pill — including the 16 px horizontal padding zones — focus
+        // the search field instead of passing through to background content.
+        // Without this, AdaptiveGlass.grouped defers hit-testing to its
+        // children, leaving the padding area as a transparent pass-through.
+        //
+        // iOS 26: wrapped in GlassGlowLayer so GlassGlow inside can report
+        // touch position and paint a soft directional highlight on the surface.
+        // iOS 26: directional glow on press (GlassGlowLayer + GlassGlow).
+        // No scale animation here — the pill is spring-positioned alongside
+        // the dismiss button so any visual overflow causes overlap.
+        return LiquidStretch(
+          interactionScale: widget.enableBackgroundAnimation
+              ? widget.backgroundPressScale
+              : 1.0,
+          stretch: 0.0,
+          resistance: 0.08,
+          anchorStretch: false, // Search pill uses jelly-follow, not anchored
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: _focusNode.requestFocus,
+            child: AdaptiveGlass.grouped(
+              shape: shape,
+              quality: widget.quality,
+              platformViewBackdrop: widget.platformViewBackdrop,
+              child: _wrapWithGlow(
+                child: _buildExpanded(iconColor, micColor),
+              ),
+            ),
+          ), // GestureDetector
+        ); // LiquidStretch
+      },
+    );
+  }
+
+  void _handleClear() {
+    _controller.clear();
+    widget.config.onChanged?.call('');
+  }
+
+  Widget _buildExpanded(Color iconColor, Color micColor) {
+    final config = widget.config;
+    final textColor =
+        config.textColor ?? CupertinoColors.label.resolveFrom(context);
+
+    // Trailing slot priority:
+    //   1. trailingBuilder — caller has full control.
+    //   2. Animated × clear when _hasText (iOS 26 pattern — clears without dismissing).
+    //   3. Default mic icon.
+    // Note: the dismiss (close-search) × is a SEPARATE sibling pill in the
+    // outer bar Row — it is NOT rendered here. This matches the real iOS 26
+    // Apple News layout where the × is its own glass button outside the search pill.
+    Widget trailing;
+    if (config.trailingBuilder != null) {
+      trailing = config.trailingBuilder!(context);
+    } else {
+      trailing = AnimatedSwitcher(
+        duration: const Duration(milliseconds: 180),
+        transitionBuilder: (child, animation) => FadeTransition(
+          opacity: animation,
+          child: ScaleTransition(scale: animation, child: child),
+        ),
+        child: _hasText
+            ? GestureDetector(
+                key: const ValueKey('clear'),
+                behavior: HitTestBehavior.opaque,
+                onTap: _handleClear,
+                child: Icon(
+                  CupertinoIcons.clear_circled_solid,
+                  color: iconColor,
+                  size: 18,
+                ),
+              )
+            : GestureDetector(
+                key: const ValueKey('mic'),
+                behavior: HitTestBehavior.opaque,
+                onTap: config.onMicTap,
+                child: config.onMicTap != null
+                    ? Icon(
+                        CupertinoIcons.mic_fill,
+                        color: micColor,
+                        size: 18,
+                      )
+                    : const SizedBox.shrink(),
+              ),
+      );
+    }
+
+    // The expanded pill content.
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Icon(CupertinoIcons.search, color: iconColor, size: 18),
+          const SizedBox(width: 8),
+          Expanded(
+            child: CupertinoTextField(
+              controller: _controller,
+              focusNode: _focusNode,
+              autofocus: false,
+              onTap: config.onSearchFieldTap,
+              onChanged: config.onChanged,
+              onSubmitted: config.onSubmitted,
+              onTapOutside: config.onTapOutside,
+              textInputAction: config.textInputAction,
+              keyboardType: config.keyboardType,
+              autocorrect: config.autocorrect,
+              enableSuggestions: config.enableSuggestions,
+              style: config.hintStyle ??
+                  TextStyle(
+                    color: textColor,
+                    fontSize: 17,
+                    fontWeight: FontWeight.w400,
+                  ),
+              // When null, Flutter's standard cursor-color resolution
+              // kicks in (textSelectionTheme → Cupertino primaryColor
+              // on iOS → colorScheme.primary). Callers wanting the
+              // pre-0.13.0 "cursor matches textColor" behaviour pass
+              // `cursorColor: textColor` explicitly via [config].
+              cursorColor: config.cursorColor,
+              placeholder: config.hintText,
+              placeholderStyle: (config.hintStyle ??
+                      const TextStyle(
+                          fontSize: 17, fontWeight: FontWeight.w400))
+                  .copyWith(color: iconColor),
+              padding: EdgeInsets.zero,
+              decoration: null,
+            ),
+          ),
+          const SizedBox(width: 8),
+          trailing,
+        ],
+      ),
+    );
+  }
+}
+
+/// Clips out the interior of the bar shape for shadow painting.
+class _InverseSearchBarClipper extends CustomClipper<Path> {
+  const _InverseSearchBarClipper(this.shape);
+
+  final ShapeBorder shape;
+
+  @override
+  Path getClip(Size size) {
+    final rect = Offset.zero & size;
+    final shapePath = shape.getOuterPath(rect);
+    final outerRect = rect.inflate(50.0);
+    final outerPath = Path()..addRect(outerRect);
+    return Path.combine(PathOperation.difference, outerPath, shapePath);
+  }
+
+  @override
+  bool shouldReclip(_InverseSearchBarClipper oldClipper) =>
+      oldClipper.shape != shape;
+}

--- a/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_searchable_layout.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/surfaces/shared/tab_bar_searchable_layout.dart
@@ -1,0 +1,833 @@
+// ignore_for_file: deprecated_member_use
+// Internal layout engine for [GlassTabBar] searchable placement.
+//
+// Extracted from the old _GlassSearchableBottomBarState so that [GlassTabBar]
+// is the single owner of all rendering logic. The deprecated
+// [GlassSearchableBottomBar] shim simply calls [GlassTabBar.searchable()]
+// which dispatches here.
+//
+// Do NOT import this file directly — use [GlassTabBar.searchable()] instead.
+
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show ValueListenable;
+import '../../../src/renderer/liquid_glass_renderer.dart';
+import '../../../src/types/glass_interaction_behavior.dart';
+import '../../../types/glass_quality.dart';
+import '../../shared/adaptive_liquid_glass_layer.dart';
+import '../../shared/glass_content_aware_scope.dart';
+import '../../../theme/glass_theme_data.dart';
+import '../../../theme/glass_theme.dart';
+import '../../../theme/glass_theme_helpers.dart';
+import '../glass_bottom_bar.dart'
+    show
+        GlassExtraButtonPosition,
+        GlassTabBarExtraButton,
+        GlassBottomBarTab,
+        GlassTabPillAnchor,
+        MaskingQuality;
+import 'tab_bar_bottom_internal.dart'
+    show
+        BottomBarExtraBtn,
+        BottomBarTabItem,
+        kBottomBarGlassDefaults,
+        resolveBarLabelColor;
+import 'glass_search_bar_config.dart';
+import 'tab_bar_searchable_controller.dart';
+import 'tab_bar_searchable_internal.dart'
+    show DismissPill, SearchPill, SearchableTabIndicator;
+
+/// Internal [StatefulWidget] that owns the searchable-placement rendering engine.
+///
+/// Created by [GlassTabBar._buildSearchable()] when
+/// [_GlassTabBarPlacement.searchable] is active. Not part of the public API.
+class TabBarSearchableLayout extends StatefulWidget {
+  const TabBarSearchableLayout({
+    required this.tabs,
+    required this.selectedIndex,
+    required this.onTabSelected,
+    required this.searchConfig,
+    super.key,
+    this.controller,
+    this.isSearchActive = false,
+    this.extraButton,
+    this.spacing = 8,
+    this.horizontalPadding = 20,
+    this.verticalPadding = 20,
+    this.barHeight = 64,
+    this.searchBarHeight = 50,
+    this.barBorderRadius = _kDefaultBorderRadius,
+    this.tabPadding = const EdgeInsets.symmetric(horizontal: 4),
+    this.iconLabelSpacing = 4,
+    this.enableBlend = true,
+    this.blendAmount = 10,
+    this.settings,
+    this.showIndicator = true,
+    this.indicatorColor,
+    this.indicatorSettings,
+    this.indicatorPinchStrength = 0.4,
+    this.selectedIconColor,
+    this.unselectedIconColor,
+    this.selectedLabelColor,
+    this.unselectedLabelColor,
+    this.selectedLabelStyle,
+    this.unselectedLabelStyle,
+    this.iconSize = 24,
+    this.labelFontSize = 11,
+    this.textStyle,
+    this.glowDuration = const Duration(milliseconds: 300),
+    this.glowBlurRadius = 32,
+    this.glowSpreadRadius = 8,
+    this.glowOpacity = 0.6,
+    this.interactionGlowColor,
+    this.interactionGlowRadius = 1.5,
+    this.quality,
+    this.magnification = 1.15,
+    this.innerBlur = 0.0,
+    this.platformViewBackdrop = false,
+    this.maskingQuality = MaskingQuality.high,
+    this.backgroundKey,
+    this.springDescription,
+    this.tabPillAnchor = GlassTabPillAnchor.start,
+    this.interactionBehavior = GlassInteractionBehavior.full,
+    this.pressScale = 1.04,
+    this.tabWidth,
+    this.indicatorBorderRadius,
+    this.indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    this.onBarTap,
+    this.whitenAtBottom = true,
+    this.whitenBottomThreshold = 45.0,
+    this.whitenAtBottomTarget = 1.0,
+    this.scrollController,
+    this.adaptiveBrightness = false,
+    this.onBrightnessChanged,
+    this.brightnessOverride,
+  });
+
+  static const double _kDefaultBorderRadius = 32.0;
+
+  /// iOS 26-style spring for the pill morph animations.
+  static const _kSpring =
+      SpringDescription(mass: 1.0, stiffness: 350.0, damping: 30.0);
+
+  final List<GlassBottomBarTab> tabs;
+  final int selectedIndex;
+  final ValueChanged<int> onTabSelected;
+  final GlassSearchBarConfig searchConfig;
+  final SearchableBottomBarController? controller;
+  final bool isSearchActive;
+  final GlassTabBarExtraButton? extraButton;
+  final double spacing;
+  final double horizontalPadding;
+  final double verticalPadding;
+  final double barHeight;
+  final double searchBarHeight;
+  final double barBorderRadius;
+  final EdgeInsetsGeometry tabPadding;
+  final double iconLabelSpacing;
+  final bool enableBlend;
+  final double blendAmount;
+  final LiquidGlassSettings? settings;
+  final bool showIndicator;
+  final Color? indicatorColor;
+  final LiquidGlassSettings? indicatorSettings;
+  final double indicatorPinchStrength;
+  final Color? selectedIconColor;
+  final Color? unselectedIconColor;
+  final Color? selectedLabelColor;
+  final Color? unselectedLabelColor;
+  final TextStyle? selectedLabelStyle;
+  final TextStyle? unselectedLabelStyle;
+  final double iconSize;
+  final double labelFontSize;
+  final TextStyle? textStyle;
+  final Duration glowDuration;
+  final double glowBlurRadius;
+  final double glowSpreadRadius;
+  final double glowOpacity;
+  final Color? interactionGlowColor;
+  final double interactionGlowRadius;
+  final GlassQuality? quality;
+  final double magnification;
+  final double innerBlur;
+  final bool platformViewBackdrop;
+  final MaskingQuality maskingQuality;
+  final GlobalKey? backgroundKey;
+  final SpringDescription? springDescription;
+  final GlassTabPillAnchor tabPillAnchor;
+  final GlassInteractionBehavior interactionBehavior;
+  final double pressScale;
+  final double? tabWidth;
+  final double? indicatorBorderRadius;
+  final EdgeInsetsGeometry indicatorExpansion;
+  final VoidCallback? onBarTap;
+  final bool whitenAtBottom;
+  final double whitenBottomThreshold;
+  final double whitenAtBottomTarget;
+  final ScrollController? scrollController;
+  final bool adaptiveBrightness;
+  final ValueChanged<Brightness>? onBrightnessChanged;
+  final ValueListenable<Brightness>? brightnessOverride;
+
+  @override
+  State<TabBarSearchableLayout> createState() => _TabBarSearchableLayoutState();
+}
+
+class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
+    with TickerProviderStateMixin {
+  static const _defaultGlassSettings = kBottomBarGlassDefaults;
+
+  late SearchableBottomBarController _controller;
+  bool _ownsController = false;
+
+  // Stable identity for the tab indicator. Without it the indicator's State is
+  // torn down + recreated on every rebuild — which orphans a live press-hold
+  // gesture mid-flight and freezes the bar (reproduced at standard/minimal over
+  // an iOS PlatformView; the premium render path happens to avoid the churn). A
+  // GlobalKey preserves the State across rebuilds AND across the
+  // AdaptiveLiquidGlassLayer wrapper's quality-path reparenting.
+  final GlobalKey _indicatorKey = GlobalKey();
+
+  void _onControllerChanged() => setState(() {});
+
+  // D1: whitenBoostCtrl still uses setState — it fires at most once per scroll-to-bottom
+  // (200 ms easeOut, not a 120 Hz spring). Full rebuild cost is acceptable here.
+  // The three spring controllers (_tabWCtrl, _searchLeftCtrl, _searchWCtrl) drive
+  // ListenableBuilder widgets directly — no setState on spring ticks.
+  void _onWhitenTick() => setState(() {});
+
+  late AnimationController _tabWCtrl;
+  late AnimationController _searchLeftCtrl;
+  late AnimationController _searchWCtrl;
+  late AnimationController _whitenBoostCtrl;
+  double _whitenTarget = 0.0;
+
+  // D1: hoisted — avoids allocating a new _MergedListenable on every LayoutBuilder call.
+  late Listenable _searchPillListenable;
+
+  @override
+  void initState() {
+    super.initState();
+    assert(
+      widget.searchConfig.collapsedTabWidth == null ||
+          widget.searchConfig.collapsedTabWidth! > 0,
+      'GlassSearchBarConfig.collapsedTabWidth must be positive',
+    );
+    if (widget.controller != null) {
+      _controller = widget.controller!;
+      _ownsController = false;
+    } else {
+      _controller = SearchableBottomBarController();
+      _ownsController = true;
+    }
+    _controller.addListener(_onControllerChanged);
+
+    // D1: no addListener — these controllers drive ListenableBuilder widgets directly.
+    // Spring ticks rebuild only the single Positioned child they animate, not the
+    // full State.build(). See the Stack children in _buildBar.
+    _tabWCtrl = AnimationController(
+      vsync: this,
+      lowerBound: double.negativeInfinity,
+      upperBound: double.infinity,
+    );
+    _searchLeftCtrl = AnimationController(
+      vsync: this,
+      lowerBound: double.negativeInfinity,
+      upperBound: double.infinity,
+    );
+    _searchWCtrl = AnimationController(
+      vsync: this,
+      lowerBound: double.negativeInfinity,
+      upperBound: double.infinity,
+    );
+    _whitenBoostCtrl = AnimationController(vsync: this)
+      ..addListener(_onWhitenTick);
+    // D1: create once — the controllers never change after initState.
+    _searchPillListenable = Listenable.merge([_searchLeftCtrl, _searchWCtrl]);
+    widget.scrollController?.addListener(_onScrollMaybeWhiten);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _onScrollMaybeWhiten();
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant TabBarSearchableLayout old) {
+    super.didUpdateWidget(old);
+    if (widget.controller != old.controller) {
+      _controller.removeListener(_onControllerChanged);
+      if (_ownsController) _controller.dispose();
+      if (widget.controller != null) {
+        _controller = widget.controller!;
+        _ownsController = false;
+      } else {
+        _controller = SearchableBottomBarController();
+        _ownsController = true;
+      }
+      _controller.addListener(_onControllerChanged);
+    }
+    if (widget.scrollController != old.scrollController) {
+      old.scrollController?.removeListener(_onScrollMaybeWhiten);
+      widget.scrollController?.addListener(_onScrollMaybeWhiten);
+      _onScrollMaybeWhiten();
+    }
+    if (widget.whitenAtBottom != old.whitenAtBottom) {
+      _onScrollMaybeWhiten();
+    }
+    _controller.onSearchActiveChanged(
+      wasActive: old.isSearchActive,
+      isActive: widget.isSearchActive,
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabWCtrl.dispose();
+    _searchLeftCtrl.dispose();
+    _searchWCtrl.dispose();
+    widget.scrollController?.removeListener(_onScrollMaybeWhiten);
+    _whitenBoostCtrl.dispose();
+    _controller.removeListener(_onControllerChanged);
+    if (_ownsController) _controller.dispose();
+    super.dispose();
+  }
+
+  void _onFocusLost() => _controller.onFocusChanged(false);
+
+  void _onScrollMaybeWhiten() {
+    final c = widget.scrollController;
+    final atBottom = widget.whitenAtBottom &&
+        c != null &&
+        c.hasClients &&
+        c.position.maxScrollExtent > 0 &&
+        (c.position.maxScrollExtent - c.position.pixels) <=
+            widget.whitenBottomThreshold;
+    final target = atBottom ? 1.0 : 0.0;
+    if (_whitenTarget != target) {
+      _whitenTarget = target;
+      _whitenBoostCtrl.animateTo(target,
+          duration: const Duration(milliseconds: 200), curve: Curves.easeOut);
+    }
+  }
+
+  LiquidGlassSettings _applyWhiten(LiquidGlassSettings s, bool isLight) {
+    final base = s.whitenStrength;
+    final t = (widget.whitenAtBottom && isLight) ? _whitenBoostCtrl.value : 0.0;
+    final eff = (base + (widget.whitenAtBottomTarget - base) * t)
+        .clamp(0.0, 1.0)
+        .toDouble();
+    return s.copyWith(whitenStrength: eff);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.adaptiveBrightness && widget.brightnessOverride == null) {
+      return _buildBar(context, null);
+    }
+    return GlassContentAwareBrightness(
+      brightnessOverride: widget.brightnessOverride,
+      onBrightnessChanged: widget.onBrightnessChanged,
+      builder: (context, brightness, darkAmount) =>
+          _buildBar(context, darkAmount),
+    );
+  }
+
+  Widget _buildBar(BuildContext context, double? darkAmount) {
+    final effectiveQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+      fallback: GlassQuality.premium,
+    );
+
+    final resolvedGlowColors =
+        GlassThemeData.of(context).glowColorsFor(context);
+    final effectiveInteractionGlowColor =
+        widget.interactionGlowColor ?? resolvedGlowColors.primary;
+
+    final dynamicLabelColor = resolveBarLabelColor(context, darkAmount);
+    final resolvedSelectedIconColor =
+        widget.selectedIconColor ?? dynamicLabelColor;
+    final resolvedUnselectedIconColor =
+        widget.unselectedIconColor ?? dynamicLabelColor;
+
+    final effectiveGlowBlurRadius = resolvedGlowColors.glowBlurRadius;
+    final effectiveGlowSpreadRadius = resolvedGlowColors.glowSpreadRadius;
+    final effectiveGlowOpacity = resolvedGlowColors.glowOpacity;
+
+    final bool isLight = GlassTheme.brightnessOf(context) == Brightness.light;
+    final effectiveSettings =
+        _applyWhiten(widget.settings ?? _defaultGlassSettings, isLight);
+    final searching = widget.isSearchActive;
+
+    final barContent = TweenAnimationBuilder<double>(
+      tween: Tween<double>(
+          end: searching ? widget.searchBarHeight : widget.barHeight),
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+      builder: (context, animH, child) {
+        return AdaptiveLiquidGlassLayer(
+          settings: effectiveSettings,
+          quality: effectiveQuality,
+          platformViewBackdrop: widget.platformViewBackdrop,
+          blendAmount: widget.enableBlend ? widget.blendAmount : 0,
+          child: Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: widget.horizontalPadding,
+              vertical: widget.verticalPadding,
+            ),
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final totalW = constraints.maxWidth;
+
+                final keyboardH = MediaQuery.viewInsetsOf(context).bottom;
+                final keyboardPresent = keyboardH > 0;
+                final hasDismiss = widget.searchConfig.showsCancelButton;
+                final isKeyboardActive =
+                    _controller.searchFocused && keyboardPresent;
+                final dismissVisible = searching &&
+                    _controller.searchFocused &&
+                    hasDismiss &&
+                    keyboardPresent;
+
+                final extraPos = widget.extraButton?.position ??
+                    GlassExtraButtonPosition.beforeSearch;
+                final extraFullW = widget.extraButton?.size ?? 0.0;
+                final extraCollapsesOnSearch =
+                    widget.extraButton?.collapseOnSearchFocus ?? true;
+
+                final layout = _controller.computeLayout(
+                  totalW: totalW,
+                  searching: widget.isSearchActive,
+                  expandWhenActive: widget.searchConfig.expandWhenActive,
+                  barHeight: widget.barHeight,
+                  searchBarHeight: widget.searchBarHeight,
+                  spacing: widget.spacing,
+                  hasDismiss: hasDismiss,
+                  dismissVisible: dismissVisible,
+                  collapsedTabWidth: widget.searchConfig.collapsedTabWidth,
+                  tabPillAnchor: widget.tabPillAnchor,
+                  extraFullW: extraFullW,
+                  extraPos: extraPos,
+                  extraCollapsesOnSearch: extraCollapsesOnSearch,
+                  isKeyboardActive: isKeyboardActive,
+                  keyboardH: keyboardH,
+                  tabCount: widget.tabs.length,
+                  perTabWidth: widget.tabWidth,
+                );
+
+                final targetTabW = layout.targetTabW;
+                final targetSearchLeft = layout.targetSearchLeft;
+                final targetSearchW = layout.targetSearchW;
+                final targetH =
+                    searching ? widget.searchBarHeight : widget.barHeight;
+                final extraTargetW = layout.extraTargetW;
+                final extraWLeft = (extraFullW > 0 &&
+                        extraPos == GlassExtraButtonPosition.beforeSearch)
+                    ? (extraTargetW + widget.spacing)
+                    : 0.0;
+                final doCollapseLayout =
+                    isKeyboardActive && extraCollapsesOnSearch;
+                final targetDismissReserve = layout.dismissReserve;
+                final centeredTab =
+                    widget.tabPillAnchor == GlassTabPillAnchor.center;
+                final maxTabW = totalW -
+                    targetH -
+                    widget.spacing -
+                    (extraFullW > 0 &&
+                            extraPos == GlassExtraButtonPosition.beforeSearch
+                        ? extraFullW + widget.spacing
+                        : 0.0) -
+                    (extraFullW > 0 &&
+                            extraPos == GlassExtraButtonPosition.afterSearch
+                        ? extraFullW + widget.spacing
+                        : 0.0);
+
+                if (!_controller.pillsInitialized &&
+                    !_controller.pillsInitScheduled) {
+                  _controller.markInitScheduled(totalW: totalW);
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    if (!mounted) return;
+                    _tabWCtrl.value = targetTabW;
+                    _searchLeftCtrl.value = targetSearchLeft;
+                    _searchWCtrl.value = targetSearchW;
+                    _controller.initializePills(
+                      tabW: targetTabW,
+                      searchLeft: targetSearchLeft,
+                      searchW: targetSearchW,
+                    );
+                  });
+                } else if (_controller.pillsInitialized) {
+                  final retarget = _controller.checkRetarget(layout);
+                  if (retarget.any) {
+                    final fromTabW = _tabWCtrl.value;
+                    final fromLeft = _searchLeftCtrl.value;
+                    final fromSearchW = _searchWCtrl.value;
+                    final toTabW = targetTabW;
+                    final toLeft = targetSearchLeft;
+                    final toSearchW = targetSearchW;
+
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      if (!mounted) return;
+                      final spring = widget.springDescription ??
+                          TabBarSearchableLayout._kSpring;
+                      if (retarget.tabW) {
+                        _tabWCtrl.animateWith(
+                            SearchableBottomBarController.makeSpring(
+                                spring: spring, from: fromTabW, to: toTabW));
+                      }
+                      if (retarget.searchLeft) {
+                        _searchLeftCtrl.animateWith(
+                            SearchableBottomBarController.makeSpring(
+                                spring: spring, from: fromLeft, to: toLeft));
+                      }
+                      if (retarget.searchW) {
+                        _searchWCtrl.animateWith(
+                            SearchableBottomBarController.makeSpring(
+                                spring: spring,
+                                from: fromSearchW,
+                                to: toSearchW));
+                      }
+                    });
+                  }
+                  if (totalW != _controller.cachedTotalW) {
+                    _controller.cachedTotalW = totalW;
+                  }
+                }
+
+                // D1: curTabW, curTabLeft, curSearchLeft, curSearchW are now computed
+                // inside their respective ListenableBuilder builders below, so each
+                // Positioned child reads a fresh controller value on its own tick
+                // without involving the enclosing LayoutBuilder or State.build().
+
+                final floatY = layout.floatY;
+                final totalH = animH + floatY;
+
+                return SizedBox(
+                  width: totalW,
+                  height: totalH,
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      // 1. Search pill — D1: rebuilt only when position/width tick.
+                      ListenableBuilder(
+                        listenable: _searchPillListenable,
+                        builder: (context, _) {
+                          final curSearchLeft = (_controller.pillsInitialized
+                                  ? _searchLeftCtrl.value
+                                  : targetSearchLeft)
+                              .clamp(0.0, totalW);
+                          final curSearchW = (_controller.pillsInitialized
+                                  ? _searchWCtrl.value
+                                  : targetSearchW)
+                              .clamp(0.0, totalW);
+                          return Positioned(
+                            left: curSearchLeft,
+                            bottom: floatY,
+                            width: math.max(0.01, curSearchW),
+                            height: animH,
+                            child: SearchPill(
+                              config: widget.searchConfig,
+                              isActive: searching,
+                              barBorderRadius: widget.barBorderRadius,
+                              quality: effectiveQuality,
+                              platformViewBackdrop: widget.platformViewBackdrop,
+                              enableBackgroundAnimation:
+                                  widget.interactionBehavior.hasScale,
+                              backgroundPressScale: widget.pressScale,
+                              iconColor: resolvedUnselectedIconColor,
+                              interactionGlowColor:
+                                  widget.interactionBehavior.hasGlow
+                                      ? effectiveInteractionGlowColor
+                                      : const Color(0x00000000),
+                              interactionGlowRadius:
+                                  widget.interactionGlowRadius,
+                              interactionGlowBlurRadius:
+                                  effectiveGlowBlurRadius,
+                              interactionGlowSpreadRadius:
+                                  effectiveGlowSpreadRadius,
+                              interactionGlowOpacity: effectiveGlowOpacity,
+                              onFocusChanged: (focused) {
+                                if (focused) {
+                                  _controller.onFocusChanged(true);
+                                } else {
+                                  _onFocusLost();
+                                }
+                                widget.searchConfig.onSearchFocusChanged
+                                    ?.call(focused);
+                              },
+                            ),
+                          );
+                        },
+                      ),
+
+                      // 2. Optional extra button — D1: left position tracks _searchLeftCtrl.
+                      if (widget.extraButton != null)
+                        ListenableBuilder(
+                          listenable: _searchLeftCtrl,
+                          builder: (context, _) {
+                            final curSearchLeft = (_controller.pillsInitialized
+                                    ? _searchLeftCtrl.value
+                                    : targetSearchLeft)
+                                .clamp(0.0, totalW);
+                            return Positioned(
+                              left: extraPos ==
+                                      GlassExtraButtonPosition.beforeSearch
+                                  ? curSearchLeft - extraWLeft
+                                  : null,
+                              right: extraPos ==
+                                      GlassExtraButtonPosition.afterSearch
+                                  ? (dismissVisible
+                                      ? targetDismissReserve
+                                      : 0.0)
+                                  : null,
+                              bottom: extraCollapsesOnSearch ? 0 : floatY,
+                              width: doCollapseLayout
+                                  ? math.min(extraTargetW, animH)
+                                  : extraTargetW,
+                              height: animH,
+                              child: AnimatedOpacity(
+                                opacity: (searching && extraCollapsesOnSearch)
+                                    ? 0.0
+                                    : 1.0,
+                                duration: const Duration(milliseconds: 180),
+                                curve: Curves.easeOut,
+                                child: IgnorePointer(
+                                  ignoring: searching && extraCollapsesOnSearch,
+                                  child: FittedBox(
+                                    fit: BoxFit.scaleDown,
+                                    alignment: Alignment.center,
+                                    child: BottomBarExtraBtn(
+                                      config: widget.extraButton!,
+                                      quality: effectiveQuality,
+                                      iconColor:
+                                          widget.extraButton!.iconColor ??
+                                              resolvedUnselectedIconColor,
+                                      enableBlend: widget.enableBlend,
+                                      borderRadius: widget.barBorderRadius ==
+                                              TabBarSearchableLayout
+                                                  ._kDefaultBorderRadius
+                                          ? null
+                                          : widget.barBorderRadius,
+                                      platformViewBackdrop:
+                                          widget.platformViewBackdrop,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+
+                      // 3. Tab pill — D1: rebuilt only when _tabWCtrl ticks.
+                      //    childUnselected is passed as ListenableBuilder.child so the
+                      //    unselected row is built once and reused across spring ticks.
+                      ListenableBuilder(
+                        listenable: _tabWCtrl,
+                        child: _buildTabRow(
+                          selected: false,
+                          resolvedSelectedIconColor: resolvedSelectedIconColor,
+                          resolvedUnselectedIconColor:
+                              resolvedUnselectedIconColor,
+                        ),
+                        builder: (context, child) {
+                          final curTabW = (_controller.pillsInitialized
+                                  ? _tabWCtrl.value
+                                  : targetTabW)
+                              .clamp(0.0, totalW);
+                          final curTabLeft = centeredTab
+                              ? ((maxTabW - curTabW) / 2).clamp(0.0, maxTabW)
+                              : 0.0;
+                          return Positioned(
+                            left: curTabLeft,
+                            bottom: 0,
+                            width: math.max(0.01, curTabW),
+                            height: animH,
+                            child: SearchableTabIndicator(
+                              key: _indicatorKey,
+                              quality: effectiveQuality,
+                              visible: widget.showIndicator && !searching,
+                              tabIndex: widget.selectedIndex,
+                              tabCount: widget.tabs.length,
+                              onTabChanged: widget.onTabSelected,
+                              barHeight: animH,
+                              barBorderRadius: widget.barBorderRadius,
+                              indicatorBorderRadius:
+                                  widget.indicatorBorderRadius,
+                              tabPadding: widget.tabPadding,
+                              maskingQuality: widget.maskingQuality,
+                              magnification: widget.magnification,
+                              innerBlur: widget.innerBlur,
+                              indicatorColor: widget.indicatorColor,
+                              indicatorExpansion: widget.indicatorExpansion,
+                              indicatorSettings: widget.indicatorSettings,
+                              indicatorPinchStrength:
+                                  widget.indicatorPinchStrength,
+                              backgroundKey: widget.backgroundKey,
+                              platformViewBackdrop: widget.platformViewBackdrop,
+                              isSearchActive: searching,
+                              interactionGlowColor:
+                                  widget.interactionBehavior.hasGlow
+                                      ? effectiveInteractionGlowColor
+                                      : const Color(0x00000000),
+                              interactionGlowRadius:
+                                  widget.interactionGlowRadius,
+                              interactionGlowBlurRadius:
+                                  effectiveGlowBlurRadius,
+                              interactionGlowSpreadRadius:
+                                  effectiveGlowSpreadRadius,
+                              interactionGlowOpacity: effectiveGlowOpacity,
+                              enableBackgroundAnimation:
+                                  widget.interactionBehavior.hasScale,
+                              backgroundPressScale: widget.pressScale,
+                              collapsedLogoBuilder:
+                                  widget.searchConfig.collapsedLogoBuilder ??
+                                      (context) {
+                                        final currentTab =
+                                            widget.tabs[widget.selectedIndex];
+                                        return Center(
+                                          child: IconTheme(
+                                            data: IconThemeData(
+                                              color: widget.unselectedIconColor,
+                                              size: widget.iconSize,
+                                            ),
+                                            child: currentTab.activeIcon ??
+                                                currentTab.icon,
+                                          ),
+                                        );
+                                      },
+                              onDismissSearch: () =>
+                                  widget.searchConfig.onSearchToggle(false),
+                              childUnselected: child!,
+                              selectedTabBuilder: (ctx, intensity, alignment) =>
+                                  _buildTabRow(
+                                selected: true,
+                                intensity: intensity,
+                                alignment: alignment,
+                                resolvedSelectedIconColor:
+                                    resolvedSelectedIconColor,
+                                resolvedUnselectedIconColor:
+                                    resolvedUnselectedIconColor,
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+
+                      // 4. Dismiss × pill
+                      if (hasDismiss && dismissVisible)
+                        Positioned(
+                          right: 0,
+                          bottom: floatY,
+                          width: animH,
+                          height: animH,
+                          child: DismissPill(
+                            onTap: () {
+                              widget.searchConfig.onCancelTap?.call();
+                              FocusManager.instance.primaryFocus?.unfocus();
+                            },
+                            pillSize: animH,
+                            barBorderRadius: widget.barBorderRadius,
+                            quality: effectiveQuality,
+                            indicatorColor: widget.indicatorColor,
+                            settings: widget.settings,
+                            cancelButtonColor:
+                                widget.searchConfig.cancelButtonColor,
+                            cancelIcon: widget.searchConfig.cancelIcon,
+                            cancelIconSize: widget.searchConfig.cancelIconSize,
+                          ),
+                        ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+      },
+    );
+
+    if (widget.onBarTap == null) return barContent;
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTap: widget.onBarTap,
+      child: barContent,
+    );
+  }
+
+  Widget _buildTabRow({
+    required bool selected,
+    required Color resolvedSelectedIconColor,
+    required Color resolvedUnselectedIconColor,
+    double intensity = 0,
+    Alignment alignment = Alignment.center,
+  }) {
+    if (selected) {
+      final scale = ui.lerpDouble(1.0, widget.magnification, intensity) ?? 1.0;
+      final currentTabFloat = ((alignment.x + 1) / 2) * widget.tabs.length;
+      final aStart =
+          (currentTabFloat - 1).floor().clamp(0, widget.tabs.length - 1);
+      final aEnd =
+          (currentTabFloat + 1).ceil().clamp(0, widget.tabs.length - 1);
+
+      return Row(
+        children: [
+          for (var i = 0; i < widget.tabs.length; i++)
+            Expanded(
+              child: (i >= aStart && i <= aEnd)
+                  ? Transform.scale(
+                      scale: scale,
+                      child: BottomBarTabItem(
+                        tab: widget.tabs[i],
+                        selected: true,
+                        selectedIconColor: resolvedSelectedIconColor,
+                        unselectedIconColor: resolvedUnselectedIconColor,
+                        selectedLabelColor: widget.selectedLabelColor,
+                        unselectedLabelColor: widget.unselectedLabelColor,
+                        selectedLabelStyle: widget.selectedLabelStyle,
+                        unselectedLabelStyle: widget.unselectedLabelStyle,
+                        iconSize: widget.iconSize,
+                        labelFontSize: widget.labelFontSize,
+                        textStyle: widget.textStyle,
+                        iconLabelSpacing: widget.iconLabelSpacing,
+                        glowDuration: widget.glowDuration,
+                        glowBlurRadius: widget.glowBlurRadius,
+                        glowSpreadRadius: widget.glowSpreadRadius,
+                        glowOpacity: widget.glowOpacity,
+                        onTap: null,
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            ),
+        ],
+      );
+    }
+
+    return Row(
+      children: [
+        for (var i = 0; i < widget.tabs.length; i++)
+          Expanded(
+            child: BottomBarTabItem(
+              tab: widget.tabs[i],
+              selected: false,
+              selectedIconColor: resolvedSelectedIconColor,
+              unselectedIconColor: resolvedUnselectedIconColor,
+              selectedLabelColor: widget.selectedLabelColor,
+              unselectedLabelColor: widget.unselectedLabelColor,
+              selectedLabelStyle: widget.selectedLabelStyle,
+              unselectedLabelStyle: widget.unselectedLabelStyle,
+              iconSize: widget.iconSize,
+              labelFontSize: widget.labelFontSize,
+              textStyle: widget.textStyle,
+              iconLabelSpacing: widget.iconLabelSpacing,
+              glowDuration: widget.glowDuration,
+              glowBlurRadius: widget.glowBlurRadius,
+              glowSpreadRadius: widget.glowSpreadRadius,
+              glowOpacity: widget.glowOpacity,
+              onTap: null,
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/packages/liquid_glass_widgets/pubspec.yaml
+++ b/packages/liquid_glass_widgets/pubspec.yaml
@@ -1,0 +1,49 @@
+name: liquid_glass_widgets
+description: A Flutter UI kit implementing the iOS 26 Liquid Glass design language. Features shader-based glassmorphism, physics-driven jelly animations, and dynamic lighting.
+version: 0.21.3
+
+
+homepage: https://github.com/sdegenaar/liquid_glass_widgets
+repository: https://github.com/sdegenaar/liquid_glass_widgets
+issue_tracker: https://github.com/sdegenaar/liquid_glass_widgets/issues
+
+topics:
+  - liquid-glass
+  - widgets
+  - glassmorphism
+  - flutter
+  - apple
+
+# Platform support declaration for pub.dev
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:
+
+environment:
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.41.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  equatable: ^2.0.8
+  flutter_shaders: ^0.1.3
+  logging: ^1.3.0
+  meta: ^1.18.0
+dev_dependencies:
+  alchemist: ^0.14.0
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+  mocktail: ^1.0.5
+
+flutter:
+  shaders:
+    - shaders/lightweight_glass.frag
+    - shaders/interactive_indicator.frag
+    - shaders/liquid_glass_geometry_blended.frag
+    - shaders/liquid_glass_final_render.frag

--- a/packages/liquid_glass_widgets/scripts/validate_shaders.sh
+++ b/packages/liquid_glass_widgets/scripts/validate_shaders.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# validate_shaders.sh
+#
+# Validates liquid_glass_widgets GLSL shaders for Windows/SkSL compatibility
+# using glslangValidator (the same compiler core used by Flutter on Windows).
+#
+# Usage:
+#   bash scripts/validate_shaders.sh
+#
+# Install (once):
+#   macOS:   brew install glslang
+#   Ubuntu:  sudo apt-get install glslang-tools
+#   Windows: choco install glslang
+#            (or download from https://github.com/KhronosGroup/glslang/releases)
+#
+# What this catches:
+#   - Dynamic array indices  ("index expression must be constant")
+#   - Non-constant loop bounds
+#   - Forbidden builtins (min(int,int), dFdx on scalar outside #ifdef, etc.)
+#   - General GLSL syntax / type errors
+#
+# What this does NOT catch:
+#   - Impeller-specific builtins (FlutterFragCoord, layout locations) — these
+#     will warn but not error. They are valid at Impeller runtime.
+#   - Semantic / visual bugs — only visual testing catches those.
+
+set -euo pipefail
+
+# ── Path resolution ───────────────────────────────────────────────────────────
+# Works whether the script is called from the project root or the scripts/ dir,
+# and on Windows (Git for Windows bash) where the path separator may differ.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SHADER_DIR="$REPO_ROOT/shaders"
+
+# ── glslangValidator resolution ───────────────────────────────────────────────
+# On Windows the chocolatey package installs as "glslangValidator.exe".
+# Prefer a direct path lookup; fall back to bare name for PATH-based installs.
+if command -v glslangValidator &>/dev/null; then
+  VALIDATOR="glslangValidator"
+elif command -v glslangValidator.exe &>/dev/null; then
+  VALIDATOR="glslangValidator.exe"
+else
+  echo "❌  glslangValidator not found."
+  echo ""
+  echo "    Install instructions:"
+  echo "      macOS:   brew install glslang"
+  echo "      Ubuntu:  sudo apt-get install glslang-tools"
+  echo "      Windows: choco install glslang"
+  echo "               (or: winget install KhronosGroup.glslang)"
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+WARN=0
+
+VALIDATOR_VERSION=$("$VALIDATOR" --version 2>&1 | head -1 || echo "version unknown")
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Liquid Glass — Windows/SkSL Shader Validation"
+echo "  Validator:  $VALIDATOR ($VALIDATOR_VERSION)"
+echo "  Shader dir: $SHADER_DIR"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# We only validate .frag files (entry-point shaders).
+# .glsl include files are pulled in by the including shader, so validating
+# each .frag automatically validates all included .glsl files too.
+for frag in "$SHADER_DIR"/*.frag; do
+  name="$(basename "$frag")"
+
+  # Run validator. Redirect stderr→stdout so we capture all output.
+  # --target-env vulkan1.0  → SPIR-V target (same as Windows Flutter).
+  # -S frag                 → treat as fragment shader stage.
+  # -I "$SHADER_DIR"        → resolve #include relative to shader dir.
+  output=$("$VALIDATOR" \
+    --target-env vulkan1.0 \
+    -S frag \
+    -I "$SHADER_DIR" \
+    "$frag" 2>&1) || true
+
+  # ── Classify output lines ─────────────────────────────────────────────────
+  has_error=false
+  has_impeller_warn=false
+  clean_output=""
+
+  while IFS= read -r line; do
+    # Impeller-specific extensions that glslang warns about but are valid at
+    # Impeller runtime. These are intentional; suppress them from output.
+    if [[ "$line" == *"FlutterFragCoord"* ]] ||
+       [[ "$line" == *"GL_GOOGLE_include_directive"* ]] ||
+       [[ "$line" == *"layout"*"location"* && "$line" == *"warning"* ]]; then
+      has_impeller_warn=true
+      continue
+    fi
+
+    # Real errors the Windows SkSL compiler will also reject.
+    if [[ "$line" == *"error"* ]]; then
+      has_error=true
+      clean_output+="  ❌  $line"$'\n'
+    elif [[ "$line" == *"warning"* ]]; then
+      clean_output+="  ⚠️   $line"$'\n'
+    fi
+  done <<< "$output"
+
+  if $has_error; then
+    echo "FAIL  $name"
+    echo "$clean_output"
+    FAIL=$((FAIL + 1))
+  elif [[ -n "$clean_output" ]]; then
+    echo "WARN  $name"
+    echo "$clean_output"
+    WARN=$((WARN + 1))
+  else
+    if $has_impeller_warn; then
+      echo "PASS  $name  (Impeller extensions suppressed)"
+    else
+      echo "PASS  $name"
+    fi
+    PASS=$((PASS + 1))
+  fi
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Results: ${PASS} passed  ${WARN} warnings  ${FAIL} failed"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [[ $FAIL -gt 0 ]]; then
+  echo ""
+  echo "  ⛔  Windows build will fail. Fix the errors above before releasing."
+  echo "  Ref: https://github.com/sdegenaar/liquid_glass_widgets/blob/main/knowledge/liquid_glass_shader_windows/artifacts/compatibility_rules.md"
+  exit 1
+else
+  echo ""
+  echo "  ✅  All shaders pass Windows/SkSL validation."
+  exit 0
+fi

--- a/packages/liquid_glass_widgets/shaders/displacement_encoding.glsl
+++ b/packages/liquid_glass_widgets/shaders/displacement_encoding.glsl
@@ -1,0 +1,34 @@
+// Copyright 2025, Tim Lehmann for whynotmake.it
+//
+// Shared utilities for encoding and decoding geometry data.
+//
+// Texture layout (V1 — stores true surface normal instead of displacement):
+//   R: normal.x  mapped from [-1, 1] → [0, 1]
+//   G: normal.y  mapped from [-1, 1] → [0, 1]
+//   B: height    normalized to [0, 1] by dividing by thickness
+//   A: alpha     for SDF anti-aliasing at the glass boundary
+
+// Encode the surface normal XY, height, and alpha into RGBA channels.
+// normal.xy is the true SDF surface normal (from dFdx/dFdy in the geometry pass).
+// Storing the genuine normal instead of the refraction displacement vector fixes
+// lighting in blend-group neck zones, where normalize(displacement) diverges from
+// the actual surface orientation.
+vec4 encodeGeometryData(vec2 normalXY, float height, float thickness, float alpha) {
+    // Map normal.xy from [-1, 1] to [0, 1] for texture storage.
+    // normal components are already unit-length so clamping is just a guard.
+    vec2 encodedNormal = clamp(normalXY * 0.5 + 0.5, 0.0, 1.0);
+    float normalizedHeight = thickness > 0.0 ? clamp(height / thickness, 0.0, 1.0) : 0.0;
+    return vec4(encodedNormal.x, encodedNormal.y, normalizedHeight, alpha);
+}
+
+// Decode surface normal XY from RG channels.
+// Returns the XY components of the unit surface normal.
+// Reconstruct normal.z in the render pass: sqrt(1.0 - dot(n.xy, n.xy)).
+vec2 decodeNormalXY(vec4 encoded) {
+    return encoded.rg * 2.0 - 1.0;
+}
+
+// Decode height from B channel.
+float decodeHeight(vec4 encoded, float thickness) {
+    return encoded.b * thickness;
+}

--- a/packages/liquid_glass_widgets/shaders/interactive_indicator.frag
+++ b/packages/liquid_glass_widgets/shaders/interactive_indicator.frag
@@ -1,0 +1,378 @@
+#include <flutter/runtime_effect.glsl>
+
+precision highp float;
+
+/*
+  iOS 26 LIQUID GLASS INDICATOR SHADER
+  =====================================
+  
+  This shader creates the liquid glass refraction effect for interactive
+  indicators (like the pill in a segmented control). It samples a captured
+  background texture and applies edge distortion to simulate light bending
+  through glass.
+  
+  COORDINATE SYSTEM:
+  - All calculations use LOGICAL pixels (not physical/device pixels)
+  - uBackgroundOrigin and uBackgroundSize are in logical pixels
+  - This avoids DPR scaling issues across different devices
+  
+  MAIN EFFECTS:
+  1. Edge refraction - bends the background image at the pill edges
+  2. Chromatic aberration - separates RGB channels at edges for prism effect
+  3. Directional lighting - rim highlights based on light angle
+  4. Fresnel glow - subtle glow at grazing angles
+  5. Synthetic bevel gradient - top-bright / bottom-dim rim falloff that
+     simulates the view-angle gradient of a real 3D Impeller bevel
+*/
+
+// -----------------------------------------------------------------------------
+// UNIFORMS
+// -----------------------------------------------------------------------------
+// We pack uniforms into vec4s to avoid Metal's 14 constant buffer limit on the iOS Simulator.
+uniform vec4 uData0; // 0..3 (size.x, size.y, origin.x, origin.y)
+uniform vec4 uData1; // 4..7 (glassColor)
+uniform vec4 uData2; // 8..11 (thickness, lightDir.x, lightDir.y, lightIntensity)
+uniform vec4 uData3; // 12..15 (ambientStrength, saturation, refractiveIndex, chromaticAberration)
+uniform vec4 uData4; // 16..19 (cornerRadius, scale.x, scale.y, glowIntensity)
+uniform vec4 uData5; // 20..23 (densityFactor, interactionIntensity, bgOrigin.x, bgOrigin.y)
+uniform vec4 uData6; // 24..27 (bgSize.width, bgSize.height, hasBackground, ambientRim)
+uniform vec4 uData7; // 28..31 (baseAlphaMultiplier, edgeAlphaMultiplier, rimThickness, rimSmoothing)
+
+uniform sampler2D uTexture;         // Captured background image
+
+// 32: Device pixel ratio — passed from Dart _RenderInteractiveIndicator.
+// The background texture is now captured at full DPR resolution, so the
+// physical texel size = logical uBackgroundSize * uDpr.
+uniform float uDpr;
+
+out vec4 fragColor;
+
+// ── Manual Bilinear Filtering ─────────────────────────────────────────────
+// Impeller's explicit setImageSampler() binding may also default to
+// Nearest-Neighbor. Even when it does not, the background texture was
+// previously captured at pixelRatio: 1.0, meaning each "texel" covered
+// a 3×3 block of physical pixels on a 3× Retina screen. Both issues
+// produced blocky staircase aliasing on edge refraction and chromatic
+// aberration.
+//
+// This function replaces all uTexture lookups with a 4-texel bilinear
+// interpolation in GLSL, guaranteeing smooth sub-pixel sampling regardless
+// of Impeller's sampler default.
+//
+// uv       — UV coordinate in [0,1] (relative to logical uBackgroundSize)
+// logSize  — uBackgroundSize in logical pixels
+// physSize — uBackgroundSize * uDpr = actual pixel dimensions of the texture
+// invPhys  — 1.0 / physSize (precomputed for efficiency)
+vec4 textureBilinear(vec2 uv, vec2 physSize, vec2 invPhys) {
+    // Convert UV to physical texel coordinate, centre on the texel grid.
+    vec2 px = uv * physSize - 0.5;
+    vec2 f  = fract(px);
+    vec2 p0 = floor(px);
+    vec2 p1 = p0 + vec2(1.0, 0.0);
+    vec2 p2 = p0 + vec2(0.0, 1.0);
+    vec2 p3 = p0 + vec2(1.0, 1.0);
+
+    // Explicitly clamp to texture bounds. In Impeller, custom FragmentShader 
+    // samplers may not use ClampToEdge by default. When the indicator pill 
+    // expands outside the RepaintBoundary bounds (e.g. via jelly overshoot 
+    // or LiquidStretch scaling), out-of-bounds UVs cause extreme wrap-around 
+    // chromatic aliasing (jagged rainbows) on the pill's top/left edges.
+    vec2 maxPx = max(vec2(0.0), physSize - 1.0);
+    p0 = clamp(p0, vec2(0.0), maxPx);
+    p1 = clamp(p1, vec2(0.0), maxPx);
+    p2 = clamp(p2, vec2(0.0), maxPx);
+    p3 = clamp(p3, vec2(0.0), maxPx);
+
+    vec4 c0 = texture(uTexture, (p0 + 0.5) * invPhys);
+    vec4 c1 = texture(uTexture, (p1 + 0.5) * invPhys);
+    vec4 c2 = texture(uTexture, (p2 + 0.5) * invPhys);
+    vec4 c3 = texture(uTexture, (p3 + 0.5) * invPhys);
+
+    vec4 cTop = mix(c0, c1, f.x);
+    vec4 cBot = mix(c2, c3, f.x);
+    return mix(cTop, cBot, f.y);
+}
+
+void main() {
+  vec2 uSize = uData0.xy;
+  vec2 uOrigin = uData0.zw;
+  vec4 uGlassColor = uData1;
+  float uThickness = uData2.x;
+  vec2 uLightDirection = uData2.yz;
+  float uLightIntensity = uData2.w;
+  float uAmbientStrength = uData3.x;
+  float uSaturation = uData3.y;
+  float uRefractiveIndex = uData3.z;
+  float uChromaticAberration = uData3.w;
+  float uCornerRadius = uData4.x;
+  vec2 uScale = uData4.yz;
+  float uGlowIntensity = uData4.w;
+  float uDensityFactor = uData5.x;
+  float uInteractionIntensity = uData5.y;
+  vec2 uBackgroundOrigin = uData5.zw;
+  vec2 uBackgroundSize = uData6.xy;
+  float uHasBackground = uData6.z;
+  float uAmbientRim = uData6.w;
+  float uBaseAlphaMultiplier = uData7.x;
+  float uEdgeAlphaMultiplier = uData7.y;
+  float uRimThickness = uData7.z;
+  float uRimSmoothing = uData7.w;
+
+  // ==========================================================================
+  // COORDINATE SETUP
+  // ==========================================================================
+  // FlutterFragCoord gives pixel position within the current drawing layer.
+  // Since we're inside a RepaintBoundary layer, this starts at (0,0).
+  
+  vec2 fragPx = FlutterFragCoord().xy;
+  
+  // Convert to local logical position (0 to uSize)
+  // Note: uOrigin is (0,0) and uScale is (1,1) due to layer boundaries
+  vec2 localLogical = (fragPx - uOrigin) / uScale;
+  vec2 center = uSize * 0.5;
+  vec2 normalizedP = (localLogical - center) / center;
+  float radialDist = length(normalizedP);  // 0 at center, 1 at edge
+  
+  // ==========================================================================
+  // SDF PILL SHAPE
+  // ==========================================================================
+  // Using a standard high-fidelity Rounded Rectangle SDF for lighting stability.
+  
+  vec2 halfSize = uSize * 0.5;
+  vec2 q = abs(localLogical - halfSize) - halfSize + uCornerRadius;
+  float dist = length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - uCornerRadius;
+
+  // Anti-aliasing: smooth transition at edge
+  float smoothing = 1.0 / uScale.x;
+  float mask = 1.0 - smoothstep(-smoothing, smoothing, dist);
+  
+  // Early exit if outside the shape
+  if (mask <= 0.0) {
+    fragColor = vec4(0.0);
+    return;
+  }
+  
+  // ==========================================================================
+  // SURFACE NORMAL
+  // ==========================================================================
+  vec2 innerHalfSize = halfSize - uCornerRadius;
+  vec2 p = localLogical - halfSize;
+  vec2 closestOnSkeleton = clamp(p, -innerHalfSize, innerHalfSize);
+  vec2 toEdge = p - closestOnSkeleton;
+  float edgeLen = length(toEdge);
+  // Reuse edgeLen for the division — normalize(toEdge) would recompute length()
+  // internally. Dividing by the already-computed scalar saves one length() call
+  // per fragment in the surface normal path.
+  vec2 surfaceNormal = (edgeLen > 0.001) ? (toEdge / edgeLen) : vec2(0.0);
+  
+  // ==========================================================================
+  // BACKGROUND REFRACTION (THE MAIN EFFECT)
+  // ==========================================================================
+  // Sample the background texture with UV coordinates.
+  // All values are in LOGICAL pixels for consistency.
+  
+  vec2 posInBg = uBackgroundOrigin + localLogical;
+  vec2 uvBase = posInBg / uBackgroundSize;
+  
+  // --------------------------------------------------------------------------
+  // EDGE DISTORTION
+  // --------------------------------------------------------------------------
+  // Creates the "liquid lens" effect at the pill edges by bending the
+  // sampled background position inward along the surface normal.
+  
+  float distFromEdge = abs(dist);
+  
+  // TWEAK: edgeZone - How far from the edge the distortion extends (logical px)
+  //   Smaller = sharper transition, concentrated at very edge
+  //   Larger = softer, more gradual effect spreading inward
+  float edgeZone = 14.0;
+  
+  // Calculate influence: 1.0 at edge, 0.0 at edgeZone pixels inward
+  float edgeInfluence = smoothstep(edgeZone, 0.0, distFromEdge);
+  
+  // TWEAK: Quadratic falloff makes the bend gentler (less abrupt)
+  //   Use edgeInfluence directly for sharper edge effect
+  //   Use edgeInfluence * edgeInfluence for gentler, more natural curve
+  //   Use pow(edgeInfluence, 3.0) for even gentler effect
+  edgeInfluence = edgeInfluence * edgeInfluence;
+  
+  // TWEAK: bendStrength - Overall refraction intensity
+  //   Base (0.9): stronger edge lens distortion, closer to Impeller volumetric warp
+  //   Range: 0.45 (rest) → 1.17 (fully pressed)
+  float bendStrength = 0.9 * (0.5 + uInteractionIntensity * 0.7);
+  
+  // TWEAK: The final multiplier (uSize.y * 0.35) scales by widget height
+  //   0.35 means max offset is 35% of widget height
+  //   Increase for more dramatic effect, decrease for subtler
+  vec2 edgeOffsetLogical = surfaceNormal * edgeInfluence * bendStrength * uSize.y * 0.35;
+  vec2 edgeOffsetUV = edgeOffsetLogical / uBackgroundSize;
+  
+  // Apply refraction offset along the surface normal.
+  // On OpenGL ES the background texture is stored with a bottom-left Y origin,
+  // so edgeOffsetLogical.y (computed in Flutter's Y-down space) must be
+  // negated to sample in the correct outward direction in the Y-up UV space.
+  #ifdef IMPELLER_TARGET_OPENGLES
+    vec2 localRefracted = posInBg + vec2(edgeOffsetLogical.x, -edgeOffsetLogical.y);
+  #else
+    vec2 localRefracted = posInBg - edgeOffsetLogical;
+  #endif
+  
+  // --------------------------------------------------------------------------
+  // CHROMATIC ABERRATION
+  // --------------------------------------------------------------------------
+  // Separates RGB channels slightly at edges, creating a subtle prism effect.
+  // Red shifts one way, blue shifts the opposite, green stays centered.
+  
+  // TWEAK: (0.12) - subtle chromatic shift for "Apple style" refraction
+  vec2 distort = surfaceNormal * edgeInfluence * uChromaticAberration;
+  vec2 chromaticShift = distort * 0.12; 
+  
+  vec3 bg;
+  if (uHasBackground > 0.5) {
+    // Physical texture size (actual pixel dimensions after DPR capture).
+    // uBackgroundSize is in LOGICAL pixels; the texture has uDpr× more texels.
+    vec2 physBgSize = uBackgroundSize * uDpr;
+    vec2 invPhysBgSize = 1.0 / physBgSize;
+
+    if (uChromaticAberration < 0.001) {
+      // No chromatic aberration — single bilinear fetch.
+      bg = textureBilinear(localRefracted / uBackgroundSize, physBgSize, invPhysBgSize).rgb;
+    } else {
+      // Chromatic aberration: separate RGB channels with bilinear filtering.
+      vec3 colR = textureBilinear((localRefracted + chromaticShift) / uBackgroundSize, physBgSize, invPhysBgSize).rgb;
+      vec3 colG = textureBilinear(localRefracted / uBackgroundSize, physBgSize, invPhysBgSize).rgb;
+      vec3 colB = textureBilinear((localRefracted - chromaticShift) / uBackgroundSize, physBgSize, invPhysBgSize).rgb;
+      bg = vec3(colR.r, colG.g, colB.b);
+    }
+  } else {
+    // SYNTHETIC LIQUID: Use the passed indicator color
+    // This allows the standard mode to respect the color passed to the widget
+    bg = uGlassColor.rgb;
+  }
+  
+  // uLightDirection is passed from Dart as [cos(angle), -sin(angle)]
+  float edgeLightCatch = dot(surfaceNormal, uLightDirection);
+  
+  // Key light: bright highlight on edges facing the light
+  // PP2: pow(x, 8.0) replaced with multiply chain — zero transcendentals.
+  // x^8 = ((x^2)^2)^2 — 3 multiplies vs exp(8·log(x)).
+  // Same optimisation already applied in lightweight_glass.frag.
+  float lc  = max(edgeLightCatch,  0.0);
+  float lc2 = lc  * lc;
+  float lc4 = lc2 * lc2;
+  float keyHighlight = lc4 * lc4 * uLightIntensity * 0.5;  // lc^8
+  
+  // Kick light: subtle highlight on opposite edge (back-reflection)
+  // PP2: pow(x, 12.0) = x^8 * x^4 — 4 multiplies vs transcendental.
+  float kc  = max(-edgeLightCatch, 0.0);
+  float kc2 = kc  * kc;
+  float kc4 = kc2 * kc2;
+  float kc8 = kc4 * kc4;
+  float kickHighlight = kc8 * kc4 * uLightIntensity * 0.5; // kc^12
+  
+  // TWEAK: ambientRim - minimum rim brightness regardless of light direction
+  float rimBrightness = uAmbientRim + keyHighlight + kickHighlight;
+  
+  // ==========================================================================
+  // FRESNEL GLOW
+  // ==========================================================================
+  // Subtle glow at grazing angles (edges appear slightly brighter)
+  
+  // PP2: pow(radialDist, 2.0) → radialDist * radialDist (1 multiply, no transcendental).
+  float fresnel = (radialDist * radialDist) * 0.25;
+  
+  // ==========================================================================
+  // HAIRLINE RIM
+  // ==========================================================================
+  // Thin bright line at the very edge of the pill
+  
+  // Configurable hairline rim
+  float borderMask = 1.0 - smoothstep(0.0, smoothing * uRimSmoothing, distFromEdge - uRimThickness);
+
+  // --------------------------------------------------------------------------
+  // SYNTHETIC BEVEL GRADIENT
+  // --------------------------------------------------------------------------
+  // The Impeller 3D bevel naturally brightens at the top because the top-face
+  // normals angle toward the viewer, catching more ambient light. On a flat 2D
+  // ring every point gets the same brightness, which reads as "fake".
+  //
+  // We simulate this by blending rim brightness with a vertical gradient derived
+  // from the Y component of the surface normal:
+  //   surfaceNormal.y < 0  → top of pill  → brighter (add bevelBoost)
+  //   surfaceNormal.y > 0  → bottom       → dimmer   (subtract bevelDip)
+  //
+  // This is pure ALU — no texture samples, no uniforms required.
+  // kBevelStrength: calibrated so the gradient reads clearly on large pills
+  // (tab bar ~50px) without being aggressive on small elements (switch thumb ~22px).
+  const float kBevelStrength = 0.18;
+  // normalY range: -1 (top edge) to +1 (bottom edge) in Flutter's Y-down space
+  float bevelGradient = -surfaceNormal.y * kBevelStrength;
+  // Blend the gradient in only where the border mask is visible to avoid
+  // affecting the body of the pill.
+  // Clamp to 0.0: gradient dims the bottom rim to neutral, never to negative
+  // (negative values subtract from finalColor and cause dark jagged artefacts).
+  float modifiedRimBrightness = max(0.0, rimBrightness + bevelGradient * borderMask);
+
+  // Scale rim brightness with ambientRim parameter
+  vec3 rimColor = vec3(1.0) * modifiedRimBrightness * (uAmbientRim * 10.0);
+  
+  // ==========================================================================
+  // COMPOSITE FINAL COLOR
+  // ==========================================================================
+  
+  // Start with background — glass transmits and adds luminosity, not darkness.
+  // bgBoost boosts the background texture (if present) based on saturation.
+  // In synthetic mode, we just use the un-boosted bg color so it matches exactly
+  // what the user passed as the indicatorColor, preserving its brightness.
+  float bgBoost = uSaturation;
+  vec3 finalColor = (uHasBackground > 0.5) ? (bg * bgBoost) : bg;
+  
+  // Rim highlight: primary + secondary bevel definition collapsed to one operation.
+  // Was: finalColor += rimColor * borderMask; finalColor += rimColor * borderMask * 0.5;
+  // 1.5× is mathematically identical with one fewer MAD per border fragment.
+  finalColor += rimColor * borderMask * 1.5;
+
+  // Add fresnel glow — uGlowIntensity controls how visible the glass-edge luminosity is.
+  // Default: glowIntensity=0.75 matches previous hardcoded value.
+  finalColor += vec3(1.0) * fresnel * uGlowIntensity; // TUNE via LiquidGlassSettings.glowIntensity
+  
+  // Interior light lift — matches Premium Impeller's internal SDF specular glow.
+  // uAmbientStrength directly controls this lift value.
+  // Ambient strength is already normalized (0.25x) in the Dart layout pass.
+  finalColor += vec3(uAmbientStrength); // TUNE via LiquidGlassSettings.ambientStrength
+  
+  // Apply glass tint color
+  finalColor = mix(finalColor, finalColor + uGlassColor.rgb * 0.2, uGlassColor.a);
+  
+  // Clamp to prevent over-bright pixels
+  finalColor = min(finalColor, vec3(1.2));
+  
+  // ==========================================================================
+  // ALPHA / TRANSPARENCY
+  // ==========================================================================
+  
+  // TWEAK: baseAlpha - center transparency (lower = more see-through)
+  // Standard mode: Provide a solid glassy body even at rest (Intensity 0), 
+  // boosting it slightly when pressed.
+  float standardBaseAlpha = uBaseAlphaMultiplier * mix(0.6, 1.0, uInteractionIntensity);
+  // Restore original 0.70 when background is enabled — clear glass is translucent, not frosted.
+  float baseAlpha = (uHasBackground > 0.5) ? 0.70 : standardBaseAlpha;
+  
+  // TWEAK: edgeAlpha - edge opacity (higher = more solid edges)
+  // Standard mode: Keep a strong structural rim at rest to match 3D bevel.
+  float standardEdgeAlpha = uEdgeAlphaMultiplier * mix(0.6, 1.0, uInteractionIntensity);
+  float edgeAlpha = (uHasBackground > 0.5) ? 0.95 : standardEdgeAlpha;
+  
+  // Blend from center to edge
+  float glassAlpha = mix(baseAlpha, edgeAlpha, edgeInfluence);
+  float ringOpacity = borderMask * 0.9 * clamp(uAmbientRim * 10.0, 0.0, 1.0);
+  glassAlpha = max(glassAlpha, ringOpacity);
+
+
+
+  
+  float alpha = glassAlpha * mask;
+  
+  // Premultiplied alpha output
+  fragColor = vec4(finalColor * alpha, alpha);
+}

--- a/packages/liquid_glass_widgets/shaders/lightweight_glass.frag
+++ b/packages/liquid_glass_widgets/shaders/lightweight_glass.frag
@@ -1,0 +1,469 @@
+#include <flutter/runtime_effect.glsl>
+
+precision highp float;
+
+/*
+  Primary rendering path for all platforms (Skia, Web, Impeller).
+  Standard quality default + automatic premium quality fallback on non-Impeller.
+  -----------------------------------------
+*/
+
+// -----------------------------------------------------------------------------
+// UNIFORMS
+// -----------------------------------------------------------------------------
+uniform vec4 uData0; // 0..3  (size.x, size.y, origin.x, origin.y)
+uniform vec4 uData1; // 4..7  (glassColor)
+uniform vec4 uData2; // 8..11 (thickness, lightDir.x, lightDir.y, lightIntensity)
+uniform vec4 uData3; // 12..15 (ambientStrength, saturation, refractiveIndex, chromaticAberration)
+uniform vec4 uData4; // 16..19 (cornerRadius, scale.x, scale.y, glowIntensity)
+uniform vec4 uData5; // 20..23 (densityFactor, indicatorWeight, specularSharpnessF, backdropLuma)
+// cornerRadius < 0 → asymmetric mode; per-corner radii come from uData6.
+uniform vec4 uData6; // 24..27 (topLeft, topRight, bottomRight, bottomLeft) — asymmetric only
+uniform vec4 uData7; // 28..31 (bgOrigin.x, bgOrigin.y, bgSize.width, bgSize.height)
+
+uniform sampler2D uBackground; // The captured background texture
+// Slot 22 (uData5.z): specular sharpness level — passed as float 0.0/1.0/2.0, cast to int.
+// Flutter's FragmentShader API only supports setFloat — no setInt exists.
+// Passing as a float and rounding in GLSL gives an exact integer; the GPU
+// compiler still sees literal-constant exponents per if/else branch.
+// Slot 23 (uData5.w): backdropLuma — VQ4 content-adaptive strength proxy.
+//   Dart passes MediaQuery.platformBrightness: dark=0.15, light=0.85.
+//   When LiquidGlassScope is active the app is explicitly light/dark themed;
+//   the brightness flag is the correct per-app signal.
+
+// -----------------------------------------------------------------------------
+// iOS 26 LIQUID GLASS: AESTHETIC PARAMETERS (ORIGINAL CALIBRATION)
+// -----------------------------------------------------------------------------
+// These constants were calibrated to match iOS 26's liquid glass aesthetic.
+// Modifications will affect the entire visual appearance.
+
+// Shape & Structure
+const float kBorderThickness      = 0.5;   // Rim width in logical pixels (iOS 26 hairline)
+const float kNormalThreshold      = 0.01;  // Minimum gradient for surface normal calculation
+
+// Dual-Highlight Specular Model (simulates glass depth)
+const float kSpecularPowerPrimary = 14.0;
+const float kSpecularPowerKick    = 20.0;
+const float kKickIntensity        = 0.4;
+
+// Rim & Body Color Balance
+const float kRimBaseOpacity       = 0.4;   // Base rim brightness before light modulation
+const float kRimSpecularMix       = 0.6;   // How much specular highlights boost rim
+const float kRimAlphaBase         = 0.65;  // Base rim opacity (calibrated to Impeller parity)
+const float kRimAlphaSpecular     = 0.5;   // Additional opacity from specular highlights
+// Light Intensity Response
+const float kMinRimVisibility     = 0.35;  // Minimum rim brightness floor
+const float kRimIntensityScale    = 0.6;   // Rim sensitivity to light intensity changes
+
+// Thickness Response
+const float kThicknessReference   = 10.0;  // Neutral thickness value (no visual modulation)
+const float kThicknessRimBoost    = 0.15;  // Rim opacity boost per unit thickness deviation
+
+
+// -----------------------------------------------------------------------------
+// iOS 26 GLASS TINT MODEL (inlined from render.glsl::applyGlassColor)
+// -----------------------------------------------------------------------------
+// Luminosity-preserving glass tint — matches the Impeller final-render path.
+//
+// Chromatic glass (blue, amber, green): preserves backdrop luminance while
+// shifting hue toward the glass colour.  Prevents the "muddy" darkening that
+// a straight alpha-composite produces on saturated colours.
+//
+// Achromatic glass (white, grey, black): uses a direct alpha-composite so
+// white glass actually lifts toward white (a brightness/frost effect).
+// Without this, white glass collapses to a luminance-matched grey.
+//
+// The chroma factor blends smoothly between the two paths — fully branchless.
+// glassColor.a = 0 → returns liquidColor unchanged via mix() in both paths.
+//
+// NOTE: In this shader "liquidColor" = the synthesised glass body (finalColor),
+// not a background-texture sample.  The luminance-shift still applies correctly.
+const vec3 LUMA_WEIGHTS = vec3(0.299, 0.587, 0.114);
+
+vec3 applyGlassColorLW(vec3 liquidColor, vec4 glassColor) {
+    float backdropLuminance = dot(liquidColor, LUMA_WEIGHTS);
+    float glassLuminance    = dot(glassColor.rgb, LUMA_WEIGHTS);
+
+    // Luminosity-preserving tint: shift chroma toward glass, keep body brightness.
+    vec3 tinted = clamp(glassColor.rgb + (backdropLuminance - glassLuminance), 0.0, 1.0);
+
+    // Chroma of the glass colour: 0 = achromatic, 1 = fully saturated.
+    // Sharp ramp so anything with meaningful colour uses the luminosity path.
+    float chroma = max(max(glassColor.r, glassColor.g), glassColor.b)
+                 - min(min(glassColor.r, glassColor.g), glassColor.b);
+    float chromaWeight = clamp(chroma * 8.0, 0.0, 1.0);
+
+    vec3 directMix     = mix(liquidColor, glassColor.rgb, glassColor.a); // achromatic: lift toward glass
+    vec3 luminosityMix = mix(liquidColor, tinted,         glassColor.a); // chromatic:  hue-shift, brightness held
+
+    return mix(directMix, luminosityMix, chromaWeight);
+}
+
+out vec4 fragColor;
+
+void main() {
+  vec2 uSize = uData0.xy;
+  vec2 uOrigin = uData0.zw;
+  vec4 uGlassColor = uData1;
+  float uThickness = uData2.x;
+  vec2 uLightDirection = uData2.yz;
+  float uLightIntensity = uData2.w;
+  float uAmbientStrength = uData3.x;
+  float uSaturation = uData3.y;
+  float uRefractiveIndex = uData3.z;
+  float uChromaticAberration = uData3.w;
+  float uCornerRadius = uData4.x;
+  vec2 uScale = uData4.yz;
+  float uGlowIntensity = uData4.w;
+  float uDensityFactor   = uData5.x;
+  float uIndicatorWeight = uData5.y;
+  // VQ4 + specular: packed into uData5.z / uData5.w to use correct slot 22/23
+  // (uSpecularSharpnessF was previously declared as a separate uniform at slot 24,
+  // but Dart only writes 23 floats. Packing into uData5.z fixes the alignment.)
+  float uSpecularSharpnessF = uData5.z; // 0=soft, 1=medium, 2=sharp
+  float uBackdropLuma       = uData5.w; // VQ4: 0.15=dark platform, 0.85=light platform
+  vec2 uBackgroundOrigin    = uData7.xy;
+  vec2 uBackgroundSize      = uData7.zw;
+
+  // ---- STAGE 0: COORDINATE SYNC ----
+  vec2 pixelCoord = FlutterFragCoord().xy;
+  vec2 localLogical = (pixelCoord - uOrigin) / uScale;
+
+  // ---- STAGE 1: SDF SHAPE & COMBINED NORMALS ----
+  // OPTIMIZATION: We merge SDF distance calculation with surface normal generation.
+  // The vector maxQ generated for the SDF exactly defines the surface gradient!
+  vec2 halfSize = uSize * 0.5;
+  vec2 p = localLogical - halfSize;
+
+  // Asymmetric mode: uCornerRadius < 0 means per-corner radii are in uData6.
+  // Quadrant selection: p.x<0 && p.y<0 → topLeft, p.x≥0 && p.y<0 → topRight,
+  //                     p.x≥0 && p.y≥0 → bottomRight, p.x<0 && p.y≥0 → bottomLeft.
+  // (Y increases downward in logical coords; top = negative p.y half.)
+  float r;
+  if (uCornerRadius < 0.0) {
+    // Select per-corner radius based on fragment quadrant
+    if (p.x < 0.0 && p.y < 0.0) {
+      r = uData6.x; // topLeft
+    } else if (p.x >= 0.0 && p.y < 0.0) {
+      r = uData6.y; // topRight
+    } else if (p.x >= 0.0 && p.y >= 0.0) {
+      r = uData6.z; // bottomRight
+    } else {
+      r = uData6.w; // bottomLeft
+    }
+  } else {
+    r = uCornerRadius;
+  }
+
+  vec2 q = abs(p) - halfSize + r;
+  
+  vec2 maxQ = max(q, 0.0);
+  float maxQLen = length(maxQ);
+  float dist = maxQLen + min(max(q.x, q.y), 0.0) - r;
+  float smoothing = 1.0 / uScale.x;
+  float mask = 1.0 - smoothstep(-smoothing, smoothing, dist);
+
+  if (mask <= 0.0) {
+    fragColor = vec4(0.0);
+    return;
+  }
+
+  // ---- STAGE 2: SURFACE NORMALS ----
+  // Since gradient is analytically derived from maximum positive divergence,
+  // we do not need to re-clamp and calculate vector magnitudes.
+  bool isEdge = maxQLen > kNormalThreshold;
+  vec2 surfaceNormal = isEdge ? (sign(p) * maxQ / maxQLen) : vec2(0.0);
+
+  // normalZ: the Z component of the 3D surface normal (view-facing component).
+  // normalZ → 0 at the rim (surface nearly perpendicular to view ray)
+  // normalZ → 1 at flat interior (surface facing camera directly)
+  // Used by VQ2 Fresnel at Stage 7.8. Must be computed from dot(n,n) — not
+  // collapsed to a binary int — because the SDF normal varies smoothly across
+  // the corner arc, producing a continuous grazing-angle ramp that drives the
+  // iOS 26 rim brightening effect. A binary snap would turn this into a hard
+  // step, eliminating the smooth Fresnel highlight on rounded corners.
+  float normalZ = sqrt(max(0.0, 1.0 - dot(surfaceNormal, surfaceNormal)));
+
+  // ---- STAGE 3: HAIRLINE MASK ----
+  float effectiveBorder = kBorderThickness + uIndicatorWeight * 0.2;
+  float effectiveSmoothing = smoothing * (1.0 + uIndicatorWeight * 0.2);
+  float borderMask = 1.0 - smoothstep(0.0, effectiveSmoothing, abs(dist) - effectiveBorder);
+
+  // ---- STAGE 3.5: SYNTHETIC DENSITY PHYSICS ----
+  // Performance Optimization: When a parent container provides blur (Batch-Blur O(1) optimization),
+  // child buttons lose the visual "double-darkening" effect of nested BackdropFilters.
+  // This stage ANALYTICALLY SIMULATES that visual effect without the O(n) performance cost.
+  //
+  // Density Factor (uDensityFactor):
+  //   - Provided explicitly by AdaptiveGlass for elevated buttons
+  //   - 0.0 = normal button (standalone or no elevation)
+  //   - 1.0 = fully elevated button (inside glass container with shared blur)
+  //
+  // Four Coordinated Effects (mimic physics of nested blur):
+  //   1. Sharper specular (+20% sharpness) - Appears "harder" like denser material
+  //   2. Darker body (-30% ambient) - Simulates double-blur darkening
+  //   3. Higher opacity (+15% alpha) - More "solid" appearance
+  //   4. Brighter rim (+5% brightness) - Enhanced frost/edge definition
+  float densityFactor = uDensityFactor;
+
+  // Density elevation physics: elevated surfaces have a slightly tighter highlight.
+  // Applied as a multiplier on the specular, NOT on the exponent — the exponent is
+  // now fixed per enum variant (zero-transcendental multiply chain below).
+  // Range: 1.0 (normal) → 1.2 (fully elevated), continuous.
+  float thicknessNorm = uThickness / kThicknessReference;
+  float densitySpecularBoost = (1.0 + (thicknessNorm - 1.0) * 0.15) * (1.0 + densityFactor * 0.2);
+
+  // Decode specular level. Flutter's FragmentShader API only supports setFloat,
+  // so the Dart side passes 0.0/1.0/2.0 and we round() to get an exact int.
+  // The GPU compiler sees literal-constant exponents per branch and fully unrolls.
+  int specLevel = int(round(uSpecularSharpnessF));
+
+  // ---- STAGE 4: DETERMINISTIC LIGHTING (zero-transcendental specular) ----
+  // PP2 optimisation: The old code was:
+  //   pow(lightCatch, kSpecularPowerPrimary * specularSharpness)
+  // pow(x, uniform) compiles on Metal/Vulkan as exp(n·log(x)) — two transcendental
+  // ops per fragment. On Apple Metal, ARM Mali, and Qualcomm Adreno this is 4–8×
+  // slower than a multiply. kSpecularPowerPrimary * specularSharpness ranged 14–20.
+  //
+  // Fix: uSpecularSharpness is an integer uniform (0/1/2). Each branch uses a
+  // GLSL literal-constant exponent the GPU compiler sees at compilation time and
+  // fully unrolls into a pure multiply chain — zero transcendentals.
+  //
+  // Wave coherency bonus: all fragments in a glass surface share the same value.
+  // The driver eliminates dead branches for the entire draw call. In practice:
+  // one branch executes, the rest are compiled away — zero warp divergence.
+  //
+  // Exponents chosen as powers-of-2 for minimum multiply count:
+  //   n=8  → 3 multiplies  (soft:   x² → x⁴ → x⁸)
+  //   n=16 → 4 multiplies  (medium: x² → x⁴ → x⁸ → x¹⁶, iOS 26 default)
+  //   n=32 → 5 multiplies  (sharp:  x² → x⁴ → x⁸ → x¹⁶ → x³²)
+  
+  // VQ1: Anisotropic specular
+  // Mathematical shortcut: surfaceNormal is strictly length 1.0 (if isEdge)
+  // or 0.0. We avoid length(), division, and normalize() entirely.
+  // length(surfaceNormal + tangent*0.2) = sqrt(1.0 + 0.04) = 1.0198039
+  // 1.0 / 1.0198039 = 0.9805806
+  vec2 anisoN = isEdge 
+      ? (surfaceNormal + vec2(-surfaceNormal.y, surfaceNormal.x) * 0.2) * 0.9805806
+      : vec2(0.0);
+
+  float lightCatch = max(dot(anisoN, uLightDirection), 0.0);
+  float kickCatch  = max(dot(anisoN, -uLightDirection), 0.0);
+
+  float keySpecular;
+  float kickSpecular;
+  if (specLevel == 0) {
+    // soft: n=8 — 3 multiplies
+    float lc2 = lightCatch * lightCatch;
+    float lc4 = lc2 * lc2;
+    keySpecular = lc4 * lc4;
+    float kc2 = kickCatch * kickCatch;
+    float kc4 = kc2 * kc2;
+    kickSpecular = kc4 * kc4;
+  } else if (specLevel == 1) {
+    // medium: n=16 — 4 multiplies (iOS 26 default)
+    float lc2 = lightCatch * lightCatch;
+    float lc4 = lc2 * lc2;
+    float lc8 = lc4 * lc4;
+    keySpecular = lc8 * lc8;
+    float kc2 = kickCatch * kickCatch;
+    float kc4 = kc2 * kc2;
+    float kc8 = kc4 * kc4;
+    kickSpecular = kc8 * kc8;
+  } else {
+    // sharp: n=32 — 5 multiplies
+    float lc2 = lightCatch * lightCatch;
+    float lc4 = lc2 * lc2;
+    float lc8 = lc4 * lc4;
+    float lc16 = lc8 * lc8;
+    keySpecular = lc16 * lc16;
+    float kc2 = kickCatch * kickCatch;
+    float kc4 = kc2 * kc2;
+    float kc8 = kc4 * kc4;
+    float kc16 = kc8 * kc8;
+    kickSpecular = kc16 * kc16;
+  }
+  keySpecular  *= uLightIntensity * densitySpecularBoost;
+  kickSpecular *= uLightIntensity * kKickIntensity * densitySpecularBoost;
+  // ---- STAGE 5: GLASS ALPHA ----
+  // glassColor.a IS the opacity. 
+  float glassAlpha = clamp(uGlassColor.a, 0.0, 1.0);
+
+  // ---- STAGE 6: RIM & BEVEL LAYER ----
+  float thicknessOffset = (uThickness - kThicknessReference) / kThicknessReference;
+  float totalSpecular = keySpecular + kickSpecular;
+  float rimBaseWithIntensity = max(kMinRimVisibility, kRimBaseOpacity * uLightIntensity * kRimIntensityScale);
+  float rimBrightness = rimBaseWithIntensity + thicknessOffset * 0.10 + (densityFactor * 0.05);
+  vec3 rimColorBase = vec3(1.0) * (rimBrightness + totalSpecular * kRimSpecularMix);
+
+  // Directional light influence for a subtle lit-side bonus.
+  float normalDotLight = max(0.0, dot(surfaceNormal, uLightDirection));
+  float normalDotOpposite = max(0.0, dot(surfaceNormal, -uLightDirection));
+  float directionalInfluence = normalDotLight + normalDotOpposite * 0.8;
+  directionalInfluence *= directionalInfluence; // squared for tighter highlight
+
+  // Constant base rim (structural edge) + small directional bonus.
+  // iOS 26 uses near-invisible rims in light mode — the glass edge is
+  // defined by subtle refraction and shadow, not by an opaque border.
+  //
+  // smoothstep(0.3, 0.5, luma) creates a sharp binary-like transition:
+  //   dark  (luma=0.15) → smoothstep=0.0 → rimFade=1.0  (FULL rim, untouched)
+  //   light (luma=0.85) → smoothstep=1.0 → rimFade=0.08 (near-invisible rim)
+  // Dark mode is completely unaffected.
+  float rimFade = 1.0 - smoothstep(0.3, 0.5, uBackdropLuma) * 0.92;
+  float rimAlphaBase = kRimAlphaBase * rimFade + 0.15 * directionalInfluence * uLightIntensity;
+  rimAlphaBase *= uRefractiveIndex;
+  rimAlphaBase += totalSpecular * kRimAlphaSpecular * rimFade;
+  rimAlphaBase *= (1.0 + thicknessOffset * kThicknessRimBoost) * (1.0 + densityFactor * 0.1);
+  rimAlphaBase *= borderMask;
+  rimAlphaBase = clamp(rimAlphaBase, 0.0, 1.0);
+
+  // ---- STAGE 7: EXTRAS (fresnel) ----
+  float adaptiveStrength = mix(1.2, 0.8, uBackdropLuma);
+  float fresnel = (1.0 - normalZ) * borderMask * 0.10 * adaptiveStrength;
+
+  // ---- STAGE 8: FINAL COMPOSITE ----
+  float vertCoord = localLogical.y / max(uSize.y, 1.0);
+
+  // PATH-SPECIFIC frosted-glass material weight.
+  // PATH A (BG texture): background ALREADY provides visual presence. Adding white frost
+  //   neutralises the warm background colours that show through the glass (wrong look).
+  //   Premium shows blurred warm background through glass — so frost = 0 in PATH A.
+  // PATH B (no texture): need modest opacity so glass body is visible over the blur layer.
+  //   20% white lift is enough to be distinct without looking frosty.
+  if (uBackgroundSize.x > 1.0) {
+    // PATH A: BG Sample ON
+    // We have the background. We composite glass over it manually.
+    // Output: fully opaque (mask) — Flutter must NOT re-composite the bg on top.
+    vec2 posInBg = uBackgroundOrigin + localLogical;
+    vec2 uv = posInBg / uBackgroundSize;
+
+    // Safety valve: first do a fast baseline sample to check if the texture is valid.
+    // If the texture is near-black, the GPU hasn't flushed yet.
+    vec3 testRgb = texture(uBackground, uv).rgb;
+    float testLuma = dot(testRgb, LUMA_WEIGHTS);
+
+    if (testLuma < 0.02) {
+      // Treat as PATH B — premultiplied transparent output.
+      float isLightFallback = step(0.5, uBackdropLuma);
+      float frost2 = 0.08 + densityFactor * 0.05 + isLightFallback * 0.04;
+      float pmA2 = max(glassAlpha, frost2);
+      vec3 frostRgb2 = vec3(isLightFallback);
+      vec3 baseRgb2 = mix(frostRgb2, uGlassColor.rgb, min(glassAlpha / (frost2 + 0.01), 1.0));
+      vec3 pmRgb2 = baseRgb2 * pmA2;
+      
+      // Min 3% ambient darkening + bottom volumetric gradient shadow
+      float bottomDarken = vertCoord * 0.04;
+      float ambientDarken2 = clamp((uAmbientStrength * 0.25 + 0.03) * (1.0 + densityFactor * 0.5) + bottomDarken, 0.0, 0.8);
+      ambientDarken2 *= mix(1.0, 0.2, isLightFallback); // Reduce grey shadow in light mode
+      pmA2 = pmA2 + ambientDarken2 * (1.0 - pmA2);
+      
+      float outA2 = rimAlphaBase + pmA2 * (1.0 - rimAlphaBase);
+      vec3 outRgb2 = rimColorBase * rimAlphaBase + pmRgb2 * (1.0 - rimAlphaBase);
+      pmRgb2 = outRgb2 + vec3(0.05) * uIndicatorWeight + vec3(fresnel);
+      fragColor = vec4(clamp(pmRgb2, 0.0, 1.0) * mask, outA2 * mask);
+    } else {
+      // Normal PATH A — background texture is valid.
+      //
+      // Edge-zone refraction: indicator-style background warping at rounded
+      // corners. Uses the same approach as interactive_indicator.frag —
+      // smoothstep edge zone with quadratic falloff — but scaled for containers.
+      //
+      // Zero transcendentals: smoothstep compiles to a polynomial (3t²−2t³),
+      // and all remaining ops are multiplies. No refract(), no sqrt().
+      //
+      // Flat interior: when distFromEdge > edgeZone, edgeInfluence = 0 and
+      // edgeOffset = vec2(0) — the texture sample is identical to a flat read.
+      // No branch needed; the GPU computes the same UV for all interior pixels.
+      float distFromEdge = abs(dist);
+      float edgeZone = 10.0;
+      float edgeInfluence = smoothstep(edgeZone, 0.0, distFromEdge);
+      edgeInfluence *= edgeInfluence; // quadratic falloff for natural lens curve
+
+      vec2 edgeOffset = surfaceNormal * edgeInfluence * uThickness * 0.5;
+      vec2 refractedUV = uv + edgeOffset / uBackgroundSize;
+
+      // On OpenGL ES the background texture uses bottom-left Y origin;
+      // edgeOffset.y (computed in Flutter's Y-down space) must be negated.
+      #ifdef IMPELLER_TARGET_OPENGLES
+          refractedUV = uv + vec2(edgeOffset.x, -edgeOffset.y) / uBackgroundSize;
+      #endif
+
+      vec3 bgRgb = texture(uBackground, refractedUV).rgb;
+      float bgLuminance = dot(bgRgb, LUMA_WEIGHTS);
+
+      // Apply saturation to the background to match Premium's depth.
+      vec3 saturatedBg = mix(vec3(bgLuminance), bgRgb, uSaturation);
+
+      // Min 8% ambient darkening + bottom volumetric gradient shadow
+      float bottomDarken = vertCoord * 0.04;
+      float ambientDarken = clamp((uAmbientStrength * 0.25 + 0.08) * (1.0 + densityFactor * 0.5) + bottomDarken, 0.0, 0.8);
+      vec3 darkenedBg = saturatedBg * (1.0 - ambientDarken);
+
+      // PATH A body: use luminosity-preserving glass tint (applyGlassColorLW).
+      vec3 bodyColor = applyGlassColorLW(darkenedBg, uGlassColor);
+
+      // Adaptive rim color: brighten the background at the edge (Premium's getHighlightColor).
+      vec3 adaptiveRimColor = mix(bgRgb, vec3(1.0), 0.7);
+
+      vec3 finalColor = bodyColor * (1.0 - rimAlphaBase) + adaptiveRimColor * rimAlphaBase;
+      finalColor += vec3(0.05) * uIndicatorWeight;
+
+      // Unified interactive glow: active state feedback on standard interactive widgets
+      float glowMask = step(0.01, uGlowIntensity);
+      finalColor += vec3(uGlowIntensity * 0.3 * glowMask);
+
+      finalColor = clamp(finalColor + vec3(fresnel), 0.0, 1.0);
+      fragColor = vec4(finalColor * mask, mask);
+    }
+
+  } else {
+    // PATH B: All Standard widgets use this path.
+    // Flutter SrcOver composites us over the BackdropFilter(blur+saturation) background.
+    float isLight = step(0.5, uBackdropLuma);
+    
+    // 8% frost floor ensures minimum material visibility
+    // In light mode, add more frost for a cleaner white look
+    float simulatedFrost = 0.08 + densityFactor * 0.05 + isLight * 0.04;
+    float pmA = max(glassAlpha, simulatedFrost);
+    
+    // In light mode, transparent glass becomes white frost. In dark mode, it remains black (ambient darken).
+    vec3 frostRgb = vec3(isLight);
+    vec3 baseRgb = mix(frostRgb, uGlassColor.rgb, min(glassAlpha / (simulatedFrost + 0.01), 1.0));
+    vec3 pmRgb = baseRgb * pmA;
+
+    // Min 3% ambient darkening + bottom volumetric gradient shadow:
+    float bottomDarken = vertCoord * 0.04;
+    float ambientDarken = clamp((uAmbientStrength * 0.25 + 0.03) * (1.0 + densityFactor * 0.5) + bottomDarken, 0.0, 0.8);
+    // Reduce ambient darken in light mode to prevent greyness
+    ambientDarken *= mix(1.0, 0.2, isLight);
+    
+    pmA = pmA + ambientDarken * (1.0 - pmA);
+
+    // Rim color: full white in dark mode, no dimming needed in light mode
+    // because rimAlphaBase is already near-zero via rimFade.
+    vec3 pathBRimColor = rimColorBase;
+
+    // Minimum border floor: only active in dark mode (rimFade=1.0).
+    // In light mode rimFade≈0.08, so this floor is effectively zero.
+    float minRimAlpha = borderMask * 0.06 * rimFade;
+    float effectiveRimAlpha = max(rimAlphaBase, minRimAlpha);
+
+    // Rim composited over body.
+    float outA = effectiveRimAlpha + pmA * (1.0 - effectiveRimAlpha);
+    vec3 outRgb = pathBRimColor * effectiveRimAlpha + pmRgb * (1.0 - effectiveRimAlpha);
+    pmA = outA;
+    pmRgb = outRgb;
+
+    pmRgb += vec3(0.05) * uIndicatorWeight;
+    pmRgb += vec3(fresnel);
+
+    // Interactive glow: active state on switches/sliders (restored from main).
+    float glowMask = step(0.01, uGlowIntensity);
+    pmRgb += vec3(uGlowIntensity * 0.3 * glowMask);
+    pmA = max(pmA, uGlowIntensity * 0.3 * glowMask);
+
+    fragColor = vec4(clamp(pmRgb, 0.0, 1.0) * mask, pmA * mask);
+  }
+}
+

--- a/packages/liquid_glass_widgets/shaders/liquid_glass_final_render.frag
+++ b/packages/liquid_glass_widgets/shaders/liquid_glass_final_render.frag
@@ -1,0 +1,497 @@
+// Copyright 2025, Tim Lehmann for whynotmake.it
+//
+// Final rendering pass for liquid glass with pre-computed geometry.
+// Reads surface normal data from the geometry texture (V1 encoding) and applies
+// the liquid glass effect: refraction, chromatic aberration, tint, and edge lighting.
+//
+// Geometry texture layout (displacement_encoding.glsl):
+//   R: normal.x  [-1, 1] → [0, 1]
+//   G: normal.y  [-1, 1] → [0, 1]
+//   B: height    normalized to thickness
+//   A: foreground alpha (SDF AA)
+
+#version 460 core
+precision highp float; // mediump causes colour banding (10-bit mantissa on mobile)
+
+#define DEBUG_GEOMETRY 0
+
+#include <flutter/runtime_effect.glsl>
+#include "displacement_encoding.glsl"
+#include "render.glsl"
+
+// Slot 0-1:  uSize           — physical-pixel size of the backdrop capture
+// Slots 2-3: uGeometryOffset — top-left of geometry matte in physical pixels
+// Slots 4-5: uGeometrySize   — size of geometry matte in physical pixels
+// Slots 6-9: uGlassColor
+// Slots 10-12: uOpticalProps (refractiveIndex, chromaticAberration, thickness)
+// Slots 13-15: uLightConfig  (lightIntensity, ambientStrength, saturation)
+// Slots 16-17: uLightDirection
+// Slot 18: uWhiten
+// Slot 19: uWhitenGated
+// Slot 20: uPinchStrength
+uniform vec2 uSize;          // physical-pixel size of the backdrop capture
+uniform vec2 uGeometryOffset;
+uniform vec2 uGeometrySize;
+
+uniform vec4 uGlassColor;
+uniform vec3 uOpticalProps;
+uniform vec3 uLightConfig;
+uniform vec2 uLightDirection;
+
+// Slot 18: uWhiten — whitening ("legibility veil") amount [0..1]. Lifts the
+// glass toward white (result = mix(glass, white, uWhiten)). A single
+// control-wide value (not spatially varying), so there is no spatial seam and
+// therefore no halo/outline artifacts. Models iOS 26 light-mode glass, which
+// places an even whitening veil over the refracted content for legibility on
+// light backgrounds. 0 = pure glass (no-op); higher = whiter.
+uniform float uWhiten;
+
+// Slot 19: uWhitenGated. 1 = the whiten is luminance-gated (protects dark
+// pixels — the light-mode behaviour, keeps text/icons beneath the glass dark);
+// 0 = ungated, uniform whiten across the whole control (the dark-mode
+// behaviour, gives dark glass a small even lift toward white).
+uniform float uWhitenGated;
+
+// Slot 20: uPinchStrength. Concave horizontal-pinch strength [0..1].
+// When > 0, the pill's refraction is squeezed inward at the left/right edges,
+// creating the iOS 26 "pinched through a lens" look. The centre is left flat.
+uniform float uPinchStrength;
+
+// Slot 21-24: uBackgroundFallback — Per-mode opaque stand-in for backdrop
+// regions the engine can't capture (e.g. a PlatformView past the glass).
+// Straight (non-premultiplied) RGBA; a == 0 disables it.
+uniform vec4 uBackgroundFallback;
+
+// Slot 25-26: uCaptureOffset — physical-pixel offset from the render surface
+// origin to the capture-boundary origin. Only non-zero on the Impeller capture
+// path (GlassEffect with backgroundKey on Impeller premium). When zero (the
+// default / BackdropFilter path), (fragCoord + uCaptureOffset) == fragCoord, so
+// this is a mathematical no-op and has zero performance impact on existing paths.
+//
+// BackdropFilter mode (default, uCaptureOffset == vec2(0)):
+//   FlutterFragCoord() is screen-space physical pixels.
+//   uSize == full-screen physical pixel size.
+//   screenUV = fragCoord / uSize → samples the backdrop at screen position.
+//
+// Capture mode (uCaptureOffset != vec2(0)):
+//   FlutterFragCoord() is RepaintBoundary-surface-space physical pixels.
+//   uSize == captured image physical pixel size.
+//   uCaptureOffset shifts fragCoord so that (fragCoord + offset) is the
+//   position within the capture image — mapping the indicator's fragment
+//   to the correct texel in the pre-captured bar texture.
+uniform vec2 uCaptureOffset;
+
+// Slot 27: uAmbientRim — full-perimeter Fresnel rim boost. Added to the base
+// 0.12 edge-luminosity strength; 0 = unchanged default rendering.
+uniform float uAmbientRim;
+
+uniform sampler2D uBackgroundTexture;
+uniform sampler2D uGeometryTexture;
+
+layout(location = 0) out vec4 fragColor;
+
+// ── Manual Bilinear Filtering ─────────────────────────────────────────────
+// Impeller's implicit BackdropFilterLayer sampler is bound to the
+// FragmentShader as Nearest-Neighbor with no Dart API to override it.
+// Tracked as:
+//   Flutter Issue #139887 — original bug report (NN aliasing on backdrop)
+//   Flutter Issue #188365 — feature request to expose FilterQuality on
+//                           BackdropFilterLayer (filed during 0.18.2 work)
+// Once #188365 is resolved, this entire function can be replaced with a
+// single texture() call and the physTexSize/invTexSize derivation removed.
+//
+// On-screen bilinear is lost without this workaround, which means continuous
+// sub-pixel UV shifts (pinch lens, refraction) snap to integer texels and
+// produce stair-step aliasing on high-contrast background edges.
+//
+// This function replaces all uBackgroundTexture lookups with 4 Nearest-Neighbor
+// fetches and a standard bilinear mix, restoring perfectly smooth sub-pixel
+// sampling at the cost of 3 additional cache-hot reads per invocation.
+//
+// NOTE: uGeometryTexture is intentionally excluded — it is a pre-rasterized
+// SDF picture whose texels are pixel-aligned by construction. Bilinear
+// filtering it would soften the SDF alpha channel and degrade anti-aliasing.
+//
+// Windows/SkSL: texture() with literal-computed UVs is legal in glslang
+// SPIR-V path; floor(), fract(), and vec2 arithmetic are all universally
+// supported. This function introduces no new platform compatibility issues.
+vec4 textureBilinear(vec2 uv, vec2 size, vec2 invSize) {
+    vec2 px = uv * size - 0.5;
+    vec2 f = fract(px);
+    vec2 p0 = floor(px);
+    vec2 p1 = p0 + vec2(1.0, 0.0);
+    vec2 p2 = p0 + vec2(0.0, 1.0);
+    vec2 p3 = p0 + vec2(1.0, 1.0);
+
+    vec4 c0 = texture(uBackgroundTexture, (p0 + 0.5) * invSize);
+    vec4 c1 = texture(uBackgroundTexture, (p1 + 0.5) * invSize);
+    vec4 c2 = texture(uBackgroundTexture, (p2 + 0.5) * invSize);
+    vec4 c3 = texture(uBackgroundTexture, (p3 + 0.5) * invSize);
+
+    vec4 cTop = mix(c0, c1, f.x);
+    vec4 cBot = mix(c2, c3, f.x);
+    vec4 bg = mix(cTop, cBot, f.y);
+
+    // Composite the (premultiplied) backdrop sample OVER the fallback colour.
+    // Where the engine couldn't capture a backdrop (a PlatformView past the bar
+    // → transparent black, bg.a ≈ 0) this yields the fallback; where the
+    // backdrop is real (bg.a ≈ 1) it is left untouched. uBackgroundFallback is
+    // straight RGBA, so premultiply it by its own alpha before the over.
+    bg.rgb += uBackgroundFallback.rgb * uBackgroundFallback.a * (1.0 - bg.a);
+    bg.a += uBackgroundFallback.a * (1.0 - bg.a);
+    return bg;
+}
+
+void main() {
+    // Unpacked here rather than at global scope: global non-constant initialisers
+    // (e.g. float x = uniform.y) are valid in desktop GLSL 4.6 but rejected by
+    // SkSL / glslang on Windows (SPIR-V path). Same fix as 0.7.10 geometry shader.
+    float uRefractiveIndex     = uOpticalProps.x;
+    float uChromaticAberration = uOpticalProps.y;
+    float uThickness           = uOpticalProps.z;
+    float uLightIntensity      = uLightConfig.x;
+    float uAmbientStrength     = uLightConfig.y;
+    float uSaturation          = uLightConfig.z;
+
+    vec2 fragCoord = FlutterFragCoord().xy;
+
+    vec2 physTexSize = uSize;
+    vec2 invTexSize = 1.0 / physTexSize;
+    // uCaptureOffset shifts the fragment into capture-image space.
+    // In BackdropFilter mode uCaptureOffset == vec2(0) so this is a no-op.
+    vec2 screenUV = (fragCoord + uCaptureOffset) * invTexSize;
+
+    #ifdef IMPELLER_TARGET_OPENGLES
+        screenUV.y = 1.0 - screenUV.y;
+    #endif
+
+    vec2 geometryUV = (fragCoord - uGeometryOffset) / uGeometrySize;
+    #ifdef IMPELLER_TARGET_OPENGLES
+        geometryUV.y = 1.0 - geometryUV.y;
+    #endif
+
+    // Clamp geometryUV to [0, 1] for two reasons:
+    // 1. Impeller's texture samplers may default to Repeat mode. Without this
+    //    clamp, a fragment slightly outside uGeometrySize (e.g. during
+    //    LiquidStretch scaling overshoot) wraps around and samples the opposite
+    //    edge of the geometry SDF, producing inverted normals and extreme
+    //    chromatic aliasing (jagged rainbows).
+    // 2. Fragments genuinely outside the pill (the _clipExpansion zone) get
+    //    clamped to the SDF edge, which has near-zero alpha. The
+    //    `geometryData.a < 0.01` early-out below discards them efficiently
+    //    without needing a separate bounds check here.
+    geometryUV = clamp(geometryUV, 0.0, 1.0);
+
+    vec4 geometryData = texture(uGeometryTexture, geometryUV);
+
+    #if DEBUG_GEOMETRY
+        fragColor = geometryData;
+        return;
+    #endif
+
+    if (geometryData.a < 0.01) {
+        fragColor = vec4(0);
+        return;
+    }
+
+    // --- V1: Decode true surface normal from geometry texture ---
+    //
+    // The geometry pass stores the SDF-gradient-derived normal in RG.
+    // Before V1 this stored displacement XY, and the render pass called
+    // normalize(displacement) as a proxy for the normal — which diverges
+    // from the true normal in blend-group neck zones (smooth-union joins).
+    // The true normal is now decoded and used for both refraction and lighting.
+    vec2 normalXY = decodeNormalXY(geometryData);
+    float normalZSq = max(0.0, 1.0 - dot(normalXY, normalXY));
+    float normalZ   = sqrt(normalZSq);
+    vec3  normal    = vec3(normalXY, normalZ);   // unit-length surface normal
+
+    // Recompute refraction displacement from the true normal.
+    // This is the same refract() call used in the geometry pass — exact, not
+    // approximated.  Height is still read from the B channel.
+    float height = decodeHeight(geometryData, uThickness);
+    float baseHeight = uThickness * 8.0;
+    vec3  incident   = vec3(0.0, 0.0, -1.0);
+    float invN       = 1.0 / max(uRefractiveIndex, 0.001);
+    vec3  baseRefract = refract(incident, normal, invN);
+    float refractLen  = (height + baseHeight) / max(0.001, abs(baseRefract.z));
+    vec2  displacement = baseRefract.xy * refractLen;
+    // On OpenGL ES, screenUV.y is already flipped to (1.0 - y) to compensate
+    // for the bottom-left texture-origin convention.  The displacement is
+    // computed in Flutter's native Y-down space (outward normal at the bottom
+    // edge has +Y), but adding a positive Y delta to the flipped UV moves the
+    // sample TOWARD the centre rather than away — inverting the refraction.
+    // Negating displacement.y re-aligns it with the Y-up UV sampling space.
+    #ifdef IMPELLER_TARGET_OPENGLES
+        displacement.y = -displacement.y;
+    #endif
+
+    // ── Concave horizontal pinch ──────────────────────────────────────────────
+    // iOS 26 indicator pills make the bar content behind the left/right edges
+    // appear slightly compressed inward — as if the pill is a convex lens
+    // squeezing the bar through its edges. The effect is HORIZONTAL ONLY:
+    // the bar content at the pill edges is sampled from a position slightly
+    // closer to the pill centre, making those edge regions appear to pinch in.
+    //
+    // The centre of the pill (over the icon/label) is left completely flat.
+    //
+    // Scale: shifts are in UV space relative to the FULL backdrop (uSize).
+    // 0.015 UV on a 390pt screen ≈ 6pt logical pixels — subtle but visible.
+    //
+    // ── iOS 26 Concave Lens Pinch ─────────────────────────────────────────────
+    if (uPinchStrength > 0.001) {
+        // We cannot use normalXY because it is 0.0 in the flat interior of the pill,
+        // which prevents the background from being pinched at all.
+        // We also cannot use a circular distance field, because a circle mapped to a
+        // wide pill creates an elliptical lens that curves the flat top/bottom edges.
+        //
+        // Solution: Use an L6 norm (superellipse/squircle) distance field.
+        // This mathematically mimics the physical shape of a rounded rectangle:
+        // perfectly flat on the top/bottom/sides, and perfectly rounded in the corners.
+        vec2 centered = geometryUV - vec2(0.5);
+        vec2 absCentered = abs(centered) * 2.0; // 0.0 to 1.0
+
+        // Compute x^6 and y^6 using multiply chains instead of pow().
+        // pow(x, 6.0) compiles to exp(6*log(x)) — a pair of transcendentals.
+        // Two squares and two multiplies is significantly faster.
+        float x2 = absCentered.x * absCentered.x;
+        float ax6 = x2 * x2 * x2;
+        float y2 = absCentered.y * absCentered.y;
+        float ay6 = y2 * y2 * y2;
+
+        // PP3: pow(s, 1.0/6.0) = exp((1/6)·log(s)) — two transcendentals.
+        // ⁶√x = √(√(√x)) — three sqrt() calls, each a single SFU instruction.
+        // Error vs true cube-root-of-cube-root: <0.3%, imperceptible in the
+        // smoothstep ramp that follows. Only executes when uPinchStrength > 0.001.
+        float s = ax6 + ay6;
+        float squircleDist = sqrt(sqrt(sqrt(s)));
+
+        // Map the squircle distance to a 0..1 smooth curve.
+        float pinchRamp = smoothstep(0.0, 1.0, squircleDist);
+
+        // Vector pointing outwards from the pill centre, scaled by the ramp.
+        // uPinchStrength interpolates the effect during spring animations.
+        // 0.025 is the baseline UV shift magnitude (subtle but visible).
+        vec2 pinchShift = centered * pinchRamp * uPinchStrength * 0.025;
+
+        // Feather the pinch shift to zero at the pill's SDF boundary.
+        // Without this, there is a hard UV discontinuity at the pill edge:
+        // the background content inside the pill is sampled from a shifted UV
+        // while the content immediately outside is at the natural UV — this
+        // mismatch produces the "stepped/aliased" edge visible through the lens,
+        // especially where the bar's own clip edge is refracted inward.
+        // Multiplying by geometryData.a (which is 0 at the boundary and 1 by 2 px
+        // inside) ramps the shift smoothly from 0 → full pinch over the same AA
+        // zone as the pill alpha, eliminating the hard UV seam.
+        pinchShift *= geometryData.a;
+
+        // Correct Y-axis for OpenGL ES.
+        #ifdef IMPELLER_TARGET_OPENGLES
+            pinchShift.y = -pinchShift.y;
+        #endif
+
+        screenUV += pinchShift;
+        
+        // Guarantee we never sample outside the valid backdrop capture bounds,
+        // preventing black/void artifacts if the pill is pressed tightly against the edge.
+        screenUV = clamp(screenUV, vec2(0.001), vec2(0.999));
+    }
+
+    // PP1 optimisation: when the surface normal is flat (pointing straight up,
+    // i.e. normalXY ≈ 0), refract() always produces displacement = vec2(0) and
+    // the refracted UV is identical to screenUV.  Skip refract() entirely and
+    // take a single background sample.  This covers the majority of pixels on
+    // large surfaces (GlassAppBar, GlassPanel), where the edge zone is a small
+    // fraction of the total area.
+    //
+    // Threshold chosen conservatively: 1e-4 in squared magnitude corresponds to
+    // a normal tilted < 0.6° from vertical — visually indistinguishable from a
+    // zero-displacement sample at any display resolution.
+    vec4 refractColor;
+    if (dot(normalXY, normalXY) < 1e-4) {
+        // Flat interior — surface is pointing straight at the camera.
+        // Displacement is mathematically zero; sample the background directly.
+        refractColor = textureBilinear(screenUV, physTexSize, invTexSize);
+    } else if (uChromaticAberration < 0.01) {
+        vec2 refractedUV = screenUV + displacement * invTexSize;
+        refractColor = textureBilinear(refractedUV, physTexSize, invTexSize);
+    } else {
+        float dispersionStrength = uChromaticAberration * 0.5;
+        vec2 redOffset  = displacement * (1.0 + dispersionStrength);
+        vec2 blueOffset = displacement * (1.0 - dispersionStrength);
+
+        vec2 redUV   = screenUV + redOffset   * invTexSize;
+        vec2 greenUV = screenUV + displacement * invTexSize;
+        vec2 blueUV  = screenUV + blueOffset  * invTexSize;
+
+        float red         = textureBilinear(redUV, physTexSize, invTexSize).r;
+        vec4  greenSample = textureBilinear(greenUV, physTexSize, invTexSize);
+        float blue        = textureBilinear(blueUV, physTexSize, invTexSize).b;
+
+        refractColor = vec4(red, greenSample.g, blue, greenSample.a);
+    }
+
+    // Un-premultiply the background sample before refraction math.
+    // BackdropFilter delivers premultiplied RGBA; toImageSync captures also
+    // deliver premultiplied RGBA. Without un-premultiply, the chromatic
+    // aberration dispersion channels (red/blue split) operate on premultiplied
+    // values, which biases saturated colours toward grey at the edges.
+    // On fully-opaque backdrops (refractColor.a == 1.0) this is a no-op.
+    if (refractColor.a > 0.001) {
+        refractColor.rgb /= refractColor.a;
+    }
+
+    vec4 finalColor = applyGlassColor(refractColor, uGlassColor);
+
+    // VQ4: Content-adaptive glass strength.
+    //
+    // iOS 26 glass dynamically adjusts its material intensity based on the
+    // luminance of the content beneath it.  Dark backdrops produce richer,
+    // more vivid glass; bright or uniform backdrops produce a subtler material
+    // to avoid overwhelming the UI.
+    //
+    // Implementation: dot-product backdrop luminance from refractColor —
+    // the already-sampled background at the refracted UV.  Zero extra texture
+    // reads; the sample is already in the register file.
+    //
+    // LUMA_WEIGHTS = vec3(0.299, 0.587, 0.114) (BT.601, defined in render.glsl)
+    //
+    // adaptiveStrength range [0.8, 1.2]:
+    //   • backdropLuma = 0.0 (black)  → strength 1.2 (richer glass)
+    //   • backdropLuma = 1.0 (white)  → strength 0.8 (subtler glass)
+    //
+    // Cost: 1 dot product + 1 mix() + 1 extra mix() for tint = 3 MADs.
+    // Effectively free on modern GPUs.
+    float backdropLuma     = dot(refractColor.rgb, LUMA_WEIGHTS);
+    float adaptiveStrength = mix(1.2, 0.8, backdropLuma);
+
+    // Apply saturation with adaptive scaling.
+    // adaptiveStrength > 1.0 → more vivid (dark backdrop).
+    // adaptiveStrength < 1.0 → more muted (bright/uniform backdrop).
+    // uSaturation is the artist-set base; we only modulate it, never replace it.
+    finalColor.rgb = applySaturation(finalColor.rgb, uSaturation * adaptiveStrength);
+
+    // Modulate glass tint blend weight by adaptiveStrength.
+    // On dark backgrounds the tint reads heavier (+20%); on bright backgrounds
+    // it reads lighter (-20%).  The delta is small (max ±20% of the 12% base
+    // weight = ±2.4%) — within a single JND step, noticeable as a property
+    // not a glitch.  Uses mix() to re-blend toward uGlassColor.rgb over the
+    // already-tinted finalColor, scaled by the adaptive delta only.
+    finalColor.rgb = mix(finalColor.rgb,
+                         uGlassColor.rgb,
+                         uGlassColor.a * 0.12 * (adaptiveStrength - 1.0));
+
+    // Whitening veil — applied here, right after the body tint and BEFORE the
+    // rim/fresnel passes. Applying it before the edge lighting means the rim
+    // and fresnel highlights are drawn on top of the whitened body, so the
+    // bright edges stay crisp even when the body is heavily whitened —
+    // matching iOS 26's light-mode bar, where the white ring / edge
+    // reflections stay sharp over a whitened interior.
+    //
+    // Luminance-gated mode: scale the whiten by how bright this pixel already
+    // is, so near-white content beneath the glass lifts to pure white while
+    // darks (text, icons) are left untouched — instead of a uniform veil that
+    // grays the darks too. This is a point operation (per-pixel, depending
+    // only on this pixel's own luminance — no neighbourhood sampling), so
+    // unlike a spatial content detector it cannot produce a halo or seam; at
+    // a dark-on-light edge it just steepens the existing gradient (crisper
+    // edge, no gray ring).
+    //
+    // WHITEN_LO / WHITEN_HI are content-classification thresholds (what
+    // luminance counts as "a dark to protect" vs "a white to push"), not
+    // aesthetic per-recipe values — so they are hardcoded rather than passed
+    // as uniforms. The single tunable lever is uWhiten (the strength).
+    //   below WHITEN_LO → gate 0 (fully protected, stays dark)
+    //   above WHITEN_HI → gate 1 (fully whitened, lifts to white)
+    const float WHITEN_LO = 0.40;
+    const float WHITEN_HI = 0.80;
+    float whitenLuma = dot(finalColor.rgb, LUMA_WEIGHTS);
+    // uWhitenGated 1 → gate by luminance (light mode, protects darks);
+    // uWhitenGated 0 → gate = 1, uniform whiten (dark mode, even lift).
+    float whitenGate =
+        mix(1.0, smoothstep(WHITEN_LO, WHITEN_HI, whitenLuma), uWhitenGated);
+    finalColor.rgb =
+        mix(finalColor.rgb, vec3(1.0), clamp(uWhiten, 0.0, 1.0) * whitenGate);
+
+    // Edge lighting — uses the true normal.xy (V1; was normalize(displacement))
+    float normalizedHeight = geometryData.b;
+    float thicknessScale   = clamp(40.0 / max(uThickness, 1.0), 1.0, 4.0);
+    float edgeThreshold    = mix(0.8, 0.5, 1.0 / thicknessScale);
+    float edgeFactor       = uThickness < 0.01 ? 0.0 : 1.0 - smoothstep(0.0, edgeThreshold, normalizedHeight);
+
+
+    if (edgeFactor > 0.01) {
+        // VQ1: Anisotropic specular — stretch the highlight lobe 20% along the
+        // surface tangent, producing an oval iOS 26 highlight instead of a dot.
+        //
+        // Pre-baked constant: normalXY from the geometry texture is unit-length
+        // by construction (stored as a unit normal in the geometry pass).
+        // The tangent vec2(-n.y, n.x) is therefore perp and also unit-length.
+        // length(normalXY + tangent * 0.20) = sqrt(1.0 + 0.04) = 1.0198039
+        // 1.0 / 1.0198039 = 0.9805806
+        // This eliminates max(length(normalXY), 0.01), division, and normalize().
+        // The edgeFactor > 0.01 gate above already guards the near-zero interior.
+        vec2  anisoN  = normalXY; // True non-chiral normal for symmetric highlights
+
+        float mainLight     = max(0.0, dot(anisoN, uLightDirection));
+        float oppositeLight = max(0.0, dot(anisoN, -uLightDirection));
+        float totalInfluence = mainLight + oppositeLight * 0.8;
+
+        // PP2 follow-up: pow(x, 1.5) = x·√x. sqrt() is a single hardware SFU
+        // instruction on all Metal/Vulkan/OpenGLES targets — not a transcendental.
+        // This replaces the last pow() in the Impeller path with zero exp/log ops.
+        float directional = totalInfluence * sqrt(totalInfluence) * uLightIntensity * 3.0;
+        float ambient     = uAmbientStrength * 0.5;
+
+        // Soft-clamp brightness with x/(1+x) to prevent mix() extrapolating
+        // beyond highlightColor. The original * 3.0 drove the corner brightness
+        // to ~9.6, causing a blinding "leading dot". The soft clamp maps all
+        // values to [0, 1) so corners and edges converge gracefully.
+        float brightnessRaw = (directional + ambient) * edgeFactor * thicknessScale * 0.8;
+        float brightness    = brightnessRaw / (1.0 + brightnessRaw);
+
+        vec3 highlightColor = getHighlightColor(refractColor.rgb, 1.0);
+        finalColor.rgb = mix(finalColor.rgb, highlightColor, brightness);
+    }
+
+    // VQ2: Fresnel edge luminosity ramp.
+    //
+    // iOS 26 glass is subtly brighter at grazing angles (the rim) even when
+    // no directional specular highlight lands there.  This is the Fresnel term:
+    // at near-normal incidence (flat interior) reflected light is minimal;
+    // at grazing incidence (edges) it increases.
+    //
+    // normalZ → 0 at the rim (surface nearly perpendicular to view ray),
+    // normalZ → 1 at flat interior (surface facing the camera directly).
+    // So (1.0 - normalZ) gives a smooth 0→1 ramp from interior to rim.
+    //
+    // Gated by edgeFactor so the effect is naturally confined to the rim zone
+    // and doesn't accumulate on interior pixels where edgeFactor ≈ 0.
+    //
+    // Strength 0.10 produces a gentle brightening calibrated against Apple
+    // reference screenshots. Fully branchless — no extra GPU divergence.
+    // Fresnel strength 0.12 (was 0.10 in the calibration build).
+    // The extra 0.02 restores the subtle rim luminosity that the geometry AA band
+    // experiment temporarily reduced — keeping the glass edge visually present
+    // against dark bar backgrounds without making it glowing or harsh.
+    float rimBase = (1.0 - normalZ) * edgeFactor;
+    // uAmbientRim > 0 draws an ADDITIONAL rim band of that width (in the
+    // SDF's pixel units). The stock Fresnel profile cannot be widened by
+    // intensity scaling: within the circular bevel normalizedHeight == normalZ
+    // == sqrt(1-((T-d)/T)^2), which rises so steeply that the edgeFactor gate
+    // confines (1-normalZ)*edgeFactor to the outer ~10% of the bevel — a
+    // hairline. Inverting that profile recovers the true distance from the
+    // shape edge, d = T*(1-sqrt(1-h^2)), so the band below has an exact,
+    // thickness-independent geometric width with a ±0.75px AA edge.
+    // At uAmbientRim = 0 rendering is exactly stock.
+    float cosTerm = sqrt(max(0.0, 1.0 - normalizedHeight * normalizedHeight));
+    float rimDist = uThickness * (1.0 - cosTerm);
+    float ring    = (1.0 - smoothstep(uAmbientRim - 0.75, uAmbientRim + 0.75, rimDist))
+                  * step(0.001, uAmbientRim);
+    float fresnel = rimBase * 0.12 + ring * 0.45;
+    finalColor.rgb = clamp(finalColor.rgb + vec3(fresnel), 0.0, 1.0);
+
+    float alpha  = geometryData.a;
+    fragColor    = vec4(finalColor.rgb * alpha, alpha);
+}
+

--- a/packages/liquid_glass_widgets/shaders/liquid_glass_geometry_blended.frag
+++ b/packages/liquid_glass_widgets/shaders/liquid_glass_geometry_blended.frag
@@ -1,0 +1,103 @@
+// Copyright 2025, Tim Lehmann for whynotmake.it
+//
+// Geometry precomputation shader for blended liquid glass shapes
+// This shader pre-computes the surface normal and encodes it into a texture.
+// Only needs to be re-run when shape geometry or layout changes.
+//
+// Texture layout (slots → displacement_encoding.glsl):
+//   R: normal.x  [-1, 1] → [0, 1]
+//   G: normal.y  [-1, 1] → [0, 1]
+//   B: height    normalized to thickness
+//   A: foreground alpha (SDF anti-aliasing)
+
+#version 460 core
+precision highp float; // mediump caused ~1.5px displacement banding on mobile (10-bit mantissa)
+
+#include <flutter/runtime_effect.glsl>
+
+// MAX_SHAPES must be defined before uShapeData so the array size is known.
+// sdf.glsl uses an #ifndef guard so this definition takes precedence.
+#define MAX_SHAPES 16
+
+layout(location = 0) uniform vec2 uSize;
+layout(location = 1) uniform vec4 uOpticalProps;
+layout(location = 2) uniform vec2 uShapeSettings; // x = numShapes, y = dpr
+layout(location = 3) uniform float uShapeData[MAX_SHAPES * 7];
+
+// sdf.glsl functions access uShapeData as a global (no array-by-value parameters,
+// which are rejected by glslang on Windows/Vulkan SPIR-V compilation).
+#include "sdf.glsl"
+#include "displacement_encoding.glsl"
+
+layout(location = 0) out vec4 fragColor;
+
+void main() {
+    // Unpacked here rather than at global scope: global non-constant initialisers
+    // (e.g. float x = uniform.y) are valid in desktop GLSL 4.6 but rejected by
+    // SkSL / glslang on Windows.
+    float uThickness = uOpticalProps.z;
+    float uBlend = uOpticalProps.w;
+
+    float uNumShapes = uShapeSettings.x;
+    float uDpr = uShapeSettings.y;
+
+    vec2 fragCoord = FlutterFragCoord().xy;
+
+    float sd = sceneSDF(fragCoord, int(uNumShapes), uBlend);
+
+    // Apply logical-pixel anti-aliasing.
+    // Centering the smoothstep around 0.0 ensures the mathematical boundary (sd=0)
+    // is exactly 50% opaque. This correctly aligns the peak edge highlight with
+    // the visual edge of the shape, restoring maximum brightness.
+    // 1.5 logical pixels of smoothing guarantees a pristine edge that survives
+    // the 4% bilinear scaling of press animations without stair-stepping.
+    float smoothing = 1.5 * max(1.0, uDpr);
+    float foregroundAlpha = smoothstep(smoothing * 0.5, -smoothing * 0.5, sd);
+    if (foregroundAlpha < 0.01) {
+        fragColor = vec4(0.0);
+        return;
+    }
+
+    // Compute the SDF gradient for surface normal generation.
+    //
+    // We MUST use central ±0.5 px finite differences on ALL platforms.
+    // While Metal supports dFdx/dFdy on scalar floats, hardware derivatives are
+    // computed in 2x2 pixel quads, resulting in blocky 2x2 normals. When these
+    // blocky normals refract high-contrast edges (like the base pill's white rim),
+    // they produce severe stair-step aliasing.
+    // Central differences guarantee a perfectly smooth, continuous normal per-pixel.
+    //
+    // PP4: Reduce 5 sceneSDF() calls to 4 by approximating the center sample
+    // from the average of the 4 offset samples. The approximation error is ~0.5%
+    // — below the AA smoothstep band and imperceptible in the alpha/height output.
+    // For a blend group with N shapes this saves N smooth-union evaluations.
+    float sdPX = sceneSDF(fragCoord + vec2(0.5, 0.0), int(uNumShapes), uBlend);
+    float sdMX = sceneSDF(fragCoord - vec2(0.5, 0.0), int(uNumShapes), uBlend);
+    float sdPY = sceneSDF(fragCoord + vec2(0.0, 0.5), int(uNumShapes), uBlend);
+    float sdMY = sceneSDF(fragCoord - vec2(0.0, 0.5), int(uNumShapes), uBlend);
+    sd = (sdPX + sdMX + sdPY + sdMY) * 0.25; // reassign center approximation
+    float dx = sdPX - sdMX;
+    float dy = sdPY - sdMY;
+
+    float n_cos = max(uThickness + sd, 0.0) / uThickness;
+    float n_sin = sqrt(max(0.0, 1.0 - n_cos * n_cos));
+
+    // True surface normal from the SDF gradient — this is what we store.
+    // In blend-group neck zones the displacement vector diverges from this
+    // normal, which is why storing the normal (not displacement) fixes lighting.
+    vec3 normal = normalize(vec3(dx * n_cos, dy * n_cos, n_sin));
+
+    if (sd >= 0.0 || uThickness <= 0.0) {
+        fragColor = vec4(0.0);
+        return;
+    }
+
+    float x = uThickness + sd;
+    float sqrtTerm = sqrt(max(0.0, uThickness * uThickness - x * x));
+    float height = mix(sqrtTerm, uThickness, float(sd < -uThickness));
+
+    // Encode normal.xy + height + alpha.
+    // The render pass recomputes displacement = refract(incident, normal, 1/n)
+    // so there is no information loss compared to storing displacement directly.
+    fragColor = encodeGeometryData(normal.xy, height, uThickness, foregroundAlpha);
+}

--- a/packages/liquid_glass_widgets/shaders/render.glsl
+++ b/packages/liquid_glass_widgets/shaders/render.glsl
@@ -1,0 +1,79 @@
+// Copyright 2025, Tim Lehmann for whynotmake.it
+//
+// Shared rendering functions for liquid glass shaders.
+//
+// Functions used by liquid_glass_final_render.frag:
+//   getHighlightColor  — adaptive specular highlight tint
+//   applySaturation    — Rec. 709 saturation matrix
+//   applyGlassColor    — iOS 26 luminosity-preserving tint
+
+// Constants
+const vec3 LUMA_WEIGHTS = vec3(0.299, 0.587, 0.114);
+
+// NOTE: rotate2d() was removed — it was never called by any shader and was
+// compiled into every shader binary that includes render.glsl for no benefit.
+
+// ── getHighlightColor ─────────────────────────────────────────────────────────
+// Optimized highlight color - ~60% fewer operations than original version.
+// Computes a luminosity-tinted white using a fast rational approximation for
+// the lum/saturation blend weight instead of the slower smoothstep path.
+vec3 getHighlightColor(vec3 backgroundColor, float targetBrightness) {
+    float luminance = dot(backgroundColor, LUMA_WEIGHTS);
+    
+    // Fast saturation approximation using max component only
+    float maxComponent = max(max(backgroundColor.r, backgroundColor.g), backgroundColor.b);
+    
+    // Combined color influence factor using fast rational approximation
+    // x/(1+x) is faster than smoothstep and visually similar
+    float lum = luminance * 2.5;
+    float lumFactor = lum / (1.0 + lum);
+    
+    float sat = maxComponent * 2.5;
+    float satFactor = sat / (1.0 + sat);
+    
+    float colorInfluence = lumFactor * satFactor;
+    
+    // Normalize and tint in one step
+    vec3 tinted = (backgroundColor / max(luminance, 0.001)) * targetBrightness;
+    
+    return mix(vec3(targetBrightness), tinted, colorInfluence);
+}
+
+// ── applySaturation ───────────────────────────────────────────────────────────
+// Rec. 709 luminance-preserving saturation.
+// saturation = 1.0 → no change; > 1.0 → over-saturated; < 1.0 → desaturated.
+vec3 applySaturation(vec3 color, float saturation) {
+    float luminance = dot(color, LUMA_WEIGHTS);
+    vec3 saturatedColor = mix(vec3(luminance), color, saturation);
+    return clamp(saturatedColor, 0.0, 1.0);
+}
+
+// ── applyGlassColor ───────────────────────────────────────────────────────────
+// Apply glass color tinting to the liquid color.
+// iOS 26 model: chromatic glass (blue, amber) preserves backdrop luminance while
+// shifting hue — unlike Overlay which produced unintuitive darkening/brightening.
+// Achromatic glass (white, grey, black) uses a direct alpha-composite mix so
+// that white glass actually lifts toward white (brightness effect). Without this,
+// whites collapse to a luminance-matched grey and can never frost the surface.
+// The chroma factor blends smoothly between the two paths — fully branchless.
+// glassColor.a = 0 naturally returns liquidColor via mix() in both paths.
+vec4 applyGlassColor(vec4 liquidColor, vec4 glassColor) {
+    float backdropLuminance = dot(liquidColor.rgb, LUMA_WEIGHTS);
+    float glassLuminance    = dot(glassColor.rgb, LUMA_WEIGHTS);
+
+    // Luminosity-preserving tint: shift chroma toward glass, keep backdrop brightness.
+    vec3 tinted = clamp(glassColor.rgb + (backdropLuminance - glassLuminance), 0.0, 1.0);
+
+    // Chroma of the glass colour: 0 = achromatic (white/grey/black), 1 = fully saturated.
+    // Use a sharp ramp so anything with meaningful colour uses the luminosity path.
+    float chroma = max(max(glassColor.r, glassColor.g), glassColor.b)
+                 - min(min(glassColor.r, glassColor.g), glassColor.b);
+    float chromaWeight = clamp(chroma * 8.0, 0.0, 1.0);
+
+    // achromatic path: direct mix toward the glass colour (white lifts to white)
+    vec3 directMix     = mix(liquidColor.rgb, glassColor.rgb, glassColor.a);
+    // chromatic path:  mix toward luminosity-shifted tint (hue shift, brightness held)
+    vec3 luminosityMix = mix(liquidColor.rgb, tinted, glassColor.a);
+
+    return vec4(mix(directMix, luminosityMix, chromaWeight), liquidColor.a);
+}

--- a/packages/liquid_glass_widgets/shaders/sdf.glsl
+++ b/packages/liquid_glass_widgets/shaders/sdf.glsl
@@ -1,0 +1,384 @@
+// Copyright 2025, Tim Lehmann for whynotmake.it
+// Modified 2026 by Sebastian Degenaar (liquid_glass_widgets)
+//
+// SDF primitives and scene composition for liquid glass geometry shaders.
+//
+// ── Windows / SkSL compatibility ─────────────────────────────────────────────
+// SkSL (Skia's shader language, used on Windows) compiles GLSL to SPIR-V via
+// glslang.  glslang enforces the GLSL ES 1.0 rule that array indices MUST be
+// constant-integral-expressions.  Computing `index * 6 + offset` at runtime
+// and using the result to index uShapeData[] fails with:
+//   error: index expression must be constant
+//
+// Fix: every uShapeData[] access uses a literal integer index only.
+// getShapeSDFFromArray() is gone; sdf0()…sdf15() helpers expand each
+// shape slot with hardcoded literal offsets so glslang sees only constants.
+// sceneSDF is fully unrolled — no for-loops, no dynamic indexing.
+//
+// ── Backward pass correctness ─────────────────────────────────────────────────
+// The symmetric bidirectional blend is a left-fold in both directions:
+//   fwd(n) = leftFold(smoothUnion, [s0, s1, …, s_{n-1}], k)
+//   bwd(n) = leftFold(smoothUnion, [s_{n-1}, s_{n-2}, …, s0], k)
+// result  = mix(fwd, bwd, 0.5)
+//
+// The backward pass for each n is computed with named intermediate variables
+// rather than deeply-nested call expressions, so the GLSL parser never sees
+// expression depth > 3 regardless of n.  This avoids the "exceeded max parse
+// depth" error that the user-attempted loop-expansion triggered.
+//
+// ── Shape slots ──────────────────────────────────────────────────────────────
+// Each shape occupies 7 consecutive floats in uShapeData[]:
+//   [base+0] type             1=squircle/superellipse  2=ellipse  3=roundrect
+//   [base+1] center.x
+//   [base+2] center.y
+//   [base+3] size.x
+//   [base+4] size.y
+//   [base+5] cornerRadius     (top corners; or symmetric)
+//   [base+6] bottomCornerRadius (bottom corners; equals [base+5] for symmetric)
+
+#ifndef MAX_SHAPES
+#define MAX_SHAPES 16
+#endif
+
+// ── SDF primitives ────────────────────────────────────────────────────────────
+
+float sdfRRect(in vec2 p, in vec2 b, in float r) {
+    float shortest = min(b.x, b.y);
+    r = min(r, shortest);
+    vec2 q = abs(p) - b + r;
+    return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r;
+}
+
+// Asymmetric rounded-rect SDF: independent top/bottom corner radii.
+//
+// Computes two `sdfRRect` evaluations (one with rTop applied to all corners,
+// one with rBottom) and `mix`es them along p.y with a smooth `smoothstep`
+// across the horizontal centerline. This keeps the SDF — and therefore its
+// gradient — continuous across the centerline, which matters for the
+// geometry-blended pipeline that derives surface normals from dFdx/dFdy of
+// the SDF: a per-quadrant `r = p.y < 0 ? rTop : rBottom` lookup would emit
+// garbage normals along the centerline. 2-pixel half-width matches the
+// typical anti-aliasing band on Skia/Impeller.
+//
+// Outside the corner regions both inner SDFs agree (the radius doesn't enter
+// the distance formula along the straight edges), so the blend is a no-op
+// there and only the corner regions actually differ. When rTop == rBottom,
+// dT == dB and `mix` returns either value unchanged — symmetric shapes are
+// bit-exact identical to a plain `sdfRRect(p, b, r)` call.
+float sdfRRectAsym(in vec2 p, in vec2 b, in float rTop, in float rBottom) {
+    float dT = sdfRRect(p, b, rTop);
+    float dB = sdfRRect(p, b, rBottom);
+    float t = smoothstep(-2.0, 2.0, p.y);
+    return mix(dT, dB, t);
+}
+
+float sdfRect(vec2 p, vec2 b) {
+    vec2 d = abs(p) - b;
+    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
+}
+
+// NOTE: sdfSquircle removed — byte-for-byte identical to sdfRRect.
+// Both squircle/superellipse and rounded-rect route through sdfRRect.
+
+float sdfEllipse(vec2 p, vec2 r) {
+    r = max(r, 1e-4);
+    vec2 invR   = 1.0 / r;
+    vec2 invR2  = invR * invR;
+    vec2 pInvR  = p * invR;
+    float k1    = length(pInvR);
+    vec2  pInvR2 = p * invR2;
+    float k2    = length(pInvR2);
+    return (k1 * (k1 - 1.0)) / max(k2, 1e-4);
+}
+
+// Branchless smooth-union.
+// When k=0: e=0, result = min(d1,d2) — identical to the branching form.
+float smoothUnion(float d1, float d2, float k) {
+    float e = max(k - abs(d1 - d2), 0.0);
+    return min(d1, d2) - e * e * 0.25 / max(k, 1e-5);
+}
+
+// ── Per-type dispatch ─────────────────────────────────────────────────────────
+
+// rTop / rBottom collapse to a single radius for symmetric shapes (caller
+// writes rBottom == rTop), so this dispatch is back-compat: routing through
+// `sdfRRectAsym` with equal radii is bit-identical to `sdfRRect`.
+float getShapeSDF(float type, vec2 p, vec2 center, vec2 size, float rTop, float rBottom) {
+    if      (type == 1.0) return sdfRRectAsym(p - center, size / 2.0, rTop, rBottom);
+    else if (type == 2.0) return sdfEllipse  (p - center, size / 2.0);
+    else if (type == 3.0) return sdfRRectAsym(p - center, size / 2.0, rTop, rBottom);
+    return 0.0;
+}
+
+// ── Constant-index shape accessors ───────────────────────────────────────────
+// Macro reads uShapeData[] with *literal* offsets only — satisfies the GLSL ES
+// / SkSL / glslang requirement that array indices be constant expressions.
+// uShapeData[] is declared by the including shader before #include "sdf.glsl".
+//
+// Stride: 7 floats per shape (was 6). Slot +6 is the bottom corner radius;
+// see the layout comment near the top of this file.
+
+#define SDF_SHAPE_N(BASE) \
+    getShapeSDF(uShapeData[BASE], p, \
+                vec2(uShapeData[BASE+1], uShapeData[BASE+2]), \
+                vec2(uShapeData[BASE+3], uShapeData[BASE+4]), \
+                uShapeData[BASE+5], \
+                uShapeData[BASE+6])
+
+float sdf0(vec2 p)  { return SDF_SHAPE_N(0);   }
+float sdf1(vec2 p)  { return SDF_SHAPE_N(7);   }
+float sdf2(vec2 p)  { return SDF_SHAPE_N(14);  }
+float sdf3(vec2 p)  { return SDF_SHAPE_N(21);  }
+float sdf4(vec2 p)  { return SDF_SHAPE_N(28);  }
+float sdf5(vec2 p)  { return SDF_SHAPE_N(35);  }
+float sdf6(vec2 p)  { return SDF_SHAPE_N(42);  }
+float sdf7(vec2 p)  { return SDF_SHAPE_N(49);  }
+float sdf8(vec2 p)  { return SDF_SHAPE_N(56);  }
+float sdf9(vec2 p)  { return SDF_SHAPE_N(63);  }
+float sdf10(vec2 p) { return SDF_SHAPE_N(70);  }
+float sdf11(vec2 p) { return SDF_SHAPE_N(77);  }
+float sdf12(vec2 p) { return SDF_SHAPE_N(84);  }
+float sdf13(vec2 p) { return SDF_SHAPE_N(91);  }
+float sdf14(vec2 p) { return SDF_SHAPE_N(98);  }
+float sdf15(vec2 p) { return SDF_SHAPE_N(105); }
+
+// ── sceneSDF — fully unrolled, no loops, no dynamic indices ──────────────────
+//
+// MAINTAINER GUIDE — READ BEFORE EDITING
+// ────────────────────────────────────────
+// This function is intentionally written in a fully-unrolled style.
+// This is NOT a code-quality issue; it is the correct cross-platform
+// approach for GLSL that must compile on both Impeller/Metal AND
+// SkSL/glslang (Windows), where dynamic array indices are illegal.
+//
+// HOW IT WORKS
+//   Symmetric bidirectional smooth-union, averaged 50/50:
+//     fwd(n) = leftFold(smoothUnion, [s0,  s1, …, s_{n-1}], k)  (L→R)
+//     bwd(n) = leftFold(smoothUnion, [s_{n-1}, …, s1,  s0], k)  (R→L)
+//     result = mix(fwd, bwd, 0.5)
+//   This cancels the blend-influence asymmetry in multi-shape groups.
+//   For n=2 smoothUnion is commutative so fwd==bwd (no visual change vs n=1).
+//
+// WHAT IS SAFE TO CHANGE — single touch points that propagate everywhere:
+//   • Shape type logic        → edit getShapeSDF()     above
+//   • Blend formula           → edit smoothUnion()     above
+//   • Shape data layout       → edit SDF_SHAPE_N macro above (and sdf0…sdf15)
+//
+// WHAT REQUIRES UNROLL UPDATE — mechanical but must be consistent:
+//   • Increasing MAX_SHAPES   → add sdfN() below, add one more n==N block
+//     with the same bNa/bNb/… intermediate-variable pattern shown for n=16.
+//   • Changing the fwd/bwd averaging strategy → update all 16 n-blocks;
+//     they all follow the same pattern so find-replace is reliable.
+//
+// WHY NOT #ifdef IMPELLER_TARGET_METAL + dynamic fallback?
+//   That would require maintaining two separate algorithm copies that must
+//   be kept in sync — a higher maintenance burden than the unrolled form.
+//   The literal-index version is equally or more efficient on Metal too,
+//   since the compiler can constant-fold and prefetch known offsets.
+
+float sceneSDF(vec2 p, int n, float k) {
+    if (n <= 0) return 1e9;
+
+    // ── n = 1 ────────────────────────────────────────────────────────────────
+    float s0 = sdf0(p);
+    if (n == 1) return s0;
+
+    // ── n = 2 ────────────────────────────────────────────────────────────────
+    float s1  = sdf1(p);
+    float fwd = smoothUnion(s0, s1, k);
+    // bwd(2): smooth(s1, s0) — smoothUnion is commutative for n=2
+    float bwd = smoothUnion(s1, s0, k);
+    if (n == 2) return mix(fwd, bwd, 0.5);
+
+    // ── n = 3 ────────────────────────────────────────────────────────────────
+    float s2  = sdf2(p);
+    fwd = smoothUnion(fwd, s2, k);
+    // bwd(3): leftFold([s2, s1, s0])
+    // = smooth(smooth(s2, s1), s0)
+    float b3a = smoothUnion(s2, s1, k);
+    bwd       = smoothUnion(b3a, s0, k);
+    if (n == 3) return mix(fwd, bwd, 0.5);
+
+    // ── n = 4 ────────────────────────────────────────────────────────────────
+    float s3  = sdf3(p);
+    fwd = smoothUnion(fwd, s3, k);
+    // bwd(4): smooth(smooth(smooth(s3, s2), s1), s0)
+    float b4a = smoothUnion(s3, s2, k);
+    float b4b = smoothUnion(b4a, s1, k);
+    bwd       = smoothUnion(b4b, s0, k);
+    if (n == 4) return mix(fwd, bwd, 0.5);
+
+    // ── n = 5 ────────────────────────────────────────────────────────────────
+    float s4  = sdf4(p);
+    fwd = smoothUnion(fwd, s4, k);
+    float b5a = smoothUnion(s4, s3, k);
+    float b5b = smoothUnion(b5a, s2, k);
+    float b5c = smoothUnion(b5b, s1, k);
+    bwd       = smoothUnion(b5c, s0, k);
+    if (n == 5) return mix(fwd, bwd, 0.5);
+
+    // ── n = 6 ────────────────────────────────────────────────────────────────
+    float s5  = sdf5(p);
+    fwd = smoothUnion(fwd, s5, k);
+    float b6a = smoothUnion(s5, s4, k);
+    float b6b = smoothUnion(b6a, s3, k);
+    float b6c = smoothUnion(b6b, s2, k);
+    float b6d = smoothUnion(b6c, s1, k);
+    bwd       = smoothUnion(b6d, s0, k);
+    if (n == 6) return mix(fwd, bwd, 0.5);
+
+    // ── n = 7 ────────────────────────────────────────────────────────────────
+    float s6  = sdf6(p);
+    fwd = smoothUnion(fwd, s6, k);
+    float b7a = smoothUnion(s6, s5, k);
+    float b7b = smoothUnion(b7a, s4, k);
+    float b7c = smoothUnion(b7b, s3, k);
+    float b7d = smoothUnion(b7c, s2, k);
+    float b7e = smoothUnion(b7d, s1, k);
+    bwd       = smoothUnion(b7e, s0, k);
+    if (n == 7) return mix(fwd, bwd, 0.5);
+
+    // ── n = 8 ────────────────────────────────────────────────────────────────
+    float s7  = sdf7(p);
+    fwd = smoothUnion(fwd, s7, k);
+    float b8a = smoothUnion(s7, s6, k);
+    float b8b = smoothUnion(b8a, s5, k);
+    float b8c = smoothUnion(b8b, s4, k);
+    float b8d = smoothUnion(b8c, s3, k);
+    float b8e = smoothUnion(b8d, s2, k);
+    float b8f = smoothUnion(b8e, s1, k);
+    bwd       = smoothUnion(b8f, s0, k);
+    if (n == 8) return mix(fwd, bwd, 0.5);
+
+    // ── n = 9 ────────────────────────────────────────────────────────────────
+    float s8  = sdf8(p);
+    fwd = smoothUnion(fwd, s8, k);
+    float b9a = smoothUnion(s8, s7, k);
+    float b9b = smoothUnion(b9a, s6, k);
+    float b9c = smoothUnion(b9b, s5, k);
+    float b9d = smoothUnion(b9c, s4, k);
+    float b9e = smoothUnion(b9d, s3, k);
+    float b9f = smoothUnion(b9e, s2, k);
+    float b9g = smoothUnion(b9f, s1, k);
+    bwd       = smoothUnion(b9g, s0, k);
+    if (n == 9) return mix(fwd, bwd, 0.5);
+
+    // ── n = 10 ───────────────────────────────────────────────────────────────
+    float s9   = sdf9(p);
+    fwd = smoothUnion(fwd, s9, k);
+    float b10a = smoothUnion(s9, s8, k);
+    float b10b = smoothUnion(b10a, s7, k);
+    float b10c = smoothUnion(b10b, s6, k);
+    float b10d = smoothUnion(b10c, s5, k);
+    float b10e = smoothUnion(b10d, s4, k);
+    float b10f = smoothUnion(b10e, s3, k);
+    float b10g = smoothUnion(b10f, s2, k);
+    float b10h = smoothUnion(b10g, s1, k);
+    bwd        = smoothUnion(b10h, s0, k);
+    if (n == 10) return mix(fwd, bwd, 0.5);
+
+    // ── n = 11 ───────────────────────────────────────────────────────────────
+    float s10   = sdf10(p);
+    fwd = smoothUnion(fwd, s10, k);
+    float b11a  = smoothUnion(s10, s9, k);
+    float b11b  = smoothUnion(b11a, s8, k);
+    float b11c  = smoothUnion(b11b, s7, k);
+    float b11d  = smoothUnion(b11c, s6, k);
+    float b11e  = smoothUnion(b11d, s5, k);
+    float b11f  = smoothUnion(b11e, s4, k);
+    float b11g  = smoothUnion(b11f, s3, k);
+    float b11h  = smoothUnion(b11g, s2, k);
+    float b11i  = smoothUnion(b11h, s1, k);
+    bwd         = smoothUnion(b11i, s0, k);
+    if (n == 11) return mix(fwd, bwd, 0.5);
+
+    // ── n = 12 ───────────────────────────────────────────────────────────────
+    float s11   = sdf11(p);
+    fwd = smoothUnion(fwd, s11, k);
+    float b12a  = smoothUnion(s11, s10, k);
+    float b12b  = smoothUnion(b12a, s9, k);
+    float b12c  = smoothUnion(b12b, s8, k);
+    float b12d  = smoothUnion(b12c, s7, k);
+    float b12e  = smoothUnion(b12d, s6, k);
+    float b12f  = smoothUnion(b12e, s5, k);
+    float b12g  = smoothUnion(b12f, s4, k);
+    float b12h  = smoothUnion(b12g, s3, k);
+    float b12i  = smoothUnion(b12h, s2, k);
+    float b12j  = smoothUnion(b12i, s1, k);
+    bwd         = smoothUnion(b12j, s0, k);
+    if (n == 12) return mix(fwd, bwd, 0.5);
+
+    // ── n = 13 ───────────────────────────────────────────────────────────────
+    float s12   = sdf12(p);
+    fwd = smoothUnion(fwd, s12, k);
+    float b13a  = smoothUnion(s12, s11, k);
+    float b13b  = smoothUnion(b13a, s10, k);
+    float b13c  = smoothUnion(b13b, s9, k);
+    float b13d  = smoothUnion(b13c, s8, k);
+    float b13e  = smoothUnion(b13d, s7, k);
+    float b13f  = smoothUnion(b13e, s6, k);
+    float b13g  = smoothUnion(b13f, s5, k);
+    float b13h  = smoothUnion(b13g, s4, k);
+    float b13i  = smoothUnion(b13h, s3, k);
+    float b13j  = smoothUnion(b13i, s2, k);
+    float b13k  = smoothUnion(b13j, s1, k);
+    bwd         = smoothUnion(b13k, s0, k);
+    if (n == 13) return mix(fwd, bwd, 0.5);
+
+    // ── n = 14 ───────────────────────────────────────────────────────────────
+    float s13   = sdf13(p);
+    fwd = smoothUnion(fwd, s13, k);
+    float b14a  = smoothUnion(s13, s12, k);
+    float b14b  = smoothUnion(b14a, s11, k);
+    float b14c  = smoothUnion(b14b, s10, k);
+    float b14d  = smoothUnion(b14c, s9, k);
+    float b14e  = smoothUnion(b14d, s8, k);
+    float b14f  = smoothUnion(b14e, s7, k);
+    float b14g  = smoothUnion(b14f, s6, k);
+    float b14h  = smoothUnion(b14g, s5, k);
+    float b14i  = smoothUnion(b14h, s4, k);
+    float b14j  = smoothUnion(b14i, s3, k);
+    float b14k  = smoothUnion(b14j, s2, k);
+    float b14l  = smoothUnion(b14k, s1, k);
+    bwd         = smoothUnion(b14l, s0, k);
+    if (n == 14) return mix(fwd, bwd, 0.5);
+
+    // ── n = 15 ───────────────────────────────────────────────────────────────
+    float s14   = sdf14(p);
+    fwd = smoothUnion(fwd, s14, k);
+    float b15a  = smoothUnion(s14, s13, k);
+    float b15b  = smoothUnion(b15a, s12, k);
+    float b15c  = smoothUnion(b15b, s11, k);
+    float b15d  = smoothUnion(b15c, s10, k);
+    float b15e  = smoothUnion(b15d, s9, k);
+    float b15f  = smoothUnion(b15e, s8, k);
+    float b15g  = smoothUnion(b15f, s7, k);
+    float b15h  = smoothUnion(b15g, s6, k);
+    float b15i  = smoothUnion(b15h, s5, k);
+    float b15j  = smoothUnion(b15i, s4, k);
+    float b15k  = smoothUnion(b15j, s3, k);
+    float b15l  = smoothUnion(b15k, s2, k);
+    float b15m  = smoothUnion(b15l, s1, k);
+    bwd         = smoothUnion(b15m, s0, k);
+    if (n == 15) return mix(fwd, bwd, 0.5);
+
+    // ── n = 16 (MAX_SHAPES) ───────────────────────────────────────────────────
+    float s15   = sdf15(p);
+    fwd = smoothUnion(fwd, s15, k);
+    float b16a  = smoothUnion(s15, s14, k);
+    float b16b  = smoothUnion(b16a, s13, k);
+    float b16c  = smoothUnion(b16b, s12, k);
+    float b16d  = smoothUnion(b16c, s11, k);
+    float b16e  = smoothUnion(b16d, s10, k);
+    float b16f  = smoothUnion(b16e, s9, k);
+    float b16g  = smoothUnion(b16f, s8, k);
+    float b16h  = smoothUnion(b16g, s7, k);
+    float b16i  = smoothUnion(b16h, s6, k);
+    float b16j  = smoothUnion(b16i, s5, k);
+    float b16k  = smoothUnion(b16j, s4, k);
+    float b16l  = smoothUnion(b16k, s3, k);
+    float b16m  = smoothUnion(b16l, s2, k);
+    float b16n  = smoothUnion(b16m, s1, k);
+    bwd         = smoothUnion(b16n, s0, k);
+    return mix(fwd, bwd, 0.5);
+}

--- a/packages/liquid_glass_widgets/test/fallback_rendering_regression_test.dart
+++ b/packages/liquid_glass_widgets/test/fallback_rendering_regression_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/widgets/shared/glass_effect.dart';
+import 'package:liquid_glass_widgets/widgets/shared/liquid_shape_shader_geometry.dart';
+
+void main() {
+  test('LiquidOval resolves to a circular shader radius', () {
+    expect(
+      resolveLiquidShapeCornerRadius(
+        const LiquidOval(),
+        const Size.square(40),
+      ),
+      20,
+    );
+  });
+
+  test('rounded shader radii are clamped to the surface bounds', () {
+    expect(
+      resolveLiquidShapeCornerRadius(
+        const LiquidRoundedSuperellipse(borderRadius: 999),
+        const Size(40, 24),
+      ),
+      12,
+    );
+  });
+
+  testWidgets('lightweight glass retains its backdrop layer across repaints',
+      (tester) async {
+    LightweightLiquidGlass.resetForTesting();
+    await LightweightLiquidGlass.preWarm();
+    final glow = ValueNotifier<double>(0);
+    addTearDown(glow.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: ValueListenableBuilder<double>(
+            valueListenable: glow,
+            builder: (context, value, child) => SizedBox.square(
+              dimension: 40,
+              child: LightweightLiquidGlass(
+                shape: const LiquidOval(),
+                settings: const LiquidGlassSettings(blur: 6),
+                glowIntensity: value,
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final firstLayer = _onlyBackdropLayer(tester);
+
+    glow.value = 0.5;
+    await tester.pump();
+    final secondLayer = _onlyBackdropLayer(tester);
+
+    expect(identical(firstLayer, secondLayer), isTrue);
+  });
+
+  testWidgets('interactive glass retains its backdrop layer across repaints',
+      (tester) async {
+    await GlassEffect.preWarm();
+    final intensity = ValueNotifier<double>(0.25);
+    final backgroundKey = GlobalKey();
+    addTearDown(intensity.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Stack(
+          children: [
+            Positioned.fill(
+              child: RepaintBoundary(
+                key: backgroundKey,
+                child: const ColoredBox(color: Colors.blue),
+              ),
+            ),
+            Center(
+              child: ValueListenableBuilder<double>(
+                valueListenable: intensity,
+                builder: (context, value, child) => SizedBox(
+                  width: 120,
+                  height: 36,
+                  child: GlassEffect(
+                    shape: const LiquidRoundedSuperellipse(borderRadius: 18),
+                    settings: const LiquidGlassSettings(blur: 6),
+                    interactionIntensity: value,
+                    backgroundKey: backgroundKey,
+                    child: const SizedBox.expand(),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    final firstLayer = _onlyBackdropLayer(tester);
+
+    intensity.value = 0.75;
+    await tester.pump();
+    final secondLayer = _onlyBackdropLayer(tester);
+
+    expect(identical(firstLayer, secondLayer), isTrue);
+  });
+}
+
+BackdropFilterLayer _onlyBackdropLayer(WidgetTester tester) {
+  final rootLayer = tester.binding.renderViews.single.debugLayer;
+  expect(rootLayer, isNotNull);
+  final allLayers = <Layer>[
+    rootLayer!,
+    ...rootLayer.depthFirstIterateChildren(),
+  ];
+  final layers = allLayers.whereType<BackdropFilterLayer>().toList();
+  expect(layers, hasLength(1));
+  return layers.single;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -790,10 +790,9 @@ packages:
   liquid_glass_widgets:
     dependency: "direct main"
     description:
-      name: liquid_glass_widgets
-      sha256: "0641f378af6e69455fe5c57717c8640792ae5ce1201a6e1fbb9733cb40901c22"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/liquid_glass_widgets"
+      relative: true
+    source: path
     version: "0.21.3"
   logging:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -238,6 +238,9 @@ flutter:
 
 # Add dependency_overrides for all media_kit related packages
 dependency_overrides:
+  # Forked from 0.21.3 to fix obfuscated shape geometry and retain Android blur layers.
+  liquid_glass_widgets:
+    path: packages/liquid_glass_widgets
   media_kit:
     path: packages/media_kit
   media_kit_video:

--- a/test/cupertino_glass_navigation_insets_test.dart
+++ b/test/cupertino_glass_navigation_insets_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/themes/cupertino/utils/cupertino_glass_navigation_insets.dart';
+
+void main() {
+  group('resolveGlassTabBarBottomOffset', () {
+    test('fully clears Android three-button navigation', () {
+      expect(
+        resolveGlassTabBarBottomOffset(
+          viewPaddingBottom: 48,
+        ),
+        54,
+      );
+    });
+
+    test('fully clears Android gesture navigation', () {
+      expect(
+        resolveGlassTabBarBottomOffset(
+          viewPaddingBottom: 24,
+        ),
+        30,
+      );
+    });
+
+    test('fully clears the iOS home indicator', () {
+      expect(
+        resolveGlassTabBarBottomOffset(
+          viewPaddingBottom: 34,
+        ),
+        40,
+      );
+    });
+
+    test('uses the edge gap when there is no bottom inset', () {
+      expect(
+        resolveGlassTabBarBottomOffset(
+          viewPaddingBottom: 0,
+        ),
+        6,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- keep the fallback liquid-glass tab bar above the complete Android/iOS bottom safe area with a consistent 6 logical-pixel gap
- vendor `liquid_glass_widgets` 0.21.3 so NipaPlay can patch the fallback renderer directly
- resolve circle and rounded-rectangle shader geometry with concrete shape types instead of runtime class-name strings
- retain lightweight and interactive `BackdropFilterLayer` instances across animated repaints
- preserve the existing liquid-glass effects, route transitions, and segmented-control behavior

## Root causes

The tab bar previously subtracted 8 pixels from larger bottom insets. That pushed it into Android three-button navigation and left gesture-navigation/iOS fallback layouts too close to the bottom edge.

The fallback shader inferred its corner radius from `runtimeType.toString()`. Android release CI builds use Dart obfuscation, so the shape name is not stable and a `LiquidOval` could be treated as a rectangle. The circular outer clip then cut the four corners off the rectangular specular rim.

The anime-detail sheet jank was raster/compositor bound rather than caused by its business layout. A captured timeline showed low UI build times while `GPURasterizer::Draw` reached roughly 255 ms. Both fallback render objects allocated a new backdrop-filter layer on every route/spring repaint, discarding the reusable engine layer during the sheet animation.

## Validation

- `flutter test test/cupertino_glass_navigation_insets_test.dart`
- `flutter test test/fallback_rendering_regression_test.dart` in `packages/liquid_glass_widgets`
- `flutter analyze lib test` in `packages/liquid_glass_widgets`
- `flutter build bundle --debug --no-pub`
- visually verified the circular sheet button and bottom safe-area placement on the Android emulator

The new package tests cover obfuscation-safe oval radius resolution and verify that both fallback renderers keep the same backdrop-filter layer across repaints.
