### PR TITLE
[Bug] fix(ios): resolve web compilation error and lipo thin-payload error

### DIFF
--- a/lib/utils/remote_media_fetcher.dart
+++ b/lib/utils/remote_media_fetcher.dart
@@ -39,7 +39,7 @@ class RemoteMediaFetcher {
         );
         return RemoteMediaHead(
           fileName: result.fileName,
-          fileSize: result.fileSize,
+          fileSize: result.fileSize.toInt(),
           headBytes: Uint8List(0),
           bytesHashed: result.bytesHashed,
           hash: result.hash,

--- a/thin-payload.sh
+++ b/thin-payload.sh
@@ -9,7 +9,11 @@ foreachThin(){
            if [ "$mime" == 'application/x-mach-binary' ]  || [ "${file##*.}"x = "dylib"x ]
            then
                 echo thin $file
-                xcrun -sdk iphoneos lipo "$file" -thin arm64 -output "$file"
+                if xcrun -sdk iphoneos lipo -info "$file" | grep -q "Architectures in the fat file"; then
+                     xcrun -sdk iphoneos lipo "$file" -thin arm64 -output "$file"
+                else
+                     echo "$file is already thin, skipping lipo"
+                fi
                 xcrun -sdk iphoneos bitcode_strip "$file" -r -o  "$file"
                 strip -S -x "$file" -o "$file"
            fi


### PR DESCRIPTION
Resolves the iOS build issues on main branch:
1. Web compilation type mismatch for PlatformInt64 (BigInt) by using toInt() in remote_media_fetcher.dart.
2. thin-payload.sh crash due to single-architecture frameworks being lipo'd, by checking if it is a fat binary first.