### PR TITLE
feat: improve the macOS mpv danmaku console

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -15,14 +15,17 @@ class SettingsKeys {
 
   static const String fastPlaybackStartup = 'fast_playback_startup';
 
-
   // =========================== 外部播放器相关设置 ============================
 
-  static const String useExternalPlayer                        = 'external_player_enabled';                        // 是否启用外部播放器
-  static const String externalPlayerPath                       = 'external_player_path';                           // 外部播放器路径
-  static const String externalPlayerDanmakuOverlay             = 'external_player_danmaku_overlay';                // 外部播放器弹幕外挂开关 (ASS 字幕注入)
-  static const String externalPlayerAutoSwitchToDanmakuConsole = 'external_player_auto_switch_to_danmaku_console'; // 启动外部播放器后自动切换到弹幕控制台
-
+  static const String useExternalPlayer =
+      'external_player_enabled'; // 是否启用外部播放器
+  static const String externalPlayerPath = 'external_player_path'; // 外部播放器路径
+  static const String externalPlayerDanmakuOverlay =
+      'external_player_danmaku_overlay'; // 外部播放器弹幕外挂开关 (ASS 字幕注入)
+  static const String externalPlayerAutoSwitchToDanmakuConsole =
+      'external_player_auto_switch_to_danmaku_console'; // 启动外部播放器后自动切换到弹幕控制台
+  static const String externalPlayerShrinkWindow =
+      'external_player_shrink_window'; // 外部播放期间将主窗口缩至屏幕半宽
 
   /// 自定义播放器请求视频的 User-Agent（空字符串 = 用内核默认 UA）。
   static const String customPlayerUA = 'custom_player_ua';
@@ -73,52 +76,66 @@ class SettingsKeys {
 
   static const String danmakuSupersample = 'danmaku_supersample';
 
-
   // ===========================================================================
   // ============================ 弹幕相关设置 =================================
   // ===========================================================================
 
   // 弹幕基本设置
-  static const String danmakuOpacity                    = 'danmaku_opacity';                        // 透明度设置
-  static const String danmakuOutlineStyle               = 'danmaku_outline_style';                  // 描边样式设置
-  static const String danmakuVisible                    = 'danmaku_visible';                        // 可见性设置
-  static const String mergeDanmaku                      = 'merge_danmaku';                          // 合并设置
-  static const String danmakuStacking                   = 'danmaku_stacking';                       // 堆叠设置
-  static const String danmakuRandomColorEnabled         = 'danmaku_random_color_enabled';           // 随机颜色设置
-  static const String blockTopDanmaku                   = 'block_top_danmaku';                      // 屏蔽设置
-  static const String blockBottomDanmaku                = 'block_bottom_danmaku';                   // 屏蔽设置
-  static const String blockScrollDanmaku                = 'block_scroll_danmaku';                   // 屏蔽设置
-  static const String timelineDanmakuEnabled            = 'timeline_danmaku_enabled';               // 时间轴弹幕设置
-  static const String danmakuBlockWords                 = 'danmaku_block_words';                    // 弹幕屏蔽词设置
-  static const String danmakuFontSize                   = 'danmaku_font_size';                      // 字体大小设置
-  static const String danmakuFontFilePath               = 'danmaku_font_file_path';                 // 字体文件路径设置
-  static const String danmakuFontFamily                 = 'danmaku_font_family';                    // 字体族设置
-  static const String danmakuShadowStyle                = 'danmaku_shadow_style';                   // 阴影样式设置
-  static const String next2DanmakuOutlineWidth          = 'next2_danmaku_outline_width';            // 描边宽度设置
-  static const String danmakuDisplayArea                = 'danmaku_display_area';                   // 显示区域设置
-  static const String danmakuSpeedMultiplier            = 'danmaku_speed_multiplier';               // 速度倍数设置
-  static const String danmakuDfmPlusTrackGap            = 'danmaku_dfm_plus_track_gap';             // 轨道间距设置
-  static const String rememberDanmakuOffset             = 'remember_danmaku_offset';                // 记住偏移设置
-  static const String danmakuConvertToSimplified        = 'danmaku_convert_to_simplified';          // 简繁转换设置
-  static const String danmakuRenderEngine               = 'danmaku_render_engine';                  // 渲染引擎设置
-  static const String legacyDanmakuKernel               = 'danmaku_kernel';                         // 内核设置（已废弃，保留用于迁移旧设置）
-  static const String showDanmakuDensityChart           = 'show_danmaku_density_chart';             // 密度图设置
-  static const String playerTopSendDanmakuButtonVisible = 'player_top_send_danmaku_button_visible'; // 播放器顶部发送按钮可见性设置
+  static const String danmakuOpacity = 'danmaku_opacity'; // 透明度设置
+  static const String danmakuOutlineStyle = 'danmaku_outline_style'; // 描边样式设置
+  static const String danmakuVisible = 'danmaku_visible'; // 可见性设置
+  static const String mergeDanmaku = 'merge_danmaku'; // 合并设置
+  static const String danmakuStacking = 'danmaku_stacking'; // 堆叠设置
+  static const String danmakuRandomColorEnabled =
+      'danmaku_random_color_enabled'; // 随机颜色设置
+  static const String blockTopDanmaku = 'block_top_danmaku'; // 屏蔽设置
+  static const String blockBottomDanmaku = 'block_bottom_danmaku'; // 屏蔽设置
+  static const String blockScrollDanmaku = 'block_scroll_danmaku'; // 屏蔽设置
+  static const String timelineDanmakuEnabled =
+      'timeline_danmaku_enabled'; // 时间轴弹幕设置
+  static const String danmakuBlockWords = 'danmaku_block_words'; // 弹幕屏蔽词设置
+  static const String danmakuFontSize = 'danmaku_font_size'; // 字体大小设置
+  static const String danmakuFontFilePath =
+      'danmaku_font_file_path'; // 字体文件路径设置
+  static const String danmakuFontFamily = 'danmaku_font_family'; // 字体族设置
+  static const String danmakuShadowStyle = 'danmaku_shadow_style'; // 阴影样式设置
+  static const String next2DanmakuOutlineWidth =
+      'next2_danmaku_outline_width'; // 描边宽度设置
+  static const String danmakuDisplayArea = 'danmaku_display_area'; // 显示区域设置
+  static const String danmakuSpeedMultiplier =
+      'danmaku_speed_multiplier'; // 速度倍数设置
+  static const String danmakuDfmPlusTrackGap =
+      'danmaku_dfm_plus_track_gap'; // 轨道间距设置
+  static const String rememberDanmakuOffset =
+      'remember_danmaku_offset'; // 记住偏移设置
+  static const String danmakuConvertToSimplified =
+      'danmaku_convert_to_simplified'; // 简繁转换设置
+  static const String danmakuRenderEngine = 'danmaku_render_engine'; // 渲染引擎设置
+  static const String legacyDanmakuKernel =
+      'danmaku_kernel'; // 内核设置（已废弃，保留用于迁移旧设置）
+  static const String showDanmakuDensityChart =
+      'show_danmaku_density_chart'; // 密度图设置
+  static const String playerTopSendDanmakuButtonVisible =
+      'player_top_send_danmaku_button_visible'; // 播放器顶部发送按钮可见性设置
 
   // 弹幕防剧透设置
-  static const String spoilerPreventionEnabled          = 'spoiler_prevention_enabled';
-  static const String spoilerAiUseCustomKey             = 'spoiler_ai_use_custom_key';
-  static const String spoilerAiApiFormat                = 'spoiler_ai_api_format';
-  static const String spoilerAiApiUrl                   = 'spoiler_ai_api_url';
-  static const String spoilerAiApiKey                   = 'spoiler_ai_api_key';
-  static const String spoilerAiModel                    = 'spoiler_ai_model';
-  static const String spoilerAiTemperature              = 'spoiler_ai_temperature';
-  static const String spoilerAiDebugPrintResponse       = 'spoiler_ai_debug_print_response';
+  static const String spoilerPreventionEnabled = 'spoiler_prevention_enabled';
+  static const String spoilerAiUseCustomKey = 'spoiler_ai_use_custom_key';
+  static const String spoilerAiApiFormat = 'spoiler_ai_api_format';
+  static const String spoilerAiApiUrl = 'spoiler_ai_api_url';
+  static const String spoilerAiApiKey = 'spoiler_ai_api_key';
+  static const String spoilerAiModel = 'spoiler_ai_model';
+  static const String spoilerAiTemperature = 'spoiler_ai_temperature';
+  static const String spoilerAiDebugPrintResponse =
+      'spoiler_ai_debug_print_response';
 
   // 弹幕开发调试设置
-  static const String showCanvasDanmakuCollisionBoxes   = 'show_canvas_danmaku_collision_boxes';
-  static const String showCanvasDanmakuTrackNumbers     = 'show_canvas_danmaku_track_numbers';
-  static const String showGpuDanmakuCollisionBoxes      = 'show_gpu_danmaku_collision_boxes';
-  static const String showGpuDanmakuTrackNumbers        = 'show_gpu_danmaku_track_numbers';
-
+  static const String showCanvasDanmakuCollisionBoxes =
+      'show_canvas_danmaku_collision_boxes';
+  static const String showCanvasDanmakuTrackNumbers =
+      'show_canvas_danmaku_track_numbers';
+  static const String showGpuDanmakuCollisionBoxes =
+      'show_gpu_danmaku_collision_boxes';
+  static const String showGpuDanmakuTrackNumbers =
+      'show_gpu_danmaku_track_numbers';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -708,6 +708,8 @@ class _NipaPlayAppState extends State<NipaPlayApp> with WidgetsBindingObserver {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    ExternalPlayerConsoleService.sessionAvailability
+        .addListener(_onExternalPlayerConsoleAvailabilityChanged);
     // 启动后设置WatchHistoryProvider监听ScanService
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (globals.isDesktop) {
@@ -745,7 +747,13 @@ class _NipaPlayAppState extends State<NipaPlayApp> with WidgetsBindingObserver {
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    ExternalPlayerConsoleService.sessionAvailability
+        .removeListener(_onExternalPlayerConsoleAvailabilityChanged);
     super.dispose();
+  }
+
+  void _onExternalPlayerConsoleAvailabilityChanged() {
+    if (mounted) setState(() {});
   }
 
   @override
@@ -826,7 +834,8 @@ class _NipaPlayAppState extends State<NipaPlayApp> with WidgetsBindingObserver {
             showDownloader:
                 globals.isDownloaderSupportedPlatform && downloader.enabled,
             showExternalPlayerConsole:
-                ExternalPlayerConsoleService.isSupportedPlatform,
+                ExternalPlayerConsoleService.isSupportedPlatform &&
+                    ExternalPlayerConsoleService.hasActiveSession,
           ),
         );
         return pages
@@ -1100,6 +1109,9 @@ class MainPageState extends State<MainPage>
   List<Widget> _pages = [];
   bool _showWebDAVTab = false;
   bool _showDownloaderTab = globals.isDownloaderSupportedPlatform;
+  bool _showExternalPlayerConsoleTab =
+      ExternalPlayerConsoleService.isSupportedPlatform &&
+          ExternalPlayerConsoleService.hasActiveSession;
   WebDAVQuickAccessProvider? _webdavQuickAccessProvider;
   PluginService? _pluginService;
 
@@ -1190,6 +1202,8 @@ class MainPageState extends State<MainPage>
   @override
   void initState() {
     super.initState();
+    ExternalPlayerConsoleService.sessionAvailability
+        .addListener(_onExternalPlayerConsoleAvailabilityChanged);
     _initialize();
   }
 
@@ -1222,6 +1236,9 @@ class MainPageState extends State<MainPage>
     } catch (_) {}
 
     // 构建初始页面列表
+    _showExternalPlayerConsoleTab =
+        ExternalPlayerConsoleService.isSupportedPlatform &&
+            ExternalPlayerConsoleService.hasActiveSession;
     _rebuildPages();
 
     await _initializeController();
@@ -1270,13 +1287,33 @@ class MainPageState extends State<MainPage>
     );
   }
 
+  void _onExternalPlayerConsoleAvailabilityChanged() {
+    if (!mounted) return;
+    final shouldShow = ExternalPlayerConsoleService.isSupportedPlatform &&
+        ExternalPlayerConsoleService.hasActiveSession;
+    if (shouldShow == _showExternalPlayerConsoleTab) return;
+
+    final currentPageId = _selectedPageId;
+    _showExternalPlayerConsoleTab = shouldShow;
+    _rebuildPages();
+    if (globalTabController == null) {
+      setState(() {});
+      return;
+    }
+    _rebuildTabController(
+      targetPageId:
+          !shouldShow && currentPageId == AppPageIds.externalPlayerConsole
+              ? AppPageIds.home
+              : currentPageId,
+    );
+  }
+
   void _rebuildPages() {
     _pageDefinitions = buildUnifiedAppPages(
       availability: AppPageAvailability(
         showWebDAV: _showWebDAVTab,
         showDownloader: _showDownloaderTab,
-        showExternalPlayerConsole:
-            ExternalPlayerConsoleService.isSupportedPlatform,
+        showExternalPlayerConsole: _showExternalPlayerConsoleTab,
       ),
     );
     _pages = _pageDefinitions
@@ -1443,6 +1480,8 @@ class MainPageState extends State<MainPage>
     _webdavQuickAccessProvider?.removeListener(_onWebDAVSettingsChanged);
     _downloaderSettingsProvider?.removeListener(_onDownloaderSettingsChanged);
     _pluginService?.removeListener(_onDownloaderSettingsChanged);
+    ExternalPlayerConsoleService.sessionAvailability
+        .removeListener(_onExternalPlayerConsoleAvailabilityChanged);
     _androidFileAssociationSubscription?.cancel();
     globalTabController?.removeListener(_onTabChange);
     _videoPlayerState?.removeListener(_manageHotkeys);

--- a/lib/models/external_player_session/mpv_session.dart
+++ b/lib/models/external_player_session/mpv_session.dart
@@ -1,5 +1,4 @@
-
-// lib/models/external_player_session/linux_session.dart
+// lib/models/external_player_session/mpv_session.dart
 // 外部播放器相关的模型
 
 import 'dart:async';
@@ -11,57 +10,82 @@ import 'package:nipaplay/constants/media_extensions.dart';
 import 'package:nipaplay/models/external_player_session/session.dart';
 import 'package:nipaplay/utils/danmaku/assets.dart';
 
-
 /// 掌管外部播放器会话的神
 ///
-/// 管理一个 Linux mpv 进程, IPC, 播放状态和 ASS 弹幕交互.
+/// 管理一个 Linux 或 macOS mpv 进程, IPC, 播放状态和 ASS 弹幕交互.
 ///
 /// 本类保存当前媒体路径; 番剧和剧集展示信息由控制台服务管理.
-class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession {
-
+class MpvSession extends ChangeNotifier implements ExternalPlayerLaunchSession {
   /// 关联一个已经存在的外部播放器进程.
-  LinuxSession.attach(
-    {
-      required this.playerPath,
-      required this.mediaPath,
-      required this.processId,
-      required this.ipcPath,
-      required this.duration,
+  MpvSession.attach({
+    required this.playerPath,
+    required this.mediaPath,
+    required this.processId,
+    required this.ipcPath,
+    required this.duration,
+    this.position = Duration.zero,
+    this.isPaused = false,
+    this.danmakuAssets,
+    Future<int>? processExitCode,
+    bool monitorProcess = true,
+  }) : _processExitCode = processExitCode {
+    if (monitorProcess) _startLifecycleMonitoring();
+  }
 
-      this.position = Duration.zero,
-      this.isPaused = false,
-      this.danmakuAssets,
-      bool monitorProcess = true,
-    }
-  ) { if (monitorProcess) _startLifecycleMonitoring(); }
-
-  /// 启动 Linux mpv, 并启用 IPC 和生命周期监控.
-  static Future<LinuxSession> launch({
-    required String       playerPath,
-    required String       mediaPath,
+  /// 启动 Linux 或 macOS mpv, 并启用 IPC 和生命周期监控.
+  static Future<MpvSession> launch({
+    required String playerPath,
+    required String mediaPath,
     required List<String> extraArgs,
     DanmakuLaunchAssets? danmakuAssets,
     Duration duration = Duration.zero,
     Duration position = Duration.zero,
   }) async {
+    final ipcPath = _createMpvIpcPath();
+    final launchArgs = [
+      mediaPath,
+      ...extraArgs,
+      '--input-ipc-server=$ipcPath',
+    ];
+    final executablePath = await _resolveExecutablePath(playerPath);
 
-    final ipcPath    = _createMpvIpcPath();
-    final launchArgs = [mediaPath, ...extraArgs, '--input-ipc-server=$ipcPath'];
+    debugPrint(
+      '[MpvSession] Launching mpv: playerPath="$playerPath", '
+      'executablePath="$executablePath", args=$launchArgs',
+    );
 
-    debugPrint('[LinuxSession] Launching Linux mpv: playerPath="$playerPath", args=$launchArgs');
+    // 不通过 `open --args` 启动 mpv.app。沙盒应用交给 LaunchServices 后，
+    // 参数可能不会转交给新实例，最终只会出现一个未加载媒体的空白 mpv 窗口。
+    // 直接执行包内主程序也能让 processId 精确指向本次 mpv 会话。
+    final monitorThroughProcessHandle = Platform.isMacOS;
+    final process = await Process.start(
+      executablePath,
+      launchArgs,
+      mode: monitorThroughProcessHandle
+          ? ProcessStartMode.normal
+          : ProcessStartMode.detached,
+    );
+    Future<int>? processExitCode;
+    if (monitorThroughProcessHandle) {
+      process.stdin.close();
+      unawaited(process.stdout.drain<void>());
+      unawaited(process.stderr.drain<void>());
+      processExitCode = process.exitCode;
+    }
 
-    final process = await Process.start(playerPath, launchArgs, mode: ProcessStartMode.detached);
+    debugPrint(
+      '[MpvSession] mpv started: pid=${process.pid}, ipcPath=$ipcPath',
+    );
 
-    debugPrint('[LinuxSession] Linux mpv started: pid=${process.pid}, ipcPath=$ipcPath');
-
-    return LinuxSession.attach(
-      playerPath : playerPath,
-      mediaPath  : mediaPath,
-      processId  : process.pid,
-      ipcPath    : ipcPath,
-      duration   : duration,
-      position   : position,
+    return MpvSession.attach(
+      playerPath: playerPath,
+      mediaPath: mediaPath,
+      processId: process.pid,
+      ipcPath: ipcPath,
+      duration: duration,
+      position: position,
       danmakuAssets: danmakuAssets,
+      processExitCode: processExitCode,
     );
   }
 
@@ -69,29 +93,29 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
   @override
   ExternalPlayerType get type => ExternalPlayerType.mpv;
   @override
-  final String   playerPath;     // 外部播放器的路径
+  final String playerPath; // 外部播放器的路径
   @override
-  final String   mediaPath;      // 当前播放的媒体路径
+  final String mediaPath; // 当前播放的媒体路径
   @override
-  final int      processId;      // 外部播放器进程 ID
+  final int processId; // 外部播放器进程 ID
   @override
-  final String?  ipcPath;        // 外部播放器的 IPC 通道路径
+  final String? ipcPath; // 外部播放器的 IPC 通道路径
   DanmakuLaunchAssets? danmakuAssets; // 启动时加载的弹幕文件和导出设置
 
   // 播放相关
   @override
-  Duration       duration;       // 媒体文件总时长
+  Duration duration; // 媒体文件总时长
   @override
-  Duration?      position;       // 当前播放位置
+  Duration? position; // 当前播放位置
   @override
-  bool?          isPaused;       // 是否暂停
+  bool? isPaused; // 是否暂停
 
   // 进程轮询相关
   static const Duration _processPollingInterval = Duration(milliseconds: 250);
   Timer? _processPollingTimer;
-  bool   _closed   = false; // 外部播放器会话是否已关闭, 关闭后不再轮询进程和播放状态
-  bool   _disposed = false; // ChangeNotifier 是否已被 dispose, dispose 后不再通知监听器
-
+  bool _closed = false; // 外部播放器会话是否已关闭, 关闭后不再轮询进程和播放状态
+  bool _disposed = false; // ChangeNotifier 是否已被 dispose, dispose 后不再通知监听器
+  final Future<int>? _processExitCode;
 
   // --- Setters & Getters --- //
 
@@ -99,8 +123,11 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
   @override
   double? get fraction {
     if (position == null || duration <= Duration.zero) return null;
-    return (position!.inMilliseconds / duration.inMilliseconds).clamp(0.0, 1.0).toDouble();
+    return (position!.inMilliseconds / duration.inMilliseconds)
+        .clamp(0.0, 1.0)
+        .toDouble();
   }
+
   @override
   bool get isClosed => _closed;
 
@@ -110,11 +137,15 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
   @override
   void terminate() {
     if (_closed) return;
+
     try {
       final killed = Process.killPid(processId, ProcessSignal.sigterm);
-      if (!killed) debugPrint('[LinuxSession] Failed to terminate player: pid=$processId');
+      if (!killed) {
+        debugPrint('[MpvSession] Failed to terminate player: pid=$processId');
+      }
+    } catch (error) {
+      debugPrint('[MpvSession] Failed to close player: $error');
     }
-    catch (error) { debugPrint('[LinuxSession] Failed to close player: $error'); }
     _close();
   }
 
@@ -151,13 +182,15 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
     return true;
   }
 
-
   /// 通知指定的 mpv Lua 脚本重新加载 ASS 弹幕轨.
   @override
   Future<bool> refreshDanmaku(String assPath, String luaPath) async {
     final path = ipcPath;
-    if (_closed || path == null || path.isEmpty ||
-        assPath.isEmpty || luaPath.isEmpty) {
+    if (_closed ||
+        path == null ||
+        path.isEmpty ||
+        assPath.isEmpty ||
+        luaPath.isEmpty) {
       return false;
     }
 
@@ -208,6 +241,17 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
 
   void _startLifecycleMonitoring() {
     _stopLifecycleMonitoring();
+    final processExitCode = _processExitCode;
+    if (processExitCode != null) {
+      processExitCode.then(
+        (_) {
+          if (!_closed) _close();
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          debugPrint('[MpvSession] Failed to watch player exit: $error');
+        },
+      );
+    }
     _scheduleNextProcessPoll();
   }
 
@@ -231,14 +275,37 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
       final socketFile = File(path);
       if (socketFile.existsSync()) socketFile.deleteSync();
     } catch (error) {
-      debugPrint('[LinuxSession] Failed to delete IPC socket: $error');
+      debugPrint('[MpvSession] Failed to delete IPC socket: $error');
     }
   }
 
   static String _createMpvIpcPath() {
     final timestamp = DateTime.now().microsecondsSinceEpoch;
+    // macOS 的 sockaddr_un.sun_path 最多只能容纳 104 字节（含结尾的 NUL）。
+    // 沙盒的 systemTemp 本身已经很长，因此文件名必须保持紧凑。
+    final compactTimestamp = timestamp.toRadixString(36);
     return '${Directory.systemTemp.path}${Platform.pathSeparator}'
-        'nipaplay_mpv_${pid}_$timestamp.sock';
+        'np_${pid}_$compactTimestamp.sock';
+  }
+
+  static Future<String> _resolveExecutablePath(String playerPath) async {
+    if (!Platform.isMacOS || !playerPath.toLowerCase().endsWith('.app')) {
+      return playerPath;
+    }
+
+    final executablePath = [
+      playerPath,
+      'Contents',
+      'MacOS',
+      'mpv',
+    ].join(Platform.pathSeparator);
+    if (await File(executablePath).exists()) return executablePath;
+
+    throw ProcessException(
+      playerPath,
+      const [],
+      'mpv.app 中未找到 Contents/MacOS/mpv',
+    );
   }
 
   Future<void> _setMpvPaused(bool paused) async {
@@ -272,13 +339,13 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
           continue;
         }
         debugPrint(
-          '[LinuxSession] _setMpvPaused response: ${value['error']}',
+          '[MpvSession] _setMpvPaused response: ${value['error']}',
         );
         changed = value['error'] == 'success';
         break;
       }
     } catch (error) {
-      debugPrint('[LinuxSession] Failed to set mpv pause: $error');
+      debugPrint('[MpvSession] Failed to set mpv pause: $error');
     } finally {
       socket?.destroy();
     }
@@ -326,13 +393,13 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
         }
         if (value['error'] != 'success') {
           debugPrint(
-            '[LinuxSession] Failed to seek mpv: ${value['error']}',
+            '[MpvSession] Failed to seek mpv: ${value['error']}',
           );
         }
         return;
       }
     } catch (error) {
-      debugPrint('[LinuxSession] Failed to seek mpv: $error');
+      debugPrint('[MpvSession] Failed to seek mpv: $error');
     } finally {
       socket?.destroy();
     }
