### PR TITLE
Fix App Store notes and add iOS publish recovery

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -672,7 +672,7 @@ jobs:
             exit 1
           fi
 
-          info_plist_entry="$(unzip -Z1 "$signed_ipa" | awk '/^Payload\/[^/]+\.app\/Info\.plist$/ { print; exit }')"
+          info_plist_entry="$(unzip -Z1 "$signed_ipa" | grep -E '^Payload/[^/]+\.app/Info\.plist$' | head -n 1)"
           if [ -z "$info_plist_entry" ]; then
             echo "Unable to locate the app Info.plist inside the signed IPA." >&2
             exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,11 @@ on:
         required: true
         default: true
         type: boolean
+      publish_ios_from_run_id:
+        description: 'Publish iOS from artifacts in an existing workflow run; skips all builds when set'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: write
@@ -25,6 +30,7 @@ concurrency:
 jobs:
   Gatekeeper:
     name: Check Release Input
+    if: inputs.publish_ios_from_run_id == ''
     runs-on: ubuntu-latest
     outputs:
       triggered: ${{ steps.check.outputs.triggered }}
@@ -486,6 +492,225 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-store-release-notes
+          path: ${{ runner.temp }}/app-store-metadata
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Setup Ruby for fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install fastlane
+        run: gem install fastlane --version 2.237.0 --no-document
+
+      - name: Prepare App Store Connect API key
+        shell: bash
+        env:
+          APP_STORE_CONNECT_API_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          api_key_path="$RUNNER_TEMP/app-store-connect-api-key.json"
+          jq -n \
+            --arg key_id "$APP_STORE_CONNECT_API_KEY_ID" \
+            --arg issuer_id "$APP_STORE_CONNECT_ISSUER_ID" \
+            --arg key "$APP_STORE_CONNECT_API_PRIVATE_KEY" \
+            '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
+            > "$api_key_path"
+          chmod 600 "$api_key_path"
+          echo "APP_STORE_CONNECT_API_KEY_PATH=$api_key_path" >> "$GITHUB_ENV"
+
+      - name: Check whether this App Store build is already uploaded
+        id: existing_build
+        shell: bash
+        run: |
+          set +e
+          ruby .github/workflows/scripts/check-app-store-build.rb \
+            "$APP_STORE_CONNECT_API_KEY_PATH" \
+            "$APP_BUNDLE_ID" \
+            "$APP_VERSION" \
+            "$APP_BUILD_NUMBER"
+          status=$?
+          set -e
+
+          case "$status" in
+            0)
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              ;;
+            10)
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unable to check the existing App Store build." >&2
+              exit "$status"
+              ;;
+          esac
+
+      - name: Upload metadata, upload build, and submit for review
+        if: steps.existing_build.outputs.exists != 'true'
+        shell: bash
+        env:
+          SUBMIT_FOR_REVIEW: ${{ inputs.submit_ios_for_review }}
+        run: |
+          fastlane deliver \
+            --api_key_path "$APP_STORE_CONNECT_API_KEY_PATH" \
+            --ipa "$SIGNED_IPA" \
+            --app_identifier "$APP_BUNDLE_ID" \
+            --app_version "$APP_VERSION" \
+            --platform ios \
+            --metadata_path "$RUNNER_TEMP/app-store-metadata" \
+            --skip_screenshots true \
+            --submit_for_review "$SUBMIT_FOR_REVIEW" \
+            --automatic_release true \
+            --submission_information '{"export_compliance_uses_encryption":false}' \
+            --run_precheck_before_submit false \
+            --version_check_wait_retry_limit 10 \
+            --force true
+
+      - name: Reuse existing build, update metadata, and submit for review
+        if: steps.existing_build.outputs.exists == 'true'
+        shell: bash
+        env:
+          SUBMIT_FOR_REVIEW: ${{ inputs.submit_ios_for_review }}
+        run: |
+          fastlane deliver \
+            --api_key_path "$APP_STORE_CONNECT_API_KEY_PATH" \
+            --skip_binary_upload true \
+            --build_number "$APP_BUILD_NUMBER" \
+            --app_identifier "$APP_BUNDLE_ID" \
+            --app_version "$APP_VERSION" \
+            --platform ios \
+            --metadata_path "$RUNNER_TEMP/app-store-metadata" \
+            --skip_screenshots true \
+            --submit_for_review "$SUBMIT_FOR_REVIEW" \
+            --automatic_release true \
+            --submission_information '{"export_compliance_uses_encryption":false}' \
+            --run_precheck_before_submit false \
+            --version_check_wait_retry_limit 10 \
+            --force true
+
+      - name: Clean App Store credentials
+        if: always()
+        shell: bash
+        run: rm -f "$RUNNER_TEMP/app-store-connect-api-key.json"
+
+  Publish-iOS-Existing-Run:
+    name: Publish existing iOS artifact to App Store Connect
+    if: inputs.publish_ios_from_run_id != ''
+    runs-on: macos-26
+    timeout-minutes: 120
+    permissions:
+      actions: read
+      contents: read
+    env:
+      APP_BUNDLE_ID: com.aimessoft.nipaplay
+      APP_STORE_ZH_LOCALE: ${{ vars.APP_STORE_ZH_LOCALE || 'zh-Hans' }}
+      APP_STORE_EN_LOCALE: ${{ vars.APP_STORE_EN_LOCALE || 'en-US' }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+      AI_API_URL: ${{ vars.RELEASE_AI_API_URL }}
+      AI_MODEL: ${{ vars.RELEASE_AI_MODEL || 'gemini-3-flash-preview' }}
+      FASTLANE_SKIP_UPDATE_CHECK: "1"
+      FASTLANE_HIDE_CHANGELOG: "1"
+      FASTLANE_DISABLE_COLORS: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download signed App Store IPA from source run
+        uses: actions/download-artifact@v4
+        with:
+          name: app-store-iOS
+          path: ${{ runner.temp }}/app-store-ipa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.publish_ios_from_run_id }}
+
+      - name: Download generated GitHub release notes from source run
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes
+          path: ${{ runner.temp }}/release-notes
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.publish_ios_from_run_id }}
+
+      - name: Validate and inspect existing App Store artifact
+        shell: bash
+        env:
+          APP_STORE_CONNECT_API_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
+          AI_API_TOKEN: ${{ secrets.RELEASE_AI_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for variable_name in \
+            APP_STORE_CONNECT_API_KEY_ID \
+            APP_STORE_CONNECT_ISSUER_ID \
+            APP_STORE_CONNECT_API_PRIVATE_KEY \
+            AI_API_URL \
+            AI_MODEL \
+            AI_API_TOKEN; do
+            if [ -z "${!variable_name:-}" ]; then
+              missing+=("$variable_name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "Missing App Store publishing configuration: ${missing[*]}" >&2
+            exit 1
+          fi
+
+          signed_ipa="$(find "$RUNNER_TEMP/app-store-ipa" -maxdepth 2 -type f -name '*.ipa' -print -quit)"
+          if [ -z "$signed_ipa" ]; then
+            echo "Signed App Store IPA was not found in source run ${{ inputs.publish_ios_from_run_id }}." >&2
+            exit 1
+          fi
+
+          release_notes="$RUNNER_TEMP/release-notes/release_notes.md"
+          if [ ! -s "$release_notes" ]; then
+            echo "Generated GitHub release notes are empty." >&2
+            exit 1
+          fi
+
+          info_plist_entry="$(unzip -Z1 "$signed_ipa" | awk '/^Payload\/[^/]+\.app\/Info\.plist$/ { print; exit }')"
+          if [ -z "$info_plist_entry" ]; then
+            echo "Unable to locate the app Info.plist inside the signed IPA." >&2
+            exit 1
+          fi
+
+          info_plist="$RUNNER_TEMP/AppStore-Info.plist"
+          unzip -p "$signed_ipa" "$info_plist_entry" > "$info_plist"
+          app_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info_plist")"
+          app_build_number="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$info_plist")"
+
+          if [ -z "$app_version" ] || [ -z "$app_build_number" ]; then
+            echo "Unable to determine the version and build number from the signed IPA." >&2
+            exit 1
+          fi
+
+          echo "Publishing existing iOS artifact: version $app_version, build $app_build_number"
+          echo "SIGNED_IPA=$signed_ipa" >> "$GITHUB_ENV"
+          echo "GITHUB_RELEASE_NOTES=$release_notes" >> "$GITHUB_ENV"
+          echo "APP_VERSION=$app_version" >> "$GITHUB_ENV"
+          echo "APP_BUILD_NUMBER=$app_build_number" >> "$GITHUB_ENV"
+
+      - name: Generate Chinese and English App Store release notes
+        shell: bash
+        env:
+          AI_API_TOKEN: ${{ secrets.RELEASE_AI_TOKEN }}
+        run: |
+          python3 .github/workflows/scripts/generate-app-store-release-notes.py \
+            --source "$GITHUB_RELEASE_NOTES" \
+            --output-dir "$RUNNER_TEMP/app-store-metadata" \
+            --zh-locale "$APP_STORE_ZH_LOCALE" \
+            --en-locale "$APP_STORE_EN_LOCALE" \
+            --max-characters 4000 \
+            --max-attempts 5
+
+      - name: Upload recovered App Store release notes artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-store-release-notes-recovery-${{ github.run_id }}
           path: ${{ runner.temp }}/app-store-metadata
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/scripts/generate-app-store-release-notes.py
+++ b/.github/workflows/scripts/generate-app-store-release-notes.py
@@ -141,11 +141,13 @@ Source GitHub release notes:
 
 def shorten_prompt(language: str, previous: str, current_count: int, max_characters: int) -> str:
     language_instruction = "继续使用简体中文。" if language == "zh" else "Continue in natural US English."
+    target_characters = min(max_characters, max(1, current_count // 2))
     return f"""
 The following App Store release notes are {current_count} characters long and exceed the {max_characters}-character limit.
 {language_instruction}
-Rewrite and shorten them to no more than {max_characters} characters; aim for no more than 3600.
-Preserve the most important user-visible features and fixes.
+Rewrite them as substantially shorter iOS “What's New” copy. Cut the current length by about half and aim for no more than {target_characters} characters; never exceed {max_characters} characters.
+Use your editorial judgment to decide what iOS users need to know. Merge related items, summarize verbose details, and omit lower-priority information.
+Preserve only the most important user-visible features, improvements, and fixes.
 Return only plain text, with no Markdown headings, links, URLs, code fences, emoji, contributor names, or internal maintenance details.
 
 Text to shorten:


### PR DESCRIPTION
## What changed

- Changed overlong App Store release-note retries to target roughly half of the current character count.
- Allows the AI editor to merge related items, summarize verbose details, omit lower-priority information, and decide what iOS users need to know.
- Added a `publish_ios_from_run_id` recovery input to the release workflow.
- Recovery runs download the signed `app-store-iOS` and `release-notes` artifacts from an existing run, derive the version/build directly from the IPA, and publish without starting any platform builds.

## Why

Attempt 2 of [release run 29753516053](https://github.com/AimesSoft/NipaPlay-Reload/actions/runs/29753516053/attempts/2) generated valid Chinese notes, but the English notes remained at 4,156 characters after five retries. Rebuilding every platform merely to retry App Store metadata and submission would waste time and runner capacity.

## Recovery validation

The recovery path was exercised in [run 29765270600](https://github.com/AimesSoft/NipaPlay-Reload/actions/runs/29765270600):

- Every platform build and the normal release jobs were skipped.
- Existing signed IPA version `1.11.1`, build `997.2` was reused.
- Chinese notes passed at 1,504 characters.
- English notes were reduced from 4,707 to 2,645 characters on the first shortening retry.
- The package was successfully uploaded to App Store Connect.
- The app was successfully submitted for review with automatic release enabled.

## Impact

- No application code or IPA signing changes.
- Normal releases behave as before unless `publish_ios_from_run_id` is explicitly supplied.
- Failed App Store publishing can now be recovered without recompiling any platform.

## Validation

- Workflow YAML parsed successfully.
- Release-note script syntax compiled successfully.
- Prompt target assertions passed for Chinese and English.
- `git diff --check` passed.