### PR TITLE
Fix iOS App Store archive signing

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -199,7 +199,6 @@ jobs:
             -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY='Apple Distribution' \
             FLUTTER_BUILD_NAME="$marketing_version" \
             FLUTTER_BUILD_NUMBER="$build_number" \
             CURRENT_PROJECT_VERSION="$build_number" \


### PR DESCRIPTION
## What changed

- Removed the global `CODE_SIGN_IDENTITY='Apple Distribution'` override from the App Store archive command.
- Kept automatic signing, the Apple team, App Store Connect API authentication, and App Store Connect export settings unchanged.

## Why

The [iOS release job](https://github.com/AimesSoft/NipaPlay-Reload/actions/runs/29743731797/job/88356477270) failed with exit code 65 because the command-line identity was applied to `Runner` and every CocoaPods target. Xcode reported conflicting provisioning settings: targets were automatically signed while `Apple Distribution` was also manually forced.

With automatic signing, Xcode should select the appropriate identity for each archive target, while `ExportOptions.plist` (`method=app-store-connect`, `signingStyle=automatic`) continues to produce the distribution-signed IPA for App Store Connect.

## Impact

- No application code or runtime behavior changes.
- No change to the public unsigned IPA build.
- Only the App Store signed archive path is affected.

## Validation

- YAML syntax parsed successfully.
- `git diff --check` passed.
- Diff contains exactly one deleted workflow argument.
- Full archive/upload requires the repository's Apple signing secrets and will be verified by the next release run.