@@ -354,7 +421,7 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
     try {
       running = await _refreshProcessState(timer);
     } catch (error) {
-      debugPrint('[LinuxSession] Failed to refresh player state: $error');
+      debugPrint('[MpvSession] Failed to refresh player state: $error');
       running = true;
     }
 
@@ -369,7 +436,7 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
   }
 
   Future<bool> _refreshProcessState(Timer timer) async {
-    final running = await _isLinuxProcessRunning();
+    final running = await _isProcessRunning();
     if (!identical(_processPollingTimer, timer) || !running) return running;
 
     final nextState = await _readMpvState();
@@ -390,17 +457,39 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
     return true;
   }
 
-  Future<bool> _isLinuxProcessRunning() async {
+  Future<bool> _isProcessRunning() async {
     if (processId <= 0) return false;
 
-    try {
-      final value = await File('/proc/$processId/stat').readAsString();
-      final closingParen = value.lastIndexOf(')');
-      if (closingParen < 0 || closingParen + 2 >= value.length) return true;
-      return value.substring(closingParen + 2, closingParen + 3) != 'Z';
-    } on FileSystemException {
-      return false;
+    // macOS 沙盒内执行 `ps` 可能失败并把仍在播放的 mpv 误判为已退出。
+    // launch 创建的会话通过 Process.exitCode 精确监听，轮询期间保持存活。
+    if (_processExitCode != null) return true;
+
+    if (Platform.isLinux) {
+      try {
+        final value = await File('/proc/$processId/stat').readAsString();
+        final closingParen = value.lastIndexOf(')');
+        if (closingParen < 0 || closingParen + 2 >= value.length) return true;
+        return value.substring(closingParen + 2, closingParen + 3) != 'Z';
+      } on FileSystemException {
+        return false;
+      }
     }
+
+    if (Platform.isMacOS) {
+      try {
+        final result = await Process.run(
+          '/bin/ps',
+          ['-p', '$processId', '-o', 'stat='],
+        );
+        if (result.exitCode != 0) return false;
+        final state = (result.stdout as String).trim();
+        return state.isNotEmpty && !state.startsWith('Z');
+      } on ProcessException {
+        return false;
+      }
+    }
+
+    return false;
   }
 
   Future<_ExternalPlayerPlaybackState?> _readMpvState() async {
@@ -468,7 +557,7 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
         isPaused: paused,
       );
     } catch (error) {
-      debugPrint('[LinuxSession] Failed to read mpv state: $error');
+      debugPrint('[MpvSession] Failed to read mpv state: $error');
       return null;
     } finally {
       socket?.destroy();
@@ -482,7 +571,6 @@ class LinuxSession extends ChangeNotifier implements ExternalPlayerLaunchSession
     _stopLifecycleMonitoring();
     super.dispose();
   }
-
 }
 
 /// 外部播放器本轮轮询得到的播放状态

--- a/lib/models/external_player_session/other_session.dart
+++ b/lib/models/external_player_session/other_session.dart
@@ -9,7 +9,7 @@ import 'package:nipaplay/constants/media_extensions.dart';
 import 'package:nipaplay/models/external_player_session/session.dart';
 
 
-/// 管理非 Linux mpv 外部播放器进程的轻量会话.
+/// 管理未启用 mpv JSON IPC 的外部播放器进程的轻量会话.
 class OtherSession extends ChangeNotifier implements ExternalPlayerLaunchSession {
 
   OtherSession.attach({

--- a/lib/pages/external_player_console_page.dart
+++ b/lib/pages/external_player_console_page.dart
@@ -1,8 +1,4 @@
-
-// lib/pages/external_player_console_page.dart
-// 掌管 Linux/macOS 平台下外部播放器会话的控制台页面
-
-
+import 'package:fluent_ui/fluent_ui.dart' as fluent;
 import 'package:flutter/material.dart';
 import 'package:nipaplay/constants/danmaku/mode.dart';
 import 'package:nipaplay/l10n/l10n.dart';
@@ -10,9 +6,12 @@ import 'package:nipaplay/models/danmaku/blocked_item.dart';
 import 'package:nipaplay/models/danmaku/danmaku_item.dart';
 import 'package:nipaplay/models/danmaku/style.dart';
 import 'package:nipaplay/services/external_player_console_service.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_editable_slider.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_focusable_action.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_page_scaffold.dart';
+import 'package:nipaplay/utils/app_accent_color.dart';
 
-
-/// 一个用于显示外部播放器会话信息的控制台页面
+/// Linux/macOS mpv 外部播放会话的桌面控制台。
 class ExternalPlayerConsolePage extends StatelessWidget {
   const ExternalPlayerConsolePage({super.key});
 
@@ -21,28 +20,56 @@ class ExternalPlayerConsolePage extends StatelessWidget {
     return AnimatedBuilder(
       animation: ExternalPlayerConsoleService.instance,
       builder: (context, _) {
-        return SafeArea(
-          child: Center(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.all(32),
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 1040),
-                child: !ExternalPlayerConsoleService.hasActiveSession
-                    ? const _EmptyConsole()
-                    : _ConsoleCard(
+        final hasSession = ExternalPlayerConsoleService.hasActiveSession;
+        final animeTitle = ExternalPlayerConsoleService.animeTitle;
+        final episodeTitle = ExternalPlayerConsoleService.episodeTitle;
+        final subtitle = <String>[
+          if (animeTitle != null && animeTitle.trim().isNotEmpty) animeTitle,
+          if (episodeTitle != null && episodeTitle.trim().isNotEmpty)
+            episodeTitle,
+        ].join(' · ');
+
+        return fluent.FluentTheme(
+          data: fluent.FluentThemeData(
+            brightness: Theme.of(context).brightness,
+            accentColor: fluent.AccentColor.swatch({
+              'normal': AppAccentColors.current,
+              'default': AppAccentColors.current,
+            }),
+          ),
+          child: Material(
+            type: MaterialType.transparency,
+            child: SafeArea(
+              child: NipaplayLargeScreenPageScaffold(
+                title: context.l10n.externalPlayerConsoleTitle,
+                subtitle: hasSession && subtitle.isNotEmpty ? subtitle : null,
+                padding: const EdgeInsets.fromLTRB(34, 24, 34, 28),
+                headerBottomSpacing: 18,
+                showBackgroundEffects: false,
+                child: hasSession
+                    ? _ConsoleWorkspace(
                         processId: ExternalPlayerConsoleService.processId,
                         mediaPath: ExternalPlayerConsoleService.mediaPath,
-                        animeTitle: ExternalPlayerConsoleService.animeTitle,
-                        episodeTitle: ExternalPlayerConsoleService.episodeTitle,
+                        animeTitle: animeTitle,
+                        episodeTitle: episodeTitle,
                         episodeId: ExternalPlayerConsoleService.episodeId,
-                        danmakuList: ExternalPlayerConsoleService.displayDanmakuList,
-                        isPaused: ExternalPlayerConsoleService.isPaused ?? false,
-                        supportsSessionControl: ExternalPlayerConsoleService.ipcPath != null,
+                        danmakuList:
+                            ExternalPlayerConsoleService.displayDanmakuList,
+                        isPaused:
+                            ExternalPlayerConsoleService.isPaused ?? false,
+                        supportsSessionControl:
+                            ExternalPlayerConsoleService.ipcPath != null,
                         position: ExternalPlayerConsoleService.position,
                         duration: ExternalPlayerConsoleService.duration,
                         fraction: ExternalPlayerConsoleService.fraction,
                         danmakuStyle: ExternalPlayerConsoleService.danmakuStyle,
                         blockedItems: ExternalPlayerConsoleService.blockedItems,
+                      )
+                    : NipaplayLargeScreenEmptyState(
+                        icon: Icons.subtitles_outlined,
+                        title: context.l10n.externalPlayerConsoleEmptyTitle,
+                        subtitle:
+                            context.l10n.externalPlayerConsoleEmptyDescription,
                       ),
               ),
             ),
@@ -53,44 +80,8 @@ class ExternalPlayerConsolePage extends StatelessWidget {
   }
 }
 
-class _EmptyConsole extends StatelessWidget {
-  const _EmptyConsole();
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 80),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Icons.subtitles_outlined,
-            size: 64,
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-          const SizedBox(height: 20),
-          Text(
-            context.l10n.externalPlayerConsoleEmptyTitle,
-            style: theme.textTheme.titleLarge,
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 8),
-          Text(
-            context.l10n.externalPlayerConsoleEmptyDescription,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-            textAlign: TextAlign.center,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _ConsoleCard extends StatelessWidget {
-  const _ConsoleCard({
+class _ConsoleWorkspace extends StatelessWidget {
+  const _ConsoleWorkspace({
     required this.processId,
     required this.mediaPath,
     required this.animeTitle,
@@ -122,293 +113,325 @@ class _ConsoleCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final localizations = context.l10n;
-    return Card(
-      elevation: 0,
-      color: theme.colorScheme.surfaceContainer,
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Icon(
-                  Icons.subtitles_outlined,
-                  color: theme.colorScheme.primary,
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    localizations.externalPlayerConsoleTitle,
-                    style: theme.textTheme.titleLarge,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 20),
-            _detailRow(
-              context,
-              localizations.externalPlayerConsoleAnime,
-              _nonEmptyOr(
-                animeTitle,
-                localizations.externalPlayerConsoleUnknownAnime,
-              ),
-            ),
-            _detailRow(
-              context,
-              localizations.externalPlayerConsoleEpisode,
-              _nonEmptyOr(
-                episodeTitle,
-                localizations.externalPlayerConsoleUnknownEpisode,
-              ),
-            ),
-            _detailRow(
-              context,
-              localizations.externalPlayerConsoleEpisodeId,
-              episodeId?.toString() ?? '-',
-            ),
-            _detailRow(
-              context,
-              localizations.externalPlayerConsoleProcessId,
-              processId?.toString() ?? '-',
-            ),
-            _detailRow(
-              context,
-              localizations.externalPlayerConsoleMediaPath,
-              mediaPath ?? '-',
-            ),
-            const SizedBox(height: 20),
-            _buildProgress(context),
-            const SizedBox(height: 20),
-            _buildDanmakuOpacity(context),
-            const SizedBox(height: 8),
-            _buildDanmakuFontSize(context),
-            const SizedBox(height: 8),
-            _buildDanmakuOutlineWidth(context),
-            const SizedBox(height: 8),
-            _DanmakuOffsetControl(
-              sessionId: processId,
-              offset: danmakuStyle.danmakuOffset,
-              initialOffset: 0.0,
-            ),
-            const SizedBox(height: 8),
-            _DanmakuBlockRuleEditor(
-              enabled: danmakuList.isNotEmpty,
-              items: blockedItems,
-            ),
-            const SizedBox(height: 20),
-            Align(
-              alignment: Alignment.centerRight,
-              child: Wrap(
-                spacing: 12,
-                runSpacing: 8,
-                children: [
-                  FilledButton.tonalIcon(
-                    onPressed: !supportsSessionControl
-                        ? null
-                        : ExternalPlayerConsoleService.togglePause,
-                    icon: Icon(isPaused ? Icons.play_arrow : Icons.pause),
-                    label: Text(
-                      isPaused
-                          ? localizations.externalPlayerConsoleResume
-                          : localizations.externalPlayerConsolePause,
-                    ),
-                  ),
-                  FilledButton.icon(
-                    onPressed:
-                        ExternalPlayerConsoleService.closePlayerAndConsole,
-                    icon: const Icon(Icons.close),
-                    label: Text(localizations.externalPlayerConsoleClose),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 24),
-            Divider(color: theme.colorScheme.outlineVariant),
-            const SizedBox(height: 16),
-            _DanmakuList(
-              sessionId: processId,
-              items: danmakuList,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final useTwoColumns = constraints.maxWidth >= 980;
+        final controlPanels = <Widget>[
+          _buildSessionPanel(context),
+          const SizedBox(height: 14),
+          _buildAppearancePanel(context),
+          const SizedBox(height: 14),
+          _buildRulesPanel(context),
+        ];
+        final listPanel = NipaplayLargeScreenPanel(
+          padding: const EdgeInsets.all(16),
+          child: _DanmakuList(
+            sessionId: processId,
+            items: danmakuList,
+            fillAvailableHeight: useTwoColumns,
+          ),
+        );
 
-  Widget _detailRow(BuildContext context, String label, String value) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 6),
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          if (constraints.maxWidth < 480) {
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+        if (!useTwoColumns) {
+          return SingleChildScrollView(
+            key: const Key('external-player-console-single-column'),
+            padding: const EdgeInsets.only(right: 4),
+            child: Column(
               children: [
-                Text(label, style: Theme.of(context).textTheme.labelLarge),
-                const SizedBox(height: 4),
-                SelectableText(value),
+                ...controlPanels,
+                const SizedBox(height: 14),
+                listPanel,
               ],
-            );
-          }
-          return Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              SizedBox(width: 140, child: Text(label)),
-              Expanded(child: SelectableText(value)),
-            ],
+            ),
           );
-        },
+        }
+
+        return Row(
+          key: const Key('external-player-console-two-column'),
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              flex: 9,
+              child: ListView(
+                padding: const EdgeInsets.only(right: 4),
+                children: controlPanels,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(flex: 11, child: listPanel),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildSessionPanel(BuildContext context) {
+    final localizations = context.l10n;
+    return NipaplayLargeScreenPanel(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          NipaplayLargeScreenSectionHeader(
+            title: _localized(context, '播放会话', '播放工作階段', 'Playback Session'),
+            subtitle: _localized(
+              context,
+              'mpv 播放状态与精确定位',
+              'mpv 播放狀態與精確定位',
+              'mpv status and precise seeking',
+            ),
+          ),
+          const SizedBox(height: 16),
+          _DetailRow(
+            label: localizations.externalPlayerConsoleAnime,
+            value: _nonEmptyOr(
+              animeTitle,
+              localizations.externalPlayerConsoleUnknownAnime,
+            ),
+          ),
+          _DetailRow(
+            label: localizations.externalPlayerConsoleEpisode,
+            value: _nonEmptyOr(
+              episodeTitle,
+              localizations.externalPlayerConsoleUnknownEpisode,
+            ),
+          ),
+          _DetailRow(
+            label: localizations.externalPlayerConsoleEpisodeId,
+            value: episodeId?.toString() ?? '-',
+          ),
+          _DetailRow(
+            label: localizations.externalPlayerConsoleProcessId,
+            value: processId?.toString() ?? '-',
+          ),
+          _DetailRow(
+            label: localizations.externalPlayerConsoleMediaPath,
+            value: mediaPath ?? '-',
+          ),
+          const SizedBox(height: 16),
+          Text(
+            localizations.externalPlayerConsoleProgress,
+            style: _sectionLabelStyle(context),
+          ),
+          const SizedBox(height: 10),
+          _SeekProgress(
+            sessionId: processId,
+            supportsProgress: supportsSessionControl,
+            position: position,
+            duration: duration,
+            fraction: fraction,
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 10,
+            runSpacing: 10,
+            children: [
+              NipaplayLargeScreenActionButton(
+                icon: isPaused ? Icons.play_arrow_rounded : Icons.pause_rounded,
+                label: isPaused
+                    ? localizations.externalPlayerConsoleResume
+                    : localizations.externalPlayerConsolePause,
+                onPressed: supportsSessionControl
+                    ? ExternalPlayerConsoleService.togglePause
+                    : null,
+                compact: true,
+              ),
+              NipaplayLargeScreenActionButton(
+                icon: Icons.close_rounded,
+                label: localizations.externalPlayerConsoleClose,
+                onPressed: ExternalPlayerConsoleService.closePlayerAndConsole,
+                compact: true,
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }
 
-  Widget _buildProgress(BuildContext context) {
-    final theme = Theme.of(context);
+  Widget _buildAppearancePanel(BuildContext context) {
     final localizations = context.l10n;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          localizations.externalPlayerConsoleProgress,
-          style: theme.textTheme.titleMedium,
-        ),
-        const SizedBox(height: 10),
-        _SeekProgress(
-          sessionId: processId,
-          supportsProgress: supportsSessionControl,
-          position: position,
-          duration: duration,
-          fraction: fraction,
-        ),
-      ],
+    return NipaplayLargeScreenPanel(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          NipaplayLargeScreenSectionHeader(
+            title: _localized(context, '弹幕显示', '彈幕顯示', 'Danmaku Appearance'),
+            subtitle: _localized(
+              context,
+              '修改后会立即重新生成并加载弹幕',
+              '修改後會立即重新產生並載入彈幕',
+              'Changes are regenerated and loaded immediately',
+            ),
+          ),
+          const SizedBox(height: 16),
+          _ConsoleSlider(
+            label: localizations.danmakuOpacityTitle,
+            valueText: '${(danmakuStyle.opacity * 100).round()}%',
+            value: danmakuStyle.opacity,
+            min: 0,
+            max: 1,
+            divisions: 100,
+            onChanged: (value) {
+              danmakuStyle.opacity = value;
+              ExternalPlayerConsoleService.queueDanmakuRefresh();
+            },
+          ),
+          const SizedBox(height: 12),
+          _ConsoleSlider(
+            sliderKey: const Key('external-player-danmaku-font-size'),
+            label: localizations.danmakuFontSizeTitle,
+            valueText: '${danmakuStyle.danmakuFontSize.toStringAsFixed(1)}px',
+            value: danmakuStyle.danmakuFontSize
+                .clamp(
+                  DanmakuStyle.minDanmakuFontSize,
+                  DanmakuStyle.maxDanmakuFontSize,
+                )
+                .toDouble(),
+            min: DanmakuStyle.minDanmakuFontSize,
+            max: DanmakuStyle.maxDanmakuFontSize,
+            divisions: 96,
+            onChanged: (value) {
+              danmakuStyle.danmakuFontSize = value;
+              ExternalPlayerConsoleService.queueDanmakuRefresh();
+            },
+          ),
+          const SizedBox(height: 12),
+          _ConsoleSlider(
+            label: localizations.danmakuOutlineWidthTitle,
+            valueText: danmakuStyle.outlineWidth.toStringAsFixed(1),
+            value: danmakuStyle.outlineWidth
+                .clamp(0.0, DanmakuStyle.maxOutlineWidth)
+                .toDouble(),
+            min: 0,
+            max: DanmakuStyle.maxOutlineWidth,
+            divisions: 10,
+            onChanged: (value) {
+              danmakuStyle.outlineWidth = value;
+              ExternalPlayerConsoleService.queueDanmakuRefresh();
+            },
+          ),
+        ],
+      ),
     );
   }
 
-  Widget _buildDanmakuOpacity(BuildContext context) {
-    final theme = Theme.of(context);
-    final localizations = context.l10n;
+  Widget _buildRulesPanel(BuildContext context) {
+    return NipaplayLargeScreenPanel(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          NipaplayLargeScreenSectionHeader(
+            title: _localized(context, '同步与过滤', '同步與過濾', 'Sync & Filters'),
+            subtitle: _localized(
+              context,
+              '校正时间偏移并管理当前会话的屏蔽规则',
+              '校正時間偏移並管理目前工作階段的封鎖規則',
+              'Correct timing and manage filters for this session',
+            ),
+          ),
+          const SizedBox(height: 16),
+          _DanmakuOffsetControl(
+            sessionId: processId,
+            offset: danmakuStyle.danmakuOffset,
+            initialOffset: 0,
+          ),
+          const SizedBox(height: 20),
+          _DanmakuBlockRuleEditor(
+            enabled: danmakuList.isNotEmpty,
+            items: blockedItems,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.onSurface;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 112,
+            child: Text(
+              label,
+              style: TextStyle(
+                color: color.withValues(alpha: 0.58),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Expanded(
+            child: SelectableText(
+              value,
+              maxLines: 2,
+              style: TextStyle(color: color, fontWeight: FontWeight.w600),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ConsoleSlider extends StatelessWidget {
+  const _ConsoleSlider({
+    this.sliderKey,
+    required this.label,
+    required this.valueText,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.divisions,
+    required this.onChanged,
+  });
+
+  final Key? sliderKey;
+  final String label;
+  final String valueText;
+  final double value;
+  final double min;
+  final double max;
+  final int divisions;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final muted =
+        Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.62);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
           children: [
-            Expanded(
-              child: Text(
-                localizations.danmakuOpacityTitle,
-                style: theme.textTheme.titleMedium,
-              ),
-            ),
+            Expanded(child: Text(label, style: _sectionLabelStyle(context))),
             Text(
-              '${(danmakuStyle.opacity * 100).round()}%',
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
+              valueText,
+              style: TextStyle(color: muted, fontWeight: FontWeight.w700),
             ),
           ],
         ),
-        Slider(
-          value: danmakuStyle.opacity,
-          min: 0,
-          max: 1,
-          divisions: 100,
-          label: '${(danmakuStyle.opacity * 100).round()}%',
-          onChanged: (value) {
-            danmakuStyle.opacity = value;
-            ExternalPlayerConsoleService.queueDanmakuRefresh();
-          },
+        const SizedBox(height: 4),
+        NipaplayLargeScreenEditableSlider(
+          key: sliderKey,
+          value: value,
+          min: min,
+          max: max,
+          divisions: divisions,
+          label: valueText,
+          onChanged: onChanged,
         ),
       ],
     );
-  }
-
-  Widget _buildDanmakuOutlineWidth(BuildContext context) {
-    final theme = Theme.of(context);
-    final localizations = context.l10n;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            Expanded(
-              child: Text(
-                localizations.danmakuOutlineWidthTitle,
-                style: theme.textTheme.titleMedium,
-              ),
-            ),
-            Text(
-              danmakuStyle.outlineWidth.toStringAsFixed(1),
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ],
-        ),
-        Slider(
-          value: danmakuStyle.outlineWidth.clamp(
-            0.0,
-            DanmakuStyle.maxOutlineWidth,
-          ).toDouble(),
-          min: 0.0,
-          max: DanmakuStyle.maxOutlineWidth,
-          divisions: 10,
-          label: danmakuStyle.outlineWidth.toStringAsFixed(1),
-          onChanged: (value) {
-            danmakuStyle.outlineWidth = value;
-            ExternalPlayerConsoleService.queueDanmakuRefresh();
-          },
-        ),
-      ],
-    );
-  }
-
-  Widget _buildDanmakuFontSize(BuildContext context) {
-    final theme = Theme.of(context);
-    final localizations = context.l10n;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            Expanded(
-              child: Text(
-                localizations.danmakuFontSizeTitle,
-                style: theme.textTheme.titleMedium,
-              ),
-            ),
-            Text(
-              '${danmakuStyle.danmakuFontSize.toStringAsFixed(1)}px',
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ],
-        ),
-        Slider(
-          key: const Key('external-player-danmaku-font-size'),
-          value: danmakuStyle.danmakuFontSize.clamp(
-            DanmakuStyle.minDanmakuFontSize,
-            DanmakuStyle.maxDanmakuFontSize,
-          ).toDouble(),
-          min: DanmakuStyle.minDanmakuFontSize,
-          max: DanmakuStyle.maxDanmakuFontSize,
-          divisions: 96,
-          label: '${danmakuStyle.danmakuFontSize.toStringAsFixed(1)}px',
-          onChanged: (value) {
-            danmakuStyle.danmakuFontSize = value;
-            ExternalPlayerConsoleService.queueDanmakuRefresh();
-          },
-        ),
-      ],
-    );
-  }
-
-  String _nonEmptyOr(String? value, String fallback) {
-    return value == null || value.trim().isEmpty ? fallback : value;
   }
 }
 
@@ -441,7 +464,8 @@ class _DanmakuOffsetControlState extends State<_DanmakuOffsetControl> {
   @override
   void didUpdateWidget(_DanmakuOffsetControl oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.sessionId != widget.sessionId || oldWidget.offset != widget.offset) {
+    if (oldWidget.sessionId != widget.sessionId ||
+        oldWidget.offset != widget.offset) {
       _controller.text = _formatSeconds(widget.offset);
       _invalid = false;
     }
@@ -467,17 +491,18 @@ class _DanmakuOffsetControlState extends State<_DanmakuOffsetControl> {
     final localizations = context.l10n;
     final seconds = _formatSeconds(widget.offset.abs());
     if (widget.offset < 0) {
-      return localizations.externalPlayerConsoleDanmakuOffsetCurrentAdvance(seconds);
+      return localizations
+          .externalPlayerConsoleDanmakuOffsetCurrentAdvance(seconds);
     }
     if (widget.offset > 0) {
-      return localizations.externalPlayerConsoleDanmakuOffsetCurrentDelay(seconds);
+      return localizations
+          .externalPlayerConsoleDanmakuOffsetCurrentDelay(seconds);
     }
     return localizations.externalPlayerConsoleDanmakuOffsetCurrentNone;
   }
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final localizations = context.l10n;
     final step = _formatSeconds(_stepSeconds);
     return Column(
@@ -485,82 +510,94 @@ class _DanmakuOffsetControlState extends State<_DanmakuOffsetControl> {
       children: [
         Text(
           localizations.externalPlayerConsoleDanmakuOffsetTitle,
-          style: theme.textTheme.titleMedium,
+          style: _sectionLabelStyle(context),
         ),
         const SizedBox(height: 4),
         Text(
           _currentOffsetText(context),
           key: const Key('external-player-danmaku-offset-current'),
-          style: theme.textTheme.bodyMedium?.copyWith(
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
+          style: _mutedStyle(context),
         ),
         const SizedBox(height: 10),
         Wrap(
           spacing: 8,
           runSpacing: 8,
           children: [
-            OutlinedButton.icon(
+            KeyedSubtree(
               key: const Key('external-player-danmaku-offset-advance'),
-              onPressed: () => ExternalPlayerConsoleService.adjustDanmakuOffset(-_stepSeconds),
-              icon: const Icon(Icons.fast_rewind),
-              label: Text(localizations.externalPlayerConsoleDanmakuOffsetAdvance(step)),
+              child: NipaplayLargeScreenActionButton(
+                icon: Icons.fast_rewind_rounded,
+                label: localizations
+                    .externalPlayerConsoleDanmakuOffsetAdvance(step),
+                onPressed: () =>
+                    ExternalPlayerConsoleService.adjustDanmakuOffset(
+                  -_stepSeconds,
+                ),
+                compact: true,
+              ),
             ),
-            OutlinedButton.icon(
+            KeyedSubtree(
               key: const Key('external-player-danmaku-offset-delay'),
-              onPressed: () => ExternalPlayerConsoleService.adjustDanmakuOffset(_stepSeconds),
-              icon: const Icon(Icons.fast_forward),
-              label: Text(localizations.externalPlayerConsoleDanmakuOffsetDelay(step)),
+              child: NipaplayLargeScreenActionButton(
+                icon: Icons.fast_forward_rounded,
+                label:
+                    localizations.externalPlayerConsoleDanmakuOffsetDelay(step),
+                onPressed: () =>
+                    ExternalPlayerConsoleService.adjustDanmakuOffset(
+                  _stepSeconds,
+                ),
+                compact: true,
+              ),
             ),
-            TextButton(
+            KeyedSubtree(
               key: const Key('external-player-danmaku-offset-reset'),
-              onPressed: widget.offset == widget.initialOffset
-                  ? null
-                  : ExternalPlayerConsoleService.resetDanmakuOffset,
-              child: Text(localizations.externalPlayerConsoleDanmakuOffsetReset),
+              child: NipaplayLargeScreenActionButton(
+                icon: Icons.restart_alt_rounded,
+                label: localizations.externalPlayerConsoleDanmakuOffsetReset,
+                onPressed: widget.offset == widget.initialOffset
+                    ? null
+                    : ExternalPlayerConsoleService.resetDanmakuOffset,
+                compact: true,
+              ),
             ),
           ],
         ),
         const SizedBox(height: 10),
-        Wrap(
-          crossAxisAlignment: WrapCrossAlignment.center,
-          spacing: 8,
-          runSpacing: 8,
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SizedBox(
-              width: 240,
-              child: TextField(
+            KeyedSubtree(
+              key: const Key('external-player-danmaku-offset-apply'),
+              child: NipaplayLargeScreenActionButton(
+                icon: Icons.done_rounded,
+                label: localizations.externalPlayerConsoleDanmakuOffsetApply,
+                onPressed: _applyCustomOffset,
+                compact: true,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: _ConsoleTextField(
                 key: const Key('external-player-danmaku-offset-input'),
                 controller: _controller,
+                hintText:
+                    localizations.externalPlayerConsoleDanmakuOffsetCustomHint,
+                prefixIcon: Icons.timelapse_rounded,
                 keyboardType: const TextInputType.numberWithOptions(
                   decimal: true,
                   signed: true,
                 ),
-                decoration: InputDecoration(
-                  labelText: localizations.externalPlayerConsoleDanmakuOffsetCustomLabel,
-                  hintText: localizations.externalPlayerConsoleDanmakuOffsetCustomHint,
-                  errorText: _invalid
-                      ? localizations.externalPlayerConsoleDanmakuOffsetInvalid
-                      : null,
-                ),
+                errorText: _invalid
+                    ? localizations.externalPlayerConsoleDanmakuOffsetInvalid
+                    : null,
                 onSubmitted: (_) => _applyCustomOffset(),
               ),
-            ),
-            FilledButton.tonal(
-              key: const Key('external-player-danmaku-offset-apply'),
-              onPressed: _applyCustomOffset,
-              child: Text(localizations.externalPlayerConsoleDanmakuOffsetApply),
             ),
           ],
         ),
       ],
     );
   }
-}
-
-String _formatSeconds(double value) {
-  final text = value.toStringAsFixed(3);
-  return text.replaceFirst(RegExp(r'\.?0+$'), '');
 }
 
 class _DanmakuBlockRuleEditor extends StatefulWidget {
@@ -592,14 +629,10 @@ class _DanmakuBlockRuleEditorState extends State<_DanmakuBlockRuleEditor> {
         valid = false;
       }
     }
-    final added = valid && ExternalPlayerConsoleService.addBlockedItem(
-      value,
-      _selectedType,
-    );
+    final added = valid &&
+        ExternalPlayerConsoleService.addBlockedItem(value, _selectedType);
     setState(() => _hasInputError = !added);
-    if (added) {
-      _controller.clear();
-    }
+    if (added) _controller.clear();
   }
 
   String _typeLabel(BuildContext context, BlockedItemType type) {
@@ -630,58 +663,53 @@ class _DanmakuBlockRuleEditorState extends State<_DanmakuBlockRuleEditor> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final localizations = context.l10n;
+    final borderColor =
+        Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.10);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           localizations.externalPlayerConsoleDanmakuKeywordFilter,
-          style: theme.textTheme.titleMedium,
+          style: _sectionLabelStyle(context),
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: 10),
         SingleChildScrollView(
+          key: const Key('external-player-danmaku-block-mode'),
           scrollDirection: Axis.horizontal,
-          child: SegmentedButton<BlockedItemType>(
-            key: const Key('external-player-danmaku-block-mode'),
-            segments: BlockedItemType.values.map((type) {
-              return ButtonSegment<BlockedItemType>(
-                value: type,
-                icon: Icon(_typeIcon(type)),
-                label: Text(_typeLabel(context, type)),
+          child: Row(
+            children: BlockedItemType.values.map((type) {
+              return Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: _ChoiceButton(
+                  icon: _typeIcon(type),
+                  label: _typeLabel(context, type),
+                  selected: _selectedType == type,
+                  onPressed: widget.enabled
+                      ? () => setState(() {
+                            _selectedType = type;
+                            _hasInputError = false;
+                          })
+                      : null,
+                ),
               );
             }).toList(growable: false),
-            selected: {_selectedType},
-            showSelectedIcon: false,
-            onSelectionChanged: widget.enabled
-                ? (selection) {
-                    setState(() {
-                      _selectedType = selection.single;
-                      _hasInputError = false;
-                    });
-                  }
-                : null,
           ),
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: 10),
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Expanded(
-              child: TextField(
+              child: _ConsoleTextField(
                 key: const Key('external-player-danmaku-keyword-input'),
                 controller: _controller,
                 enabled: widget.enabled,
-                decoration: InputDecoration(
-                  hintText: localizations
-                      .externalPlayerConsoleDanmakuKeywordHint,
-                  errorText: _hasInputError
-                      ? localizations.externalPlayerConsoleDanmakuBlockInvalid
-                      : null,
-                  border: const OutlineInputBorder(),
-                  isDense: true,
-                ),
-                textInputAction: TextInputAction.done,
+                hintText: localizations.externalPlayerConsoleDanmakuKeywordHint,
+                prefixIcon: _typeIcon(_selectedType),
+                errorText: _hasInputError
+                    ? localizations.externalPlayerConsoleDanmakuBlockInvalid
+                    : null,
                 onChanged: (_) {
                   if (_hasInputError) {
                     setState(() => _hasInputError = false);
@@ -691,55 +719,72 @@ class _DanmakuBlockRuleEditorState extends State<_DanmakuBlockRuleEditor> {
               ),
             ),
             const SizedBox(width: 8),
-            FilledButton.tonalIcon(
+            KeyedSubtree(
               key: const Key('external-player-danmaku-keyword-add'),
-              onPressed: widget.enabled ? _addItem : null,
-              icon: const Icon(Icons.add),
-              label: Text(
-                localizations.externalPlayerConsoleDanmakuKeywordAdd,
+              child: NipaplayLargeScreenActionButton(
+                icon: Icons.add_rounded,
+                label: localizations.externalPlayerConsoleDanmakuKeywordAdd,
+                onPressed: widget.enabled ? _addItem : null,
+                compact: true,
               ),
             ),
           ],
         ),
         if (widget.items.isNotEmpty) ...[
           const SizedBox(height: 12),
-          Container(
-            decoration: BoxDecoration(
-              color: theme.colorScheme.surfaceContainerLow,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: theme.colorScheme.outlineVariant),
-            ),
-            clipBehavior: Clip.antiAlias,
-            child: Column(
-              children: List.generate(widget.items.length, (index) {
-                final item = widget.items[index];
-                return Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    ListTile(
-                      key: ValueKey(
-                        'external-player-danmaku-block-item-${item.type.name}-${item.value}',
-                      ),
-                      dense: true,
-                      leading: Icon(_typeIcon(item.type)),
-                      title: Text(item.value),
-                      subtitle: Text(_typeLabel(context, item.type)),
-                      trailing: IconButton(
-                        tooltip: localizations
-                            .externalPlayerConsoleDanmakuBlockRemove,
-                        onPressed: () =>
-                            ExternalPlayerConsoleService.removeBlockedItem(item),
-                        icon: const Icon(Icons.delete_outline_rounded),
-                      ),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: DecoratedBox(
+              decoration: BoxDecoration(border: Border.all(color: borderColor)),
+              child: Column(
+                children: List.generate(widget.items.length, (index) {
+                  final item = widget.items[index];
+                  return Container(
+                    key: ValueKey(
+                      'external-player-danmaku-block-item-${item.type.name}-${item.value}',
                     ),
-                    if (index < widget.items.length - 1)
-                      Divider(
-                        height: 1,
-                        color: theme.colorScheme.outlineVariant,
-                      ),
-                  ],
-                );
-              }),
+                    padding: const EdgeInsets.fromLTRB(12, 8, 6, 8),
+                    decoration: BoxDecoration(
+                      border: index == widget.items.length - 1
+                          ? null
+                          : Border(bottom: BorderSide(color: borderColor)),
+                    ),
+                    child: Row(
+                      children: [
+                        Icon(_typeIcon(item.type), size: 19),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                item.value,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                              Text(
+                                _typeLabel(context, item.type),
+                                style: _mutedStyle(context),
+                              ),
+                            ],
+                          ),
+                        ),
+                        NipaplayLargeScreenIconButton(
+                          icon: Icons.delete_outline_rounded,
+                          tooltip: localizations
+                              .externalPlayerConsoleDanmakuBlockRemove,
+                          onPressed: () =>
+                              ExternalPlayerConsoleService.removeBlockedItem(
+                                  item),
+                        ),
+                      ],
+                    ),
+                  );
+                }),
+              ),
             ),
           ),
         ],
@@ -748,16 +793,16 @@ class _DanmakuBlockRuleEditorState extends State<_DanmakuBlockRuleEditor> {
   }
 }
 
-
-/// 显示当前外部播放会话构建的弹幕展示列表
 class _DanmakuList extends StatefulWidget {
   const _DanmakuList({
     required this.sessionId,
     required this.items,
+    required this.fillAvailableHeight,
   });
 
   final int? sessionId;
   final List<DisplayDanmakuItem> items;
+  final bool fillAvailableHeight;
 
   @override
   State<_DanmakuList> createState() => _DanmakuListState();
@@ -770,7 +815,12 @@ class _DanmakuListState extends State<_DanmakuList> {
   int _scrollGeneration = 0;
   int? _lastFirstActiveIndex;
   int? _pendingScrollIndex;
-  double _itemExtent = 64;
+  double _itemExtent = 72;
+
+  int? get _firstActiveIndex {
+    final index = widget.items.indexWhere((item) => item.isActive);
+    return index < 0 ? null : index;
+  }
 
   @override
   void initState() {
@@ -789,18 +839,12 @@ class _DanmakuListState extends State<_DanmakuList> {
       _lastFirstActiveIndex = null;
       if (_scrollController.hasClients) _scrollController.jumpTo(0);
     }
-
     final firstActiveIndex = _firstActiveIndex;
     if (firstActiveIndex == _lastFirstActiveIndex) return;
     _lastFirstActiveIndex = firstActiveIndex;
     if (_followPlayback && firstActiveIndex != null) {
       _scheduleScrollTo(firstActiveIndex);
     }
-  }
-
-  int? get _firstActiveIndex {
-    final index = widget.items.indexWhere((item) => item.isActive);
-    return index < 0 ? null : index;
   }
 
   void _scheduleScrollTo(int index) {
@@ -810,29 +854,23 @@ class _DanmakuListState extends State<_DanmakuList> {
       final pendingIndex = _pendingScrollIndex;
       _pendingScrollIndex = null;
       if (pendingIndex == null) return;
-
       final target = (pendingIndex * _itemExtent)
           .clamp(0.0, _scrollController.position.maxScrollExtent)
           .toDouble();
       final generation = ++_scrollGeneration;
       _programmaticScroll = true;
-      _scrollController.animateTo(
+      _scrollController
+          .animateTo(
         target,
         duration: const Duration(milliseconds: 220),
         curve: Curves.easeOutCubic,
-      ).whenComplete(() {
+      )
+          .whenComplete(() {
         if (mounted && generation == _scrollGeneration) {
           _programmaticScroll = false;
         }
       });
     });
-  }
-
-  void _toggleFollowPlayback() {
-    setState(() => _followPlayback = !_followPlayback);
-    if (_followPlayback && _firstActiveIndex != null) {
-      _scheduleScrollTo(_firstActiveIndex!);
-    }
   }
 
   bool _handleScrollNotification(ScrollNotification notification) {
@@ -845,6 +883,13 @@ class _DanmakuListState extends State<_DanmakuList> {
     return false;
   }
 
+  void _toggleFollowPlayback() {
+    setState(() => _followPlayback = !_followPlayback);
+    if (_followPlayback && _firstActiveIndex != null) {
+      _scheduleScrollTo(_firstActiveIndex!);
+    }
+  }
+
   @override
   void dispose() {
     _scrollController.dispose();
@@ -853,113 +898,98 @@ class _DanmakuListState extends State<_DanmakuList> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final localizations = context.l10n;
-    final items = widget.items;
-    final activeCount = items.where((item) => item.isActive).length;
+    final activeCount = widget.items.where((item) => item.isActive).length;
     final followDescription = _followPlayback
         ? localizations.externalPlayerConsoleDanmakuFollowEnabled
         : localizations.externalPlayerConsoleDanmakuFollowDisabled;
+    final list = LayoutBuilder(
+      builder: (context, constraints) {
+        final compact = constraints.maxWidth < 620;
+        _itemExtent = compact ? 104 : 72;
+        final borderColor =
+            Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.09);
+        return ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: DecoratedBox(
+            decoration: BoxDecoration(border: Border.all(color: borderColor)),
+            child: NotificationListener<ScrollNotification>(
+              onNotification: _handleScrollNotification,
+              child: Scrollbar(
+                controller: _scrollController,
+                child: ListView.builder(
+                  controller: _scrollController,
+                  itemExtent: _itemExtent,
+                  itemCount: widget.items.length,
+                  itemBuilder: (context, index) {
+                    final displayItem = widget.items[index];
+                    final item = displayItem.item;
+                    return _DanmakuRow(
+                      item: item,
+                      itemId: '${displayItem.index}-${item.danmakuId ?? ''}',
+                      startTime: displayItem.startTime,
+                      active: displayItem.isActive,
+                      blocked: displayItem.isBlocked,
+                      compact: compact,
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          children: [
-            Icon(Icons.view_list_outlined, color: theme.colorScheme.primary),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    localizations.externalPlayerConsoleDanmakuList,
-                    style: theme.textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    localizations.externalPlayerConsoleDanmakuStats(
-                      items.length,
-                      activeCount,
-                    ),
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Tooltip(
-              message: followDescription,
-              child: IconButton(
-                onPressed: items.isEmpty ? null : _toggleFollowPlayback,
-                icon: Icon(
-                  _followPlayback
-                      ? Icons.my_location
-                      : Icons.location_disabled_outlined,
-                ),
-              ),
-            ),
-          ],
+        NipaplayLargeScreenSectionHeader(
+          title: localizations.externalPlayerConsoleDanmakuList,
+          subtitle: localizations.externalPlayerConsoleDanmakuStats(
+            widget.items.length,
+            activeCount,
+          ),
+          trailing: NipaplayLargeScreenIconButton(
+            icon: _followPlayback
+                ? Icons.my_location_rounded
+                : Icons.location_disabled_outlined,
+            tooltip: followDescription,
+            onPressed: widget.items.isEmpty ? null : _toggleFollowPlayback,
+          ),
         ),
         const SizedBox(height: 12),
-        if (items.isEmpty)
-          Container(
-            width: double.infinity,
-            padding: const EdgeInsets.symmetric(vertical: 36, horizontal: 16),
-            decoration: BoxDecoration(
-              color: theme.colorScheme.surfaceContainerLow,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: theme.colorScheme.outlineVariant),
-            ),
-            child: Text(
-              localizations.externalPlayerConsoleDanmakuEmpty,
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
+        if (widget.items.isEmpty && widget.fillAvailableHeight)
+          Expanded(
+            child: NipaplayLargeScreenEmptyState(
+              icon: Icons.speaker_notes_off_outlined,
+              title: localizations.externalPlayerConsoleDanmakuEmpty,
+              subtitle: _localized(
+                context,
+                '当前播放会话没有可显示的弹幕。',
+                '目前播放工作階段沒有可顯示的彈幕。',
+                'There are no danmaku comments for this session.',
               ),
             ),
           )
+        else if (widget.items.isEmpty)
+          SizedBox(
+            height: 430,
+            child: NipaplayLargeScreenEmptyState(
+              icon: Icons.speaker_notes_off_outlined,
+              title: localizations.externalPlayerConsoleDanmakuEmpty,
+              subtitle: _localized(
+                context,
+                '当前播放会话没有可显示的弹幕。',
+                '目前播放工作階段沒有可顯示的彈幕。',
+                'There are no danmaku comments for this session.',
+              ),
+            ),
+          )
+        else if (widget.fillAvailableHeight)
+          Expanded(child: list)
         else
-          LayoutBuilder(
-            builder: (context, constraints) {
-              final compact = constraints.maxWidth < 680;
-              _itemExtent = compact ? 106 : 64;
-              return Container(
-                height: 384,
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.surfaceContainerLow,
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(color: theme.colorScheme.outlineVariant),
-                ),
-                clipBehavior: Clip.antiAlias,
-                child: NotificationListener<ScrollNotification>(
-                  onNotification: _handleScrollNotification,
-                  child: Scrollbar(
-                    controller: _scrollController,
-                    child: ListView.builder(
-                      controller: _scrollController,
-                      itemExtent: _itemExtent,
-                      itemCount: items.length,
-                      itemBuilder: (context, index) {
-                        final displayItem = items[index];
-                        final item = displayItem.item;
-                        return _DanmakuRow(
-                          item: item,
-                          itemId:
-                              '${displayItem.index}-${item.danmakuId ?? ''}',
-                          startTime: displayItem.startTime,
-                          active: displayItem.isActive,
-                          blocked: displayItem.isBlocked,
-                          compact: compact,
-                        );
-                      },
-                    ),
-                  ),
-                ),
-              );
-            },
-          ),
+          SizedBox(height: 430, child: list),
       ],
     );
   }
@@ -993,14 +1023,14 @@ class _DanmakuRow extends StatelessWidget {
       DanmakuMode.reverseScroll ||
       DanmakuMode.advanced =>
         localizations.externalPlayerConsoleDanmakuTypeScroll,
-      DanmakuMode.top =>
-        localizations.externalPlayerConsoleDanmakuTypeTop,
+      DanmakuMode.top => localizations.externalPlayerConsoleDanmakuTypeTop,
       DanmakuMode.bottom =>
         localizations.externalPlayerConsoleDanmakuTypeBottom,
     };
     final rgb = item.colorRgb & 0xFFFFFF;
     final colorText = '#${rgb.toRadixString(16).toUpperCase().padLeft(6, '0')}';
     final color = Color(0xFF000000 | rgb);
+    final divider = theme.colorScheme.onSurface.withValues(alpha: 0.08);
 
     return Container(
       key: ValueKey('external-player-danmaku-$itemId'),
@@ -1010,14 +1040,14 @@ class _DanmakuRow extends StatelessWidget {
       ),
       decoration: BoxDecoration(
         color: active
-            ? theme.colorScheme.primaryContainer.withValues(alpha: 0.55)
+            ? AppAccentColors.current.withValues(alpha: 0.15)
             : blocked
-                ? theme.colorScheme.surfaceContainerHighest
+                ? theme.colorScheme.onSurface.withValues(alpha: 0.05)
                 : null,
         border: Border(
-          bottom: BorderSide(color: theme.colorScheme.outlineVariant),
+          bottom: BorderSide(color: divider),
           left: BorderSide(
-            color: active ? theme.colorScheme.primary : Colors.transparent,
+            color: active ? AppAccentColors.current : Colors.transparent,
             width: 3,
           ),
         ),
@@ -1025,48 +1055,34 @@ class _DanmakuRow extends StatelessWidget {
       child: compact
           ? Column(
               crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Row(
                   children: [
-                    Text(
-                      _formatDanmakuTime(startTime),
-                      style: theme.textTheme.labelMedium,
-                    ),
+                    Text(_formatDanmakuTime(startTime),
+                        style: theme.textTheme.labelMedium),
                     const SizedBox(width: 10),
-                    Text(
-                      type,
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                    ),
+                    Text(type, style: _mutedStyle(context)),
                     const Spacer(),
-                    if (blocked) _BlockedDanmakuIndicator(itemId: itemId),
+                    if (blocked) _BlockedIndicator(itemId: itemId),
                     if (blocked && active) const SizedBox(width: 6),
-                    if (active) _ActiveDanmakuIndicator(itemId: itemId),
+                    if (active) _ActiveIndicator(itemId: itemId),
                   ],
                 ),
                 const SizedBox(height: 5),
-                Text(
-                  item.content,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
+                Text(item.content,
+                    maxLines: 1, overflow: TextOverflow.ellipsis),
                 const SizedBox(height: 5),
                 Row(
                   children: [
                     _DanmakuColor(color: color, label: colorText),
                     const SizedBox(width: 14),
                     Expanded(
-                      child: Tooltip(
-                        message: sender,
-                        child: Text(
-                          '${localizations.externalPlayerConsoleDanmakuSender}: $sender',
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant,
-                          ),
-                        ),
+                      child: Text(
+                        '${localizations.externalPlayerConsoleDanmakuSender}: $sender',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: _mutedStyle(context),
                       ),
                     ),
                   ],
@@ -1076,58 +1092,32 @@ class _DanmakuRow extends StatelessWidget {
           : Row(
               children: [
                 SizedBox(
-                  width: 96,
-                  child: Text(
-                    _formatDanmakuTime(startTime),
-                    style: theme.textTheme.labelMedium,
-                  ),
+                  width: 92,
+                  child: Text(_formatDanmakuTime(startTime),
+                      style: theme.textTheme.labelMedium),
                 ),
                 SizedBox(
-                  width: 112,
-                  child: _DanmakuColor(color: color, label: colorText),
-                ),
+                    width: 112,
+                    child: _DanmakuColor(color: color, label: colorText)),
                 SizedBox(
-                  width: 72,
-                  child: Text(
-                    type,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ),
+                    width: 64, child: Text(type, style: _mutedStyle(context))),
                 SizedBox(
-                  width: 150,
-                  child: Tooltip(
-                    message: sender,
-                    child: Text(
-                      sender,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
+                  width: 120,
                   child: Text(
-                    item.content,
-                    maxLines: 2,
+                    sender,
+                    maxLines: 1,
                     overflow: TextOverflow.ellipsis,
+                    style: _mutedStyle(context),
                   ),
                 ),
-                SizedBox(
-                  width: 64,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      if (blocked) _BlockedDanmakuIndicator(itemId: itemId),
-                      if (blocked && active) const SizedBox(width: 6),
-                      if (active) _ActiveDanmakuIndicator(itemId: itemId),
-                    ],
-                  ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(item.content,
+                      maxLines: 2, overflow: TextOverflow.ellipsis),
                 ),
+                if (blocked) _BlockedIndicator(itemId: itemId),
+                if (blocked && active) const SizedBox(width: 6),
+                if (active) _ActiveIndicator(itemId: itemId),
               ],
             ),
     );
@@ -1152,7 +1142,9 @@ class _DanmakuColor extends StatelessWidget {
             color: color,
             borderRadius: BorderRadius.circular(3),
             border: Border.all(
-              color: Theme.of(context).colorScheme.outline,
+              color: Theme.of(context).colorScheme.onSurface.withValues(
+                    alpha: 0.25,
+                  ),
               width: 0.5,
             ),
           ),
@@ -1164,8 +1156,8 @@ class _DanmakuColor extends StatelessWidget {
   }
 }
 
-class _ActiveDanmakuIndicator extends StatelessWidget {
-  const _ActiveDanmakuIndicator({required this.itemId});
+class _ActiveIndicator extends StatelessWidget {
+  const _ActiveIndicator({required this.itemId});
 
   final String itemId;
 
@@ -1177,14 +1169,14 @@ class _ActiveDanmakuIndicator extends StatelessWidget {
         Icons.motion_photos_on_rounded,
         key: ValueKey('external-player-danmaku-active-$itemId'),
         size: 18,
-        color: Theme.of(context).colorScheme.primary,
+        color: AppAccentColors.current,
       ),
     );
   }
 }
 
-class _BlockedDanmakuIndicator extends StatelessWidget {
-  const _BlockedDanmakuIndicator({required this.itemId});
+class _BlockedIndicator extends StatelessWidget {
+  const _BlockedIndicator({required this.itemId});
 
   final String itemId;
 
@@ -1202,16 +1194,6 @@ class _BlockedDanmakuIndicator extends StatelessWidget {
   }
 }
 
-String _formatDanmakuTime(Duration value) {
-  final hours = value.inHours.toString().padLeft(2, '0');
-  final minutes = value.inMinutes.remainder(60).toString().padLeft(2, '0');
-  final seconds = value.inSeconds.remainder(60).toString().padLeft(2, '0');
-  final milliseconds = value.inMilliseconds.remainder(1000).toString().padLeft(3, '0');
-  return '$hours:$minutes:$seconds.$milliseconds';
-}
-
-
-/// 显示外部播放器进度的滑块组件
 class _SeekProgress extends StatefulWidget {
   const _SeekProgress({
     required this.sessionId,
@@ -1231,19 +1213,11 @@ class _SeekProgress extends StatefulWidget {
   State<_SeekProgress> createState() => _SeekProgressState();
 }
 
-/// 显示外部播放器进度的滑块组件的状态类
 class _SeekProgressState extends State<_SeekProgress> {
   double? _dragFraction;
   final TextEditingController _timestampController = TextEditingController();
   bool _timestampInvalid = false;
 
-  @override
-  void dispose() {
-    _timestampController.dispose();
-    super.dispose();
-  }
-
-  /// 当 widget 更新时, 如果 session 发生变化, 则重置拖动进度
   @override
   void didUpdateWidget(_SeekProgress oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -1254,19 +1228,26 @@ class _SeekProgressState extends State<_SeekProgress> {
     }
   }
 
-  /// 构建进度滑块组件
+  @override
+  void dispose() {
+    _timestampController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    final theme            = Theme.of(context);
-    final localizations    = context.l10n;
-    final supportsProgress = widget.supportsProgress;
-    final hasProgress      = widget.position != null && widget.duration > Duration.zero;
-    final canSeek          = supportsProgress && hasProgress;
-    final fraction         = (_dragFraction ?? widget.fraction ?? 0.0).clamp(0.0, 1.0).toDouble();
-    final displayPosition  = _dragFraction == null || !hasProgress
+    final localizations = context.l10n;
+    final hasProgress =
+        widget.position != null && widget.duration > Duration.zero;
+    final canSeek = widget.supportsProgress && hasProgress;
+    final fraction =
+        (_dragFraction ?? widget.fraction ?? 0).clamp(0.0, 1.0).toDouble();
+    final displayPosition = _dragFraction == null || !hasProgress
         ? widget.position
-        : Duration(milliseconds: (widget.duration.inMilliseconds * fraction).round());
-    final progressText = !supportsProgress
+        : Duration(
+            milliseconds: (widget.duration.inMilliseconds * fraction).round(),
+          );
+    final progressText = !widget.supportsProgress
         ? localizations.externalPlayerConsoleProgressUnsupported
         : !hasProgress
             ? localizations.externalPlayerConsoleProgressLoading
@@ -1275,17 +1256,15 @@ class _SeekProgressState extends State<_SeekProgress> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Slider(
+        NipaplayLargeScreenEditableSlider(
           value: fraction,
           min: 0,
           max: 1,
           label: hasProgress ? _formatDuration(displayPosition!) : null,
-          onChangeStart: canSeek
-              ? (value) => setState(() => _dragFraction = value)
-              : null,
-          onChanged: canSeek
-              ? (value) => setState(() => _dragFraction = value)
-              : null,
+          onChangeStart:
+              canSeek ? (value) => setState(() => _dragFraction = value) : null,
+          onChanged:
+              canSeek ? (value) => setState(() => _dragFraction = value) : null,
           onChangeEnd: canSeek
               ? (value) {
                   ExternalPlayerConsoleService.seekToFraction(value);
@@ -1293,50 +1272,41 @@ class _SeekProgressState extends State<_SeekProgress> {
                 }
               : null,
         ),
-        const SizedBox(height: 8),
-        Text(
-          progressText,
-          style: theme.textTheme.bodyMedium?.copyWith(
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-        ),
-        const SizedBox(height: 12),
-        Wrap(
-          spacing: 12,
-          runSpacing: 8,
-          crossAxisAlignment: WrapCrossAlignment.center,
+        const SizedBox(height: 6),
+        Text(progressText, style: _mutedStyle(context)),
+        const SizedBox(height: 10),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SizedBox(
-              width: 280,
-              child: TextField(
+            Expanded(
+              child: _ConsoleTextField(
                 key: const Key('external-player-timestamp-input'),
                 controller: _timestampController,
-                enabled: supportsProgress,
+                enabled: widget.supportsProgress,
+                hintText: localizations.externalPlayerConsoleTimestampHint,
+                prefixIcon: Icons.schedule_rounded,
                 keyboardType: TextInputType.datetime,
-                textInputAction: TextInputAction.go,
-                decoration: InputDecoration(
-                  isDense: true,
-                  border: const OutlineInputBorder(),
-                  labelText: localizations.externalPlayerConsoleTimestampLabel,
-                  hintText: localizations.externalPlayerConsoleTimestampHint,
-                  errorText: _timestampInvalid
-                      ? localizations.externalPlayerConsoleTimestampInvalid
-                      : null,
-                  prefixIcon: const Icon(Icons.schedule),
-                ),
+                errorText: _timestampInvalid
+                    ? localizations.externalPlayerConsoleTimestampInvalid
+                    : null,
                 onChanged: (_) {
                   if (_timestampInvalid) {
                     setState(() => _timestampInvalid = false);
                   }
                 },
-                onSubmitted: supportsProgress ? (_) => _seekToTimestamp() : null,
+                onSubmitted:
+                    widget.supportsProgress ? (_) => _seekToTimestamp() : null,
               ),
             ),
-            FilledButton.tonalIcon(
+            const SizedBox(width: 8),
+            KeyedSubtree(
               key: const Key('external-player-timestamp-seek'),
-              onPressed: supportsProgress ? _seekToTimestamp : null,
-              icon: const Icon(Icons.my_location),
-              label: Text(localizations.externalPlayerConsoleTimestampSeek),
+              child: NipaplayLargeScreenActionButton(
+                icon: Icons.my_location_rounded,
+                label: localizations.externalPlayerConsoleTimestampSeek,
+                onPressed: widget.supportsProgress ? _seekToTimestamp : null,
+                compact: true,
+              ),
             ),
           ],
         ),
@@ -1352,11 +1322,156 @@ class _SeekProgressState extends State<_SeekProgress> {
     if (succeeded) FocusScope.of(context).unfocus();
   }
 
-  /// 将给定的 Duration 转换为格式化的字符串 (HH:MM:SS 或 MM:SS)
   static String _formatDuration(Duration value) {
     final hours = value.inHours;
     final minutes = value.inMinutes.remainder(60).toString().padLeft(2, '0');
     final seconds = value.inSeconds.remainder(60).toString().padLeft(2, '0');
     return hours > 0 ? '$hours:$minutes:$seconds' : '$minutes:$seconds';
   }
+}
+
+class _ChoiceButton extends StatelessWidget {
+  const _ChoiceButton({
+    required this.icon,
+    required this.label,
+    required this.selected,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool selected;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = AppAccentColors.current;
+    return NipaplayLargeScreenFocusableAction(
+      onActivate: onPressed,
+      borderRadius: BorderRadius.circular(8),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+      style: NipaplayLargeScreenFocusableStyle(
+        idleBackgroundDark: selected
+            ? accent.withValues(alpha: 0.24)
+            : Colors.white.withValues(alpha: 0.08),
+        idleBackgroundLight: selected
+            ? accent.withValues(alpha: 0.16)
+            : Colors.black.withValues(alpha: 0.04),
+        focusStrokeColor: accent,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 18),
+          const SizedBox(width: 7),
+          Text(label, style: const TextStyle(fontWeight: FontWeight.w700)),
+        ],
+      ),
+    );
+  }
+}
+
+class _ConsoleTextField extends StatelessWidget {
+  const _ConsoleTextField({
+    super.key,
+    required this.controller,
+    required this.hintText,
+    required this.prefixIcon,
+    this.enabled = true,
+    this.keyboardType,
+    this.errorText,
+    this.onChanged,
+    this.onSubmitted,
+  });
+
+  final TextEditingController controller;
+  final String hintText;
+  final IconData prefixIcon;
+  final bool enabled;
+  final TextInputType? keyboardType;
+  final String? errorText;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final color = Theme.of(context).colorScheme.onSurface;
+    final border = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: BorderSide(color: color.withValues(alpha: 0.10)),
+    );
+    return TextField(
+      controller: controller,
+      enabled: enabled,
+      keyboardType: keyboardType,
+      textInputAction: TextInputAction.done,
+      onChanged: onChanged,
+      onSubmitted: onSubmitted,
+      decoration: InputDecoration(
+        isDense: true,
+        filled: true,
+        fillColor: isDark
+            ? Colors.white.withValues(alpha: 0.075)
+            : Colors.white.withValues(alpha: 0.72),
+        prefixIcon: Icon(prefixIcon, size: 19),
+        hintText: hintText,
+        errorText: errorText,
+        border: border,
+        enabledBorder: border,
+        focusedBorder: border.copyWith(
+          borderSide: BorderSide(color: AppAccentColors.current, width: 1.5),
+        ),
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+      ),
+    );
+  }
+}
+
+TextStyle _sectionLabelStyle(BuildContext context) {
+  return TextStyle(
+    color: Theme.of(context).colorScheme.onSurface,
+    fontSize: 15,
+    fontWeight: FontWeight.w800,
+  );
+}
+
+TextStyle _mutedStyle(BuildContext context) {
+  return TextStyle(
+    color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.60),
+    fontSize: 12,
+    fontWeight: FontWeight.w600,
+  );
+}
+
+String _nonEmptyOr(String? value, String fallback) {
+  return value == null || value.trim().isEmpty ? fallback : value;
+}
+
+String _formatSeconds(double value) {
+  final text = value.toStringAsFixed(3);
+  return text.replaceFirst(RegExp(r'\.?0+$'), '');
+}
+
+String _formatDanmakuTime(Duration value) {
+  final hours = value.inHours.toString().padLeft(2, '0');
+  final minutes = value.inMinutes.remainder(60).toString().padLeft(2, '0');
+  final seconds = value.inSeconds.remainder(60).toString().padLeft(2, '0');
+  final milliseconds =
+      value.inMilliseconds.remainder(1000).toString().padLeft(3, '0');
+  return '$hours:$minutes:$seconds.$milliseconds';
+}
+
+String _localized(
+  BuildContext context,
+  String simplified,
+  String traditional,
+  String english,
+) {
+  return switch (context.l10n.localeName) {
+    'en' => english,
+    'zh_Hant' => traditional,
+    _ => simplified,
+  };
 }

--- a/lib/pages/external_player_console_page.dart
+++ b/lib/pages/external_player_console_page.dart
@@ -1,6 +1,6 @@
 
 // lib/pages/external_player_console_page.dart
-// 掌管 Linux 平台下外部播放器会话的控制台页面
+// 掌管 Linux/macOS 平台下外部播放器会话的控制台页面
 
 
 import 'package:flutter/material.dart';

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -29,6 +29,7 @@ class SettingsProvider with ChangeNotifier {
   String _externalPlayerPath = '';
   bool _externalPlayerDanmakuOverlay = true; // 弹幕外挂默认开启
   bool _externalPlayerAutoSwitchToDanmakuConsole = true;
+  bool _externalPlayerShrinkWindow = false;
 
   // GitHub 代理设置
   String _githubProxyUrl = '';
@@ -49,7 +50,9 @@ class SettingsProvider with ChangeNotifier {
   bool get useExternalPlayer => _useExternalPlayer;
   String get externalPlayerPath => _externalPlayerPath;
   bool get externalPlayerDanmakuOverlay => _externalPlayerDanmakuOverlay;
-  bool get externalPlayerAutoSwitchToDanmakuConsole => _externalPlayerAutoSwitchToDanmakuConsole;
+  bool get externalPlayerAutoSwitchToDanmakuConsole =>
+      _externalPlayerAutoSwitchToDanmakuConsole;
+  bool get externalPlayerShrinkWindow => _externalPlayerShrinkWindow;
   String get githubProxyUrl => _githubProxyUrl;
   double get danmakuSupersample => _danmakuSupersample;
 
@@ -62,11 +65,13 @@ class SettingsProvider with ChangeNotifier {
     // Load blur power, defaulting to 0.0 if not set (无模糊)
     _blurPower = _prefs.getDouble(_blurPowerKey) ?? _defaultBlur;
     // 当用户仍为“自动语言”且系统为繁中时，首次默认关闭“弹幕转简体”。
-    final savedDanmakuConvert = _prefs.getBool(SettingsKeys.danmakuConvertToSimplified);
+    final savedDanmakuConvert =
+        _prefs.getBool(SettingsKeys.danmakuConvertToSimplified);
     if (savedDanmakuConvert != null) {
       _danmakuConvertToSimplified = savedDanmakuConvert;
     } else {
-      final languageMode = _prefs.getString(SettingsKeys.appLanguageMode) ?? 'auto';
+      final languageMode =
+          _prefs.getString(SettingsKeys.appLanguageMode) ?? 'auto';
       if (languageMode == 'auto') {
         final systemLocale = WidgetsBinding.instance.platformDispatcher.locale;
         _danmakuConvertToSimplified =
@@ -75,9 +80,9 @@ class SettingsProvider with ChangeNotifier {
         _danmakuConvertToSimplified = true;
       }
     }
-    _autoMatchDanmakuFirstSearchResultOnHashFail =
-        _prefs.getBool(SettingsKeys.autoMatchDanmakuFirstSearchResultOnHashFail) ??
-            true;
+    _autoMatchDanmakuFirstSearchResultOnHashFail = _prefs.getBool(
+            SettingsKeys.autoMatchDanmakuFirstSearchResultOnHashFail) ??
+        true;
     final savedAutoMatchDanmakuOnPlay =
         _prefs.getBool(SettingsKeys.autoMatchDanmakuOnPlay);
     _autoMatchDanmakuOnPlay = savedAutoMatchDanmakuOnPlay ?? true;
@@ -99,12 +104,17 @@ class SettingsProvider with ChangeNotifier {
         _prefs.getString(SettingsKeys.externalPlayerPath) ?? '';
     _externalPlayerDanmakuOverlay =
         _prefs.getBool(SettingsKeys.externalPlayerDanmakuOverlay) ?? true;
-    _externalPlayerAutoSwitchToDanmakuConsole = _prefs.getBool(SettingsKeys.externalPlayerAutoSwitchToDanmakuConsole) ?? true;
-    _githubProxyUrl =
-        _prefs.getString(SettingsKeys.githubProxyUrl) ?? '';
+    _externalPlayerAutoSwitchToDanmakuConsole =
+        _prefs.getBool(SettingsKeys.externalPlayerAutoSwitchToDanmakuConsole) ??
+            true;
+    _externalPlayerShrinkWindow =
+        _prefs.getBool(SettingsKeys.externalPlayerShrinkWindow) ?? false;
+    _githubProxyUrl = _prefs.getString(SettingsKeys.githubProxyUrl) ?? '';
     // 弹幕超采样：默认对平板和低 DPR 桌面设备开启 2x
     final defaultSupersample =
-        globals.isTablet || (globals.isDesktop && _defaultDprBelow2()) ? 2.0 : 0.0;
+        globals.isTablet || (globals.isDesktop && _defaultDprBelow2())
+            ? 2.0
+            : 0.0;
     _danmakuSupersample =
         _prefs.getDouble(SettingsKeys.danmakuSupersample) ?? defaultSupersample;
     notifyListeners();
@@ -115,8 +125,8 @@ class SettingsProvider with ChangeNotifier {
   /// 判断当前设备默认 DPR 是否低于 2.0
   static bool _defaultDprBelow2() {
     try {
-      final dpr = WidgetsBinding.instance.platformDispatcher.views.first
-          .devicePixelRatio;
+      final dpr = WidgetsBinding
+          .instance.platformDispatcher.views.first.devicePixelRatio;
       return dpr < 2.0;
     } catch (_) {
       return false;
@@ -143,7 +153,8 @@ class SettingsProvider with ChangeNotifier {
   /// Sets the danmaku convert to simplified Chinese setting.
   Future<void> setDanmakuConvertToSimplified(bool enable) async {
     _danmakuConvertToSimplified = enable;
-    await _prefs.setBool(SettingsKeys.danmakuConvertToSimplified, _danmakuConvertToSimplified);
+    await _prefs.setBool(
+        SettingsKeys.danmakuConvertToSimplified, _danmakuConvertToSimplified);
     notifyListeners();
   }
 
@@ -226,15 +237,24 @@ class SettingsProvider with ChangeNotifier {
   }
 
   Future<void> setExternalPlayerAutoSwitchToDanmakuConsole(bool enable) async {
-
-    if   ( _externalPlayerAutoSwitchToDanmakuConsole == enable) { return; }
-    else { _externalPlayerAutoSwitchToDanmakuConsole =  enable; }
+    if (_externalPlayerAutoSwitchToDanmakuConsole == enable) return;
+    _externalPlayerAutoSwitchToDanmakuConsole = enable;
 
     await _prefs.setBool(
       SettingsKeys.externalPlayerAutoSwitchToDanmakuConsole,
       _externalPlayerAutoSwitchToDanmakuConsole,
     );
 
+    notifyListeners();
+  }
+
+  Future<void> setExternalPlayerShrinkWindow(bool enable) async {
+    if (_externalPlayerShrinkWindow == enable) return;
+    _externalPlayerShrinkWindow = enable;
+    await _prefs.setBool(
+      SettingsKeys.externalPlayerShrinkWindow,
+      _externalPlayerShrinkWindow,
+    );
     notifyListeners();
   }
 
@@ -252,5 +272,4 @@ class SettingsProvider with ChangeNotifier {
     await _prefs.setDouble(SettingsKeys.danmakuSupersample, value);
     notifyListeners();
   }
-
 }

--- a/lib/services/external_player_console_service.dart
+++ b/lib/services/external_player_console_service.dart
@@ -1,6 +1,5 @@
-
 // lib/services/external_player_console_service.dart
-// Linux 外部播放器控制台服务
+// Linux/macOS 外部播放器控制台服务
 
 import 'dart:convert';
 import 'dart:io';
@@ -9,12 +8,11 @@ import 'package:flutter/foundation.dart';
 import 'package:nipaplay/models/danmaku/blocked_item.dart';
 import 'package:nipaplay/models/danmaku/danmaku_item.dart';
 import 'package:nipaplay/models/danmaku/style.dart';
-import 'package:nipaplay/models/external_player_session/linux_session.dart';
+import 'package:nipaplay/models/external_player_session/mpv_session.dart';
 import 'package:nipaplay/models/external_player_session/session.dart';
 import 'package:nipaplay/utils/danmaku_ass_converter.dart';
 import 'package:nipaplay/utils/external_player_danmaku_ass.dart';
 import 'package:nipaplay/utils/utils.dart';
-
 
 /// 番剧元数据
 class EpisodeMetaData {
@@ -31,11 +29,10 @@ class EpisodeMetaData {
 
 /// 控制台状态
 class ConsoleState {
-
-  final ExternalPlayerLaunchSession session;          // 外部播放器会话
-  final EpisodeMetaData           ? episodeMetaData;  // 番剧元数据
-  final List<DanmakuItem>         ? danmakuList;      // 弹幕列表
-  final DanmakuStyle              ? danmakuStyle;     // 弹幕样式
+  final ExternalPlayerLaunchSession session; // 外部播放器会话
+  final EpisodeMetaData? episodeMetaData; // 番剧元数据
+  final List<DanmakuItem>? danmakuList; // 弹幕列表
+  final DanmakuStyle? danmakuStyle; // 弹幕样式
 
   const ConsoleState({
     required this.session,
@@ -45,20 +42,19 @@ class ConsoleState {
   });
 }
 
-
 /// 管理外部播放器控制台, 当前番剧信息和弹幕渲染状态.
 ///
 /// 本服务维护弹幕源列表和 ASS 设置, 样式变化时重新生成 ASS;
 /// 外部播放器进程交互统一委托给 [ExternalPlayerLaunchSession].
 class ExternalPlayerConsoleService extends ChangeNotifier {
-
   // 单例
   ExternalPlayerConsoleService._();
-  static final ExternalPlayerConsoleService _instance = ExternalPlayerConsoleService._();
+  static final ExternalPlayerConsoleService _instance =
+      ExternalPlayerConsoleService._();
 
   // 平台支持
-  static bool get isSupportedPlatform => !kIsWeb && Platform.isLinux;
-
+  static bool get isSupportedPlatform =>
+      !kIsWeb && (Platform.isLinux || Platform.isMacOS);
 
   // ======================================================================== //
   // =========================== 内部状态字段 =============================== //
@@ -66,21 +62,21 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
 
   static int _stateTimestamp = 0; // 配置变更时间戳, 用于检测异步任务是否已过期
 
-  static ExternalPlayerLaunchSession?  _session; // 外部播放器会话
+  static ExternalPlayerLaunchSession? _session; // 外部播放器会话
 
   // 动漫元数据相关
   // ------------------------------------------------------------------------ //
-  static String? _animeTitle;   // 番剧标题
+  static String? _animeTitle; // 番剧标题
   static String? _episodeTitle; // 剧集标题
-  static int?    _episodeId;    // 剧集 ID
-
+  static int? _episodeId; // 剧集 ID
 
   // 弹幕资产相关
   // ------------------------------------------------------------------------ //
 
   // 弹幕列表和屏蔽规则
   static List<BlockedDanmakuItem> _blockedItems = const []; // 弹幕屏蔽项目列表
-  static List<DisplayDanmakuItem> _displayDanmakuList = const []; // 弹幕列表, 包含源数据和显示状态
+  static List<DisplayDanmakuItem> _displayDanmakuList =
+      const []; // 弹幕列表, 包含源数据和显示状态
 
   /// 当前弹幕样式. 外部修改字段后调用 [queueDanmakuRefresh] 应用到 mpv.
   static final DanmakuStyle _danmakuStyle = DanmakuStyle();
@@ -88,42 +84,40 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
   // 由于 ASS 样式更新可能涉及文件写入和 mpv IPC 通信, 为避免并发冲突, 使用队列顺序执行样式更新任务
   static Future<void> _danmakuStyleUpdateQueue = Future<void>.value();
 
-
   // ======================================================================== //
   // ========================= Getters & Setters ============================ //
   // ======================================================================== //
 
   // 控制台相关
   // ------------------------------------------------------------------------ //
-  static Listenable get instance         => _instance;
-  static bool       get hasActiveSession => _session != null;
-  static int        get stateTimestamp   => _stateTimestamp;
+  static Listenable get instance => _instance;
+  static bool get hasActiveSession => _session != null;
+  static int get stateTimestamp => _stateTimestamp;
 
   // 播放状态相关
   // ------------------------------------------------------------------------ //
-  static String   ? get mediaPath => _session?.mediaPath;
-  static int      ? get processId => _session?.processId;
-  static String   ? get ipcPath   => _session?.ipcPath;
+  static String? get mediaPath => _session?.mediaPath;
+  static int? get processId => _session?.processId;
+  static String? get ipcPath => _session?.ipcPath;
 
   // 播放控制相关
   // ------------------------------------------------------------------------ //
-  static Duration   get duration  => _session?.duration ?? Duration.zero;
-  static Duration ? get position  => _session?.position;
-  static double   ? get fraction  => _session?.fraction;
-  static bool     ? get isPaused  => _session?.isPaused;
+  static Duration get duration => _session?.duration ?? Duration.zero;
+  static Duration? get position => _session?.position;
+  static double? get fraction => _session?.fraction;
+  static bool? get isPaused => _session?.isPaused;
 
   // 番剧信息相关
   // ------------------------------------------------------------------------ //
-  static String ? get animeTitle   => _animeTitle;
-  static String ? get episodeTitle => _episodeTitle;
-  static int    ? get episodeId    => _episodeId;
+  static String? get animeTitle => _animeTitle;
+  static String? get episodeTitle => _episodeTitle;
+  static int? get episodeId => _episodeId;
 
   // 弹幕相关
   // ------------------------------------------------------------------------ //
-  static DanmakuStyle             get danmakuStyle       => _danmakuStyle;
+  static DanmakuStyle get danmakuStyle => _danmakuStyle;
   static List<DisplayDanmakuItem> get displayDanmakuList => _displayDanmakuList;
-  static List<BlockedDanmakuItem> get blockedItems       => _blockedItems;
-
+  static List<BlockedDanmakuItem> get blockedItems => _blockedItems;
 
   // ======================================================================== //
   // ============================== 主要方法 ================================ //
@@ -134,11 +128,10 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
 
   /// 设置新的 mpv 会话和控制台展示信息.
   static void setState(ConsoleState state) {
-
-    final session         = state.session;
+    final session = state.session;
     final episodeMetaData = state.episodeMetaData;
-    final danmakuList     = state.danmakuList;
-    final danmakuStyle    = state.danmakuStyle;
+    final danmakuList = state.danmakuList;
+    final danmakuStyle = state.danmakuStyle;
 
     // 先移除之前会话的监听器
     final previous = _session;
@@ -148,10 +141,10 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
     if (previous != null && !identical(previous, session)) previous.terminate();
 
     // 设置新的会话和媒体信息
-    _session      = session;
-    _animeTitle   = episodeMetaData?.animeTitle;
+    _session = session;
+    _animeTitle = episodeMetaData?.animeTitle;
     _episodeTitle = episodeMetaData?.episodeTitle;
-    _episodeId    = episodeMetaData?.episodeId;
+    _episodeId = episodeMetaData?.episodeId;
 
     // 更新弹幕样式, 如果未提供则保持现有样式
     final style = danmakuStyle ?? DanmakuStyle();
@@ -168,12 +161,12 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
       sorted.indexed.map((entry) {
         final (index, item) = entry;
         return DisplayDanmakuItem(
-          item      : item,
-          index     : index,
-          startTime : item.time,
-          duration  : Duration.zero,
-          isBlocked : false,
-          isActive  : false,
+          item: item,
+          index: index,
+          startTime: item.time,
+          duration: Duration.zero,
+          isBlocked: false,
+          isActive: false,
         );
       }),
     );
@@ -210,7 +203,6 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
     _instance.notifyListeners();
   }
 
-
   // 视频控制
   // ------------------------------------------------------------------------ //
 
@@ -230,7 +222,6 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
     if (target == null) return false;
     return _session?.seekToPosition(target) ?? false;
   }
-
 
   // 弹幕控制
   // ------------------------------------------------------------------------ //
@@ -255,15 +246,14 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
   ///
   /// 入队时复制 [danmakuStyle], 以避免后续修改影响正在执行的任务.
   static void queueDanmakuRefresh() {
-
     _updateDisplayDanmakuList();
     _markConfigurationChanged('queueDanmakuRefresh');
     _instance.notifyListeners();
 
     // 记录当前状态
-    final currentSession  = _session;
+    final currentSession = _session;
     // 没有完整弹幕资产或 IPC 时只更新控制台状态, 无需生成 ASS
-    if (currentSession is! LinuxSession ||
+    if (currentSession is! MpvSession ||
         currentSession.ipcPath == null ||
         currentSession.danmakuAssets == null ||
         _displayDanmakuList.isEmpty) {
@@ -271,35 +261,35 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
     }
 
     // 保留当前样式和时间戳, 以便在异步任务中检查状态是否已过期
-    final style     = danmakuStyle.copyWith();
+    final style = danmakuStyle.copyWith();
     final timestamp = _stateTimestamp;
 
     Future<void> fun(_) async {
-
       // 如果在队列等待期间状态发生变化, 则跳过当前任务
       if (_configurationHasChanged(timestamp)) return;
 
       // 参数检查
       final assets = currentSession.danmakuAssets;
       if (assets == null) return;
-      final assPath  = assets.assPath;
-      final luaPath  = assets.luaPath;
+      final assPath = assets.assPath;
+      final luaPath = assets.luaPath;
 
       // 将当前弹幕样式应用到 ASS 导出设置
-      final outlineStyle = assets.assSettings.outlineStyle == AssOutlineStyle.none
-        ? AssOutlineStyle.stroke
-        : assets.assSettings.outlineStyle;
-      final AssExportSettings settings =  assets.assSettings.copyWith(
+      final outlineStyle =
+          assets.assSettings.outlineStyle == AssOutlineStyle.none
+              ? AssOutlineStyle.stroke
+              : assets.assSettings.outlineStyle;
+      final AssExportSettings settings = assets.assSettings.copyWith(
         fontSize: style.danmakuFontSize,
         opacity: style.opacity,
         timeOffsetSeconds: style.danmakuOffset,
-        outlineStyle: style.outlineEnabled ? outlineStyle : AssOutlineStyle.none,
+        outlineStyle:
+            style.outlineEnabled ? outlineStyle : AssOutlineStyle.none,
         outlineWidth: style.outlineWidth,
       );
 
       File? temporaryFile; // 临时文件, 用于在写入 ASS 文件时避免覆盖原文件
       try {
-
         // 生成 ASS 内容
         final assStr = await generateExternalPlayerDanmakuAss(
           _displayDanmakuList
@@ -326,12 +316,15 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
 
         // 刷新 mpv 弹幕
         final refreshed = await currentSession.refreshDanmaku(assPath, luaPath);
-        if (!refreshed) debugPrint('[ExternalPlayerConsoleService] Failed to refresh danmaku');
-
+        if (!refreshed) {
+          debugPrint(
+            '[ExternalPlayerConsoleService] Failed to refresh danmaku',
+          );
+        }
       } catch (error) {
-        debugPrint('[ExternalPlayerConsoleService] Failed to regenerate ASS: $error');
-      }
-      finally {
+        debugPrint(
+            '[ExternalPlayerConsoleService] Failed to regenerate ASS: $error');
+      } finally {
         // 删除临时文件, 如果存在的话
         if (temporaryFile?.existsSync() == true) temporaryFile?.deleteSync();
       }
@@ -353,8 +346,8 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
       }
     }
     if (_blockedItems.any(
-      (item) => item.type == type &&
-          item.value.toLowerCase() == value.toLowerCase(),
+      (item) =>
+          item.type == type && item.value.toLowerCase() == value.toLowerCase(),
     )) {
       return false;
     }
@@ -376,7 +369,6 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
     queueDanmakuRefresh();
   }
 
-
   // ======================================================================== //
   // ============================== 私有方法 ================================ //
   // ======================================================================== //
@@ -384,8 +376,10 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
   /// 标记配置已发生变化, 更新时间戳并打印调试信息
   static void _markConfigurationChanged(String reason) {
     final now = DateTime.now().microsecondsSinceEpoch;
-    _stateTimestamp = now > _stateTimestamp ? now : _stateTimestamp + 1; // 确保时间戳单调递增
-    debugPrint('[ExternalPlayerConsoleService] Configuration changed: $reason, timestamp=$_stateTimestamp');
+    _stateTimestamp =
+        now > _stateTimestamp ? now : _stateTimestamp + 1; // 确保时间戳单调递增
+    debugPrint(
+        '[ExternalPlayerConsoleService] Configuration changed: $reason, timestamp=$_stateTimestamp');
   }
 
   /// 检查当前状态是否与给定时间戳不一致, 用于异步任务过期检查
@@ -395,12 +389,10 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
 
   /// 处理会话状态变化的回调
   static void _handleSessionChanged() {
-
     final current = _session;
 
     // 如果当前会话已关闭, 则清空会话和媒体信息, 并通知监听器更新 UI
     if (current != null && current.isClosed) {
-
       current.removeListener(_handleSessionChanged);
       _session = null;
       _animeTitle = null;
@@ -421,30 +413,37 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
 
   /// 更新用于显示的弹幕列表
   static void _updateDisplayDanmakuList() {
-
-    final sourceItems = _displayDanmakuList
-      .map((item) => item.item)
-      .toList(growable: false);
+    final sourceItems =
+        _displayDanmakuList.map((item) => item.item).toList(growable: false);
 
     final position = _session?.position; // 当前播放位置, 用于判断弹幕是否处于显示状态
     final currentSession = _session;
-    final configuredScrollSeconds = currentSession is LinuxSession
-      ? currentSession.danmakuAssets?.assSettings.scrollDurationSeconds ?? 10.0
-      : 10.0;
-    final scrollDuration = configuredScrollSeconds.isFinite && configuredScrollSeconds > 0
-      ? Duration(microseconds: (configuredScrollSeconds * Duration.microsecondsPerSecond).round())
-      : const Duration(seconds: 10);
+    final configuredScrollSeconds = currentSession is MpvSession
+        ? currentSession.danmakuAssets?.assSettings.scrollDurationSeconds ??
+            10.0
+        : 10.0;
+    final scrollDuration =
+        configuredScrollSeconds.isFinite && configuredScrollSeconds > 0
+            ? Duration(
+                microseconds:
+                    (configuredScrollSeconds * Duration.microsecondsPerSecond)
+                        .round())
+            : const Duration(seconds: 10);
 
     DisplayDanmakuItem function(entry) {
-
       // 解构索引和弹幕项
       final (index, item) = entry;
 
       // 计算弹幕的实际显示时间, 考虑了时间偏移
-      final displayTime = item.time + Duration(microseconds:(_danmakuStyle.danmakuOffset * Duration.microsecondsPerSecond).round());
+      final displayTime = item.time +
+          Duration(
+              microseconds:
+                  (_danmakuStyle.danmakuOffset * Duration.microsecondsPerSecond)
+                      .round());
 
       // 设置弹幕的显示持续时间, 滚动弹幕和固定弹幕使用不同的默认值
-      final duration = item.mode.isScrolling ? scrollDuration : const Duration(seconds: 5);
+      final duration =
+          item.mode.isScrolling ? scrollDuration : const Duration(seconds: 5);
 
       // 判断弹幕是否被屏蔽
       bool isBlocked = false;
@@ -452,30 +451,39 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
       final content = item.content.toLowerCase();
       for (final b in _blockedItems) {
         final blockedValue = b.value.toLowerCase();
-        switch (b.type)
-        {
-        case BlockedItemType.keyword : if (content.contains(blockedValue)                              ) isBlocked = true; break;
-        case BlockedItemType.regex   : if (RegExp(b.value,caseSensitive: false).hasMatch(item.content) ) isBlocked = true; break;
-        case BlockedItemType.userId  : if (item.senderId?.toLowerCase() == blockedValue                ) isBlocked = true; break;
+        switch (b.type) {
+          case BlockedItemType.keyword:
+            if (content.contains(blockedValue)) isBlocked = true;
+            break;
+          case BlockedItemType.regex:
+            if (RegExp(b.value, caseSensitive: false).hasMatch(item.content)) {
+              isBlocked = true;
+            }
+            break;
+          case BlockedItemType.userId:
+            if (item.senderId?.toLowerCase() == blockedValue) isBlocked = true;
+            break;
         }
       }
 
       // 判断弹幕是否在当前播放位置显示
-      final isInRange = position != null && position >= displayTime && position < displayTime + duration;
+      final isInRange = position != null &&
+          position >= displayTime &&
+          position < displayTime + duration;
       final isActive = !isBlocked && isInRange;
 
       // 创建用于显示的弹幕数据项
       return DisplayDanmakuItem(
-        item      : item,
-        index     : index,
-        startTime : displayTime,
-        duration  : duration,
-        isBlocked : isBlocked,
-        isActive  : isActive,
+        item: item,
+        index: index,
+        startTime: displayTime,
+        duration: duration,
+        isBlocked: isBlocked,
+        isActive: isActive,
       );
     }
 
-    _displayDanmakuList = List<DisplayDanmakuItem>.unmodifiable(sourceItems.indexed.map(function));
+    _displayDanmakuList = List<DisplayDanmakuItem>.unmodifiable(
+        sourceItems.indexed.map(function));
   }
-
 }

--- a/lib/services/external_player_console_service.dart
+++ b/lib/services/external_player_console_service.dart
@@ -1,6 +1,7 @@
 // lib/services/external_player_console_service.dart
 // Linux/macOS 外部播放器控制台服务
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -10,6 +11,7 @@ import 'package:nipaplay/models/danmaku/danmaku_item.dart';
 import 'package:nipaplay/models/danmaku/style.dart';
 import 'package:nipaplay/models/external_player_session/mpv_session.dart';
 import 'package:nipaplay/models/external_player_session/session.dart';
+import 'package:nipaplay/services/external_player_window_service.dart';
 import 'package:nipaplay/utils/danmaku_ass_converter.dart';
 import 'package:nipaplay/utils/external_player_danmaku_ass.dart';
 import 'package:nipaplay/utils/utils.dart';
@@ -33,12 +35,14 @@ class ConsoleState {
   final EpisodeMetaData? episodeMetaData; // 番剧元数据
   final List<DanmakuItem>? danmakuList; // 弹幕列表
   final DanmakuStyle? danmakuStyle; // 弹幕样式
+  final bool shrinkMainWindow; // 播放期间是否将主窗口缩至当前屏幕半宽
 
   const ConsoleState({
     required this.session,
     this.episodeMetaData,
     this.danmakuList,
     this.danmakuStyle,
+    this.shrinkMainWindow = false,
   });
 }
 
@@ -63,6 +67,8 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
   static int _stateTimestamp = 0; // 配置变更时间戳, 用于检测异步任务是否已过期
 
   static ExternalPlayerLaunchSession? _session; // 外部播放器会话
+  static final ValueNotifier<bool> _sessionAvailability =
+      ValueNotifier<bool>(false);
 
   // 动漫元数据相关
   // ------------------------------------------------------------------------ //
@@ -91,7 +97,8 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
   // 控制台相关
   // ------------------------------------------------------------------------ //
   static Listenable get instance => _instance;
-  static bool get hasActiveSession => _session != null;
+  static ValueListenable<bool> get sessionAvailability => _sessionAvailability;
+  static bool get hasActiveSession => _sessionAvailability.value;
   static int get stateTimestamp => _stateTimestamp;
 
   // 播放状态相关
@@ -142,6 +149,7 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
 
     // 设置新的会话和媒体信息
     _session = session;
+    _sessionAvailability.value = true;
     _animeTitle = episodeMetaData?.animeTitle;
     _episodeTitle = episodeMetaData?.episodeTitle;
     _episodeId = episodeMetaData?.episodeId;
@@ -177,6 +185,12 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
     _markConfigurationChanged('showSession');
     session.addListener(_handleSessionChanged);
 
+    if (state.shrinkMainWindow) {
+      unawaited(ExternalPlayerWindowService.shrinkToHalfScreenWidth());
+    } else {
+      unawaited(ExternalPlayerWindowService.restore());
+    }
+
     // 通知监听器更新 UI
     _instance.notifyListeners();
   }
@@ -189,6 +203,8 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
     current.removeListener(_handleSessionChanged);
     current.terminate();
     _session = null;
+    _sessionAvailability.value = false;
+    unawaited(ExternalPlayerWindowService.restore());
 
     // 清空媒体信息
     _animeTitle = null;
@@ -395,6 +411,8 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
     if (current != null && current.isClosed) {
       current.removeListener(_handleSessionChanged);
       _session = null;
+      _sessionAvailability.value = false;
+      unawaited(ExternalPlayerWindowService.restore());
       _animeTitle = null;
       _episodeTitle = null;
       _episodeId = null;

--- a/lib/services/external_player_service.dart
+++ b/lib/services/external_player_service.dart
@@ -422,6 +422,7 @@ class ExternalPlayerService {
 
       final consoleState = ConsoleState(
         session: session,
+        shrinkMainWindow: settings.externalPlayerShrinkWindow,
         episodeMetaData: episodeMetaData,
         danmakuList: assets?.danmakuList,
         danmakuStyle: assets == null

--- a/lib/services/external_player_service.dart
+++ b/lib/services/external_player_service.dart
@@ -1,4 +1,3 @@
-
 // lib/services/external_player_service.dart
 // 掌管外部播放器启动, 弹幕导出和参数注入的服务
 
@@ -12,7 +11,7 @@ import 'package:nipaplay/constants/media_extensions.dart';
 import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/models/danmaku/danmaku_item.dart';
 import 'package:nipaplay/models/danmaku/style.dart';
-import 'package:nipaplay/models/external_player_session/linux_session.dart';
+import 'package:nipaplay/models/external_player_session/mpv_session.dart';
 import 'package:nipaplay/models/external_player_session/other_session.dart';
 import 'package:nipaplay/models/external_player_session/session.dart';
 import 'package:nipaplay/models/media_server_playback.dart';
@@ -30,7 +29,6 @@ import 'package:nipaplay/utils/tab_change_notifier.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-
 
 /// 外部播放器功能的持久化配置.
 ///
@@ -62,12 +60,11 @@ class ExternalPlayerConfig {
 /// 3. 按播放器类型生成命令行参数
 /// 4. 在需要时把当前弹幕导出为 ASS 文件
 ///
-/// Linux 上还会为 mpv 创建 IPC socket, 并把已启动进程注册到
+/// Linux 和 macOS 上还会为 mpv 创建 IPC socket, 并把已启动进程注册到
 /// [ExternalPlayerConsoleService].
 ///
 /// 此服务只负责发起启动, 无法保证外部播放器最终成功解码或播放媒体.
 class ExternalPlayerService {
-
   // 单例访问
   ExternalPlayerService._();
   static final instance = ExternalPlayerService._();
@@ -75,7 +72,57 @@ class ExternalPlayerService {
   /// 当前运行平台是否支持由本服务启动外部播放器.
   ///
   /// Web, 移动端以及未显式支持的桌面平台均返回 `false`.
-  static bool get isSupportedPlatform => !kIsWeb && (Platform.isWindows || Platform.isMacOS || Platform.isLinux);
+  static bool get isSupportedPlatform =>
+      !kIsWeb && (Platform.isWindows || Platform.isMacOS || Platform.isLinux);
+
+  /// 查找当前系统中已安装的 mpv.
+  ///
+  /// macOS 优先使用应用包, 随后检查 Homebrew、Intel Homebrew 和 MacPorts
+  /// 的常见可执行文件位置；Linux 会检查常见系统路径。最后再搜索 PATH。
+  /// [candidatePaths] 仅用于测试或调用方需要限定搜索范围的场景。
+  static Future<String?> detectInstalledMpv({
+    Iterable<String>? candidatePaths,
+  }) async {
+    if (kIsWeb || !(Platform.isMacOS || Platform.isLinux)) return null;
+
+    final candidates = candidatePaths ?? _defaultMpvCandidatePaths();
+    for (final candidate in candidates) {
+      final path = candidate.trim();
+      if (path.isEmpty) continue;
+      final type = await FileSystemEntity.type(path);
+      if (type == FileSystemEntityType.file ||
+          type == FileSystemEntityType.link ||
+          (Platform.isMacOS &&
+              type == FileSystemEntityType.directory &&
+              path.toLowerCase().endsWith('.app'))) {
+        return path;
+      }
+    }
+    return null;
+  }
+
+  static Iterable<String> _defaultMpvCandidatePaths() sync* {
+    if (Platform.isMacOS) {
+      yield '/Applications/mpv.app';
+      final home = Platform.environment['HOME'];
+      if (home != null && home.isNotEmpty) {
+        yield '$home/Applications/mpv.app';
+      }
+      yield '/opt/homebrew/bin/mpv';
+      yield '/usr/local/bin/mpv';
+      yield '/opt/local/bin/mpv';
+    } else if (Platform.isLinux) {
+      yield '/usr/bin/mpv';
+      yield '/usr/local/bin/mpv';
+      yield '/snap/bin/mpv';
+    }
+
+    final path = Platform.environment['PATH'];
+    if (path == null || path.isEmpty) return;
+    for (final directory in path.split(':')) {
+      if (directory.isNotEmpty) yield '$directory/mpv';
+    }
+  }
 
   /// 从持久化设置中读取外部播放器配置.
   ///
@@ -117,8 +164,8 @@ class ExternalPlayerService {
   ///
   /// 启动前会解析 macOS security bookmark, 并检查播放器路径是否存在.
   /// Windows 快捷方式通过 `cmd /c start` 打开, 普通可执行文件以 detached
-  /// 模式启动; macOS 应用包通过 `open -a` 打开; Linux 播放器以 detached
-  /// 模式启动. 只有 Linux mpv 会额外启用 JSON IPC 和弹幕控制台能力.
+  /// 模式启动; macOS 的 mpv.app 直接执行包内主程序; Linux 播放器以 detached
+  /// 模式启动. Linux 和 macOS 的 mpv 会额外启用 JSON IPC 和弹幕控制台能力.
   ///
   /// 成功派生进程时返回对应的 [ExternalPlayerLaunchSession]. 不支持的平台, 空路径,
   /// 文件不存在或进程派生异常均返回 `null`, 且异常不会向调用方抛出. 返回非空
@@ -131,7 +178,6 @@ class ExternalPlayerService {
     Duration duration = Duration.zero,
     Duration position = Duration.zero,
   }) async {
-
     debugPrint('[ExtPlayer] launch: playerPath="$playerPath", '
         'mediaPath="$mediaPath", extraArgs=$extraArgs');
     if (!isSupportedPlatform) {
@@ -156,8 +202,9 @@ class ExternalPlayerService {
 
     try {
       final type = _detectPlayer(resolvedPath);
-      if (Platform.isLinux && type == ExternalPlayerType.mpv) {
-        return await LinuxSession.launch(
+      if ((Platform.isLinux || Platform.isMacOS) &&
+          type == ExternalPlayerType.mpv) {
+        return await MpvSession.launch(
           playerPath: resolvedPath,
           mediaPath: mediaPath,
           extraArgs: extraArgs,
@@ -181,7 +228,7 @@ class ExternalPlayerService {
     }
   }
 
-  /// 启动 Linux mpv 以外的播放器进程.
+  /// 启动 Linux/macOS mpv 以外的播放器进程.
   static Future<OtherSession> _launchOtherSession({
     required ExternalPlayerType type,
     required String playerPath,
@@ -196,8 +243,11 @@ class ExternalPlayerService {
     if (Platform.isWindows) {
       final isShortcut = playerPath.toLowerCase().endsWith('.lnk');
       process = isShortcut
-          ? await Process.start('cmd',['/c', 'start',  '', playerPath, mediaPath, ...extraArgs], runInShell: true)
-          : await Process.start(playerPath, [mediaPath, ...extraArgs], mode: ProcessStartMode.detached);
+          ? await Process.start(
+              'cmd', ['/c', 'start', '', playerPath, mediaPath, ...extraArgs],
+              runInShell: true)
+          : await Process.start(playerPath, [mediaPath, ...extraArgs],
+              mode: ProcessStartMode.detached);
     } else if (Platform.isMacOS) {
       final isAppBundle = playerPath.toLowerCase().endsWith('.app');
       process = isAppBundle
@@ -227,8 +277,8 @@ class ExternalPlayerService {
   ///
   /// 本方法是外部播放器功能的主要入口. 它从 [context] 读取
   /// [SettingsProvider], 解析媒体地址, 并按设置选择性导出弹幕, 注入字幕,
-  /// Lua, 平滑渲染和 User-Agent 参数, 最后启动播放器. Linux 启动成功后还会
-  /// 建立供外部播放器控制台使用的会话.
+  /// Lua, 平滑渲染和 User-Agent 参数, 最后启动播放器. Linux 或 macOS 的 mpv
+  /// 启动成功后还会建立供外部播放器控制台使用的会话.
   ///
   /// 返回 `false` 仅表示外部播放器功能未启用, 调用方应继续使用内置播放器.
   /// 一旦功能已启用, 本方法即返回 `true` 表示播放请求已被接管; 平台不支持,
@@ -287,14 +337,14 @@ class ExternalPlayerService {
     final danmakuEnabled = settings.externalPlayerDanmakuOverlay;
     DanmakuLaunchAssets? danmakuAssets; // ASS + Lua 脚本产物
     if (danmakuEnabled && episodeId.isNotEmpty) {
-
       debugPrint('[ExtPlayer] 弹幕外挂开启, 开始准备弹幕…');
       _safeSnack(context, '正在准备弹幕…');
 
       // 获取弹幕
       final t0 = DateTime.now(); // 计时, 方便调试弹幕生成耗时
-      try { danmakuAssets = await _prepareDanmakuAss(context, episodeId, animeId); }
-      catch (e, st) {
+      try {
+        danmakuAssets = await _prepareDanmakuAss(context, episodeId, animeId);
+      } catch (e, st) {
         debugPrint('[ExtPlayer] _prepareDanmakuAss 顶层异常: $e');
         debugPrintStack(stackTrace: st);
         danmakuAssets = null;
@@ -303,11 +353,10 @@ class ExternalPlayerService {
       // 计算弹幕准备耗时
       final dt = DateTime.now().difference(t0).inMilliseconds;
       debugPrint('[ExtPlayer] 弹幕准备完成: '
-      'assPath=${danmakuAssets?.assPath}, luaPath=${danmakuAssets?.luaPath}, 耗时=${dt}ms');
+          'assPath=${danmakuAssets?.assPath}, luaPath=${danmakuAssets?.luaPath}, 耗时=${dt}ms');
 
       // 若弹幕产物不为空, 则注入 ASS + Lua 脚本参数; 否则提示弹幕加载失败
       if (danmakuAssets != null) {
-
         // 构建弹幕外挂参数: --sub-file=xxx + --script=xxx + mpv/mpv.net 平滑参数
         extraArgs = _buildSubArgs(playerPath, danmakuAssets);
 
@@ -321,16 +370,15 @@ class ExternalPlayerService {
           extraArgs = [...extraArgs, ...smoothArgs];
           debugPrint('[ExtPlayer] 注入弹幕平滑参数: $smoothArgs');
         }
-        debugPrint('[ExtPlayer] 注入弹幕参数: extraArgs=$extraArgs, playerType=${_detectPlayer(playerPath)}');
-
+        debugPrint(
+            '[ExtPlayer] 注入弹幕参数: extraArgs=$extraArgs, playerType=${_detectPlayer(playerPath)}');
       } else {
         debugPrint('[ExtPlayer] 弹幕为空/失败, 将无弹幕启动');
         if (context.mounted) _safeSnack(context, '弹幕加载失败, 将无弹幕启动');
       }
-
     } else {
       debugPrint('[ExtPlayer] 跳过弹幕外挂 '
-      '(enabled=$danmakuEnabled, episodeId="$episodeId")');
+          '(enabled=$danmakuEnabled, episodeId="$episodeId")');
     }
 
     // 自定义 User-Agent（mpv/mpv.net/vlc 支持; 与弹幕参数合并）
@@ -340,10 +388,12 @@ class ExternalPlayerService {
       debugPrint('[ExtPlayer] 注入自定义 UA 参数: $uaArgs');
     }
 
-    debugPrint('[ExtPlayer] 调用 launch: path="$playerPath", media="$mediaPath", extraArgs=$extraArgs');
+    debugPrint(
+        '[ExtPlayer] 调用 launch: path="$playerPath", media="$mediaPath", extraArgs=$extraArgs');
 
     // 如有已存在的外部播放器会话, 则先关闭它, 避免新播放器启动失败
-    if (Platform.isLinux && ExternalPlayerConsoleService.hasActiveSession) {
+    if (ExternalPlayerConsoleService.isSupportedPlatform &&
+        ExternalPlayerConsoleService.hasActiveSession) {
       ExternalPlayerConsoleService.closePlayerAndConsole();
     }
 
@@ -361,8 +411,8 @@ class ExternalPlayerService {
     final launched = session != null;
     debugPrint('[ExtPlayer] launch 返回: $launched');
 
-    // Linux 下, 若 mpv 会话启动成功, 则在控制台显示会话信息
-    if (session is LinuxSession) {
+    // Linux/macOS 下, 若 mpv 会话启动成功, 则在控制台显示会话信息
+    if (session is MpvSession) {
       final episodeMetaData = EpisodeMetaData(
         animeTitle: history?.animeName ?? item.title,
         episodeTitle: history?.episodeTitle ?? item.subtitle,
@@ -387,8 +437,10 @@ class ExternalPlayerService {
       ExternalPlayerConsoleService.setState(consoleState);
 
       // 如果设置了启动外部播放器后自动切换到弹幕控制台, 则切换页面
-      if (settings.externalPlayerAutoSwitchToDanmakuConsole && context.mounted) {
-        Provider.of<TabChangeNotifier>(context, listen: false).changePage(AppPageIds.externalPlayerConsole);
+      if (settings.externalPlayerAutoSwitchToDanmakuConsole &&
+          context.mounted) {
+        Provider.of<TabChangeNotifier>(context, listen: false)
+            .changePage(AppPageIds.externalPlayerConsole);
       }
     }
 
@@ -404,11 +456,9 @@ class ExternalPlayerService {
     return true;
   }
 
-
   // ===========================================================================
   // =============================== 内部方法 ==================================
   // ===========================================================================
-
 
   /// 按 [path] 最后一段文件名推断外部播放器类型.
   ///
@@ -799,5 +849,4 @@ end)
     }
     return path;
   }
-
 }

--- a/lib/services/external_player_window_service.dart
+++ b/lib/services/external_player_window_service.dart
@@ -1,0 +1,196 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:screen_retriever/screen_retriever.dart';
+import 'package:window_manager/window_manager.dart';
+
+/// Saves and temporarily resizes the NipaPlay window for an external session.
+///
+/// The original bounds and window mode are restored when the session ends.
+class ExternalPlayerWindowService {
+  ExternalPlayerWindowService._();
+
+  static const Size _minimumWindowSize = Size(600, 400);
+  static _WindowSnapshot? _snapshot;
+  static int _operationGeneration = 0;
+  static Future<void>? _shrinkOperation;
+
+  static bool get _isDesktop =>
+      !kIsWeb && (Platform.isMacOS || Platform.isLinux || Platform.isWindows);
+
+  static Future<void> shrinkToHalfScreenWidth() async {
+    if (!_isDesktop || _snapshot != null || _shrinkOperation != null) return;
+
+    final operation = _performShrinkToHalfScreenWidth();
+    _shrinkOperation = operation;
+    try {
+      await operation;
+    } finally {
+      if (identical(_shrinkOperation, operation)) {
+        _shrinkOperation = null;
+      }
+    }
+  }
+
+  static Future<void> _performShrinkToHalfScreenWidth() async {
+    final generation = ++_operationGeneration;
+    try {
+      final bounds = await windowManager.getBounds();
+      final isMaximized = await windowManager.isMaximized();
+      final isFullScreen = await windowManager.isFullScreen();
+      final displays = await screenRetriever.getAllDisplays();
+      if (generation != _operationGeneration) return;
+
+      final workArea = _nearestWorkArea(bounds, displays);
+      _snapshot = _WindowSnapshot(
+        bounds: bounds,
+        isMaximized: isMaximized,
+        isFullScreen: isFullScreen,
+      );
+
+      if (isFullScreen) await windowManager.setFullScreen(false);
+      if (isMaximized) await windowManager.unmaximize();
+      if (generation != _operationGeneration) return;
+
+      await windowManager.setBounds(
+        calculateHalfWidthBounds(
+          currentBounds: bounds,
+          workArea: workArea,
+          minimumSize: _minimumWindowSize,
+        ),
+        animate: true,
+      );
+    } catch (error) {
+      final snapshot = _snapshot;
+      _snapshot = null;
+      debugPrint(
+        '[ExternalPlayerWindowService] Failed to resize main window: $error',
+      );
+      if (snapshot != null) {
+        try {
+          await _restoreSnapshot(snapshot);
+        } catch (restoreError) {
+          debugPrint(
+            '[ExternalPlayerWindowService] Failed to roll back window: '
+            '$restoreError',
+          );
+        }
+      }
+    }
+  }
+
+  static Future<void> restore() async {
+    if (!_isDesktop) return;
+
+    ++_operationGeneration;
+    final pendingShrink = _shrinkOperation;
+    if (pendingShrink != null) {
+      try {
+        await pendingShrink;
+      } catch (_) {
+        // The shrink path already logs and rolls back its own failures.
+      }
+    }
+
+    final snapshot = _snapshot;
+    _snapshot = null;
+    if (snapshot == null) return;
+    try {
+      await _restoreSnapshot(snapshot);
+    } catch (error) {
+      debugPrint(
+        '[ExternalPlayerWindowService] Failed to restore main window: $error',
+      );
+    }
+  }
+
+  static Future<void> _restoreSnapshot(_WindowSnapshot snapshot) async {
+    if (await windowManager.isFullScreen()) {
+      await windowManager.setFullScreen(false);
+    }
+    if (await windowManager.isMaximized()) await windowManager.unmaximize();
+    await windowManager.setBounds(snapshot.bounds, animate: true);
+    if (snapshot.isFullScreen) {
+      await windowManager.setFullScreen(true);
+    } else if (snapshot.isMaximized) {
+      await windowManager.maximize();
+    }
+  }
+
+  @visibleForTesting
+  static Rect calculateHalfWidthBounds({
+    required Rect currentBounds,
+    required Rect workArea,
+    Size minimumSize = _minimumWindowSize,
+  }) {
+    final availableWidth = workArea.width.isFinite && workArea.width > 0
+        ? workArea.width
+        : currentBounds.width;
+    final availableHeight = workArea.height.isFinite && workArea.height > 0
+        ? workArea.height
+        : currentBounds.height;
+    final minimumWidth =
+        minimumSize.width.clamp(0.0, availableWidth).toDouble();
+    final minimumHeight =
+        minimumSize.height.clamp(0.0, availableHeight).toDouble();
+    final width =
+        (availableWidth / 2).clamp(minimumWidth, availableWidth).toDouble();
+    final aspectRatio = currentBounds.width > 0 && currentBounds.height > 0
+        ? currentBounds.width / currentBounds.height
+        : 16 / 10;
+    final height =
+        (width / aspectRatio).clamp(minimumHeight, availableHeight).toDouble();
+
+    return Rect.fromLTWH(
+      workArea.left,
+      workArea.top + (availableHeight - height) / 2,
+      width,
+      height,
+    );
+  }
+
+  static Rect _nearestWorkArea(Rect windowBounds, List<Display> displays) {
+    if (displays.isEmpty) return windowBounds;
+
+    Rect areaFor(Display display) {
+      final position = display.visiblePosition ?? Offset.zero;
+      final size = display.visibleSize ?? display.size;
+      return position & size;
+    }
+
+    var selected = areaFor(displays.first);
+    var bestIntersection = _intersectionArea(windowBounds, selected);
+    var bestDistance = (windowBounds.center - selected.center).distanceSquared;
+    for (final display in displays.skip(1)) {
+      final candidate = areaFor(display);
+      final intersection = _intersectionArea(windowBounds, candidate);
+      final distance = (windowBounds.center - candidate.center).distanceSquared;
+      if (intersection > bestIntersection ||
+          (intersection == bestIntersection && distance < bestDistance)) {
+        selected = candidate;
+        bestIntersection = intersection;
+        bestDistance = distance;
+      }
+    }
+    return selected;
+  }
+
+  static double _intersectionArea(Rect first, Rect second) {
+    final intersection = first.intersect(second);
+    if (intersection.width <= 0 || intersection.height <= 0) return 0;
+    return intersection.width * intersection.height;
+  }
+}
+
+class _WindowSnapshot {
+  const _WindowSnapshot({
+    required this.bounds,
+    required this.isMaximized,
+    required this.isFullScreen,
+  });
+
+  final Rect bounds;
+  final bool isMaximized;
+  final bool isFullScreen;
+}

--- a/lib/services/file_picker_service.dart
+++ b/lib/services/file_picker_service.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:universal_html/html.dart' as web_html;
 import 'android_saf_service.dart';
 import 'security_bookmark_service.dart';
+import 'package:nipaplay/services/external_player_service.dart';
 import 'package:nipaplay/utils/storage_service.dart';
 import 'dart:io' as io;
 
@@ -17,7 +18,8 @@ class FilePickerService {
   static final FilePickerService _instance = FilePickerService._internal();
   static final Map<String, String> _webObjectUrls = <String, String>{};
   static final Map<String, String> _webMimeTypes = <String, String>{};
-  static final Map<String, _WebFileInfo> _webFileInfo = <String, _WebFileInfo>{};
+  static final Map<String, _WebFileInfo> _webFileInfo =
+      <String, _WebFileInfo>{};
   static const int _webHashMaxBytes = 16 * 1024 * 1024;
 
   factory FilePickerService() {
@@ -358,8 +360,8 @@ class FilePickerService {
       _registerWebFileInfo(file.name, fileHash, bytes.length);
 
       final resolvedMimeType = resolveWebMimeType(fileName: file.name);
-      final blob =
-          web_html.Blob([bytes], resolvedMimeType ?? 'application/octet-stream');
+      final blob = web_html.Blob(
+          [bytes], resolvedMimeType ?? 'application/octet-stream');
       final url = web_html.Url.createObjectUrlFromBlob(blob);
       _registerWebObjectUrl(file.name, url, mimeType: resolvedMimeType);
       return file.name;
@@ -571,6 +573,13 @@ class FilePickerService {
     try {
       initialDirectory ??= await _getLastDirectory(_lastExternalPlayerDirKey);
 
+      // Homebrew formula 不会创建 mpv.app。首次选择时直接打开已检测到的 mpv
+      // 所在目录，避免用户必须手动输入隐藏的 /opt 路径。
+      if (io.Platform.isMacOS && initialDirectory == null) {
+        final detected = await ExternalPlayerService.detectInstalledMpv();
+        if (detected != null) initialDirectory = p.dirname(detected);
+      }
+
       if (io.Platform.isMacOS && initialDirectory != null) {
         final resolvedPath =
             await SecurityBookmarkService.resolveBookmark(initialDirectory);
@@ -581,15 +590,18 @@ class FilePickerService {
 
       XTypeGroup? typeGroup;
       if (io.Platform.isWindows) {
-        typeGroup = XTypeGroup(
+        typeGroup = const XTypeGroup(
           label: '播放器程序',
-          extensions: const ['exe', 'lnk'],
+          extensions: ['exe', 'lnk'],
         );
       } else if (io.Platform.isMacOS) {
         typeGroup = const XTypeGroup(
-          label: '应用程序',
+          label: '播放器应用或可执行文件',
           extensions: ['app'],
-          uniformTypeIdentifiers: ['com.apple.application-bundle'],
+          uniformTypeIdentifiers: [
+            'com.apple.application-bundle',
+            'public.unix-executable',
+          ],
         );
       }
 

--- a/lib/settings/pages/external_player_settings_content.dart
+++ b/lib/settings/pages/external_player_settings_content.dart
@@ -123,7 +123,33 @@ class ExternalPlayerSettingsContent extends StatelessWidget {
                 );
               },
             ),
-            _autoSwitchToDanmakuConsoleTile
+            _autoSwitchToDanmakuConsoleTile,
+            Consumer<SettingsProvider>(
+              builder: (context, settingsProvider, child) {
+                return AdaptiveSettingsTile<bool>.toggle(
+                  title: _text(
+                    context,
+                    '外部播放时缩小主窗口',
+                    '外部播放時縮小主視窗',
+                    'Resize Main Window During External Playback',
+                  ),
+                  subtitle: externalSupported
+                      ? _text(
+                          context,
+                          '播放期间将 NipaPlay 缩至当前屏幕一半宽度，播放结束后自动恢复',
+                          '播放期間將 NipaPlay 縮至目前螢幕一半寬度，播放結束後自動恢復',
+                          'Resize NipaPlay to half of the current screen width during playback, then restore it automatically.',
+                        )
+                      : context.l10n.desktopOnlySupported,
+                  icon: Ionicons.resize_outline,
+                  phoneIcon:
+                      cupertino.CupertinoIcons.rectangle_compress_vertical,
+                  enabled: externalSupported,
+                  value: settingsProvider.externalPlayerShrinkWindow,
+                  onChanged: settingsProvider.setExternalPlayerShrinkWindow,
+                );
+              },
+            ),
           ],
         ),
       ],

--- a/lib/settings/pages/external_player_settings_content.dart
+++ b/lib/settings/pages/external_player_settings_content.dart
@@ -4,6 +4,7 @@ import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/l10n/l10n.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/services/external_player_console_service.dart';
+import 'package:nipaplay/services/external_player_service.dart';
 import 'package:nipaplay/services/file_picker_service.dart';
 import 'package:nipaplay/settings/adaptive_settings_widgets.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_adaptive_platform_ui.dart';
@@ -15,30 +16,34 @@ class ExternalPlayerSettingsContent extends StatelessWidget {
 
   /// 开启外部播放器后自动切换到弹幕控制台的开关
   static final Consumer<SettingsProvider> _autoSwitchToDanmakuConsoleTile =
-  Consumer<SettingsProvider>(builder: (context, settingsProvider, child) {
-
+      Consumer<SettingsProvider>(builder: (context, settingsProvider, child) {
     // 文字定义
-    const String titleSimplified                = '自动切换到弹幕控制台';
-    const String titleTraditional               = '自動切換到彈幕控制台';
-    const String titleEnglish                   = 'Open Danmaku Console Automatically';
-    const String subtitleSimplified             = '开始外部播放后，主程序自动切换到弹幕控制台页面';
-    const String subtitleTraditional            = '開始外部播放後，主程式自動切換到彈幕控制台頁面';
-    const String subtitleEnglish                = 'Switch to the Danmaku Console after external playback starts.';
-    const String subtitleUnsupportedSimplified  = '弹幕控制台目前仅支持 Linux';
-    const String subtitleUnsupportedTraditional = '彈幕控制台目前僅支援 Linux';
-    const String subtitleUnsupportedEnglish     = 'The Danmaku Console is currently available on Linux only.';
+    const String titleSimplified = '自动切换到弹幕控制台';
+    const String titleTraditional = '自動切換到彈幕控制台';
+    const String titleEnglish = 'Open Danmaku Console Automatically';
+    const String subtitleSimplified = '开始外部播放后，主程序自动切换到弹幕控制台页面';
+    const String subtitleTraditional = '開始外部播放後，主程式自動切換到彈幕控制台頁面';
+    const String subtitleEnglish =
+        'Switch to the Danmaku Console after external playback starts.';
+    const String subtitleUnsupportedSimplified = '弹幕控制台目前仅支持 Linux 和 macOS';
+    const String subtitleUnsupportedTraditional = '彈幕控制台目前僅支援 Linux 和 macOS';
+    const String subtitleUnsupportedEnglish =
+        'The Danmaku Console is currently available on Linux and macOS only.';
 
     final consoleSupported = ExternalPlayerConsoleService.isSupportedPlatform;
     return AdaptiveSettingsTile<bool>.toggle(
-      title    : _text(context, titleSimplified, titleTraditional, titleEnglish),
-      subtitle : consoleSupported ? 
-        _text(context, subtitleSimplified, subtitleTraditional, subtitleEnglish) :
-        _text(context, subtitleUnsupportedSimplified, subtitleUnsupportedTraditional, subtitleUnsupportedEnglish),
-      icon     : Ionicons.chatbox_ellipses_outline,
+      title: _text(context, titleSimplified, titleTraditional, titleEnglish),
+      subtitle: consoleSupported
+          ? _text(
+              context, subtitleSimplified, subtitleTraditional, subtitleEnglish)
+          : _text(context, subtitleUnsupportedSimplified,
+              subtitleUnsupportedTraditional, subtitleUnsupportedEnglish),
+      icon: Ionicons.chatbox_ellipses_outline,
       phoneIcon: cupertino.CupertinoIcons.captions_bubble,
-      enabled  : consoleSupported,
-      value    : settingsProvider.externalPlayerAutoSwitchToDanmakuConsole,
-      onChanged: (value) => settingsProvider.setExternalPlayerAutoSwitchToDanmakuConsole(value),
+      enabled: consoleSupported,
+      value: settingsProvider.externalPlayerAutoSwitchToDanmakuConsole,
+      onChanged: (value) =>
+          settingsProvider.setExternalPlayerAutoSwitchToDanmakuConsole(value),
     );
   });
 
@@ -136,7 +141,9 @@ class ExternalPlayerSettingsContent extends StatelessWidget {
 
     if (value) {
       if (settingsProvider.externalPlayerPath.trim().isEmpty) {
-        final picked = await FilePickerService().pickExternalPlayerExecutable();
+        final detected = await ExternalPlayerService.detectInstalledMpv();
+        final picked = detected ??
+            await FilePickerService().pickExternalPlayerExecutable();
         if (picked == null || picked.trim().isEmpty) {
           if (!context.mounted) return;
           AdaptiveSnackBar.show(

--- a/lib/themes/nipaplay/widgets/large_screen_page_scaffold.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_page_scaffold.dart
@@ -16,6 +16,7 @@ class NipaplayLargeScreenPageScaffold extends StatelessWidget {
     this.trailing,
     this.padding = const EdgeInsets.fromLTRB(44, 28, 44, 32),
     this.headerBottomSpacing = 24,
+    this.showBackgroundEffects = true,
   });
 
   final String title;
@@ -25,6 +26,7 @@ class NipaplayLargeScreenPageScaffold extends StatelessWidget {
   final Widget? trailing;
   final EdgeInsetsGeometry padding;
   final double headerBottomSpacing;
+  final bool showBackgroundEffects;
   final Widget child;
 
   @override
@@ -35,43 +37,45 @@ class NipaplayLargeScreenPageScaffold extends StatelessWidget {
 
     return Stack(
       children: [
-        Positioned.fill(
-          child: ColoredBox(
-            color: isDark
-                ? Colors.black.withValues(alpha: 0.34)
-                : Colors.white.withValues(alpha: 0.18),
+        if (showBackgroundEffects) ...[
+          Positioned.fill(
+            child: ColoredBox(
+              color: isDark
+                  ? Colors.black.withValues(alpha: 0.34)
+                  : Colors.white.withValues(alpha: 0.18),
+            ),
           ),
-        ),
-        Positioned.fill(
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: RadialGradient(
-                center: const Alignment(-0.78, -0.72),
-                radius: 1.35,
-                colors: [
-                  AppAccentColors.current
-                      .withValues(alpha: isDark ? 0.12 : 0.08),
-                  Colors.transparent,
-                ],
-                stops: const [0, 0.66],
+          Positioned.fill(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: RadialGradient(
+                  center: const Alignment(-0.78, -0.72),
+                  radius: 1.35,
+                  colors: [
+                    AppAccentColors.current
+                        .withValues(alpha: isDark ? 0.12 : 0.08),
+                    Colors.transparent,
+                  ],
+                  stops: const [0, 0.66],
+                ),
               ),
             ),
           ),
-        ),
-        Positioned.fill(
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [
-                  Colors.black.withValues(alpha: isDark ? 0.08 : 0.00),
-                  Colors.black.withValues(alpha: isDark ? 0.28 : 0.04),
-                ],
+          Positioned.fill(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.black.withValues(alpha: isDark ? 0.08 : 0.00),
+                    Colors.black.withValues(alpha: isDark ? 0.28 : 0.04),
+                  ],
+                ),
               ),
             ),
           ),
-        ),
+        ],
         Positioned.fill(
           child: Padding(
             padding: padding,

--- a/lib/utils/danmaku_ass_converter.dart
+++ b/lib/utils/danmaku_ass_converter.dart
@@ -183,7 +183,7 @@ String convertDanmakuToAss(
         final xEnd = -width;
         final line = '{\\an4\\move($kAssPlayResX,${yCenter.toStringAsFixed(1)},'
             '${xEnd.toStringAsFixed(1)},${yCenter.toStringAsFixed(1)})'
-            '${_colorOverride(d.color)}${_outlineColorOverride(d.color)}\\1a$alphaHex}'
+            '${_colorOverride(d.color)}${_outlineColorOverride(d.color)}\\alpha$alphaHex}'
             '${_escapeAssText(d.content)}';
         _writeDialogue(
           buffer,
@@ -200,7 +200,7 @@ String convertDanmakuToAss(
         final yTop = (lane * laneHeight + 2).toDouble();
         final line =
             '{\\an8\\pos(${(kAssPlayResX ~/ 2)},${yTop.toStringAsFixed(1)})'
-            '${_colorOverride(d.color)}${_outlineColorOverride(d.color)}\\1a$alphaHex}'
+            '${_colorOverride(d.color)}${_outlineColorOverride(d.color)}\\alpha$alphaHex}'
             '${_escapeAssText(d.content)}';
         _writeDialogue(
           buffer,
@@ -217,7 +217,7 @@ String convertDanmakuToAss(
         final yBottom = (kAssPlayResY - lane * laneHeight - 2).toDouble();
         final line =
             '{\\an2\\pos(${(kAssPlayResX ~/ 2)},${yBottom.toStringAsFixed(1)})'
-            '${_colorOverride(d.color)}${_outlineColorOverride(d.color)}\\1a$alphaHex}'
+            '${_colorOverride(d.color)}${_outlineColorOverride(d.color)}\\alpha$alphaHex}'
             '${_escapeAssText(d.content)}';
         _writeDialogue(
           buffer,
@@ -275,13 +275,17 @@ String _resolveContent(Map<String, dynamic> item) {
 }
 
 DanmakuKind _resolveKind(Map<String, dynamic> item) {
-
   final original = item['originalType'];
-  if (original is num) return _kindFromMode(DanmakuMode.fromCode(original.toInt()));
+  if (original is num) {
+    return _kindFromMode(DanmakuMode.fromCode(original.toInt()));
+  }
 
   final v = item['type'] ?? item['y'];
-  if (v is num) { return _kindFromMode(DanmakuMode.fromCode     (v .toInt()   )); }
-  else          { return _kindFromMode(DanmakuMode.fromTypeName (v?.toString())); }
+  if (v is num) {
+    return _kindFromMode(DanmakuMode.fromCode(v.toInt()));
+  } else {
+    return _kindFromMode(DanmakuMode.fromTypeName(v?.toString()));
+  }
 }
 
 int _resolveTypeCode(Map<String, dynamic> item) {
@@ -293,11 +297,13 @@ int _resolveTypeCode(Map<String, dynamic> item) {
 }
 
 DanmakuKind _kindFromMode(DanmakuMode mode) {
-  switch (mode)
-  {
-  case DanmakuMode.top    : return DanmakuKind.top   ;
-  case DanmakuMode.bottom : return DanmakuKind.bottom;
-  default                 : return DanmakuKind.scroll;
+  switch (mode) {
+    case DanmakuMode.top:
+      return DanmakuKind.top;
+    case DanmakuMode.bottom:
+      return DanmakuKind.bottom;
+    default:
+      return DanmakuKind.scroll;
   }
 }
 
@@ -540,8 +546,8 @@ void _writeHeader(
       'OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, '
       'ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, '
       'Alignment, MarginL, MarginR, MarginV, Encoding');
-  // 样式用不透明白色；每条弹幕按需用 \c 覆盖颜色、\1a 覆盖主透明度。
-  // 阴影透明度由 BackColour(4a) 承载，不被 \1a 覆盖，保持阴影独立观感。
+  // 样式用不透明白色；每条弹幕按需用 \c 覆盖颜色、\alpha 同步覆盖
+  // 主体、描边和阴影透明度，避免主体变淡后黑色描边反而主导视觉。
   const primary = '&H00FFFFFF';
   const outlineColor = '&H00000000';
   final (outlineW, borderStyle) = outline;
@@ -680,7 +686,7 @@ String convertDanmakuToAssFromPrepared(
         x2 = (-it.width).toStringAsFixed(1);
       }
       final line =
-          '{\\an7\\move($x1,$yStr,$x2,$yStr)$colorOverride$outlineOverride\\1a$alphaHex}$escaped';
+          '{\\an7\\move($x1,$yStr,$x2,$yStr)$colorOverride$outlineOverride\\alpha$alphaHex}$escaped';
       _writeDialogue(buffer,
           layer: 0, start: start, end: end, style: 'Danmaku', text: line);
     } else {
@@ -688,7 +694,7 @@ String convertDanmakuToAssFromPrepared(
       // 顶/底部居中：用 \an8 顶中对齐 + \pos(PlayResX/2, y)，让 libass 按自身
       // 字体度量居中，避免 DFM+ paint_width 与 libass 渲染宽度不一致导致长弹幕偏移。
       final line =
-          '{\\an8\\pos($centerX,$yStr)$colorOverride$outlineOverride\\1a$alphaHex}$escaped';
+          '{\\an8\\pos($centerX,$yStr)$colorOverride$outlineOverride\\alpha$alphaHex}$escaped';
       _writeDialogue(
         buffer,
         layer: isBottom ? 2 : 1,

--- a/lib/utils/video_player_state/video_player_state_timeline_preview.dart
+++ b/lib/utils/video_player_state/video_player_state_timeline_preview.dart
@@ -3,6 +3,13 @@ part of video_player_state;
 const int _timelinePreviewMaxHeight = 180;
 const int _timelinePreviewDefaultWidth = 320;
 
+/// Timeline preview uses an extra background player to capture frames. Keep it
+/// on MDK only: enabling the MDK preference must not start another libmpv
+/// instance after the playback kernel is switched to MediaKit.
+bool supportsTimelinePreviewForKernel(PlayerKernelType kernel) {
+  return kernel == PlayerKernelType.mdk;
+}
+
 extension VideoPlayerStateTimelinePreview on VideoPlayerState {
   bool get timelinePreviewEnabled => _timelinePreviewEnabled;
   bool get isTimelinePreviewAvailable =>
@@ -199,8 +206,7 @@ extension VideoPlayerStateTimelinePreview on VideoPlayerState {
 
   bool _isTimelinePreviewKernelSupported() {
     final kernel = PlayerFactory.getKernelType();
-    return kernel == PlayerKernelType.mdk ||
-        kernel == PlayerKernelType.mediaKit;
+    return supportsTimelinePreviewForKernel(kernel);
   }
 
   Future<AbstractPlayer?> _ensureTimelinePreviewPlayer(

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - desktop_multi_window (0.0.1):
     - FlutterMacOS
-  - erika_flutter (0.0.1):
+  - erika_flutter (0.1.3):
     - FlutterMacOS
   - flutter_js (0.0.1):
     - FlutterMacOS
@@ -82,7 +82,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   desktop_multi_window: 93667594ccc4b88d91a97972fd3b1b89667fa80a
-  erika_flutter: f4d07f66427bf4e63bb5d242c3b78616c37a19f7
+  erika_flutter: 6d35f15e9b475282807ce46dc7f0d0478b059c1a
   flutter_js: 79c3c70d33ba464c67d8eb88639a61aa718cd8b8
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   fvp: ed100b827d10aff53789fb9cb9dfdd85a87d037d

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1289,7 +1289,7 @@ packages:
     source: hosted
     version: "2.1.1"
   screen_retriever:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: screen_retriever
       sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -291,7 +291,7 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: v0.1.3
+      ref: "v0.1.3"
       resolved-ref: "9ddd8a46eb69ce6d6405da91fac99aa3b19238f6"
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
@@ -1877,4 +1877,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.41.0"
+  flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   window_manager: ^0.4.3
+  screen_retriever: ^0.2.0
   tray_manager: ^0.5.2
   shared_preferences: ^2.2.2
   provider: ^6.1.2

--- a/rust/src/api/ass_converter.rs
+++ b/rust/src/api/ass_converter.rs
@@ -146,7 +146,7 @@ pub fn convert_danmaku_to_ass(
                 let Some(lane) = lane else { continue };
                 let y = lane as f64 * lane_height as f64 + lane_height as f64 / 2.0;
                 let text = format!(
-                    "{{\\an4\\move({},{:.1},{:.1},{:.1}){}{}\\1a{}}}{}",
+                    "{{\\an4\\move({},{:.1},{:.1},{:.1}){}{}\\alpha{}}}{}",
                     DEFAULT_PLAY_RES_X, y, -width, y, color, outline, alpha, escaped
                 );
                 write_dialogue(
@@ -163,7 +163,7 @@ pub fn convert_danmaku_to_ass(
                 let lane = pick_fixed_lane(&mut top_lanes, item.time, FIXED_DURATION_SECONDS);
                 let y = lane as f64 * lane_height as f64 + 2.0;
                 let text = format!(
-                    "{{\\an8\\pos({},{:.1}){}{}\\1a{}}}{}",
+                    "{{\\an8\\pos({},{:.1}){}{}\\alpha{}}}{}",
                     DEFAULT_PLAY_RES_X / 2,
                     y,
                     color,
@@ -185,7 +185,7 @@ pub fn convert_danmaku_to_ass(
                 let lane = pick_fixed_lane(&mut bottom_lanes, item.time, FIXED_DURATION_SECONDS);
                 let y = DEFAULT_PLAY_RES_Y as f64 - lane as f64 * lane_height as f64 - 2.0;
                 let text = format!(
-                    "{{\\an2\\pos({},{:.1}){}{}\\1a{}}}{}",
+                    "{{\\an2\\pos({},{:.1}){}{}\\alpha{}}}{}",
                     DEFAULT_PLAY_RES_X / 2,
                     y,
                     color,
@@ -261,7 +261,7 @@ pub fn convert_prepared_danmaku_to_ass(
                 "Danmaku",
                 Kind::Scroll,
                 format!(
-                    "{{\\an7\\move({},{},{},{}){}{}\\1a{}}}{}",
+                    "{{\\an7\\move({},{},{},{}){}{}\\alpha{}}}{}",
                     x1, y, x2, y, color, outline, alpha, escaped
                 ),
             )
@@ -271,7 +271,7 @@ pub fn convert_prepared_danmaku_to_ass(
                 "DanmakuBottom",
                 Kind::Bottom,
                 format!(
-                    "{{\\an8\\pos({},{}){}{}\\1a{}}}{}",
+                    "{{\\an8\\pos({},{}){}{}\\alpha{}}}{}",
                     center_x, y, color, outline, alpha, escaped
                 ),
             )
@@ -281,7 +281,7 @@ pub fn convert_prepared_danmaku_to_ass(
                 "DanmakuTop",
                 Kind::Top,
                 format!(
-                    "{{\\an8\\pos({},{}){}{}\\1a{}}}{}",
+                    "{{\\an8\\pos({},{}){}{}\\alpha{}}}{}",
                     center_x, y, color, outline, alpha, escaped
                 ),
             )
@@ -564,5 +564,23 @@ mod tests {
         assert_eq!(result.events[1].type_code, 5);
         assert_eq!(result.ass.matches("Dialogue:").count(), 2);
         assert!(result.ass.contains("\\move(1920,25.0,-138.2,25.0)"));
+    }
+
+    #[test]
+    fn opacity_fades_text_outline_and_shadow_together() {
+        let mut settings = settings();
+        settings.opacity = 0.5;
+        let result = convert_danmaku_to_ass(
+            vec![RustAssDanmakuInput {
+                time_seconds: 1.0,
+                content: "half transparent".into(),
+                type_code: 1,
+                color_rgb: 0xffffff,
+            }],
+            settings,
+        );
+
+        assert!(result.ass.contains("\\alpha&H80&"));
+        assert!(!result.ass.contains("\\1a&H80&"));
     }
 }

--- a/test/danmaku_ass_converter_test.dart
+++ b/test/danmaku_ass_converter_test.dart
@@ -44,6 +44,24 @@ void main() {
       expect(dialogues[1], endsWith('top'));
     });
 
+    test('applies opacity to text outline and shadow together', () {
+      const settings = AssExportSettings(
+        fontSize: 24,
+        opacity: 0.5,
+      );
+
+      final ass = convertDanmakuToAss([
+        {
+          'time': 1.0,
+          'content': 'half transparent',
+          'type': 'scroll',
+        },
+      ], settings);
+
+      expect(ass, contains(r'\alpha&H80&'));
+      expect(ass, isNot(contains(r'\1a&H80&')));
+    });
+
     test('exclude merged and lane-filtered comments', () {
       const settings = AssExportSettings(
         fontSize: 96,
@@ -129,6 +147,7 @@ void main() {
         startsWith('Dialogue: 0,0:00:01.50,0:00:08.50,Danmaku,'),
       );
       expect(dialogues.single, contains(r'\c&H563412&'));
+      expect(dialogues.single, contains(r'\alpha&H00&'));
       expect(dialogues.single, endsWith('visible'));
       expect(ass, isNot(contains('filtered')));
     });

--- a/test/external_player_console_service_test.dart
+++ b/test/external_player_console_service_test.dart
@@ -538,6 +538,28 @@ exec /bin/sleep 30
         expect(await process.exitCode, isNotNull);
       });
 
+      test('publishes tab availability only while a session is active',
+          () async {
+        final process = await _startPlayer();
+        final values = <bool>[];
+        void listener() {
+          values.add(ExternalPlayerConsoleService.sessionAvailability.value);
+        }
+
+        ExternalPlayerConsoleService.sessionAvailability.addListener(listener);
+        addTearDown(() async {
+          ExternalPlayerConsoleService.sessionAvailability
+              .removeListener(listener);
+          ExternalPlayerConsoleService.closePlayerAndConsole();
+          await _stopProcess(process);
+        });
+
+        _showSession(_session(process));
+        ExternalPlayerConsoleService.closePlayerAndConsole();
+
+        expect(values, <bool>[true, false]);
+      });
+
       test('automatically clears the session after the player exits', () async {
         final process = await _startPlayer(duration: '0.05');
         addTearDown(() async {
@@ -650,9 +672,12 @@ exec /bin/sleep 30
           );
           await tester.ensureVisible(offsetInput);
           await tester.enterText(offsetInput, '1.25');
-          await tester.tap(find.byKey(
+          final applyOffset = find.byKey(
             const Key('external-player-danmaku-offset-apply'),
-          ));
+          );
+          await tester.ensureVisible(applyOffset);
+          await tester.pumpAndSettle();
+          await tester.tap(applyOffset);
           await tester.pump();
           expect(ExternalPlayerConsoleService.danmakuStyle.danmakuOffset, 1.25);
           expect(find.text('当前弹幕延后出现 1.25 秒'), findsOneWidget);
@@ -673,6 +698,46 @@ exec /bin/sleep 30
             find.byKey(const Key('external-player-timestamp-seek')),
             findsOneWidget,
           );
+        } finally {
+          ExternalPlayerConsoleService.closePlayerAndConsole();
+          Process.killPid(process.pid, ProcessSignal.sigkill);
+        }
+      });
+
+      testWidgets('uses a two-column workspace on desktop widths',
+          (tester) async {
+        tester.view.physicalSize = const Size(1440, 900);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        final process = await tester.runAsync(_startPlayer);
+        if (process == null) fail('Failed to start the test player process');
+        try {
+          _showSession(_session(
+            process,
+            danmakuList: [
+              DanmakuItem(
+                time: const Duration(seconds: 1),
+                content: 'desktop layout comment',
+              ),
+            ],
+          ));
+          await tester.pumpWidget(const MaterialApp(
+            locale: Locale('zh'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: ExternalPlayerConsolePage(),
+          ));
+
+          expect(
+            find.byKey(const Key('external-player-console-two-column')),
+            findsOneWidget,
+          );
+          expect(
+            find.byKey(const Key('external-player-console-single-column')),
+            findsNothing,
+          );
+          expect(tester.takeException(), isNull);
         } finally {
           ExternalPlayerConsoleService.closePlayerAndConsole();
           Process.killPid(process.pid, ProcessSignal.sigkill);
@@ -962,7 +1027,7 @@ exec /bin/sleep 30
           greaterThan(initialTimestamp),
         );
         final updatedAss = await assFile.readAsString();
-        final opacityTags = RegExp(r'\\1a&H[0-9A-Fa-f]{2}&')
+        final opacityTags = RegExp(r'\\alpha&H[0-9A-Fa-f]{2}&')
             .allMatches(updatedAss)
             .map((match) => match.group(0))
             .toList();
@@ -971,7 +1036,7 @@ exec /bin/sleep 30
         expect(updatedAss, contains('first regenerated comment'));
         expect(updatedAss, contains('second regenerated comment'));
         expect(opacityTags, isNotEmpty);
-        expect(opacityTags, everyElement(r'\1a&H80&'));
+        expect(opacityTags, everyElement(r'\alpha&H80&'));
         expect(File('${assFile.path}.nipaplay.tmp').existsSync(), isFalse);
         expect(reloadCommands, <List<dynamic>>[
           <dynamic>[

--- a/test/external_player_console_service_test.dart
+++ b/test/external_player_console_service_test.dart
@@ -10,7 +10,7 @@ import 'package:nipaplay/l10n/app_localizations.dart';
 import 'package:nipaplay/models/danmaku/blocked_item.dart';
 import 'package:nipaplay/models/danmaku/danmaku_item.dart';
 import 'package:nipaplay/models/danmaku/style.dart';
-import 'package:nipaplay/models/external_player_session/linux_session.dart';
+import 'package:nipaplay/models/external_player_session/mpv_session.dart';
 import 'package:nipaplay/models/external_player_session/other_session.dart';
 import 'package:nipaplay/pages/external_player_console_page.dart';
 import 'package:nipaplay/services/external_player_console_service.dart';
@@ -18,7 +18,7 @@ import 'package:nipaplay/services/external_player_service.dart';
 import 'package:nipaplay/utils/danmaku/assets.dart';
 import 'package:nipaplay/utils/danmaku_ass_converter.dart';
 
-LinuxSession _session(
+MpvSession _session(
   Process process, {
   String mediaPath = '/tmp/test-video.mkv',
   String? ipcPath,
@@ -47,7 +47,7 @@ LinuxSession _session(
   );
 }
 
-LinuxSession _sessionFromProcessId(
+MpvSession _sessionFromProcessId(
   int processId, {
   String mediaPath = '/tmp/test-video.mkv',
   String? ipcPath,
@@ -61,7 +61,7 @@ LinuxSession _sessionFromProcessId(
   AssExportSettings? danmakuAssSettings,
   bool monitorProcess = false,
 }) {
-  final session = LinuxSession.attach(
+  final session = MpvSession.attach(
     playerPath: '/bin/mpv',
     mediaPath: mediaPath,
     processId: processId,
@@ -87,7 +87,7 @@ LinuxSession _sessionFromProcessId(
 }
 
 void _showSession(
-  LinuxSession session, {
+  MpvSession session, {
   EpisodeMetaData? episodeMetaData,
 }) {
   final assets = session.danmakuAssets;
@@ -142,7 +142,25 @@ Future<void> _waitUntil(
 }
 
 void main() {
-  test('launches a generic Linux player without opening the console', () async {
+  test('detects mpv from an explicit candidate list', () async {
+    final tempDir = await Directory.systemTemp.createTemp(
+      'nipaplay_mpv_detection_test_',
+    );
+    final fakeMpv = File('${tempDir.path}/mpv');
+    await fakeMpv.writeAsString('fake mpv');
+    addTearDown(() => tempDir.delete(recursive: true));
+
+    final detected = await ExternalPlayerService.detectInstalledMpv(
+      candidatePaths: [
+        '${tempDir.path}/missing-mpv',
+        fakeMpv.path,
+      ],
+    );
+
+    expect(detected, fakeMpv.path);
+  });
+
+  test('launches a generic Unix player without opening the console', () async {
     ExternalPlayerConsoleService.closePlayerAndConsole();
     final session = await ExternalPlayerService.launch(
       playerPath: '/bin/sleep',
@@ -158,7 +176,119 @@ void main() {
     expect(ExternalPlayerConsoleService.hasActiveSession, isFalse);
   });
 
-  group('LinuxSession progress', () {
+  test(
+    'launches mpv with a JSON IPC socket on supported Unix desktops',
+    () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'nipaplay_mpv_launch_test_',
+      );
+      final fakeMpv = File('${tempDir.path}/fake-mpv');
+      final argsFile = File('${fakeMpv.path}.args');
+      await fakeMpv.writeAsString(r'''#!/bin/sh
+printf '%s\n' "$@" > "${0}.args"
+exec /bin/sleep 30
+''');
+      final chmod = await Process.run('/bin/chmod', ['+x', fakeMpv.path]);
+      expect(chmod.exitCode, 0);
+
+      MpvSession? session;
+      addTearDown(() async {
+        session?.terminate();
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+      });
+
+      final launched = await ExternalPlayerService.launch(
+        playerPath: fakeMpv.path,
+        mediaPath: '/tmp/test-video.mkv',
+        extraArgs: const ['--pause=yes'],
+      );
+      expect(launched, isA<MpvSession>());
+      session = launched! as MpvSession;
+      await _waitUntil(argsFile.existsSync);
+
+      final args = await argsFile.readAsLines();
+      expect(args, contains('/tmp/test-video.mkv'));
+      expect(args, contains('--pause=yes'));
+      expect(
+        args,
+        contains('--input-ipc-server=${session.ipcPath}'),
+      );
+      if (Platform.isMacOS) {
+        expect(utf8.encode(session.ipcPath!).length, lessThanOrEqualTo(103));
+      }
+    },
+    skip: !(Platform.isLinux || Platform.isMacOS),
+  );
+
+  test(
+    'launches a macOS mpv app through its bundled executable',
+    () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'nipaplay_mpv_app_launch_test_',
+      );
+      final appBundle = Directory('${tempDir.path}/fake-mpv.app');
+      final executable = File(
+        '${appBundle.path}/Contents/MacOS/mpv',
+      );
+      final argsFile = File('${executable.path}.args');
+      await executable.parent.create(recursive: true);
+      await executable.writeAsString(r'''#!/bin/sh
+printf '%s\n' "$@" > "${0}.args"
+exec /bin/sleep 30
+''');
+      final chmod = await Process.run('/bin/chmod', ['+x', executable.path]);
+      expect(chmod.exitCode, 0);
+
+      MpvSession? session;
+      addTearDown(() async {
+        session?.terminate();
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+      });
+
+      final launched = await ExternalPlayerService.launch(
+        playerPath: appBundle.path,
+        mediaPath: '/tmp/test-video.mkv',
+        extraArgs: const ['--pause=yes'],
+      );
+      expect(launched, isA<MpvSession>());
+      session = launched! as MpvSession;
+      await _waitUntil(argsFile.existsSync);
+
+      final args = await argsFile.readAsLines();
+      expect(args, contains('/tmp/test-video.mkv'));
+      expect(args, contains('--pause=yes'));
+      expect(
+        args,
+        contains('--input-ipc-server=${session.ipcPath}'),
+      );
+      expect(utf8.encode(session.ipcPath!).length, lessThanOrEqualTo(103));
+    },
+    skip: !Platform.isMacOS,
+  );
+
+  test('uses the supplied process exit future for lifecycle monitoring',
+      () async {
+    final exitCode = Completer<int>();
+    final session = MpvSession.attach(
+      playerPath: '/Applications/mpv.app',
+      mediaPath: '/tmp/test-video.mkv',
+      processId: 999999,
+      ipcPath: null,
+      duration: Duration.zero,
+      processExitCode: exitCode.future,
+    );
+    addTearDown(session.dispose);
+
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+    expect(session.isClosed, isFalse);
+
+    exitCode.complete(0);
+    await _waitUntil(() => session.isClosed);
+  });
+
+  group('MpvSession progress', () {
     test('clamps its fraction to the valid range', () {
       final session = _sessionFromProcessId(
         1,
@@ -209,7 +339,7 @@ void main() {
   });
 
   group(
-    'ExternalPlayerConsoleService on Linux',
+    'ExternalPlayerConsoleService on Linux and macOS',
     () {
       test('only keeps the latest external player session', () async {
         final firstProcess = await _startPlayer();
@@ -235,7 +365,9 @@ void main() {
         expect(await firstProcess.exitCode, isNotNull);
       });
 
-      test('keeps media path in the session and playable metadata in the console service', () async {
+      test(
+          'keeps media path in the session and playable metadata in the console service',
+          () async {
         final process = await _startPlayer();
         addTearDown(() async {
           ExternalPlayerConsoleService.closePlayerAndConsole();
@@ -289,12 +421,15 @@ void main() {
         _showSession(session);
 
         expect(_activeDisplayIndices(), [0, 1]);
-        final initialDisplayList = ExternalPlayerConsoleService.displayDanmakuList;
+        final initialDisplayList =
+            ExternalPlayerConsoleService.displayDanmakuList;
         ExternalPlayerConsoleService.danmakuStyle.danmakuOffset = 1;
         ExternalPlayerConsoleService.queueDanmakuRefresh();
-        expect(ExternalPlayerConsoleService.displayDanmakuList, isNot(same(initialDisplayList)));
+        expect(ExternalPlayerConsoleService.displayDanmakuList,
+            isNot(same(initialDisplayList)));
         expect(
-          ExternalPlayerConsoleService.displayDanmakuList.map((item) => item.startTime),
+          ExternalPlayerConsoleService.displayDanmakuList
+              .map((item) => item.startTime),
           [const Duration(seconds: 2), const Duration(seconds: 4)],
         );
         ExternalPlayerConsoleService.danmakuStyle.danmakuOffset = 0;
@@ -357,13 +492,18 @@ void main() {
           isTrue,
         );
         expect(
-          ExternalPlayerConsoleService.displayDanmakuList.map((item) => item.isBlocked),
+          ExternalPlayerConsoleService.displayDanmakuList
+              .map((item) => item.isBlocked),
           [true, true, true],
         );
         expect(_activeDisplayIndices(), isEmpty);
         expect(
           ExternalPlayerConsoleService.blockedItems.map((item) => item.type),
-          [BlockedItemType.keyword, BlockedItemType.regex, BlockedItemType.userId],
+          [
+            BlockedItemType.keyword,
+            BlockedItemType.regex,
+            BlockedItemType.userId
+          ],
         );
         expect(
           ExternalPlayerConsoleService.addBlockedItem(
@@ -376,7 +516,8 @@ void main() {
         final regexItem = ExternalPlayerConsoleService.blockedItems[1];
         ExternalPlayerConsoleService.removeBlockedItem(regexItem);
         expect(
-          ExternalPlayerConsoleService.displayDanmakuList.map((item) => item.isBlocked),
+          ExternalPlayerConsoleService.displayDanmakuList
+              .map((item) => item.isBlocked),
           [true, false, true],
         );
         expect(_activeDisplayIndices(), [1]);
@@ -408,7 +549,8 @@ void main() {
         await _waitUntil(() => !ExternalPlayerConsoleService.hasActiveSession);
       });
 
-      testWidgets('does not expose per-item visibility controls', (tester) async {
+      testWidgets('does not expose per-item visibility controls',
+          (tester) async {
         final process = await tester.runAsync(_startPlayer);
         if (process == null) fail('Failed to start the test player process');
         try {
@@ -454,8 +596,10 @@ void main() {
           expect(find.text('关键词'), findsOneWidget);
           expect(find.text('正则表达式'), findsOneWidget);
           expect(find.text('发送者 ID'), findsWidgets);
-          expect(ExternalPlayerConsoleService.blockedItems.single.type, BlockedItemType.userId);
-          expect(ExternalPlayerConsoleService.blockedItems.single.value, 'sender-hash');
+          expect(ExternalPlayerConsoleService.blockedItems.single.type,
+              BlockedItemType.userId);
+          expect(ExternalPlayerConsoleService.blockedItems.single.value,
+              'sender-hash');
           expect(
             find.byKey(const ValueKey(
               'external-player-danmaku-block-item-userId-sender-hash',
@@ -577,7 +721,9 @@ void main() {
         expect(ExternalPlayerConsoleService.duration, Duration.zero);
 
         await _waitUntil(
-          () => ExternalPlayerConsoleService.duration == const Duration(minutes: 25),
+          () =>
+              ExternalPlayerConsoleService.duration ==
+              const Duration(minutes: 25),
         );
         expect(ExternalPlayerConsoleService.position, Duration.zero);
 
@@ -638,11 +784,15 @@ void main() {
 
         ExternalPlayerConsoleService.togglePause();
         await _waitUntil(
-          () => commands.length == 1 && ExternalPlayerConsoleService.isPaused == true,
+          () =>
+              commands.length == 1 &&
+              ExternalPlayerConsoleService.isPaused == true,
         );
         ExternalPlayerConsoleService.togglePause();
         await _waitUntil(
-          () => commands.length == 2 && ExternalPlayerConsoleService.isPaused == false,
+          () =>
+              commands.length == 2 &&
+              ExternalPlayerConsoleService.isPaused == false,
         );
 
         expect(commands, <bool>[true, false]);
@@ -736,7 +886,8 @@ void main() {
         expect(commands.length, 2);
       });
 
-      test('coalesces rapid danmaku opacity updates without truncating ASS', () async {
+      test('coalesces rapid danmaku opacity updates without truncating ASS',
+          () async {
         final process = await _startPlayer();
         final tempDir =
             await Directory.systemTemp.createTemp('nipaplay_ipc_test_');
@@ -831,7 +982,8 @@ void main() {
           ],
         ]);
 
-        final secondItem = ExternalPlayerConsoleService.displayDanmakuList[1].item;
+        final secondItem =
+            ExternalPlayerConsoleService.displayDanmakuList[1].item;
         final keywordTimestamp = ExternalPlayerConsoleService.stateTimestamp;
         expect(
           ExternalPlayerConsoleService.addBlockedItem(
@@ -858,18 +1010,23 @@ void main() {
 
         final filteredAss = await assFile.readAsString();
         expect(ExternalPlayerConsoleService.blockedItems, hasLength(1));
-        expect(ExternalPlayerConsoleService.blockedItems.single.value, 'SECOND');
-        expect(ExternalPlayerConsoleService.blockedItems.single.type, BlockedItemType.keyword);
         expect(
-          ExternalPlayerConsoleService.displayDanmakuList.map((item) => item.item.content),
+            ExternalPlayerConsoleService.blockedItems.single.value, 'SECOND');
+        expect(ExternalPlayerConsoleService.blockedItems.single.type,
+            BlockedItemType.keyword);
+        expect(
+          ExternalPlayerConsoleService.displayDanmakuList
+              .map((item) => item.item.content),
           ['first regenerated comment', 'second regenerated comment'],
         );
         expect(
-          ExternalPlayerConsoleService.displayDanmakuList.map((item) => item.isBlocked),
+          ExternalPlayerConsoleService.displayDanmakuList
+              .map((item) => item.isBlocked),
           [false, true],
         );
         expect(
-          identical(ExternalPlayerConsoleService.displayDanmakuList[1].item, secondItem),
+          identical(ExternalPlayerConsoleService.displayDanmakuList[1].item,
+              secondItem),
           isTrue,
         );
         expect(filteredAss, contains('first regenerated comment'));
@@ -885,15 +1042,18 @@ void main() {
         await _waitUntil(() => reloadCommands.length == 3);
         expect(ExternalPlayerConsoleService.blockedItems, isEmpty);
         expect(
-          ExternalPlayerConsoleService.displayDanmakuList.map((item) => item.item.content),
+          ExternalPlayerConsoleService.displayDanmakuList
+              .map((item) => item.item.content),
           ['first regenerated comment', 'second regenerated comment'],
         );
         expect(
-          ExternalPlayerConsoleService.displayDanmakuList.map((item) => item.isBlocked),
+          ExternalPlayerConsoleService.displayDanmakuList
+              .map((item) => item.isBlocked),
           [false, false],
         );
         expect(
-          identical(ExternalPlayerConsoleService.displayDanmakuList[1].item, secondItem),
+          identical(ExternalPlayerConsoleService.displayDanmakuList[1].item,
+              secondItem),
           isTrue,
         );
         expect(
@@ -908,8 +1068,7 @@ void main() {
             await Directory.systemTemp.createTemp('nipaplay_ipc_test_');
         final socketPath = '${tempDir.path}/mpv.sock';
         final assFile = File('${tempDir.path}/danmaku.ass');
-        const stylePrefix =
-            'Style: Danmaku,Arial,48.0,&H00FFFFFF,&H00FFFFFF,'
+        const stylePrefix = 'Style: Danmaku,Arial,48.0,&H00FFFFFF,&H00FFFFFF,'
             '&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,';
         await assFile.writeAsString(
           '[V4+ Styles]\n$stylePrefix' '2.5,0.0,2,0,0,0,1\n',
@@ -1041,6 +1200,6 @@ void main() {
         expect(ExternalPlayerConsoleService.duration, Duration.zero);
       });
     },
-    skip: !Platform.isLinux,
+    skip: !(Platform.isLinux || Platform.isMacOS),
   );
 }

--- a/test/external_player_settings_test.dart
+++ b/test/external_player_settings_test.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
+import 'package:nipaplay/providers/settings_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> _waitForInitialLoad(ChangeNotifier provider) async {
+  final completer = Completer<void>();
+  void listener() {
+    if (!completer.isCompleted) completer.complete();
+  }
+
+  provider.addListener(listener);
+  await completer.future.timeout(const Duration(seconds: 2));
+  provider.removeListener(listener);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('external playback window resize defaults off and persists', () async {
+    SharedPreferences.setMockInitialValues(const {});
+    final provider = SettingsProvider();
+    await _waitForInitialLoad(provider);
+
+    expect(provider.externalPlayerShrinkWindow, isFalse);
+
+    await provider.setExternalPlayerShrinkWindow(true);
+    final prefs = await SharedPreferences.getInstance();
+    expect(provider.externalPlayerShrinkWindow, isTrue);
+    expect(prefs.getBool(SettingsKeys.externalPlayerShrinkWindow), isTrue);
+  });
+}

--- a/test/external_player_window_service_test.dart
+++ b/test/external_player_window_service_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/services/external_player_window_service.dart';
+
+void main() {
+  group('external player window bounds', () {
+    test('uses half the current screen width and preserves aspect ratio', () {
+      final result = ExternalPlayerWindowService.calculateHalfWidthBounds(
+        currentBounds: const Rect.fromLTWH(200, 120, 1200, 800),
+        workArea: const Rect.fromLTWH(0, 24, 1920, 1056),
+      );
+
+      expect(result, const Rect.fromLTWH(0, 232, 960, 640));
+    });
+
+    test('respects the application minimum size on a small screen', () {
+      final result = ExternalPlayerWindowService.calculateHalfWidthBounds(
+        currentBounds: const Rect.fromLTWH(0, 0, 800, 800),
+        workArea: const Rect.fromLTWH(0, 0, 1000, 700),
+      );
+
+      expect(result.width, 600);
+      expect(result.height, 600);
+      expect(result.left, 0);
+      expect(result.top, 50);
+    });
+  });
+}

--- a/test/timeline_preview_kernel_policy_test.dart
+++ b/test/timeline_preview_kernel_policy_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/player_abstraction/player_factory.dart';
+import 'package:nipaplay/utils/video_player_state.dart';
+
+void main() {
+  test('timeline preview is isolated to the MDK playback kernel', () {
+    expect(
+      supportsTimelinePreviewForKernel(PlayerKernelType.mdk),
+      isTrue,
+    );
+    expect(
+      supportsTimelinePreviewForKernel(PlayerKernelType.mediaKit),
+      isFalse,
+      reason: 'The MDK preference must not create a libmpv preview player.',
+    );
+    expect(
+      supportsTimelinePreviewForKernel(PlayerKernelType.videoPlayer),
+      isFalse,
+    );
+    expect(
+      supportsTimelinePreviewForKernel(PlayerKernelType.erika),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- support mpv.app and mpv JSON IPC on macOS
- redesign the external-player console as a compact two-column NipaPlay desktop workspace without the page glow overlay
- fade danmaku text, outline, and shadow together when opacity is reduced
- optionally resize the NipaPlay window to half the active display width during external playback and restore it afterward
- show the console tab only while an external mpv session is active
- keep MDK timeline preview screenshots isolated from the MediaKit/libmpv kernel

## Validation

- `flutter test` (171 tests)
- `cargo test --manifest-path rust/Cargo.toml api::ass_converter::tests` (2 tests)
- targeted `flutter analyze --no-fatal-infos --no-fatal-warnings` (no errors; existing lint notices only)
- `flutter build macos --debug`
- `git diff --check`
