### PR TITLE
feat: complete issue 706 multi-window playback

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -26,6 +26,8 @@ class SettingsKeys {
       'external_player_auto_switch_to_danmaku_console'; // 启动外部播放器后自动切换到弹幕控制台
   static const String externalPlayerShrinkWindow =
       'external_player_shrink_window'; // 外部播放期间将主窗口缩至屏幕半宽
+  static const String externalPlayerConsoleWindowMode =
+      'external_player_console_window_mode'; // 使用独立窗口显示外部播放器弹幕控制台
 
   /// 自定义播放器请求视频的 User-Agent（空字符串 = 用内核默认 UA）。
   static const String customPlayerUA = 'custom_player_ua';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -803,6 +803,7 @@ class _NipaPlayAppState extends State<NipaPlayApp> with WidgetsBindingObserver {
       navigationItemsBuilder: (ctx) {
         final webdav = ctx.watch<WebDAVQuickAccessProvider>();
         final downloader = ctx.watch<DownloaderSettingsProvider>();
+        final settings = ctx.watch<SettingsProvider>();
         final localizations = lookupAppLocalizations(
           ctx.watch<AppLanguageProvider>().locale,
         );
@@ -813,7 +814,8 @@ class _NipaPlayAppState extends State<NipaPlayApp> with WidgetsBindingObserver {
                 globals.isDownloaderSupportedPlatform && downloader.enabled,
             showExternalPlayerConsole:
                 ExternalPlayerConsoleService.isSupportedPlatform &&
-                    ExternalPlayerConsoleService.hasActiveSession,
+                    ExternalPlayerConsoleService.hasActiveSession &&
+                    !settings.externalPlayerConsoleWindowMode,
           ),
         );
         return pages
@@ -1082,6 +1084,7 @@ class MainPageState extends State<MainPage>
   bool _useLargeScreenLayout = false;
   StreamSubscription<String>? _androidFileAssociationSubscription;
   DownloaderSettingsProvider? _downloaderSettingsProvider;
+  SettingsProvider? _settingsProvider;
 
   List<UnifiedAppPage> _pageDefinitions = const <UnifiedAppPage>[];
   List<Widget> _pages = [];
@@ -1214,11 +1217,18 @@ class MainPageState extends State<MainPage>
       _pluginService?.addListener(_onDownloaderSettingsChanged);
       PluginService.setBuildContext(context);
     } catch (_) {}
+    try {
+      _settingsProvider = Provider.of<SettingsProvider>(context, listen: false);
+      _settingsProvider?.addListener(
+        _onExternalPlayerConsoleAvailabilityChanged,
+      );
+    } catch (_) {}
 
     // 构建初始页面列表
     _showExternalPlayerConsoleTab =
         ExternalPlayerConsoleService.isSupportedPlatform &&
-            ExternalPlayerConsoleService.hasActiveSession;
+            ExternalPlayerConsoleService.hasActiveSession &&
+            !(_settingsProvider?.externalPlayerConsoleWindowMode ?? false);
     _rebuildPages();
 
     await _initializeController();
@@ -1270,7 +1280,8 @@ class MainPageState extends State<MainPage>
   void _onExternalPlayerConsoleAvailabilityChanged() {
     if (!mounted) return;
     final shouldShow = ExternalPlayerConsoleService.isSupportedPlatform &&
-        ExternalPlayerConsoleService.hasActiveSession;
+        ExternalPlayerConsoleService.hasActiveSession &&
+        !(_settingsProvider?.externalPlayerConsoleWindowMode ?? false);
     if (shouldShow == _showExternalPlayerConsoleTab) return;
 
     final currentPageId = _selectedPageId;
@@ -1461,6 +1472,9 @@ class MainPageState extends State<MainPage>
     _webdavQuickAccessProvider?.removeListener(_onWebDAVSettingsChanged);
     _downloaderSettingsProvider?.removeListener(_onDownloaderSettingsChanged);
     _pluginService?.removeListener(_onDownloaderSettingsChanged);
+    _settingsProvider?.removeListener(
+      _onExternalPlayerConsoleAvailabilityChanged,
+    );
     ExternalPlayerConsoleService.sessionAvailability
         .removeListener(_onExternalPlayerConsoleAvailabilityChanged);
     _androidFileAssociationSubscription?.cancel();

--- a/lib/pages/external_player_console_page.dart
+++ b/lib/pages/external_player_console_page.dart
@@ -12,8 +12,23 @@ import 'package:nipaplay/themes/nipaplay/widgets/large_screen_page_scaffold.dart
 import 'package:nipaplay/utils/app_accent_color.dart';
 
 /// Linux/macOS mpv 外部播放会话的桌面控制台。
+enum ExternalPlayerConsolePane {
+  all,
+  controls,
+  danmakuList,
+}
+
 class ExternalPlayerConsolePage extends StatelessWidget {
-  const ExternalPlayerConsolePage({super.key});
+  const ExternalPlayerConsolePage({
+    super.key,
+    this.pane = ExternalPlayerConsolePane.all,
+    this.onShowDanmakuList,
+    this.onCloseWindow,
+  });
+
+  final ExternalPlayerConsolePane pane;
+  final VoidCallback? onShowDanmakuList;
+  final VoidCallback? onCloseWindow;
 
   @override
   Widget build(BuildContext context) {
@@ -41,9 +56,27 @@ class ExternalPlayerConsolePage extends StatelessWidget {
             type: MaterialType.transparency,
             child: SafeArea(
               child: NipaplayLargeScreenPageScaffold(
-                title: context.l10n.externalPlayerConsoleTitle,
+                title: pane == ExternalPlayerConsolePane.danmakuList
+                    ? context.l10n.externalPlayerConsoleDanmakuList
+                    : context.l10n.externalPlayerConsoleTitle,
                 subtitle: hasSession && subtitle.isNotEmpty ? subtitle : null,
-                padding: const EdgeInsets.fromLTRB(34, 24, 34, 28),
+                actions: [
+                  if (onShowDanmakuList != null)
+                    NipaplayLargeScreenIconButton(
+                      icon: Icons.format_list_bulleted_rounded,
+                      tooltip: context.l10n.externalPlayerConsoleDanmakuList,
+                      onPressed: onShowDanmakuList,
+                    ),
+                  if (onCloseWindow != null)
+                    NipaplayLargeScreenIconButton(
+                      icon: Icons.close_rounded,
+                      tooltip: context.l10n.externalPlayerConsoleClose,
+                      onPressed: onCloseWindow,
+                    ),
+                ],
+                padding: pane == ExternalPlayerConsolePane.all
+                    ? const EdgeInsets.fromLTRB(34, 24, 34, 28)
+                    : const EdgeInsets.fromLTRB(18, 20, 18, 20),
                 headerBottomSpacing: 18,
                 showBackgroundEffects: false,
                 child: hasSession
@@ -64,6 +97,7 @@ class ExternalPlayerConsolePage extends StatelessWidget {
                         fraction: ExternalPlayerConsoleService.fraction,
                         danmakuStyle: ExternalPlayerConsoleService.danmakuStyle,
                         blockedItems: ExternalPlayerConsoleService.blockedItems,
+                        pane: pane,
                       )
                     : NipaplayLargeScreenEmptyState(
                         icon: Icons.subtitles_outlined,
@@ -95,6 +129,7 @@ class _ConsoleWorkspace extends StatelessWidget {
     required this.fraction,
     required this.danmakuStyle,
     required this.blockedItems,
+    required this.pane,
   });
 
   final int? processId;
@@ -110,12 +145,14 @@ class _ConsoleWorkspace extends StatelessWidget {
   final double? fraction;
   final DanmakuStyle danmakuStyle;
   final List<BlockedDanmakuItem> blockedItems;
+  final ExternalPlayerConsolePane pane;
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final useTwoColumns = constraints.maxWidth >= 980;
+        final useTwoColumns = pane == ExternalPlayerConsolePane.all &&
+            constraints.maxWidth >= 980;
         final controlPanels = <Widget>[
           _buildSessionPanel(context),
           const SizedBox(height: 14),
@@ -128,9 +165,25 @@ class _ConsoleWorkspace extends StatelessWidget {
           child: _DanmakuList(
             sessionId: processId,
             items: danmakuList,
-            fillAvailableHeight: useTwoColumns,
+            fillAvailableHeight:
+                useTwoColumns || pane == ExternalPlayerConsolePane.danmakuList,
           ),
         );
+
+        if (pane == ExternalPlayerConsolePane.controls) {
+          return ListView(
+            key: const Key('external-player-console-controls-pane'),
+            padding: const EdgeInsets.only(right: 4),
+            children: controlPanels,
+          );
+        }
+
+        if (pane == ExternalPlayerConsolePane.danmakuList) {
+          return KeyedSubtree(
+            key: const Key('external-player-console-danmaku-list-pane'),
+            child: listPanel,
+          );
+        }
 
         if (!useTwoColumns) {
           return SingleChildScrollView(

--- a/lib/pages/external_player_console_window.dart
+++ b/lib/pages/external_player_console_window.dart
@@ -6,29 +6,35 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:nipaplay/l10n/app_locale_utils.dart';
 import 'package:nipaplay/l10n/app_localizations.dart';
-import 'package:nipaplay/pages/play_video_page.dart';
+import 'package:nipaplay/pages/external_player_console_page.dart';
 import 'package:nipaplay/providers/app_language_provider.dart';
-import 'package:nipaplay/services/desktop_player_window_service.dart';
 import 'package:nipaplay/utils/app_theme.dart';
 import 'package:nipaplay/utils/theme_notifier.dart';
-import 'package:nipaplay/widgets/desktop_picture_in_picture_scope.dart';
 import 'package:provider/provider.dart';
 
-/// The player surface rendered in the secondary FlutterView.
-///
-/// Providers live above DesktopMultiWindowHost, so this MaterialApp sees the
-/// same VideoPlayerState and Player instance as the main window.
-class DesktopPlayerWindow extends StatelessWidget {
-  const DesktopPlayerWindow({super.key});
+class ExternalPlayerConsoleWindow extends StatelessWidget {
+  const ExternalPlayerConsoleWindow({
+    super.key,
+    required this.controller,
+    required this.pane,
+    required this.onClose,
+    this.onShowDanmakuList,
+  });
+
+  final WindowController controller;
+  final ExternalPlayerConsolePane pane;
+  final VoidCallback onClose;
+  final VoidCallback? onShowDanmakuList;
 
   @override
   Widget build(BuildContext context) {
     final themeMode = context.watch<ThemeNotifier>().themeMode;
     final locale = context.watch<AppLanguageProvider>().locale;
-    final windowController = DesktopMultiWindow.controllerOf(context);
 
     return MaterialApp(
-      title: 'NipaPlay 独立播放器',
+      title: pane == ExternalPlayerConsolePane.danmakuList
+          ? 'NipaPlay 弹幕列表'
+          : 'NipaPlay 弹幕控制台',
       debugShowCheckedModeBanner: false,
       themeMode: themeMode,
       theme: ThemeData(
@@ -49,37 +55,26 @@ class DesktopPlayerWindow extends StatelessWidget {
         GlobalCupertinoLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
       ],
-      home: ListenableBuilder(
-        listenable: DesktopPlayerWindowService.instance,
-        builder: (context, _) {
-          final isPictureInPicture =
-              DesktopPlayerWindowService.instance.isPictureInPicture;
-          return DesktopPictureInPictureScope(
-            enabled: isPictureInPicture,
-            child: ColoredBox(
-              color: Colors.black,
-              child: Stack(
-                fit: StackFit.expand,
-                children: [
-                  PlayVideoPage(
-                    key: DesktopPlayerWindowService.instance.playerPageKey,
-                  ),
-                  Positioned(
-                    top: 0,
-                    left: isPictureInPicture ? 72 : 96,
-                    right: isPictureInPicture ? 72 : 128,
-                    height: 38,
-                    child: ListenableBuilder(
-                      listenable: windowController,
-                      builder: (context, _) => windowController.isFullscreen
-                          ? const SizedBox.shrink()
-                          : _DetachedWindowDragRegion(
-                              controller: windowController,
-                            ),
-                    ),
-                  ),
-                ],
-              ),
+      home: Builder(
+        builder: (context) {
+          return ColoredBox(
+            color: Theme.of(context).colorScheme.surface,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                ExternalPlayerConsolePage(
+                  pane: pane,
+                  onShowDanmakuList: onShowDanmakuList,
+                  onCloseWindow: onClose,
+                ),
+                Positioned(
+                  top: 0,
+                  left: 0,
+                  right: onShowDanmakuList == null ? 66 : 120,
+                  height: 48,
+                  child: _ConsoleWindowDragRegion(controller: controller),
+                ),
+              ],
             ),
           );
         },
@@ -88,17 +83,17 @@ class DesktopPlayerWindow extends StatelessWidget {
   }
 }
 
-class _DetachedWindowDragRegion extends StatefulWidget {
-  const _DetachedWindowDragRegion({required this.controller});
+class _ConsoleWindowDragRegion extends StatefulWidget {
+  const _ConsoleWindowDragRegion({required this.controller});
 
   final WindowController controller;
 
   @override
-  State<_DetachedWindowDragRegion> createState() =>
-      _DetachedWindowDragRegionState();
+  State<_ConsoleWindowDragRegion> createState() =>
+      _ConsoleWindowDragRegionState();
 }
 
-class _DetachedWindowDragRegionState extends State<_DetachedWindowDragRegion> {
+class _ConsoleWindowDragRegionState extends State<_ConsoleWindowDragRegion> {
   bool _dragging = false;
 
   void _start(PointerDownEvent event) {

--- a/lib/pages/play_video_page.dart
+++ b/lib/pages/play_video_page.dart
@@ -34,6 +34,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/video_progress_bar.dart';
 import 'package:nipaplay/utils/hotkey_service.dart';
 import 'package:nipaplay/pages/anime_detail_page.dart';
 import 'package:nipaplay/services/desktop_player_window_service.dart';
+import 'package:nipaplay/widgets/desktop_picture_in_picture_scope.dart';
 
 class PlayVideoPage extends StatefulWidget {
   final String? videoPath;
@@ -60,6 +61,8 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
   bool _portraitUnlockScheduled = false;
   bool _isLargeScreenProgressDragging = false;
   bool _largeScreenPlayStateChangedByDrag = false;
+  bool _isPictureInPictureProgressDragging = false;
+  bool _pictureInPicturePlayStateChangedByDrag = false;
   Timer? _uiLockButtonTimer;
   bool _isExiting = false;
 
@@ -485,6 +488,8 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
     VideoPlayerState videoState, {
     double portraitUiScale = 1.0,
   }) {
+    final isPictureInPicture =
+        DesktopPictureInPictureScope.isEnabledOf(context);
     return Stack(
       fit: StackFit.expand,
       clipBehavior: Clip.hardEdge,
@@ -493,7 +498,8 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
           child: VideoPlayerWidget(),
         ),
         if (videoState.hasVideo)
-          NipaplayLargeScreenModeScope.isActiveOf(context)
+          NipaplayLargeScreenModeScope.isActiveOf(context) &&
+                  !isPictureInPicture
               ? _buildLargeScreenMaterialControls(videoState)
               : KeyedSubtree(
                   key: ValueKey<bool>(portraitUiScale < 0.999),
@@ -642,6 +648,7 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
                                   color: Colors.white,
                                   fontSize: 21,
                                   fontWeight: FontWeight.w800,
+                                  decoration: TextDecoration.none,
                                 ),
                               ),
                               if (episodeTitle.isNotEmpty) ...[
@@ -654,6 +661,7 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
                                     color: Colors.white70,
                                     fontSize: 14,
                                     fontWeight: FontWeight.w600,
+                                    decoration: TextDecoration.none,
                                   ),
                                 ),
                               ],
@@ -694,6 +702,30 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
                             onPressed: videoState.stepForward,
                           ),
                         ],
+                        if (DesktopPlayerWindowService.isFeatureEnabled)
+                          _LargeScreenPlayerBarButton(
+                            tooltip: ShortcutTooltipManager()
+                                .formatActionWithShortcut(
+                              'toggle_picture_in_picture',
+                              '画中画模式',
+                            ),
+                            icon: Icons.picture_in_picture_alt_rounded,
+                            onPressed: () {
+                              videoState.resetHideControlsTimer();
+                              final service =
+                                  DesktopPlayerWindowService.instance;
+                              if (detachedWindow != null) {
+                                unawaited(service.togglePictureInPicture());
+                              } else {
+                                unawaited(
+                                  service.detachAndEnterPictureInPicture(
+                                    context,
+                                    videoState,
+                                  ),
+                                );
+                              }
+                            },
+                          ),
                         if (detachedWindow != null)
                           ListenableBuilder(
                             listenable: detachedWindow,
@@ -878,6 +910,7 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
                                 color: Colors.white,
                                 fontSize: 15,
                                 fontWeight: FontWeight.w800,
+                                decoration: TextDecoration.none,
                               ),
                             ),
                           ),
@@ -947,10 +980,16 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
     final bool showAirPlayButton =
         !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
     final detachedWindow = DesktopMultiWindow.maybeControllerOf(context);
+    final isPictureInPicture =
+        DesktopPictureInPictureScope.isEnabledOf(context);
+    final showPictureInPictureButton =
+        DesktopPlayerWindowService.isFeatureEnabled;
     final double horizontalCutoutInset =
         globals.isPhone && portraitUiScale >= 0.999 ? 24.0 : 0.0;
 
-    final int rightButtonCount = (detachedWindow != null ? 1 : 0) +
+    final int rightButtonCount = (showPictureInPictureButton
+            ? (detachedWindow != null ? (isPictureInPicture ? 1 : 2) : 1)
+            : 0) +
         (showAirPlayButton ? 1 : 0) +
         (showScreenshotButton ? 1 : 0) +
         (showShareButton ? 1 : 0);
@@ -959,7 +998,7 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
         : 0.0;
     final double availableTitleWidth = (MediaQuery.of(context).size.width -
             (16.0 + horizontalCutoutInset) -
-            116.0 -
+            (isPictureInPicture ? 0.0 : 116.0) -
             (16.0 + horizontalCutoutInset) -
             rightButtonsWidth -
             (globals.isMobilePlatform ? 86.0 : 0.0) -
@@ -997,91 +1036,94 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
                     onExit: (_) => videoState.setControlsHovered(false),
                     child: Row(
                       children: [
-                        MouseRegion(
-                          cursor: _isHoveringBackButton
-                              ? SystemMouseCursors.click
-                              : SystemMouseCursors.basic,
-                          onEnter: (_) =>
-                              setState(() => _isHoveringBackButton = true),
-                          onExit: (_) =>
-                              setState(() => _isHoveringBackButton = false),
-                          child: BackButtonWidget(
-                            videoState: videoState,
-                            onExit:
-                                DesktopMultiWindow.isSecondaryWindow(context)
-                                    ? DesktopPlayerWindowService
-                                        .instance.returnPlayerToMain
-                                    : null,
+                        if (!isPictureInPicture) ...[
+                          MouseRegion(
+                            cursor: _isHoveringBackButton
+                                ? SystemMouseCursors.click
+                                : SystemMouseCursors.basic,
+                            onEnter: (_) =>
+                                setState(() => _isHoveringBackButton = true),
+                            onExit: (_) =>
+                                setState(() => _isHoveringBackButton = false),
+                            child: BackButtonWidget(
+                              videoState: videoState,
+                              onExit:
+                                  DesktopMultiWindow.isSecondaryWindow(context)
+                                      ? DesktopPlayerWindowService
+                                          .instance.returnPlayerToMain
+                                      : null,
+                            ),
                           ),
-                        ),
-                        const SizedBox(width: 12.0),
-                        if (videoState.playerTopSendDanmakuButtonVisible) ...[
-                          SendDanmakuButton(
-                            onPressed: () => _showSendDanmakuDialog(videoState),
-                          ),
-                          const SizedBox(width: 8.0),
-                        ],
-                        if (videoState.playerTopSkipButtonVisible) ...[
-                          SkipButton(
-                            onPressed: () => videoState.skip(),
-                          ),
-                          const SizedBox(width: 8.0),
-                        ],
-                        if (globals.isDesktop &&
-                            videoState.playerTopResizeButtonVisible) ...[
-                          ShadowActionButton(
-                            tooltip: ShortcutTooltipManager()
-                                .formatActionWithShortcut(
-                                    'resize_to_video', '窗口适配视频'),
-                            icon: Ionicons.resize_outline,
-                            iconSize: 28,
-                            padding: EdgeInsets.zero,
-                            onPressed: () =>
-                                _resizeCurrentWindowToVideo(videoState),
-                          ),
-                          const SizedBox(width: 8.0),
-                        ],
-                        if (globals.isDesktop &&
-                            videoState.playerTopFrameStepButtonsVisible) ...[
-                          ShadowActionButton(
-                            tooltip: ShortcutTooltipManager()
-                                .formatActionWithShortcut(
-                                    'step_backward', '逐帧后退'),
-                            icon: Ionicons.chevron_back_circle_outline,
-                            iconSize: 28,
-                            padding: EdgeInsets.zero,
-                            onPressed: () => videoState.stepBackward(),
-                          ),
-                          const SizedBox(width: 8.0),
-                          ShadowActionButton(
-                            tooltip: ShortcutTooltipManager()
-                                .formatActionWithShortcut(
-                                    'step_forward', '逐帧前进'),
-                            icon: Ionicons.chevron_forward_circle_outline,
-                            iconSize: 28,
-                            padding: EdgeInsets.zero,
-                            onPressed: () => videoState.stepForward(),
-                          ),
-                          const SizedBox(width: 8.0),
-                        ],
-                        if (!globals.isDesktop &&
-                            videoState.playerTopFrameStepButtonsVisible) ...[
-                          ShadowActionButton(
-                            tooltip: '逐帧后退',
-                            icon: Ionicons.chevron_back_circle_outline,
-                            iconSize: 28,
-                            padding: EdgeInsets.zero,
-                            onPressed: () => videoState.stepBackward(),
-                          ),
-                          const SizedBox(width: 8.0),
-                          ShadowActionButton(
-                            tooltip: '逐帧前进',
-                            icon: Ionicons.chevron_forward_circle_outline,
-                            iconSize: 28,
-                            padding: EdgeInsets.zero,
-                            onPressed: () => videoState.stepForward(),
-                          ),
-                          const SizedBox(width: 8.0),
+                          const SizedBox(width: 12.0),
+                          if (videoState.playerTopSendDanmakuButtonVisible) ...[
+                            SendDanmakuButton(
+                              onPressed: () =>
+                                  _showSendDanmakuDialog(videoState),
+                            ),
+                            const SizedBox(width: 8.0),
+                          ],
+                          if (videoState.playerTopSkipButtonVisible) ...[
+                            SkipButton(
+                              onPressed: () => videoState.skip(),
+                            ),
+                            const SizedBox(width: 8.0),
+                          ],
+                          if (globals.isDesktop &&
+                              videoState.playerTopResizeButtonVisible) ...[
+                            ShadowActionButton(
+                              tooltip: ShortcutTooltipManager()
+                                  .formatActionWithShortcut(
+                                      'resize_to_video', '窗口适配视频'),
+                              icon: Ionicons.resize_outline,
+                              iconSize: 28,
+                              padding: EdgeInsets.zero,
+                              onPressed: () =>
+                                  _resizeCurrentWindowToVideo(videoState),
+                            ),
+                            const SizedBox(width: 8.0),
+                          ],
+                          if (globals.isDesktop &&
+                              videoState.playerTopFrameStepButtonsVisible) ...[
+                            ShadowActionButton(
+                              tooltip: ShortcutTooltipManager()
+                                  .formatActionWithShortcut(
+                                      'step_backward', '逐帧后退'),
+                              icon: Ionicons.chevron_back_circle_outline,
+                              iconSize: 28,
+                              padding: EdgeInsets.zero,
+                              onPressed: () => videoState.stepBackward(),
+                            ),
+                            const SizedBox(width: 8.0),
+                            ShadowActionButton(
+                              tooltip: ShortcutTooltipManager()
+                                  .formatActionWithShortcut(
+                                      'step_forward', '逐帧前进'),
+                              icon: Ionicons.chevron_forward_circle_outline,
+                              iconSize: 28,
+                              padding: EdgeInsets.zero,
+                              onPressed: () => videoState.stepForward(),
+                            ),
+                            const SizedBox(width: 8.0),
+                          ],
+                          if (!globals.isDesktop &&
+                              videoState.playerTopFrameStepButtonsVisible) ...[
+                            ShadowActionButton(
+                              tooltip: '逐帧后退',
+                              icon: Ionicons.chevron_back_circle_outline,
+                              iconSize: 28,
+                              padding: EdgeInsets.zero,
+                              onPressed: () => videoState.stepBackward(),
+                            ),
+                            const SizedBox(width: 8.0),
+                            ShadowActionButton(
+                              tooltip: '逐帧前进',
+                              icon: Ionicons.chevron_forward_circle_outline,
+                              iconSize: 28,
+                              padding: EdgeInsets.zero,
+                              onPressed: () => videoState.stepForward(),
+                            ),
+                            const SizedBox(width: 8.0),
+                          ],
                         ],
                         if (!isCompactPortrait) ...[
                           const SizedBox(width: 4.0),
@@ -1129,26 +1171,56 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
                     onExit: (_) => videoState.setControlsHovered(false),
                     child: Row(
                       children: [
-                        if (detachedWindow != null) ...[
-                          ListenableBuilder(
-                            listenable: detachedWindow,
-                            builder: (context, _) {
-                              final isPinned = detachedWindow.isAlwaysOnTop;
-                              return ShadowActionButton(
-                                tooltip: isPinned ? '取消窗口置顶' : '窗口置顶并跟随桌面',
-                                icon: isPinned
-                                    ? Icons.push_pin_rounded
-                                    : Icons.push_pin_outlined,
-                                onPressed: () {
-                                  videoState.resetHideControlsTimer();
-                                  unawaited(
-                                    detachedWindow.toggleAlwaysOnTop(),
-                                  );
-                                },
-                              );
+                        if (showPictureInPictureButton) ...[
+                          ShadowActionButton(
+                            tooltip: isPictureInPicture
+                                ? null
+                                : ShortcutTooltipManager()
+                                    .formatActionWithShortcut(
+                                    'toggle_picture_in_picture',
+                                    '画中画模式',
+                                  ),
+                            icon: isPictureInPicture
+                                ? Icons.picture_in_picture_rounded
+                                : Icons.picture_in_picture_alt_rounded,
+                            onPressed: () {
+                              videoState.resetHideControlsTimer();
+                              final service =
+                                  DesktopPlayerWindowService.instance;
+                              if (detachedWindow != null) {
+                                unawaited(service.togglePictureInPicture());
+                              } else {
+                                unawaited(
+                                  service.detachAndEnterPictureInPicture(
+                                    context,
+                                    videoState,
+                                  ),
+                                );
+                              }
                             },
                           ),
-                          const SizedBox(width: 12),
+                          if (detachedWindow != null &&
+                              !isPictureInPicture) ...[
+                            const SizedBox(width: 12),
+                            ListenableBuilder(
+                              listenable: detachedWindow,
+                              builder: (context, _) {
+                                final isPinned = detachedWindow.isAlwaysOnTop;
+                                return ShadowActionButton(
+                                  tooltip: isPinned ? '取消窗口置顶' : '窗口置顶并跟随桌面',
+                                  icon: isPinned
+                                      ? Icons.push_pin_rounded
+                                      : Icons.push_pin_outlined,
+                                  onPressed: () {
+                                    videoState.resetHideControlsTimer();
+                                    unawaited(
+                                      detachedWindow.toggleAlwaysOnTop(),
+                                    );
+                                  },
+                                );
+                              },
+                            ),
+                          ],
                         ],
                         if (showAirPlayButton)
                           ShadowActionButton(
@@ -1237,7 +1309,10 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
               child: Container(),
             ),
           ),
-        VideoControlsOverlay(compactPortrait: portraitUiScale < 0.999),
+        if (isPictureInPicture)
+          _buildPictureInPictureControls(videoState)
+        else
+          VideoControlsOverlay(compactPortrait: portraitUiScale < 0.999),
         if (uiLocked)
           Positioned.fill(
             child: GestureDetector(
@@ -1273,6 +1348,85 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
             ),
           ),
       ],
+    );
+  }
+
+  Widget _buildPictureInPictureControls(VideoPlayerState videoState) {
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 0,
+      child: AnimatedOpacity(
+        opacity: videoState.showControls ? 1 : 0,
+        duration: const Duration(milliseconds: 150),
+        child: IgnorePointer(
+          ignoring: !videoState.showControls,
+          child: MouseRegion(
+            onEnter: (_) => videoState.setControlsHovered(true),
+            onExit: (_) => videoState.setControlsHovered(false),
+            child: DecoratedBox(
+              decoration: const BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [Colors.transparent, Color(0xB3000000)],
+                ),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(8, 12, 14, 8),
+                child: Row(
+                  children: [
+                    SizedBox(
+                      width: 44,
+                      height: 44,
+                      child: Center(
+                        child: ShadowActionButton(
+                          icon: videoState.status == PlayerStatus.playing
+                              ? Ionicons.pause
+                              : Ionicons.play,
+                          iconSize: 30,
+                          padding: const EdgeInsets.all(7),
+                          onPressed: videoState.togglePlayPause,
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: VideoProgressBar(
+                        videoState: videoState,
+                        hoverTime: null,
+                        isDragging: _isPictureInPictureProgressDragging,
+                        compact: true,
+                        showHoverPreview: false,
+                        chapters: videoState.chapterMarkersEnabled
+                            ? videoState.chapters
+                            : const [],
+                        durationMs: videoState.duration.inMilliseconds,
+                        currentChapter: videoState.currentChapter,
+                        onPositionUpdate: (_) {},
+                        onDraggingStateChange: (isDragging) {
+                          if (isDragging &&
+                              videoState.status == PlayerStatus.paused) {
+                            _pictureInPicturePlayStateChangedByDrag = true;
+                            videoState.togglePlayPause();
+                          } else if (!isDragging &&
+                              _pictureInPicturePlayStateChangedByDrag) {
+                            videoState.togglePlayPause();
+                            _pictureInPicturePlayStateChangedByDrag = false;
+                          }
+                          setState(() {
+                            _isPictureInPictureProgressDragging = isDragging;
+                          });
+                        },
+                        formatDuration: _formatDuration,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 

--- a/lib/pages/shortcuts_settings_page.dart
+++ b/lib/pages/shortcuts_settings_page.dart
@@ -40,6 +40,8 @@ class _ShortcutsSettingsPageState extends State<ShortcutsSettingsPage> {
     'step_forward': '逐帧前进',
     'step_backward': '逐帧后退',
     'resize_to_video': '窗口适配视频',
+    'toggle_picture_in_picture': '画中画模式',
+    'toggle_detached_player': '独立窗口模式',
   };
 
   // 动作描述
@@ -58,6 +60,8 @@ class _ShortcutsSettingsPageState extends State<ShortcutsSettingsPage> {
     'step_forward': '暂停后前进一帧',
     'step_backward': '暂停后后退一帧',
     'resize_to_video': '将窗口大小调整为视频原始分辨率',
+    'toggle_picture_in_picture': '进入画中画，或从画中画恢复为普通独立窗口',
+    'toggle_detached_player': '在主窗口与独立播放窗口之间移动播放器',
   };
 
   // 动作图标映射
@@ -76,6 +80,8 @@ class _ShortcutsSettingsPageState extends State<ShortcutsSettingsPage> {
     'step_forward': Ionicons.chevron_forward_circle_outline,
     'step_backward': Ionicons.chevron_back_circle_outline,
     'resize_to_video': Ionicons.resize_outline,
+    'toggle_picture_in_picture': Icons.picture_in_picture_alt_rounded,
+    'toggle_detached_player': Icons.open_in_new_rounded,
   };
 
   @override
@@ -133,6 +139,8 @@ class _ShortcutsSettingsPageState extends State<ShortcutsSettingsPage> {
       'step_forward': 'E',
       'step_backward': 'Q',
       'resize_to_video': 'R',
+      'toggle_picture_in_picture': 'P',
+      'toggle_detached_player': 'W',
     };
 
     for (final entry in defaultShortcuts.entries) {

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -30,6 +30,7 @@ class SettingsProvider with ChangeNotifier {
   bool _externalPlayerDanmakuOverlay = true; // 弹幕外挂默认开启
   bool _externalPlayerAutoSwitchToDanmakuConsole = true;
   bool _externalPlayerShrinkWindow = false;
+  bool _externalPlayerConsoleWindowMode = false;
 
   // GitHub 代理设置
   String _githubProxyUrl = '';
@@ -53,6 +54,7 @@ class SettingsProvider with ChangeNotifier {
   bool get externalPlayerAutoSwitchToDanmakuConsole =>
       _externalPlayerAutoSwitchToDanmakuConsole;
   bool get externalPlayerShrinkWindow => _externalPlayerShrinkWindow;
+  bool get externalPlayerConsoleWindowMode => _externalPlayerConsoleWindowMode;
   String get githubProxyUrl => _githubProxyUrl;
   double get danmakuSupersample => _danmakuSupersample;
 
@@ -109,6 +111,8 @@ class SettingsProvider with ChangeNotifier {
             true;
     _externalPlayerShrinkWindow =
         _prefs.getBool(SettingsKeys.externalPlayerShrinkWindow) ?? false;
+    _externalPlayerConsoleWindowMode =
+        _prefs.getBool(SettingsKeys.externalPlayerConsoleWindowMode) ?? false;
     _githubProxyUrl = _prefs.getString(SettingsKeys.githubProxyUrl) ?? '';
     // 弹幕超采样：默认对平板和低 DPR 桌面设备开启 2x
     final defaultSupersample =
@@ -254,6 +258,16 @@ class SettingsProvider with ChangeNotifier {
     await _prefs.setBool(
       SettingsKeys.externalPlayerShrinkWindow,
       _externalPlayerShrinkWindow,
+    );
+    notifyListeners();
+  }
+
+  Future<void> setExternalPlayerConsoleWindowMode(bool enable) async {
+    if (_externalPlayerConsoleWindowMode == enable) return;
+    _externalPlayerConsoleWindowMode = enable;
+    await _prefs.setBool(
+      SettingsKeys.externalPlayerConsoleWindowMode,
+      _externalPlayerConsoleWindowMode,
     );
     notifyListeners();
   }

--- a/lib/services/desktop_picture_in_picture_preferences.dart
+++ b/lib/services/desktop_picture_in_picture_preferences.dart
@@ -1,0 +1,47 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum DesktopPictureInPicturePosition {
+  topLeft,
+  topRight,
+  bottomLeft,
+  bottomRight,
+}
+
+class DesktopPictureInPicturePreferences {
+  DesktopPictureInPicturePreferences._();
+
+  static const DesktopPictureInPicturePosition defaultPosition =
+      DesktopPictureInPicturePosition.topRight;
+  static const String _positionKey =
+      'desktop_picture_in_picture_window_position';
+
+  static DesktopPictureInPicturePosition parsePosition(String? rawValue) {
+    return switch (rawValue) {
+      'topLeft' => DesktopPictureInPicturePosition.topLeft,
+      'bottomLeft' => DesktopPictureInPicturePosition.bottomLeft,
+      'bottomRight' => DesktopPictureInPicturePosition.bottomRight,
+      'topRight' || _ => defaultPosition,
+    };
+  }
+
+  static String serializePosition(DesktopPictureInPicturePosition position) {
+    return switch (position) {
+      DesktopPictureInPicturePosition.topLeft => 'topLeft',
+      DesktopPictureInPicturePosition.topRight => 'topRight',
+      DesktopPictureInPicturePosition.bottomLeft => 'bottomLeft',
+      DesktopPictureInPicturePosition.bottomRight => 'bottomRight',
+    };
+  }
+
+  static Future<DesktopPictureInPicturePosition> loadPosition() async {
+    final prefs = await SharedPreferences.getInstance();
+    return parsePosition(prefs.getString(_positionKey));
+  }
+
+  static Future<void> savePosition(
+    DesktopPictureInPicturePosition position,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_positionKey, serializePosition(position));
+  }
+}

--- a/lib/services/desktop_player_window_service.dart
+++ b/lib/services/desktop_player_window_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:nipaplay/app/app_page_ids.dart';
 import 'package:nipaplay/pages/desktop_player_window.dart';
+import 'package:nipaplay/services/desktop_picture_in_picture_preferences.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/tab_change_notifier.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
@@ -34,11 +35,17 @@ class DesktopPlayerWindowService extends ChangeNotifier {
   VideoPlayerState? _videoState;
   bool _playerDetached = false;
   bool _transitionInProgress = false;
+  bool _pictureInPicture = false;
+  bool _pictureInPictureTransitionInProgress = false;
+  bool _alwaysOnTopBeforePictureInPicture = false;
   String? _lastWindowTitle;
   double? _lastAspectRatio;
 
   bool get isPlayerDetached => _playerDetached;
   bool get isTransitionInProgress => _transitionInProgress;
+  bool get isPictureInPicture => _pictureInPicture;
+  bool get isPictureInPictureTransitionInProgress =>
+      _pictureInPictureTransitionInProgress;
   WindowController? get activeWindow => _activeWindow;
 
   Future<bool> detachPlayer(
@@ -119,11 +126,155 @@ class DesktopPlayerWindowService extends ChangeNotifier {
     await window.setFullscreen(!window.isFullscreen);
   }
 
+  Future<void> togglePictureInPicture() async {
+    if (_pictureInPictureTransitionInProgress) return;
+    if (_pictureInPicture) {
+      await exitPictureInPicture();
+    } else {
+      await enterPictureInPicture();
+    }
+  }
+
+  Future<bool> detachAndEnterPictureInPicture(
+    BuildContext context,
+    VideoPlayerState videoState,
+  ) async {
+    final detached = await detachPlayer(context, videoState);
+    if (!detached) return false;
+    await enterPictureInPicture();
+    return _pictureInPicture;
+  }
+
+  Future<void> enterPictureInPicture() async {
+    final window = _activeWindow;
+    final videoState = _videoState;
+    if (window == null || window.isClosed || videoState == null) return;
+    if (_pictureInPicture || _pictureInPictureTransitionInProgress) return;
+
+    _pictureInPictureTransitionInProgress = true;
+    _alwaysOnTopBeforePictureInPicture = window.isAlwaysOnTop;
+    _pictureInPicture = true;
+    notifyListeners();
+
+    final aspectRatio = normalizeAspectRatio(videoState.aspectRatio);
+    try {
+      final placement = await DesktopPictureInPicturePreferences.loadPosition();
+      debugPrint(
+        '[DesktopPlayerWindow] 进入画中画: '
+        'aspect=${aspectRatio.toStringAsFixed(4)} '
+        'placement=${DesktopPictureInPicturePreferences.serializePosition(placement)}',
+      );
+      if (window.isFullscreen) await window.setFullscreen(false);
+      await window.setMinimumSize(
+        pictureInPictureMinimumWindowSizeForAspect(aspectRatio),
+      );
+      await window.setAspectRatio(aspectRatio);
+      await window.setPictureInPictureMode(
+        enabled: true,
+        aspectRatio: aspectRatio,
+        placement:
+            DesktopPictureInPicturePreferences.serializePosition(placement),
+      );
+      await window.setAlwaysOnTop(true);
+    } catch (error, stackTrace) {
+      debugPrint(
+        '[DesktopPlayerWindow] 进入画中画失败: $error\n$stackTrace',
+      );
+      _pictureInPicture = false;
+      try {
+        await window.setPictureInPictureMode(
+          enabled: false,
+          aspectRatio: aspectRatio,
+          placement: DesktopPictureInPicturePreferences.serializePosition(
+            DesktopPictureInPicturePreferences.defaultPosition,
+          ),
+        );
+        await window.setMinimumSize(minimumWindowSizeForAspect(aspectRatio));
+        await window.setAlwaysOnTop(_alwaysOnTopBeforePictureInPicture);
+      } catch (rollbackError) {
+        debugPrint(
+          '[DesktopPlayerWindow] 画中画失败后的窗口恢复也失败: $rollbackError',
+        );
+      }
+    } finally {
+      _pictureInPictureTransitionInProgress = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> exitPictureInPicture() async {
+    final window = _activeWindow;
+    if (window == null || window.isClosed) {
+      _pictureInPicture = false;
+      _pictureInPictureTransitionInProgress = false;
+      notifyListeners();
+      return;
+    }
+    if (!_pictureInPicture || _pictureInPictureTransitionInProgress) return;
+
+    _pictureInPictureTransitionInProgress = true;
+    notifyListeners();
+    final aspectRatio = normalizeAspectRatio(
+      _videoState?.aspectRatio ?? _lastAspectRatio ?? 16 / 9,
+    );
+    debugPrint('[DesktopPlayerWindow] 退出画中画并恢复独立窗口');
+    try {
+      await window.setPictureInPictureMode(
+        enabled: false,
+        aspectRatio: aspectRatio,
+        placement: DesktopPictureInPicturePreferences.serializePosition(
+          DesktopPictureInPicturePreferences.defaultPosition,
+        ),
+      );
+      await window.setMinimumSize(minimumWindowSizeForAspect(aspectRatio));
+      await window.setAspectRatio(aspectRatio);
+      await window.setAlwaysOnTop(_alwaysOnTopBeforePictureInPicture);
+    } catch (error, stackTrace) {
+      debugPrint(
+        '[DesktopPlayerWindow] 退出画中画失败: $error\n$stackTrace',
+      );
+    } finally {
+      _pictureInPicture = false;
+      _pictureInPictureTransitionInProgress = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> updatePictureInPicturePlacement(
+    DesktopPictureInPicturePosition placement,
+  ) async {
+    final window = _activeWindow;
+    if (!_pictureInPicture || window == null || window.isClosed) return;
+    final aspectRatio = normalizeAspectRatio(
+      _videoState?.aspectRatio ?? _lastAspectRatio ?? 16 / 9,
+    );
+    debugPrint(
+      '[DesktopPlayerWindow] 更新画中画停靠位置: '
+      '${DesktopPictureInPicturePreferences.serializePosition(placement)}',
+    );
+    try {
+      await window.setPictureInPictureMode(
+        enabled: true,
+        aspectRatio: aspectRatio,
+        placement:
+            DesktopPictureInPicturePreferences.serializePosition(placement),
+      );
+    } catch (error, stackTrace) {
+      debugPrint(
+        '[DesktopPlayerWindow] 更新画中画停靠位置失败: $error\n$stackTrace',
+      );
+    }
+  }
+
   Future<void> resizeDetachedWindowToVideo() async {
     final window = _activeWindow;
     final videoState = _videoState;
     if (window == null || window.isClosed || videoState == null) return;
     final aspectRatio = normalizeAspectRatio(videoState.aspectRatio);
+    if (_pictureInPicture) {
+      await _applyPictureInPictureAspectRatio(window, aspectRatio);
+      return;
+    }
     await window.setAspectRatio(aspectRatio);
     await window.setMinimumSize(minimumWindowSizeForAspect(aspectRatio));
     await window.setSize(preferredWindowSizeForAspect(aspectRatio));
@@ -134,6 +285,9 @@ class DesktopPlayerWindowService extends ChangeNotifier {
     _activeWindow = null;
     _playerDetached = false;
     _transitionInProgress = false;
+    _pictureInPicture = false;
+    _pictureInPictureTransitionInProgress = false;
+    _alwaysOnTopBeforePictureInPicture = false;
     _lastWindowTitle = null;
     _lastAspectRatio = null;
     _detachVideoState();
@@ -166,7 +320,35 @@ class DesktopPlayerWindowService extends ChangeNotifier {
     if (_lastAspectRatio == null ||
         (nextAspectRatio - _lastAspectRatio!).abs() > 0.001) {
       _lastAspectRatio = nextAspectRatio;
-      unawaited(_applyVideoAspectRatio(window, nextAspectRatio));
+      if (_pictureInPicture) {
+        unawaited(_applyPictureInPictureAspectRatio(window, nextAspectRatio));
+      } else {
+        unawaited(_applyVideoAspectRatio(window, nextAspectRatio));
+      }
+    }
+  }
+
+  Future<void> _applyPictureInPictureAspectRatio(
+    WindowController window,
+    double aspectRatio,
+  ) async {
+    try {
+      final placement = await DesktopPictureInPicturePreferences.loadPosition();
+      await window.setMinimumSize(
+        pictureInPictureMinimumWindowSizeForAspect(aspectRatio),
+      );
+      await window.setAspectRatio(aspectRatio);
+      await window.setPictureInPictureMode(
+        enabled: true,
+        aspectRatio: aspectRatio,
+        placement:
+            DesktopPictureInPicturePreferences.serializePosition(placement),
+      );
+    } catch (error, stackTrace) {
+      debugPrint(
+        '[DesktopPlayerWindow] 根据新视频比例更新画中画失败: '
+        '$error\n$stackTrace',
+      );
     }
   }
 
@@ -212,5 +394,13 @@ class DesktopPlayerWindowService extends ChangeNotifier {
       return Size((shortEdge * ratio).clamp(480.0, 960.0), shortEdge);
     }
     return Size(shortEdge, (shortEdge / ratio).clamp(480.0, 960.0));
+  }
+
+  static Size pictureInPictureMinimumWindowSizeForAspect(double aspectRatio) {
+    final ratio = normalizeAspectRatio(aspectRatio);
+    const shortEdge = 120.0;
+    return ratio >= 1
+        ? Size(shortEdge * ratio, shortEdge)
+        : Size(shortEdge, shortEdge / ratio);
   }
 }

--- a/lib/services/external_player_console_window_service.dart
+++ b/lib/services/external_player_console_window_service.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:desktop_multi_window/desktop_multi_window.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:nipaplay/pages/external_player_console_page.dart';
+import 'package:nipaplay/pages/external_player_console_window.dart';
+import 'package:nipaplay/services/external_player_console_service.dart';
+import 'package:screen_retriever/screen_retriever.dart';
+
+class ExternalPlayerConsoleWindowService extends ChangeNotifier {
+  ExternalPlayerConsoleWindowService._() {
+    ExternalPlayerConsoleService.sessionAvailability.addListener(
+      _handleSessionAvailabilityChanged,
+    );
+  }
+
+  static final ExternalPlayerConsoleWindowService instance =
+      ExternalPlayerConsoleWindowService._();
+
+  static bool get isSupported =>
+      ExternalPlayerConsoleService.isSupportedPlatform &&
+      DesktopMultiWindow.isSupported;
+
+  WindowController? _controlsWindow;
+  WindowController? _danmakuListWindow;
+  bool _creatingControlsWindow = false;
+  bool _creatingDanmakuListWindow = false;
+
+  WindowController? get controlsWindow => _controlsWindow;
+  WindowController? get danmakuListWindow => _danmakuListWindow;
+
+  Future<void> showControlsWindow() async {
+    if (!isSupported || !ExternalPlayerConsoleService.hasActiveSession) return;
+    final existing = _controlsWindow;
+    if (existing != null && !existing.isClosed) {
+      await existing.show();
+      return;
+    }
+    if (_creatingControlsWindow) return;
+
+    _creatingControlsWindow = true;
+    try {
+      final size = await _preferredPortraitSize();
+      debugPrint(
+        '[ExternalPlayerConsoleWindow] 创建控制窗口: '
+        '${size.width.toStringAsFixed(1)}x${size.height.toStringAsFixed(1)}',
+      );
+      final window = await DesktopMultiWindow.createWindow(
+        title: 'NipaPlay 弹幕控制台',
+        size: size,
+        minimumSize: _minimumSizeFor(size),
+        frameless: true,
+        aspectRatio: 0.5,
+        builder: (context, controller) => ExternalPlayerConsoleWindow(
+          controller: controller,
+          pane: ExternalPlayerConsolePane.controls,
+          onShowDanmakuList: () => unawaited(showDanmakuListWindow()),
+          onClose: () => unawaited(closeControlsWindow()),
+        ),
+        onClosed: _handleControlsWindowClosed,
+      );
+      if (!window.isClosed) _controlsWindow = window;
+    } catch (error, stackTrace) {
+      debugPrint(
+        '[ExternalPlayerConsoleWindow] 创建控制窗口失败: '
+        '$error\n$stackTrace',
+      );
+    } finally {
+      _creatingControlsWindow = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> showDanmakuListWindow() async {
+    if (!isSupported || !ExternalPlayerConsoleService.hasActiveSession) return;
+    final existing = _danmakuListWindow;
+    if (existing != null && !existing.isClosed) {
+      await existing.show();
+      return;
+    }
+    if (_creatingDanmakuListWindow) return;
+
+    _creatingDanmakuListWindow = true;
+    try {
+      final size = await _preferredPortraitSize();
+      debugPrint(
+        '[ExternalPlayerConsoleWindow] 创建弹幕列表窗口: '
+        '${size.width.toStringAsFixed(1)}x${size.height.toStringAsFixed(1)}',
+      );
+      final window = await DesktopMultiWindow.createWindow(
+        title: 'NipaPlay 弹幕列表',
+        size: size,
+        minimumSize: _minimumSizeFor(size),
+        frameless: true,
+        aspectRatio: 0.5,
+        builder: (context, controller) => ExternalPlayerConsoleWindow(
+          controller: controller,
+          pane: ExternalPlayerConsolePane.danmakuList,
+          onClose: () => unawaited(closeDanmakuListWindow()),
+        ),
+        onClosed: _handleDanmakuListWindowClosed,
+      );
+      if (!window.isClosed) _danmakuListWindow = window;
+    } catch (error, stackTrace) {
+      debugPrint(
+        '[ExternalPlayerConsoleWindow] 创建弹幕列表窗口失败: '
+        '$error\n$stackTrace',
+      );
+    } finally {
+      _creatingDanmakuListWindow = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> closeControlsWindow() async {
+    final window = _controlsWindow;
+    _controlsWindow = null;
+    if (window != null && !window.isClosed) await window.close();
+    await closeDanmakuListWindow();
+    notifyListeners();
+  }
+
+  Future<void> closeDanmakuListWindow() async {
+    final window = _danmakuListWindow;
+    _danmakuListWindow = null;
+    if (window != null && !window.isClosed) await window.close();
+    notifyListeners();
+  }
+
+  Future<void> closeAll() async {
+    await closeDanmakuListWindow();
+    final window = _controlsWindow;
+    _controlsWindow = null;
+    if (window != null && !window.isClosed) await window.close();
+    notifyListeners();
+  }
+
+  void _handleControlsWindowClosed() {
+    _controlsWindow = null;
+    unawaited(closeDanmakuListWindow());
+    notifyListeners();
+  }
+
+  void _handleDanmakuListWindowClosed() {
+    _danmakuListWindow = null;
+    notifyListeners();
+  }
+
+  void _handleSessionAvailabilityChanged() {
+    if (!ExternalPlayerConsoleService.hasActiveSession) {
+      unawaited(closeAll());
+    }
+  }
+
+  Future<Size> _preferredPortraitSize() async {
+    try {
+      final display = await screenRetriever.getPrimaryDisplay();
+      final visibleSize = display.visibleSize ?? display.size;
+      if (visibleSize.height.isFinite && visibleSize.height > 0) {
+        final height = visibleSize.height / 2;
+        return Size(height / 2, height);
+      }
+    } catch (error) {
+      debugPrint(
+        '[ExternalPlayerConsoleWindow] 获取屏幕尺寸失败，使用默认尺寸: $error',
+      );
+    }
+    return const Size(270, 540);
+  }
+
+  Size _minimumSizeFor(Size preferredSize) {
+    return Size(
+      preferredSize.width.clamp(160, 220).toDouble(),
+      preferredSize.height.clamp(320, 440).toDouble(),
+    );
+  }
+}

--- a/lib/services/external_player_service.dart
+++ b/lib/services/external_player_service.dart
@@ -19,6 +19,7 @@ import 'package:nipaplay/models/playable_item.dart';
 import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/services/external_player_console_service.dart';
+import 'package:nipaplay/services/external_player_console_window_service.dart';
 import 'package:nipaplay/services/security_bookmark_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/utils/danmaku/assets.dart';
@@ -437,9 +438,11 @@ class ExternalPlayerService {
       );
       ExternalPlayerConsoleService.setState(consoleState);
 
-      // 如果设置了启动外部播放器后自动切换到弹幕控制台, 则切换页面
-      if (settings.externalPlayerAutoSwitchToDanmakuConsole &&
+      if (settings.externalPlayerConsoleWindowMode) {
+        await ExternalPlayerConsoleWindowService.instance.showControlsWindow();
+      } else if (settings.externalPlayerAutoSwitchToDanmakuConsole &&
           context.mounted) {
+        // Tab 模式保留原有的自动切换行为。
         Provider.of<TabChangeNotifier>(context, listen: false)
             .changePage(AppPageIds.externalPlayerConsole);
       }

--- a/lib/settings/pages/external_player_settings_content.dart
+++ b/lib/settings/pages/external_player_settings_content.dart
@@ -4,6 +4,7 @@ import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/l10n/l10n.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/services/external_player_console_service.dart';
+import 'package:nipaplay/services/external_player_console_window_service.dart';
 import 'package:nipaplay/services/external_player_service.dart';
 import 'package:nipaplay/services/file_picker_service.dart';
 import 'package:nipaplay/settings/adaptive_settings_widgets.dart';
@@ -29,18 +30,34 @@ class ExternalPlayerSettingsContent extends StatelessWidget {
     const String subtitleUnsupportedTraditional = '彈幕控制台目前僅支援 Linux 和 macOS';
     const String subtitleUnsupportedEnglish =
         'The Danmaku Console is currently available on Linux and macOS only.';
+    const String subtitleWindowModeSimplified = '独立窗口模式下，外部播放开始后会直接打开控制台窗口';
+    const String subtitleWindowModeTraditional = '獨立視窗模式下，外部播放開始後會直接開啟控制台視窗';
+    const String subtitleWindowModeEnglish =
+        'Window mode opens the Danmaku Console window when external playback starts.';
 
     final consoleSupported = ExternalPlayerConsoleService.isSupportedPlatform;
+    final windowMode = settingsProvider.externalPlayerConsoleWindowMode;
     return AdaptiveSettingsTile<bool>.toggle(
       title: _text(context, titleSimplified, titleTraditional, titleEnglish),
-      subtitle: consoleSupported
-          ? _text(
-              context, subtitleSimplified, subtitleTraditional, subtitleEnglish)
-          : _text(context, subtitleUnsupportedSimplified,
-              subtitleUnsupportedTraditional, subtitleUnsupportedEnglish),
+      subtitle: !consoleSupported
+          ? _text(context, subtitleUnsupportedSimplified,
+              subtitleUnsupportedTraditional, subtitleUnsupportedEnglish)
+          : windowMode
+              ? _text(
+                  context,
+                  subtitleWindowModeSimplified,
+                  subtitleWindowModeTraditional,
+                  subtitleWindowModeEnglish,
+                )
+              : _text(
+                  context,
+                  subtitleSimplified,
+                  subtitleTraditional,
+                  subtitleEnglish,
+                ),
       icon: Ionicons.chatbox_ellipses_outline,
       phoneIcon: cupertino.CupertinoIcons.captions_bubble,
-      enabled: consoleSupported,
+      enabled: consoleSupported && !windowMode,
       value: settingsProvider.externalPlayerAutoSwitchToDanmakuConsole,
       onChanged: (value) =>
           settingsProvider.setExternalPlayerAutoSwitchToDanmakuConsole(value),
@@ -124,6 +141,49 @@ class ExternalPlayerSettingsContent extends StatelessWidget {
               },
             ),
             _autoSwitchToDanmakuConsoleTile,
+            Consumer<SettingsProvider>(
+              builder: (context, settingsProvider, child) {
+                final consoleSupported =
+                    ExternalPlayerConsoleWindowService.isSupported;
+                return AdaptiveSettingsTile<bool>.toggle(
+                  title: _text(
+                    context,
+                    '弹幕控制台使用独立窗口',
+                    '彈幕控制台使用獨立視窗',
+                    'Open Danmaku Console in Windows',
+                  ),
+                  subtitle: consoleSupported
+                      ? _text(
+                          context,
+                          '不再显示控制台 Tab；左侧控制面板使用竖屏窗口，并可唤出单独的弹幕列表窗口',
+                          '不再顯示控制台分頁；左側控制面板使用直向視窗，並可叫出獨立的彈幕列表視窗',
+                          'Replace the console tab with a portrait controls window and an optional danmaku-list window.',
+                        )
+                      : _text(
+                          context,
+                          '独立控制台窗口目前仅支持 Linux 和 macOS',
+                          '獨立控制台視窗目前僅支援 Linux 和 macOS',
+                          'Console windows are currently available on Linux and macOS only.',
+                        ),
+                  icon: Ionicons.albums_outline,
+                  phoneIcon: cupertino.CupertinoIcons.rectangle_on_rectangle,
+                  enabled: consoleSupported,
+                  value: settingsProvider.externalPlayerConsoleWindowMode,
+                  onChanged: (value) async {
+                    await settingsProvider
+                        .setExternalPlayerConsoleWindowMode(value);
+                    if (value &&
+                        ExternalPlayerConsoleService.hasActiveSession) {
+                      await ExternalPlayerConsoleWindowService.instance
+                          .showControlsWindow();
+                    } else if (!value) {
+                      await ExternalPlayerConsoleWindowService.instance
+                          .closeAll();
+                    }
+                  },
+                );
+              },
+            ),
             Consumer<SettingsProvider>(
               builder: (context, settingsProvider, child) {
                 return AdaptiveSettingsTile<bool>.toggle(

--- a/lib/settings/pages/general_settings_content.dart
+++ b/lib/settings/pages/general_settings_content.dart
@@ -6,6 +6,8 @@ import 'package:nipaplay/l10n/l10n.dart';
 import 'package:nipaplay/providers/home_sections_settings_provider.dart';
 import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
 import 'package:nipaplay/services/desktop_exit_preferences.dart';
+import 'package:nipaplay/services/desktop_picture_in_picture_preferences.dart';
+import 'package:nipaplay/services/desktop_player_window_service.dart';
 import 'package:nipaplay/services/desktop_startup_window_preferences.dart';
 import 'package:nipaplay/settings/adaptive_settings_widgets.dart';
 import 'package:nipaplay/settings/common_setting_tiles.dart';
@@ -44,6 +46,7 @@ class _GeneralSettingsContentState extends State<GeneralSettingsContent> {
   final GlobalKey _startupWindowStateDropdownKey = GlobalKey();
   final GlobalKey _startupWindowPositionDropdownKey = GlobalKey();
   final GlobalKey _startupWindowSizeDropdownKey = GlobalKey();
+  final GlobalKey _pictureInPicturePositionDropdownKey = GlobalKey();
 
   int _defaultPageIndex = 0;
   DesktopExitBehavior _desktopExitBehavior = DesktopExitBehavior.askEveryTime;
@@ -52,6 +55,8 @@ class _GeneralSettingsContentState extends State<GeneralSettingsContent> {
   DesktopStartupWindowPosition _startupWindowPosition =
       DesktopStartupWindowPreferences.defaultPosition;
   Size _startupWindowSize = DesktopStartupWindowPreferences.defaultWindowSize;
+  DesktopPictureInPicturePosition _pictureInPicturePosition =
+      DesktopPictureInPicturePreferences.defaultPosition;
 
   static const List<_WindowSizePreset> _windowSizePresets = [
     _WindowSizePreset('compact', '紧凑 (960 × 600)', Size(960, 600)),
@@ -223,6 +228,34 @@ class _GeneralSettingsContentState extends State<GeneralSettingsContent> {
                 onTap: _resetStartupWindowSize,
               ),
             ],
+            AdaptiveSettingsTile<DesktopPictureInPicturePosition>.dropdown(
+              title: _text(
+                context,
+                '画中画停靠位置',
+                '畫中畫停靠位置',
+                'Picture-in-Picture Position',
+              ),
+              subtitle: _text(
+                context,
+                '进入画中画时停靠到当前屏幕的位置',
+                '進入畫中畫時停靠到目前螢幕的位置',
+                'Where the picture-in-picture window docks on its screen.',
+              ),
+              icon: Icons.picture_in_picture_alt_outlined,
+              phoneIcon: cupertino.CupertinoIcons.rectangle_on_rectangle,
+              items: _pictureInPicturePositionItems(context),
+              onChanged: (position) async {
+                setState(() {
+                  _pictureInPicturePosition = position;
+                });
+                await DesktopPictureInPicturePreferences.savePosition(
+                  position,
+                );
+                await DesktopPlayerWindowService.instance
+                    .updatePictureInPicturePlacement(position);
+              },
+              dropdownKey: _pictureInPicturePositionDropdownKey,
+            ),
           ],
         ),
       );
@@ -305,6 +338,8 @@ class _GeneralSettingsContentState extends State<GeneralSettingsContent> {
     final startupPosition =
         await DesktopStartupWindowPreferences.loadPosition();
     final startupSize = await DesktopStartupWindowPreferences.loadSize();
+    final pictureInPicturePosition =
+        await DesktopPictureInPicturePreferences.loadPosition();
     final storedHomeTab = prefs.getString(_defaultHomeTabKey);
     final storedTabIndex = _defaultPageIndexForTab(storedHomeTab);
     var resolvedIndex =
@@ -324,6 +359,7 @@ class _GeneralSettingsContentState extends State<GeneralSettingsContent> {
       _startupWindowState = startupState;
       _startupWindowPosition = startupPosition;
       _startupWindowSize = startupSize;
+      _pictureInPicturePosition = pictureInPicturePosition;
       _defaultPageIndex = resolvedIndex;
     });
   }
@@ -469,6 +505,36 @@ class _GeneralSettingsContentState extends State<GeneralSettingsContent> {
       ),
     );
     return items;
+  }
+
+  List<DropdownMenuItemData<DesktopPictureInPicturePosition>>
+      _pictureInPicturePositionItems(BuildContext context) {
+    return [
+      DropdownMenuItemData(
+        title: _text(context, '左上角', '左上角', 'Top Left'),
+        value: DesktopPictureInPicturePosition.topLeft,
+        isSelected: _pictureInPicturePosition ==
+            DesktopPictureInPicturePosition.topLeft,
+      ),
+      DropdownMenuItemData(
+        title: _text(context, '右上角', '右上角', 'Top Right'),
+        value: DesktopPictureInPicturePosition.topRight,
+        isSelected: _pictureInPicturePosition ==
+            DesktopPictureInPicturePosition.topRight,
+      ),
+      DropdownMenuItemData(
+        title: _text(context, '左下角', '左下角', 'Bottom Left'),
+        value: DesktopPictureInPicturePosition.bottomLeft,
+        isSelected: _pictureInPicturePosition ==
+            DesktopPictureInPicturePosition.bottomLeft,
+      ),
+      DropdownMenuItemData(
+        title: _text(context, '右下角', '右下角', 'Bottom Right'),
+        value: DesktopPictureInPicturePosition.bottomRight,
+        isSelected: _pictureInPicturePosition ==
+            DesktopPictureInPicturePosition.bottomRight,
+      ),
+    ];
   }
 
   Future<void> _saveDefaultPagePreference(int index) async {

--- a/lib/themes/cupertino/widgets/player_menu/cupertino_danmaku_settings_pane.dart
+++ b/lib/themes/cupertino/widgets/player_menu/cupertino_danmaku_settings_pane.dart
@@ -265,7 +265,7 @@ class _CupertinoDanmakuSettingsPaneState
       case 0:
         return '0 · 无描边';
       case 2:
-        return '2 · 粗边（原版）';
+        return '2 · 粗边';
       default:
         return '1 · 细边';
     }

--- a/lib/themes/nipaplay/widgets/anime_info_widget.dart
+++ b/lib/themes/nipaplay/widgets/anime_info_widget.dart
@@ -109,10 +109,12 @@ class _AnimeInfoWidgetState extends State<AnimeInfoWidget> {
       color: Colors.white,
       fontSize: 16,
       fontWeight: FontWeight.bold,
+      decoration: TextDecoration.none,
     );
     const episodeStyle = TextStyle(
       color: Colors.white,
       fontSize: 14,
+      decoration: TextDecoration.none,
     );
 
     const titleGap = 8.0;

--- a/lib/themes/nipaplay/widgets/danmaku_settings_menu.dart
+++ b/lib/themes/nipaplay/widgets/danmaku_settings_menu.dart
@@ -352,7 +352,7 @@ class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
       case 0:
         return '0 · 无描边';
       case 2:
-        return '2 · 粗边（原版）';
+        return '2 · 粗边';
       default:
         return '1 · 细边';
     }
@@ -665,7 +665,7 @@ class _DanmakuSettingsMenuState extends State<DanmakuSettingsMenu> {
         step: 1.0,
         displayTextBuilder: _outlineWidthLevelLabel,
         onChanged: videoState.setNext2DanmakuOutlineWidth,
-        hint: '0 无描边 · 1 细边 · 2 粗边（原版）',
+        hint: '0 无描边 · 1 细边 · 2 粗边',
       );
     }
 

--- a/lib/themes/nipaplay/widgets/modern_video_controls.dart
+++ b/lib/themes/nipaplay/widgets/modern_video_controls.dart
@@ -748,6 +748,7 @@ class _ModernVideoControlsState extends State<ModernVideoControls> {
                                           fontWeight: FontWeight.normal,
                                           height: 1.0,
                                           textBaseline: TextBaseline.alphabetic,
+                                          decoration: TextDecoration.none,
                                         ),
                                         textAlign: TextAlign.center,
                                         softWrap: false,
@@ -784,8 +785,16 @@ class _ModernVideoControlsState extends State<ModernVideoControls> {
                                         onPressed: (value) => setState(
                                             () => _isPipPressed = value),
                                         tooltip: detachedWindow != null
-                                            ? '移回主窗口'
-                                            : '移到独立窗口',
+                                            ? _tooltipManager
+                                                .formatActionWithShortcut(
+                                                'toggle_detached_player',
+                                                '移回主窗口',
+                                              )
+                                            : _tooltipManager
+                                                .formatActionWithShortcut(
+                                                'toggle_detached_player',
+                                                '移到独立窗口',
+                                              ),
                                         useAnimatedSwitcher: true,
                                       ),
 

--- a/lib/themes/nipaplay/widgets/shadow_action_button.dart
+++ b/lib/themes/nipaplay/widgets/shadow_action_button.dart
@@ -4,7 +4,7 @@ import 'tooltip_bubble.dart';
 import 'control_shadow.dart';
 
 class ShadowActionButton extends StatefulWidget {
-  final String tooltip;
+  final String? tooltip;
   final IconData icon;
   final VoidCallback onPressed;
   final double iconSize;
@@ -12,7 +12,7 @@ class ShadowActionButton extends StatefulWidget {
 
   const ShadowActionButton({
     super.key,
-    required this.tooltip,
+    this.tooltip,
     required this.icon,
     required this.onPressed,
     this.iconSize = 28,
@@ -31,6 +31,29 @@ class _ShadowActionButtonState extends State<ShadowActionButton> {
   @override
   Widget build(BuildContext context) {
     final isActive = _isHovered || _isFocused;
+    final button = GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTapDown: (_) => setState(() => _isPressed = true),
+      onTapCancel: () => setState(() => _isPressed = false),
+      onTapUp: (_) {
+        setState(() => _isPressed = false);
+        widget.onPressed();
+      },
+      child: Padding(
+        padding: widget.padding,
+        child: AnimatedScale(
+          duration: const Duration(milliseconds: 100),
+          scale: _isPressed ? 0.9 : (isActive ? 1.1 : 1.0),
+          child: ControlIconShadow(
+            child: Icon(
+              widget.icon,
+              color: Colors.white,
+              size: widget.iconSize,
+            ),
+          ),
+        ),
+      ),
+    );
     return FocusableActionDetector(
       onShowFocusHighlight: (value) {
         if (_isFocused == value) return;
@@ -55,34 +78,14 @@ class _ShadowActionButtonState extends State<ShadowActionButton> {
       child: MouseRegion(
         onEnter: (_) => setState(() => _isHovered = true),
         onExit: (_) => setState(() => _isHovered = false),
-        child: TooltipBubble(
-          text: widget.tooltip,
-          showOnRight: false,
-          verticalOffset: 8,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTapDown: (_) => setState(() => _isPressed = true),
-            onTapCancel: () => setState(() => _isPressed = false),
-            onTapUp: (_) {
-              setState(() => _isPressed = false);
-              widget.onPressed();
-            },
-            child: Padding(
-              padding: widget.padding,
-              child: AnimatedScale(
-                duration: const Duration(milliseconds: 100),
-                scale: _isPressed ? 0.9 : (isActive ? 1.1 : 1.0),
-                child: ControlIconShadow(
-                  child: Icon(
-                    widget.icon,
-                    color: Colors.white,
-                    size: widget.iconSize,
-                  ),
-                ),
+        child: widget.tooltip == null
+            ? button
+            : TooltipBubble(
+                text: widget.tooltip!,
+                showOnRight: false,
+                verticalOffset: 8,
+                child: button,
               ),
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/lib/themes/nipaplay/widgets/tooltip_bubble.dart
+++ b/lib/themes/nipaplay/widgets/tooltip_bubble.dart
@@ -195,27 +195,46 @@ class _TooltipBubbleState extends State<TooltipBubble> {
       gap: widget.verticalOffset,
       onClosed: () {
         if (!identical(_tooltipWindowController, controller)) return;
+        DesktopMultiWindow.detachTransientView(controller);
         _tooltipWindowController = null;
-        _overlayEntry?.remove();
-        _overlayEntry = null;
       },
     );
     if (created == null) return false;
     controller = created;
     _tooltipWindowController = controller;
-    _overlayEntry = OverlayEntry(
-      builder: (context) => Positioned.fill(
-        child: ViewAnchor(
-          view: DesktopTooltipWindow(
-            controller: controller,
-            child: _buildBubble(width),
-          ),
-          child: const IgnorePointer(child: SizedBox.expand()),
+    unawaited(_mountDesktopTooltipWhenReady(controller, width, height));
+    return true;
+  }
+
+  Future<void> _mountDesktopTooltipWhenReady(
+    DesktopTooltipWindowController controller,
+    double width,
+    double height,
+  ) async {
+    await controller.ready;
+    if (!mounted ||
+        controller.isClosed ||
+        !identical(_tooltipWindowController, controller)) {
+      return;
+    }
+    debugPrint(
+      '[TooltipBubble] mount native tooltip text="${widget.text}" '
+      'view=${controller.flutterView.viewId} '
+      'size=${width.toStringAsFixed(1)}x${height.toStringAsFixed(1)} '
+      'physicalSize='
+      '${controller.flutterView.physicalSize.width.toStringAsFixed(1)}x'
+      '${controller.flutterView.physicalSize.height.toStringAsFixed(1)}',
+    );
+    DesktopMultiWindow.attachTransientView(
+      controller,
+      DesktopTooltipWindow(
+        controller: controller,
+        child: DesktopMultiWindow.inheritTransientViewContext(
+          context,
+          _buildBubble(width),
         ),
       ),
     );
-    Overlay.of(context).insert(_overlayEntry!);
-    return true;
   }
 
   Rect? _desktopTooltipAnchorRect() {
@@ -300,6 +319,9 @@ class _TooltipBubbleState extends State<TooltipBubble> {
   void _hideOverlay() {
     final tooltipWindow = _tooltipWindowController;
     _tooltipWindowController = null;
+    if (tooltipWindow != null) {
+      DesktopMultiWindow.detachTransientView(tooltipWindow);
+    }
     _overlayEntry?.remove();
     _overlayEntry = null;
     tooltipWindow?.close();

--- a/lib/themes/nipaplay/widgets/video_player_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_player_ui.dart
@@ -15,6 +15,7 @@ import 'package:nipaplay/widgets/danmaku_overlay.dart';
 import 'package:nipaplay/widgets/external_subtitle_overlay.dart';
 import 'package:nipaplay/widgets/macos_native_video_view.dart';
 import 'package:nipaplay/widgets/desktop_transient_overlay.dart';
+import 'package:nipaplay/widgets/desktop_picture_in_picture_scope.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/themed_anime_detail.dart';
 import 'package:provider/provider.dart';
 import 'brightness_gesture_area.dart';
@@ -971,6 +972,8 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
 
   @override
   Widget build(BuildContext context) {
+    final isPictureInPicture =
+        DesktopPictureInPictureScope.isEnabledOf(context);
     return Consumer<VideoPlayerState>(
       builder: (context, videoState, child) {
         return ValueListenableBuilder<int?>(
@@ -1028,7 +1031,8 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                     GestureDetector(
                       behavior: HitTestBehavior.opaque,
                       onTap: _handleTap,
-                      onSecondaryTapDown: globals.isDesktop
+                      onSecondaryTapDown: globals.isDesktop &&
+                              !isPictureInPicture
                           ? (details) {
                               if (!videoState.hasVideo) return;
                               _hidePlaybackInfoOverlay();
@@ -1136,8 +1140,10 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                                       const BrightnessGestureArea(),
                                     if (videoState.hasVideo)
                                       const VolumeGestureArea(),
-                                    const MinimalProgressBar(),
-                                    const DanmakuDensityBar(),
+                                    if (!isPictureInPicture) ...[
+                                      const MinimalProgressBar(),
+                                      const DanmakuDensityBar(),
+                                    ],
                                   ],
                                 ),
                               )
@@ -1228,11 +1234,14 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
                                                 _macosNativeVideoViewId!,
                                           ),
                                         ),
-                                      if (videoState
-                                          .desktopHoverSettingsMenuEnabled)
+                                      if (!isPictureInPicture &&
+                                          videoState
+                                              .desktopHoverSettingsMenuEnabled)
                                         const RightEdgeHoverMenu(),
-                                      const MinimalProgressBar(),
-                                      const DanmakuDensityBar(),
+                                      if (!isPictureInPicture) ...[
+                                        const MinimalProgressBar(),
+                                        const DanmakuDensityBar(),
+                                      ],
                                     ],
                                   ),
                                 ),

--- a/lib/themes/nipaplay/widgets/video_progress_bar.dart
+++ b/lib/themes/nipaplay/widgets/video_progress_bar.dart
@@ -18,6 +18,7 @@ class VideoProgressBar extends StatefulWidget {
   final Function(bool) onDraggingStateChange;
   final String Function(Duration) formatDuration;
   final bool compact;
+  final bool showHoverPreview;
 
   /// MKV 章节列表（用于在轨道上画章节起点竖线标记 + 当前章节高亮段）。
   /// 参考 REFERENCE/mpv/player/lua/osc.lua:2512 markers。
@@ -41,6 +42,7 @@ class VideoProgressBar extends StatefulWidget {
     this.durationMs = 0,
     this.currentChapter = -1,
     this.compact = false,
+    this.showHoverPreview = true,
   });
 
   @override
@@ -112,6 +114,7 @@ class _VideoProgressBarState extends State<VideoProgressBar>
 
   void _showOverlay(BuildContext context, double progress,
       {Duration? displayTime, String? thumbnailPath}) {
+    if (!widget.showHoverPreview) return;
     _removeOverlay();
 
     final RenderBox? sliderBox =
@@ -270,7 +273,9 @@ class _VideoProgressBarState extends State<VideoProgressBar>
                 _localHoverTime = time;
               });
             }
-            _handleHoverPreview(time, progress);
+            if (widget.showHoverPreview) {
+              _handleHoverPreview(time, progress);
+            }
           } else {
             if (_localHoverTime != null) {
               setState(() {

--- a/lib/utils/danmaku/style.dart
+++ b/lib/utils/danmaku/style.dart
@@ -17,14 +17,16 @@ enum DanmakuShadowStyle {
 }
 
 /// 将描边宽度统一为播放器提供的三档渲染 profile：
-/// 0 = 无描边、1 = 当前细边、2 = 旧版粗边。
+/// 0 = 无描边、1 = 细边、2 = 粗边。
 ///
 /// 旧版本曾允许保存 0–4 的连续值，因此这里也负责兼容迁移：任意正数
 /// 至少保留为细边，1.5 及以上归入粗边。这里的 2 只是档位标识，
 /// Next2/DFM+ 不会再把它当成 2 倍描边宽度直接传给 MSDF shader。
+const double defaultDanmakuOutlineWidthLevel = 2.0;
+
 double normalizeDanmakuOutlineWidthLevel(double? value) {
   if (value == null || !value.isFinite) {
-    return 1.0;
+    return defaultDanmakuOutlineWidthLevel;
   }
   if (value <= 0.0) {
     return 0.0;

--- a/lib/utils/hotkey_service.dart
+++ b/lib/utils/hotkey_service.dart
@@ -145,6 +145,8 @@ class HotkeyService extends ChangeNotifier {
       'step_forward': 'E', // 逐帧前进
       'step_backward': 'Q', // 逐帧后退
       'resize_to_video': 'R', // 窗口适配视频
+      'toggle_picture_in_picture': 'P', // 切换画中画
+      'toggle_detached_player': 'W', // 移入/移回独立窗口
     });
 
     if (savedShortcutsString != null) {
@@ -234,6 +236,20 @@ class HotkeyService extends ChangeNotifier {
 
     // 注册窗口适配视频热键
     await _registerHotkey('resize_to_video', '窗口适配视频', _handleResizeToVideo);
+
+    // 注册画中画热键
+    await _registerHotkey(
+      'toggle_picture_in_picture',
+      '切换画中画',
+      _handleTogglePictureInPicture,
+    );
+
+    // 注册独立窗口热键
+    await _registerHotkey(
+      'toggle_detached_player',
+      '切换独立窗口',
+      _handleToggleDetachedPlayer,
+    );
 
     // 注册ESC键退出全屏
     await _registerEscapeKey();
@@ -805,6 +821,42 @@ class HotkeyService extends ChangeNotifier {
     if (videoState != null) {
       videoState.resizeWindowToVideoSize();
     }
+  }
+
+  void _handleTogglePictureInPicture() {
+    final windowService = DesktopPlayerWindowService.instance;
+    if (!DesktopPlayerWindowService.isFeatureEnabled) return;
+
+    if (windowService.isPlayerDetached) {
+      debugPrint('[HotkeyService] 切换画中画: 当前播放器已在独立窗口');
+      unawaited(windowService.togglePictureInPicture());
+      return;
+    }
+
+    final context = _context;
+    final videoState = _getVideoPlayerState();
+    if (context == null || videoState == null || !videoState.hasVideo) return;
+    debugPrint('[HotkeyService] 切换画中画: 从主窗口拆离并进入画中画');
+    unawaited(
+      windowService.detachAndEnterPictureInPicture(context, videoState),
+    );
+  }
+
+  void _handleToggleDetachedPlayer() {
+    final windowService = DesktopPlayerWindowService.instance;
+    if (!DesktopPlayerWindowService.isFeatureEnabled) return;
+
+    if (windowService.isPlayerDetached) {
+      debugPrint('[HotkeyService] 切换独立窗口: 将播放器移回主窗口');
+      unawaited(windowService.returnPlayerToMain());
+      return;
+    }
+
+    final context = _context;
+    final videoState = _getVideoPlayerState();
+    if (context == null || videoState == null || !videoState.hasVideo) return;
+    debugPrint('[HotkeyService] 切换独立窗口: 将播放器移入独立窗口');
+    unawaited(windowService.detachPlayer(context, videoState));
   }
 
   // 注册快进热键，支持长按倍速

--- a/lib/utils/shortcut_tooltip_manager.dart
+++ b/lib/utils/shortcut_tooltip_manager.dart
@@ -5,61 +5,63 @@ import 'dart:async';
 
 /// 快捷键提示管理器，用于统一管理和更新所有快捷键提示
 class ShortcutTooltipManager extends ChangeNotifier {
-  static final ShortcutTooltipManager _instance = ShortcutTooltipManager._internal();
-  
+  static final ShortcutTooltipManager _instance =
+      ShortcutTooltipManager._internal();
+
   // 单例模式
   factory ShortcutTooltipManager() {
     return _instance;
   }
-  
+
   ShortcutTooltipManager._internal() {
     _initialize();
   }
-  
+
   // 快捷键映射
   final Map<String, String> _shortcutTooltips = {};
-  
+
   // 热键服务
   final HotkeyService _hotkeyService = HotkeyService();
-  
+
   // 是否已初始化
   bool _isInitialized = false;
-  
+
   // 初始化
   Future<void> _initialize() async {
     if (_isInitialized) return;
-    
+
     // 确保快捷键配置已加载
     if (_hotkeyService.allShortcuts.isEmpty) {
       await _hotkeyService.loadShortcuts();
     }
-    
+
     // 从HotkeyService加载快捷键
     _updateShortcuts();
-    
+
     // 监听快捷键变化
     _hotkeyService.addListener(_updateShortcuts);
-    
+
     _isInitialized = true;
   }
-  
+
   // 更新快捷键
   void _updateShortcuts() {
     final shortcuts = _hotkeyService.allShortcuts;
-    
+
     _shortcutTooltips.clear();
-    
+
     shortcuts.forEach((action, shortcut) {
       final actionLabel = _getActionLabel(action);
       if (actionLabel != null) {
-        _shortcutTooltips[action] = shortcut.isEmpty ? actionLabel : '$actionLabel ($shortcut)';
+        _shortcutTooltips[action] =
+            shortcut.isEmpty ? actionLabel : '$actionLabel ($shortcut)';
       }
     });
-    
+
     // 通知所有监听者
     notifyListeners();
   }
-  
+
   // 获取动作标签
   String? _getActionLabel(String action) {
     final Map<String, String> actionLabels = {
@@ -77,34 +79,36 @@ class ShortcutTooltipManager extends ChangeNotifier {
       'step_forward': '逐帧前进',
       'step_backward': '逐帧后退',
       'resize_to_video': '窗口适配视频',
+      'toggle_picture_in_picture': '画中画模式',
+      'toggle_detached_player': '独立窗口模式',
     };
-    
+
     return actionLabels[action];
   }
-  
+
   // 获取动作的提示文本
   String getTooltip(String action) {
     return _shortcutTooltips[action] ?? _getActionLabel(action) ?? action;
   }
-  
+
   // 获取动作的快捷键文本
   String getShortcutText(String action) {
     final shortcut = _hotkeyService.getShortcutText(action);
     return shortcut;
   }
-  
+
   // 格式化动作和快捷键
   String formatActionWithShortcut(String action, String? customLabel) {
     final label = customLabel ?? _getActionLabel(action) ?? action;
     final shortcut = getShortcutText(action);
-    
+
     final result = shortcut.isEmpty ? label : '$label ($shortcut)';
     return result;
   }
-  
+
   @override
   void dispose() {
     _hotkeyService.removeListener(_updateShortcuts);
     super.dispose();
   }
-} 
+}

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -491,7 +491,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   DanmakuShadowStyle _danmakuShadowStyle = globals.isMobilePlatform
       ? DanmakuShadowStyle.none
       : DanmakuShadowStyle.strong;
-  double _next2DanmakuOutlineWidth = 1.0;
+  double _next2DanmakuOutlineWidth = defaultDanmakuOutlineWidthLevel;
   static const double minSubtitleScale = 0.5;
   static const double maxSubtitleScale = 2.5;
   static const double defaultSubtitleScale = 1.0;

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -1539,7 +1539,8 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _next2DanmakuOutlineWidth = loadedNext2OutlineWidth;
 
     if (loadedFontFilePath != effectiveFontPath) {
-      await prefs.setString(SettingsKeys.danmakuFontFilePath, effectiveFontPath);
+      await prefs.setString(
+          SettingsKeys.danmakuFontFilePath, effectiveFontPath);
     }
     if ((prefs.getString(SettingsKeys.danmakuFontFamily) ?? '').trim() !=
         loadedFontFamily) {
@@ -1641,7 +1642,10 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
             ? _defaultDanmakuOutlineStyle
             : _danmakuOutlineStyle)
         : DanmakuOutlineStyle.none;
-    await _setDanmakuOutlineConfiguration(style, enabled ? 1.0 : 0.0);
+    await _setDanmakuOutlineConfiguration(
+      style,
+      enabled ? defaultDanmakuOutlineWidthLevel : 0.0,
+    );
   }
 
   /// 设置弹幕描边样式
@@ -1650,7 +1654,9 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
       style,
       style == DanmakuOutlineStyle.none
           ? 0.0
-          : (_next2DanmakuOutlineWidth > 0.0 ? _next2DanmakuOutlineWidth : 1.0),
+          : (_next2DanmakuOutlineWidth > 0.0
+              ? _next2DanmakuOutlineWidth
+              : defaultDanmakuOutlineWidthLevel),
     );
   }
 
@@ -2286,7 +2292,8 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   // 加载弹幕轨道显示区域
   Future<void> _loadDanmakuDisplayArea() async {
     final prefs = await SharedPreferences.getInstance();
-    _danmakuDisplayArea = prefs.getDouble(SettingsKeys.danmakuDisplayArea) ?? 1.0;
+    _danmakuDisplayArea =
+        prefs.getDouble(SettingsKeys.danmakuDisplayArea) ?? 1.0;
     _notifyListeners();
   }
 

--- a/lib/widgets/desktop_picture_in_picture_scope.dart
+++ b/lib/widgets/desktop_picture_in_picture_scope.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/widgets.dart';
+
+/// Marks the detached player subtree while it is using the compact
+/// picture-in-picture chrome.
+class DesktopPictureInPictureScope extends InheritedWidget {
+  const DesktopPictureInPictureScope({
+    super.key,
+    required this.enabled,
+    required super.child,
+  });
+
+  final bool enabled;
+
+  static bool isEnabledOf(BuildContext context) {
+    return context
+            .dependOnInheritedWidgetOfExactType<DesktopPictureInPictureScope>()
+            ?.enabled ??
+        false;
+  }
+
+  @override
+  bool updateShouldNotify(DesktopPictureInPictureScope oldWidget) {
+    return enabled != oldWidget.enabled;
+  }
+}

--- a/lib/widgets/desktop_transient_overlay.dart
+++ b/lib/widgets/desktop_transient_overlay.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flutter/material.dart';
 
@@ -12,17 +14,20 @@ class DesktopTransientOverlay {
   DesktopTransientOverlay._({
     required DesktopPopupWindowController controller,
     required OverlayState overlay,
+    required BuildContext sourceContext,
     required DesktopPopupContentBuilder contentBuilder,
     required bool barrierDismissible,
     VoidCallback? onClosed,
   })  : _controller = controller,
         _overlay = overlay,
+        _sourceContext = sourceContext,
         _contentBuilder = contentBuilder,
         _barrierDismissible = barrierDismissible,
         _onClosed = onClosed;
 
   final DesktopPopupWindowController _controller;
   final OverlayState _overlay;
+  final BuildContext _sourceContext;
   final DesktopPopupContentBuilder _contentBuilder;
   final bool _barrierDismissible;
   final VoidCallback? _onClosed;
@@ -57,6 +62,7 @@ class DesktopTransientOverlay {
     surface = DesktopTransientOverlay._(
       controller: controller,
       overlay: overlay,
+      sourceContext: context,
       contentBuilder: contentBuilder,
       barrierDismissible: barrierDismissible,
       onClosed: onClosed,
@@ -68,30 +74,52 @@ class DesktopTransientOverlay {
   bool get isClosed => _closed;
 
   void _insert() {
-    _entry = OverlayEntry(
-      builder: (context) => Positioned.fill(
-        child: ViewAnchor(
-          view: DesktopPopupWindow(
-            controller: _controller,
-            child: _contentBuilder(context, close),
-          ),
-          child: _barrierDismissible
-              ? GestureDetector(
-                  behavior: HitTestBehavior.translucent,
-                  onTap: close,
-                  onSecondaryTap: close,
-                  child: const ColoredBox(color: Colors.transparent),
-                )
-              : const IgnorePointer(child: SizedBox.expand()),
+    unawaited(_insertWhenReady());
+  }
+
+  Future<void> _insertWhenReady() async {
+    await _controller.ready;
+    if (_closed) return;
+    debugPrint(
+      '[DesktopTransientOverlay] mount popup '
+      'view=${_controller.flutterView.viewId} '
+      'physicalSize='
+      '${_controller.flutterView.physicalSize.width.toStringAsFixed(1)}x'
+      '${_controller.flutterView.physicalSize.height.toStringAsFixed(1)}',
+    );
+    DesktopMultiWindow.attachTransientView(
+      this,
+      DesktopPopupWindow(
+        controller: _controller,
+        child: DesktopMultiWindow.inheritTransientViewContext(
+          _sourceContext,
+          _contentBuilder(_sourceContext, close),
         ),
       ),
     );
-    _overlay.insert(_entry!);
+    if (_barrierDismissible) {
+      _entry = OverlayEntry(
+        builder: (context) => Positioned.fill(
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: close,
+            onSecondaryTap: close,
+            child: const ColoredBox(color: Colors.transparent),
+          ),
+        ),
+      );
+      _overlay.insert(_entry!);
+    }
   }
 
   void close() {
     if (_closed) return;
+    debugPrint(
+      '[DesktopTransientOverlay] close popup '
+      'view=${_controller.flutterView.viewId}',
+    );
     _closed = true;
+    DesktopMultiWindow.detachTransientView(this);
     _entry?.remove();
     _entry = null;
     _controller.close();
@@ -100,7 +128,12 @@ class DesktopTransientOverlay {
 
   void _handleNativeClosed() {
     if (_closed) return;
+    debugPrint(
+      '[DesktopTransientOverlay] native closed popup '
+      'view=${_controller.flutterView.viewId}',
+    );
     _closed = true;
+    DesktopMultiWindow.detachTransientView(this);
     _entry?.remove();
     _entry = null;
     _onClosed?.call();

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -1,6 +1,7 @@
 #include "my_application.h"
 
 #include <flutter_linux/flutter_linux.h>
+#include <algorithm>
 #include <cmath>
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
@@ -13,6 +14,11 @@ struct _MyApplication {
   char** dart_entrypoint_arguments;
   GtkWindow* main_window;
   FlMethodChannel* desktop_window_channel;
+  gboolean picture_in_picture_has_restore_bounds;
+  gint picture_in_picture_restore_x;
+  gint picture_in_picture_restore_y;
+  gint picture_in_picture_restore_width;
+  gint picture_in_picture_restore_height;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
@@ -36,6 +42,14 @@ static gboolean fl_value_as_bool(FlValue* value, gboolean fallback = FALSE) {
     return fallback;
   }
   return fl_value_get_bool(value);
+}
+
+static const gchar* fl_value_as_string(FlValue* value,
+                                       const gchar* fallback = "") {
+  if (value == nullptr || fl_value_get_type(value) != FL_VALUE_TYPE_STRING) {
+    return fallback;
+  }
+  return fl_value_get_string(value);
 }
 
 static GtkWindow* find_secondary_flutter_window(MyApplication* self) {
@@ -78,6 +92,83 @@ static void apply_linux_always_on_top(GtkWindow* window, gboolean enabled) {
   }
 }
 
+static void apply_linux_picture_in_picture(MyApplication* self,
+                                           GtkWindow* window,
+                                           FlValue* args) {
+  const gboolean enabled =
+      fl_value_as_bool(fl_value_lookup_string(args, "enabled"));
+  if (!enabled) {
+    if (!self->picture_in_picture_has_restore_bounds) {
+      return;
+    }
+    self->picture_in_picture_has_restore_bounds = FALSE;
+    gtk_window_resize(window, self->picture_in_picture_restore_width,
+                      self->picture_in_picture_restore_height);
+    gtk_window_move(window, self->picture_in_picture_restore_x,
+                    self->picture_in_picture_restore_y);
+    g_message("[DesktopMultiWindow][PiP] restored %dx%d at %d,%d",
+              self->picture_in_picture_restore_width,
+              self->picture_in_picture_restore_height,
+              self->picture_in_picture_restore_x,
+              self->picture_in_picture_restore_y);
+    return;
+  }
+
+  if (!self->picture_in_picture_has_restore_bounds) {
+    gtk_window_get_position(window, &self->picture_in_picture_restore_x,
+                            &self->picture_in_picture_restore_y);
+    gtk_window_get_size(window, &self->picture_in_picture_restore_width,
+                        &self->picture_in_picture_restore_height);
+    self->picture_in_picture_has_restore_bounds = TRUE;
+  }
+
+  GdkWindow* gdk_window = gtk_widget_get_window(GTK_WIDGET(window));
+  GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(window));
+  GdkMonitor* monitor = gdk_window != nullptr
+                            ? gdk_display_get_monitor_at_window(display,
+                                                                gdk_window)
+                            : gdk_display_get_primary_monitor(display);
+  if (monitor == nullptr) {
+    return;
+  }
+  GdkRectangle work = {};
+  gdk_monitor_get_workarea(monitor, &work);
+  const double ratio = std::clamp(
+      fl_value_as_double(fl_value_lookup_string(args, "aspectRatio"),
+                         16.0 / 9.0),
+      0.5, 3.0);
+  const gint margin = static_cast<gint>(std::lround(std::max(
+      0.0, fl_value_as_double(fl_value_lookup_string(args, "margin"), 16.0))));
+  const gint available_width = std::max(1, work.width - margin * 2);
+  double height = std::min(
+      work.height / 3.0,
+      static_cast<double>(std::max(1, work.height - margin * 2)));
+  double width = height * ratio;
+  if (width > available_width) {
+    width = available_width;
+    height = width / ratio;
+  }
+  const gint target_width = static_cast<gint>(std::lround(width));
+  const gint target_height = static_cast<gint>(std::lround(height));
+  const gchar* placement = fl_value_as_string(
+      fl_value_lookup_string(args, "placement"), "topRight");
+  const gboolean place_left = g_strcmp0(placement, "topLeft") == 0 ||
+                               g_strcmp0(placement, "bottomLeft") == 0;
+  const gboolean place_bottom = g_strcmp0(placement, "bottomLeft") == 0 ||
+                                 g_strcmp0(placement, "bottomRight") == 0;
+  const gint x = place_left ? work.x + margin
+                            : work.x + work.width - target_width - margin;
+  const gint y = place_bottom ? work.y + work.height - target_height - margin
+                              : work.y + margin;
+  gtk_window_resize(window, target_width, target_height);
+  // Compositors using Wayland may choose to ignore absolute window placement.
+  gtk_window_move(window, x, y);
+  g_message(
+      "[DesktopMultiWindow][PiP] dock placement=%s work=%d,%d %dx%d size=%dx%d",
+      placement, work.x, work.y, work.width, work.height, target_width,
+      target_height);
+}
+
 static void desktop_window_method_call_cb(FlMethodChannel* channel,
                                           FlMethodCall* method_call,
                                           gpointer user_data) {
@@ -95,6 +186,7 @@ static void desktop_window_method_call_cb(FlMethodChannel* channel,
 
   const gchar* method = fl_method_call_get_name(method_call);
   if (strcmp(method, "configureWindow") == 0) {
+    self->picture_in_picture_has_restore_bounds = FALSE;
     if (fl_value_as_bool(fl_value_lookup_string(args, "frameless"))) {
       gtk_window_set_decorated(window, FALSE);
     }
@@ -129,6 +221,11 @@ static void desktop_window_method_call_cb(FlMethodChannel* channel,
     apply_linux_always_on_top(window, always_on_top);
     g_autoptr(FlValue) response = fl_value_new_bool(always_on_top);
     fl_method_call_respond_success(method_call, response, nullptr);
+    return;
+  }
+  if (strcmp(method, "setPictureInPictureMode") == 0) {
+    apply_linux_picture_in_picture(self, window, args);
+    fl_method_call_respond_success(method_call, nullptr, nullptr);
     return;
   }
   if (strcmp(method, "startDragging") == 0) {

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -309,10 +309,46 @@ extension NSWindow {
             )
         }
     }
+
+    var nipaplayIsDetachedPlayerWindow: Bool {
+        get {
+            (objc_getAssociatedObject(
+                self,
+                &AssociatedObjectKeys.detachedPlayerWindow
+            ) as? NSNumber)?.boolValue ?? false
+        }
+        set {
+            objc_setAssociatedObject(
+                self,
+                &AssociatedObjectKeys.detachedPlayerWindow,
+                NSNumber(value: newValue),
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
+    }
+
+    var nipaplayPictureInPictureRestoreFrame: NSRect? {
+        get {
+            (objc_getAssociatedObject(
+                self,
+                &AssociatedObjectKeys.pictureInPictureRestoreFrame
+            ) as? NSValue)?.rectValue
+        }
+        set {
+            objc_setAssociatedObject(
+                self,
+                &AssociatedObjectKeys.pictureInPictureRestoreFrame,
+                newValue.map { NSValue(rect: $0) },
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
+    }
 }
 
 private enum AssociatedObjectKeys {
     static var nativeVideoOverlayHost: UInt8 = 0
+    static var detachedPlayerWindow: UInt8 = 0
+    static var pictureInPictureRestoreFrame: UInt8 = 0
 }
 
 private extension NSView {
@@ -1007,40 +1043,6 @@ private final class MultiviewPluginRegistrarCompatibility {
   }
 }
 
-/// Native chrome controls for the same-engine Flutter window fork.
-///
-/// Flutter 3.44 can create regular secondary windows, but its public Dart
-/// wrapper deliberately throws for undecorated windows on macOS. This plugin
-/// changes only the NSWindow that owns the requested FlutterView; it never
-/// creates an engine, isolate, player, or replacement Flutter view.
-private final class DesktopWindowDragView: NSView {
-  override var mouseDownCanMoveWindow: Bool { true }
-
-  override func hitTest(_ point: NSPoint) -> NSView? {
-    bounds.contains(point) ? self : nil
-  }
-
-  override func mouseDown(with event: NSEvent) {
-    window?.performDrag(with: event)
-  }
-}
-
-/// Same storage layout as the NSWindow created by Flutter, but with panel
-/// activation semantics suitable for an always-on-top video companion.
-private final class DesktopDetachedPlayerPanel: NSPanel {
-  override var canBecomeKey: Bool { true }
-  override var canBecomeMain: Bool { false }
-}
-
-/// Flutter's stock popup panel deliberately refuses key focus. Player menus
-/// contain sliders and text fields, so the NipaPlay fork upgrades only its
-/// transient popup instance while retaining the same engine-owned window.
-private final class DesktopInteractivePopupPanel: NSPanel {
-  override var canBecomeKey: Bool { true }
-  override var canBecomeMain: Bool { false }
-  override var acceptsFirstResponder: Bool { true }
-}
-
 private final class DesktopMultiWindowHostPlugin: NSObject, FlutterPlugin {
   private static let channelName = "nipaplay/desktop_multi_window_host"
   private struct WindowDragState {
@@ -1049,6 +1051,8 @@ private final class DesktopMultiWindowHostPlugin: NSObject, FlutterPlugin {
   }
 
   private var dragStates: [Int: WindowDragState] = [:]
+  private var detachedPlayerClasses: Set<ObjectIdentifier> = []
+  private var interactivePopupClasses: Set<ObjectIdentifier> = []
 
   static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(
@@ -1062,8 +1066,24 @@ private final class DesktopMultiWindowHostPlugin: NSObject, FlutterPlugin {
   }
 
   func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    guard let arguments = call.arguments as? [String: Any],
-          let window = resolveWindow(arguments) else {
+    guard let arguments = call.arguments as? [String: Any] else {
+      NSLog(
+        "[DesktopMultiWindow][Host] invalid arguments method=%@",
+        call.method
+      )
+      result(FlutterError(
+        code: "INVALID_ARGUMENTS",
+        message: "Desktop window host arguments are missing",
+        details: nil
+      ))
+      return
+    }
+    guard let window = resolveWindow(arguments) else {
+      NSLog(
+        "[DesktopMultiWindow][Host] window not found method=%@ viewId=%@",
+        call.method,
+        String(describing: arguments["viewId"])
+      )
       result(FlutterError(
         code: "WINDOW_NOT_FOUND",
         message: "No macOS window owns the requested FlutterView",
@@ -1089,10 +1109,39 @@ private final class DesktopMultiWindowHostPlugin: NSObject, FlutterPlugin {
       let alwaysOnTop = boolValue(arguments["alwaysOnTop"]) ?? false
       applyAlwaysOnTop(alwaysOnTop, to: window)
       result(alwaysOnTop)
+    case "setPictureInPictureMode":
+      applyPictureInPictureMode(arguments, to: window)
+      result(nil)
     case "configureTransientWindow":
-      if boolValue(arguments["interactive"]) == true {
+      // Flutter 3.44 initially creates popup views at 0x0. Supplying tight
+      // Dart constraints alone does not produce valid view metrics on macOS,
+      // so seed the native content size before the first rendered frame.
+      let viewIdentifier = int64Value(arguments["viewId"]) ?? -1
+      let requestedWidth = doubleValue(arguments["width"]) ?? -1
+      let requestedHeight = doubleValue(arguments["height"]) ?? -1
+      let interactive = boolValue(arguments["interactive"]) ?? false
+      NSLog(
+        "[DesktopMultiWindow][Transient] configure viewId=%lld interactive=%@ requested=%.1fx%.1f beforeContent=%@ beforeFrame=%@ class=%@",
+        viewIdentifier,
+        interactive.description,
+        requestedWidth,
+        requestedHeight,
+        NSStringFromSize(window.contentView?.bounds.size ?? .zero),
+        NSStringFromRect(window.frame),
+        NSStringFromClass(type(of: window))
+      )
+      applyPreferredContentSize(arguments, to: window)
+      if interactive {
         makeInteractivePopup(window)
       }
+      NSLog(
+        "[DesktopMultiWindow][Transient] configured viewId=%lld afterContent=%@ afterFrame=%@ visible=%@ level=%ld",
+        viewIdentifier,
+        NSStringFromSize(window.contentView?.bounds.size ?? .zero),
+        NSStringFromRect(window.frame),
+        window.isVisible.description,
+        window.level.rawValue
+      )
       result(nil)
     case "startDragging":
       dragStates[window.windowNumber] = WindowDragState(
@@ -1132,12 +1181,12 @@ private final class DesktopMultiWindowHostPlugin: NSObject, FlutterPlugin {
   }
 
   private func makeFrameless(_ window: NSWindow) {
-    if !(window is DesktopDetachedPlayerPanel) {
-      // Removing `.titled` tears down AppKit's NSTitlebarView and its private
-      // KVO registrations. Do that while the object is still the original
-      // Flutter-created NSWindow. Changing its runtime class first makes
-      // NSTitlebarView attempt to unregister from a different window class and
-      // raises an uncaught NSRangeException on macOS 26.
+    if !window.nipaplayIsDetachedPlayerWindow {
+      // Never change the runtime class of an AppKit window. NSWindow owns
+      // private KVO registrations for its titlebar and layer context; replacing
+      // its class makes those observers crash either immediately or at deinit.
+      installDetachedPlayerBehavior(on: window)
+      window.nipaplayIsDetachedPlayerWindow = true
       var styleMask = window.styleMask
       styleMask.remove([.titled, .fullSizeContentView])
       styleMask.insert([
@@ -1147,48 +1196,114 @@ private final class DesktopMultiWindowHostPlugin: NSObject, FlutterPlugin {
         .nonactivatingPanel,
       ])
       window.styleMask = styleMask
-      object_setClass(window, DesktopDetachedPlayerPanel.self)
     }
     window.titleVisibility = .hidden
     window.titlebarAppearsTransparent = true
     window.isMovableByWindowBackground = true
     window.hasShadow = true
-    installDragRegion(in: window)
+  }
+
+  private func installDetachedPlayerBehavior(on window: NSWindow) {
+    guard let targetClass = object_getClass(window) else {
+      return
+    }
+    let classIdentifier = ObjectIdentifier(targetClass)
+    guard detachedPlayerClasses.insert(classIdentifier).inserted else {
+      return
+    }
+
+    // A non-activating frameless NSWindow does not accept Flutter pointer
+    // input unless it can become key. Patch the existing Flutter window class
+    // conditionally, keeping the original behavior for the main window and all
+    // other instances of that class.
+    replaceDetachedWindowBoolGetter(
+      on: targetClass,
+      named: "canBecomeKeyWindow",
+      detachedValue: true
+    )
+    replaceDetachedWindowBoolGetter(
+      on: targetClass,
+      named: "canBecomeMainWindow",
+      detachedValue: false
+    )
+    replaceDetachedWindowBoolGetter(
+      on: targetClass,
+      named: "acceptsFirstResponder",
+      detachedValue: true
+    )
+  }
+
+  private func replaceDetachedWindowBoolGetter(
+    on targetClass: AnyClass,
+    named name: String,
+    detachedValue: Bool
+  ) {
+    let selector = NSSelectorFromString(name)
+    guard let method = class_getInstanceMethod(targetClass, selector),
+          let typeEncoding = method_getTypeEncoding(method) else {
+      return
+    }
+    typealias OriginalBoolGetter = @convention(c) (
+      AnyObject,
+      Selector
+    ) -> Bool
+    let originalGetter = unsafeBitCast(
+      method_getImplementation(method),
+      to: OriginalBoolGetter.self
+    )
+    let getter = { (object: AnyObject) -> Bool in
+      if let candidate = object as? NSWindow,
+         candidate.nipaplayIsDetachedPlayerWindow {
+        return detachedValue
+      }
+      return originalGetter(object, selector)
+    } as @convention(block) (AnyObject) -> Bool
+    class_replaceMethod(
+      targetClass,
+      selector,
+      imp_implementationWithBlock(getter),
+      typeEncoding
+    )
   }
 
   private func makeInteractivePopup(_ window: NSWindow) {
-    guard window is NSPanel else {
+    guard let panel = window as? NSPanel,
+          let popupClass = object_getClass(window) else {
       return
     }
-    if !(window is DesktopInteractivePopupPanel) {
-      // Keep style-driven AppKit view updates on the original panel class for
-      // the same reason as makeFrameless(_:).
-      if !window.styleMask.contains(.nonactivatingPanel) {
-        window.styleMask.insert(.nonactivatingPanel)
-      }
-      object_setClass(window, DesktopInteractivePopupPanel.self)
+    let classIdentifier = ObjectIdentifier(popupClass)
+    if interactivePopupClasses.insert(classIdentifier).inserted {
+      // FlutterPopupWindow deliberately rejects focus. Override its getters on
+      // the existing class instead of replacing an individual panel's class;
+      // the latter corrupts AppKit's private KVO bookkeeping at deallocation.
+      replaceBoolGetter(on: popupClass, named: "canBecomeKeyWindow", value: true)
+      replaceBoolGetter(on: popupClass, named: "canBecomeMainWindow", value: false)
+      replaceBoolGetter(on: popupClass, named: "acceptsFirstResponder", value: true)
     }
     window.hidesOnDeactivate = false
     window.isExcludedFromWindowsMenu = true
-    if let panel = window as? NSPanel {
-      panel.becomesKeyOnlyIfNeeded = false
-      panel.isFloatingPanel = true
-    }
+    panel.becomesKeyOnlyIfNeeded = false
+    panel.isFloatingPanel = true
   }
 
-  private func installDragRegion(in window: NSWindow) {
-    guard let contentView = window.contentView,
-          !contentView.subviews.contains(where: { $0 is DesktopWindowDragView }) else {
+  private func replaceBoolGetter(
+    on targetClass: AnyClass,
+    named name: String,
+    value: Bool
+  ) {
+    let selector = NSSelectorFromString(name)
+    guard let method = class_getInstanceMethod(targetClass, selector),
+          let typeEncoding = method_getTypeEncoding(method) else {
       return
     }
-    let dragView = DesktopWindowDragView(frame: NSRect(
-      x: 72,
-      y: max(0, contentView.bounds.height - 38),
-      width: max(0, contentView.bounds.width - 144),
-      height: 38
-    ))
-    dragView.autoresizingMask = [.width, .minYMargin]
-    contentView.addSubview(dragView, positioned: .above, relativeTo: nil)
+    let getter = { (_: AnyObject) -> Bool in value }
+      as @convention(block) (AnyObject) -> Bool
+    class_replaceMethod(
+      targetClass,
+      selector,
+      imp_implementationWithBlock(getter),
+      typeEncoding
+    )
   }
 
   private func applyAspectRatio(_ value: Any?, to window: NSWindow) {
@@ -1217,32 +1332,89 @@ private final class DesktopMultiWindowHostPlugin: NSObject, FlutterPlugin {
     window.level = alwaysOnTop ? .floating : .normal
     window.hidesOnDeactivate = false
     window.isExcludedFromWindowsMenu = true
-    if let panel = window as? NSPanel {
-      panel.isFloatingPanel = alwaysOnTop
-      panel.becomesKeyOnlyIfNeeded = false
-    }
-    if window is DesktopDetachedPlayerPanel,
-       !window.styleMask.contains(.nonactivatingPanel) {
-      window.styleMask.insert(.nonactivatingPanel)
-    } else if !alwaysOnTop,
-              window.styleMask.contains(.nonactivatingPanel) {
-      window.styleMask.remove(.nonactivatingPanel)
-    }
     var collectionBehavior = window.collectionBehavior
     if alwaysOnTop {
       collectionBehavior.insert([
         .canJoinAllSpaces,
         .fullScreenAuxiliary,
-        .transient,
       ])
     } else {
       collectionBehavior.remove([
         .canJoinAllSpaces,
         .fullScreenAuxiliary,
-        .transient,
       ])
     }
     window.collectionBehavior = collectionBehavior
+  }
+
+  private func applyPictureInPictureMode(
+    _ arguments: [String: Any],
+    to window: NSWindow
+  ) {
+    let enabled = boolValue(arguments["enabled"]) ?? false
+    if !enabled {
+      guard let restoreFrame = window.nipaplayPictureInPictureRestoreFrame else {
+        return
+      }
+      window.nipaplayPictureInPictureRestoreFrame = nil
+      NSLog(
+        "[DesktopMultiWindow][PiP] restore frame=%@",
+        NSStringFromRect(restoreFrame)
+      )
+      window.setFrame(restoreFrame, display: true, animate: true)
+      return
+    }
+
+    if window.nipaplayPictureInPictureRestoreFrame == nil {
+      window.nipaplayPictureInPictureRestoreFrame = window.frame
+    }
+    guard let screen = window.screen ?? NSScreen.main else {
+      return
+    }
+    let visibleFrame = screen.visibleFrame
+    let aspectRatio = max(
+      0.5,
+      min(3.0, doubleValue(arguments["aspectRatio"]) ?? (16.0 / 9.0))
+    )
+    let margin = max(0, doubleValue(arguments["margin"]) ?? 16)
+    let availableWidth = max(1, visibleFrame.width - margin * 2)
+    let availableHeight = max(1, visibleFrame.height - margin * 2)
+    var contentHeight = min(visibleFrame.height / 3, availableHeight)
+    var contentWidth = contentHeight * aspectRatio
+    if contentWidth > availableWidth {
+      contentWidth = availableWidth
+      contentHeight = contentWidth / aspectRatio
+    }
+    window.setContentSize(NSSize(width: contentWidth, height: contentHeight))
+
+    let frameSize = window.frame.size
+    let placement = stringValue(arguments["placement"]) ?? "topRight"
+    let left = visibleFrame.minX + margin
+    let right = visibleFrame.maxX - frameSize.width - margin
+    let bottom = visibleFrame.minY + margin
+    let top = visibleFrame.maxY - frameSize.height - margin
+    let origin: NSPoint
+    switch placement {
+    case "topLeft":
+      origin = NSPoint(x: left, y: top)
+    case "bottomLeft":
+      origin = NSPoint(x: left, y: bottom)
+    case "bottomRight":
+      origin = NSPoint(x: right, y: bottom)
+    case "topRight":
+      fallthrough
+    default:
+      origin = NSPoint(x: right, y: top)
+    }
+    NSLog(
+      "[DesktopMultiWindow][PiP] dock placement=%@ screen=%@ content=%.1fx%.1f origin=%@",
+      placement,
+      NSStringFromRect(visibleFrame),
+      contentWidth,
+      contentHeight,
+      NSStringFromPoint(origin)
+    )
+    window.setFrameOrigin(origin)
   }
 
   private func int64Value(_ value: Any?) -> Int64? {
@@ -1273,6 +1445,10 @@ private final class DesktopMultiWindowHostPlugin: NSObject, FlutterPlugin {
       return value.boolValue
     }
     return nil
+  }
+
+  private func stringValue(_ value: Any?) -> String? {
+    value as? String
   }
 }
 

--- a/packages/desktop_multi_window/lib/desktop_multi_window.dart
+++ b/packages/desktop_multi_window/lib/desktop_multi_window.dart
@@ -35,7 +35,12 @@ void runDesktopMultiWindowApp(Widget app) {
     return;
   }
 
+  // WindowScope, PopupWindow, and TooltipWindow check this flag again when
+  // their widgets build, not only when their native controllers are created.
+  // Keep it enabled for the lifetime of this deliberately multi-view app.
+  flutter_features.isWindowingEnabled = true;
   final binding = WidgetsFlutterBinding.ensureInitialized();
+  binding.windowingOwner = flutter_windowing.createDefaultWindowingOwner();
   final dispatcher = binding.platformDispatcher;
   final views = dispatcher.views.toList(growable: false);
   if (views.isEmpty) {
@@ -86,26 +91,28 @@ class DesktopMultiWindowHost extends StatelessWidget {
       child: child,
       builder: (context, mainView) {
         final windows = DesktopMultiWindow._registry.windows;
+        final transientViews = DesktopMultiWindow._registry.transientViews;
         return ViewAnchor(
-          view: windows.isEmpty
+          view: windows.isEmpty && transientViews.isEmpty
               ? null
               : ViewCollection(
-                  views: windows
-                      .map(
-                        (entry) => _SecondaryWindowScope(
-                          controller: entry.controller,
-                          child: View(
-                            view: entry.controller.flutterView,
-                            child: _PositiveViewSizeGate(
-                              child: Builder(
-                                builder: (context) =>
-                                    entry.builder(context, entry.controller),
-                              ),
+                  views: <Widget>[
+                    ...windows.map(
+                      (entry) => _SecondaryWindowScope(
+                        controller: entry.controller,
+                        child: View(
+                          view: entry.controller.flutterView,
+                          child: _PositiveViewSizeGate(
+                            child: Builder(
+                              builder: (context) =>
+                                  entry.builder(context, entry.controller),
                             ),
                           ),
                         ),
-                      )
-                      .toList(growable: false),
+                      ),
+                    ),
+                    ...transientViews,
+                  ],
                 ),
           child: _PositiveViewSizeGate(child: mainView!),
         );
@@ -157,11 +164,15 @@ class DesktopMultiWindow {
         defaultTargetPlatform == TargetPlatform.linux;
   }
 
-  /// Flutter 3.44 currently implements interactive popup windows on macOS.
-  static bool get supportsInteractivePopupWindows =>
-      isSupported && defaultTargetPlatform == TargetPlatform.macOS;
+  /// Disabled for NipaPlay's detached player.
+  ///
+  /// Flutter 3.44 creates the native popup/tooltip window, but its FlutterView
+  /// remains at 0x0 even after AppKit applies a positive content size. Rendering
+  /// therefore never starts. Callers deliberately fall back to their existing
+  /// in-window Overlay implementations until Flutter's windowing API is stable.
+  static bool get supportsInteractivePopupWindows => false;
 
-  static bool get supportsTooltipWindows => isSupported;
+  static bool get supportsTooltipWindows => false;
 
   /// Creates a regular native window backed by a new [FlutterView] in the
   /// current engine and isolate.
@@ -266,6 +277,45 @@ class DesktopMultiWindow {
         .toList(growable: false);
   }
 
+  /// Mounts a popup or tooltip View beside regular secondary windows.
+  ///
+  /// Flutter Views must be siblings in the root [ViewCollection]. Nesting a
+  /// popup View inside the detached player's View prevents it from rendering,
+  /// while mounting it in an Overlay causes the Overlay slot-type crash.
+  static void attachTransientView(Object owner, Widget view) {
+    _registry.attachTransientView(owner, view);
+  }
+
+  static void detachTransientView(Object owner) {
+    _registry.detachTransientView(owner);
+  }
+
+  /// Copies the app-level inherited presentation context into a root-level
+  /// transient View.
+  ///
+  /// The root [ViewCollection] sits above MaterialApp, so popup children do not
+  /// otherwise inherit Directionality, MediaQuery, Localizations, or themes
+  /// from the detached player's route.
+  static Widget inheritTransientViewContext(
+    BuildContext sourceContext,
+    Widget child,
+  ) {
+    Widget result = InheritedTheme.captureAll(sourceContext, child);
+    result = Localizations.override(
+      context: sourceContext,
+      child: result,
+    );
+    result = Directionality(
+      textDirection: Directionality.of(sourceContext),
+      child: result,
+    );
+    final mediaQuery = MediaQuery.maybeOf(sourceContext);
+    if (mediaQuery != null) {
+      result = MediaQuery(data: mediaQuery, child: result);
+    }
+    return result;
+  }
+
   static DesktopPopupWindowController? createPopupWindow({
     required BuildContext context,
     required Rect anchorRect,
@@ -278,6 +328,13 @@ class DesktopMultiWindow {
     if (!supportsInteractivePopupWindows) return null;
     final parent = maybeControllerOf(context);
     if (parent == null || parent.isClosed) return null;
+
+    debugPrint(
+      '[DesktopMultiWindow][Popup] create '
+      'parentView=${parent.flutterView.viewId} '
+      'anchor=${_describeRect(anchorRect)} size=${_describeSize(size)} '
+      'placement=$placement gap=$gap',
+    );
 
     final delegate = _SameEnginePopupWindowDelegate();
     try {
@@ -295,11 +352,35 @@ class DesktopMultiWindow {
         onClosed: onClosed,
       );
       delegate.attach(controller);
-      unawaited(_invokeHostForViewId<void>(
-        'configureTransientWindow',
-        controller.flutterView.viewId,
-        const <String, Object?>{'interactive': true},
-      ));
+      debugPrint(
+        '[DesktopMultiWindow][Popup] native-created '
+        'view=${controller.flutterView.viewId} '
+        'physicalSize=${_describeSize(controller.flutterView.physicalSize)}',
+      );
+      unawaited(
+        () async {
+          await _invokeHostForViewId<void>(
+            'configureTransientWindow',
+            controller.flutterView.viewId,
+            <String, Object?>{
+              'interactive': true,
+              'width': size.width,
+              'height': size.height,
+            },
+          );
+          await _waitForPositiveViewMetrics(
+            kind: 'Popup',
+            view: controller.flutterView,
+          );
+          debugPrint(
+            '[DesktopMultiWindow][Popup] native-configured '
+            'view=${controller.flutterView.viewId} closed=${controller.isClosed} '
+            'physicalSize=${_describeSize(controller.flutterView.physicalSize)}',
+          );
+          if (!controller.isClosed) controller.updatePosition();
+          controller._markReady();
+        }(),
+      );
       return controller;
     } on UnimplementedError catch (error) {
       debugPrint('[DesktopMultiWindow] popup windows unimplemented: $error');
@@ -323,6 +404,13 @@ class DesktopMultiWindow {
     final parent = maybeControllerOf(context);
     if (parent == null || parent.isClosed) return null;
 
+    debugPrint(
+      '[DesktopMultiWindow][Tooltip] create '
+      'parentView=${parent.flutterView.viewId} '
+      'anchor=${_describeRect(anchorRect)} size=${_describeSize(size)} '
+      'placement=$placement gap=$gap',
+    );
+
     final delegate = _SameEngineTooltipWindowDelegate();
     try {
       final nativeController = _withWindowingEnabled(
@@ -339,6 +427,35 @@ class DesktopMultiWindow {
         onClosed: onClosed,
       );
       delegate.attach(controller);
+      debugPrint(
+        '[DesktopMultiWindow][Tooltip] native-created '
+        'view=${controller.flutterView.viewId} '
+        'physicalSize=${_describeSize(controller.flutterView.physicalSize)}',
+      );
+      unawaited(
+        () async {
+          await _invokeHostForViewId<void>(
+            'configureTransientWindow',
+            controller.flutterView.viewId,
+            <String, Object?>{
+              'interactive': false,
+              'width': size.width,
+              'height': size.height,
+            },
+          );
+          await _waitForPositiveViewMetrics(
+            kind: 'Tooltip',
+            view: controller.flutterView,
+          );
+          debugPrint(
+            '[DesktopMultiWindow][Tooltip] native-configured '
+            'view=${controller.flutterView.viewId} closed=${controller.isClosed} '
+            'physicalSize=${_describeSize(controller.flutterView.physicalSize)}',
+          );
+          if (!controller.isClosed) controller.updatePosition();
+          controller._markReady();
+        }(),
+      );
       return controller;
     } on UnimplementedError catch (error) {
       debugPrint('[DesktopMultiWindow] tooltip windows unimplemented: $error');
@@ -361,6 +478,35 @@ class DesktopMultiWindow {
       maxHeight: maximumSize?.height ?? double.infinity,
     );
   }
+
+  static Future<void> _waitForPositiveViewMetrics({
+    required String kind,
+    required FlutterView view,
+  }) async {
+    for (var attempt = 0; attempt < 20; attempt++) {
+      final size = view.physicalSize;
+      if (size.width > 0 && size.height > 0) {
+        debugPrint(
+          '[DesktopMultiWindow][$kind] metrics-ready '
+          'view=${view.viewId} physicalSize=${_describeSize(size)} '
+          'attempt=$attempt',
+        );
+        return;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 16));
+    }
+    debugPrint(
+      '[DesktopMultiWindow][$kind] metrics-timeout '
+      'view=${view.viewId} physicalSize=${_describeSize(view.physicalSize)}',
+    );
+  }
+
+  static String _describeSize(Size size) =>
+      '${size.width.toStringAsFixed(1)}x${size.height.toStringAsFixed(1)}';
+
+  static String _describeRect(Rect rect) =>
+      '(${rect.left.toStringAsFixed(1)},${rect.top.toStringAsFixed(1)},'
+      '${rect.width.toStringAsFixed(1)}x${rect.height.toStringAsFixed(1)})';
 
   static void _remove(WindowController controller) {
     _registry.remove(controller.windowId);
@@ -468,10 +614,16 @@ class DesktopPopupWindowController {
 
   final flutter_windowing.PopupWindowController _nativeController;
   final VoidCallback? _onClosed;
+  final Completer<void> _readyCompleter = Completer<void>();
   bool _isClosed = false;
 
   FlutterView get flutterView => _nativeController.rootView;
   bool get isClosed => _isClosed;
+  Future<void> get ready => _readyCompleter.future;
+
+  void _markReady() {
+    if (!_readyCompleter.isCompleted) _readyCompleter.complete();
+  }
 
   void close() {
     if (_isClosed) return;
@@ -508,10 +660,16 @@ class DesktopTooltipWindowController {
 
   final flutter_windowing.TooltipWindowController _nativeController;
   final VoidCallback? _onClosed;
+  final Completer<void> _readyCompleter = Completer<void>();
   bool _isClosed = false;
 
   FlutterView get flutterView => _nativeController.rootView;
   bool get isClosed => _isClosed;
+  Future<void> get ready => _readyCompleter.future;
+
+  void _markReady() {
+    if (!_readyCompleter.isCompleted) _readyCompleter.complete();
+  }
 
   void close() {
     if (_isClosed) return;
@@ -554,7 +712,7 @@ class DesktopPopupWindow extends StatelessWidget {
     return DesktopMultiWindow._withWindowingEnabled(
       () => flutter_windowing.PopupWindow(
         controller: controller._nativeController,
-        child: child,
+        child: _PositiveViewSizeGate(child: child),
       ),
     );
   }
@@ -575,7 +733,7 @@ class DesktopTooltipWindow extends StatelessWidget {
     return DesktopMultiWindow._withWindowingEnabled(
       () => flutter_windowing.TooltipWindow(
         controller: controller._nativeController,
-        child: child,
+        child: _PositiveViewSizeGate(child: child),
       ),
     );
   }
@@ -704,6 +862,27 @@ class WindowController extends ChangeNotifier {
 
   Future<void> toggleAlwaysOnTop() => setAlwaysOnTop(!isAlwaysOnTop);
 
+  /// Lets the platform resize and dock this secondary window against the
+  /// visible work area of the screen that currently contains it.
+  Future<void> setPictureInPictureMode({
+    required bool enabled,
+    required double aspectRatio,
+    required String placement,
+    double margin = 16,
+  }) async {
+    if (_isClosed) return;
+    await DesktopMultiWindow._invokeHost<void>(
+      'setPictureInPictureMode',
+      this,
+      <String, Object?>{
+        'enabled': enabled,
+        'aspectRatio': aspectRatio,
+        'placement': placement,
+        'margin': margin,
+      },
+    );
+  }
+
   Future<void> _configureHostWindow({
     required bool frameless,
     required double? aspectRatio,
@@ -808,9 +987,19 @@ class _DesktopWindowEntry {
 
 class _DesktopWindowRegistry extends ChangeNotifier {
   final List<_DesktopWindowEntry> _windows = <_DesktopWindowEntry>[];
+  final Map<Object, Widget> _transientViews = <Object, Widget>{};
 
   List<_DesktopWindowEntry> get windows =>
       List<_DesktopWindowEntry>.unmodifiable(_windows);
+
+  List<Widget> get transientViews => _transientViews.entries
+      .map(
+        (entry) => KeyedSubtree(
+          key: ObjectKey(entry.key),
+          child: entry.value,
+        ),
+      )
+      .toList(growable: false);
 
   void add(_DesktopWindowEntry entry) {
     _windows.add(entry);
@@ -821,6 +1010,26 @@ class _DesktopWindowRegistry extends ChangeNotifier {
     final oldLength = _windows.length;
     _windows.removeWhere((entry) => entry.controller.windowId == windowId);
     if (_windows.length != oldLength) notifyListeners();
+  }
+
+  void attachTransientView(Object owner, Widget view) {
+    _transientViews[owner] = view;
+    debugPrint(
+      '[DesktopMultiWindow][Transient] attach '
+      'owner=${owner.runtimeType} view=${view.runtimeType} '
+      'count=${_transientViews.length}',
+    );
+    notifyListeners();
+  }
+
+  void detachTransientView(Object owner) {
+    if (_transientViews.remove(owner) != null) {
+      debugPrint(
+        '[DesktopMultiWindow][Transient] detach '
+        'owner=${owner.runtimeType} count=${_transientViews.length}',
+      );
+      notifyListeners();
+    }
   }
 
   _DesktopWindowEntry? byId(int windowId) {

--- a/test/danmaku_outline_width_level_test.dart
+++ b/test/danmaku_outline_width_level_test.dart
@@ -5,10 +5,10 @@ import 'package:nipaplay/utils/danmaku/style.dart';
 
 void main() {
   group('normalizeDanmakuOutlineWidthLevel', () {
-    test('uses thin outline for missing or invalid settings', () {
-      expect(normalizeDanmakuOutlineWidthLevel(null), 1.0);
-      expect(normalizeDanmakuOutlineWidthLevel(double.nan), 1.0);
-      expect(normalizeDanmakuOutlineWidthLevel(double.infinity), 1.0);
+    test('uses thick outline for missing or invalid settings', () {
+      expect(normalizeDanmakuOutlineWidthLevel(null), 2.0);
+      expect(normalizeDanmakuOutlineWidthLevel(double.nan), 2.0);
+      expect(normalizeDanmakuOutlineWidthLevel(double.infinity), 2.0);
     });
 
     test('maps current values to off, thin, and thick levels', () {
@@ -40,7 +40,8 @@ void main() {
       expect(globalSettings, contains('divisions: 2'));
       expect(cupertinoMenu, contains('divisions: 2'));
       expect(nipaplayMenu, contains('step: 1.0'));
-      expect(nipaplayMenu, contains('0 无描边 · 1 细边 · 2 粗边（原版）'));
+      expect(nipaplayMenu, contains('0 无描边 · 1 细边 · 2 粗边'));
+      expect('$cupertinoMenu$nipaplayMenu', isNot(contains('原版')));
       expect(
         '$globalSettings$cupertinoMenu$nipaplayMenu',
         isNot(contains('setNext2DanmakuOutlineWidth(value ? 1.0 : 0.0)')),

--- a/test/desktop_player_multiview_test.dart
+++ b/test/desktop_player_multiview_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:ui';
 
+import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nipaplay/services/desktop_player_window_service.dart';
@@ -82,6 +83,45 @@ void main() {
       expect(key.currentState?.transientControlState, 7);
     });
 
+    testWidgets('hosts transient popup views beside regular windows',
+        (tester) async {
+      final secondary = _FakeSecondaryView(tester.view);
+      final owner = Object();
+      late BuildContext popupSourceContext;
+
+      await tester.pumpWidget(
+        DesktopMultiWindowHost(
+          child: MaterialApp(
+            home: Builder(
+              builder: (context) {
+                popupSourceContext = context;
+                return const Text('main view');
+              },
+            ),
+          ),
+        ),
+      );
+
+      DesktopMultiWindow.attachTransientView(
+        owner,
+        View(
+          view: secondary,
+          child: DesktopMultiWindow.inheritTransientViewContext(
+            popupSourceContext,
+            const Icon(Icons.play_arrow, semanticLabel: 'popup view'),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+
+      DesktopMultiWindow.detachTransientView(owner);
+      await tester.pump();
+      expect(find.byIcon(Icons.play_arrow), findsNothing);
+    });
+
     test('normalizes invalid and extreme aspect ratios', () {
       expect(
           DesktopPlayerWindowService.normalizeAspectRatio(double.nan), 16 / 9);
@@ -135,6 +175,9 @@ void main() {
       final contextMenuSource = File(
         'lib/widgets/context_menu/src/context_menu_controller.dart',
       ).readAsStringSync();
+      final transientHostSource = File(
+        'lib/widgets/desktop_transient_overlay.dart',
+      ).readAsStringSync();
 
       expect(forkSource, contains('RegularWindowController'));
       expect(forkSource, contains('ViewCollection'));
@@ -147,7 +190,22 @@ void main() {
       expect(forkSource, contains("'setAlwaysOnTop'"));
       expect(forkSource, contains('PopupWindowController'));
       expect(forkSource, contains('TooltipWindowController'));
+      expect(
+        forkSource,
+        contains('supportsInteractivePopupWindows => false'),
+      );
+      expect(forkSource, contains('supportsTooltipWindows => false'));
+      expect(
+        RegExp(r'_PositiveViewSizeGate\(child: child\)')
+            .allMatches(forkSource)
+            .length,
+        greaterThanOrEqualTo(2),
+      );
       expect(forkSource, contains('WindowPositionerConstraintAdjustment'));
+      expect(forkSource, contains("'width': size.width"));
+      expect(forkSource, contains("'height': size.height"));
+      expect(
+          forkSource, contains('flutter_features.isWindowingEnabled = true'));
       expect(mainSource, contains('runDesktopMultiWindowApp('));
       expect(serviceSource, contains('final GlobalKey playerPageKey'));
       expect(serviceSource, isNot(contains('initializePlayer')));
@@ -161,32 +219,29 @@ void main() {
       expect(macOSRunnerSource, contains('contentAspectRatio'));
       expect(macOSRunnerSource, contains('canJoinAllSpaces'));
       expect(macOSRunnerSource, contains('NSEvent.mouseLocation'));
-      expect(macOSRunnerSource, contains('DesktopWindowDragView'));
-      expect(macOSRunnerSource, contains('mouseDownCanMoveWindow'));
-      expect(macOSRunnerSource, contains('DesktopDetachedPlayerPanel'));
-      expect(macOSRunnerSource, contains('DesktopInteractivePopupPanel'));
+      expect(macOSRunnerSource, contains('nipaplayIsDetachedPlayerWindow'));
+      expect(macOSRunnerSource, contains('replaceDetachedWindowBoolGetter'));
+      expect(macOSRunnerSource, contains('replaceBoolGetter'));
+      expect(macOSRunnerSource, isNot(contains('object_setClass')));
       expect(macOSRunnerSource, contains('.nonactivatingPanel'));
       expect(macOSRunnerSource, contains('configureTransientWindow'));
-      final framelessImplementation = macOSRunnerSource.substring(
-        macOSRunnerSource.indexOf('private func makeFrameless'),
-        macOSRunnerSource.indexOf('private func makeInteractivePopup'),
-      );
       expect(
-        framelessImplementation.indexOf('window.styleMask = styleMask'),
-        lessThan(
-          framelessImplementation.indexOf(
-            'object_setClass(window, DesktopDetachedPlayerPanel.self)',
-          ),
-        ),
-        reason: 'AppKit must tear down its titlebar before the NSPanel class '
-            'conversion to preserve private KVO registration ownership.',
+        macOSRunnerSource,
+        contains('applyPreferredContentSize(arguments, to: window)'),
       );
       expect(playerPageSource, contains('Icons.push_pin_rounded'));
-      expect(detachedPlayerSource, isNot(contains('_WindowDragHandle')));
+      expect(detachedPlayerSource, contains('_DetachedWindowDragRegion'));
+      expect(detachedPlayerSource, contains('controller.startDragging()'));
       expect(mainPlayerSlotSource, contains('VideoUploadUI('));
       expect(mainPlayerSlotSource, isNot(contains('FilledButton')));
       expect(tooltipSource, contains('createTooltipWindow'));
+      expect(tooltipSource, contains('attachTransientView'));
+      expect(transientHostSource, contains('attachTransientView'));
+      expect(forkSource, contains('final transientViews'));
+      expect(forkSource, contains('...transientViews'));
       expect(controlsSource, contains('DesktopTransientOverlay.showPopup'));
+      expect(controlsSource, contains('Icons.open_in_new_rounded'));
+      expect(controlsSource, contains('Icons.call_merge_rounded'));
       expect(contextMenuSource, contains('DesktopTransientOverlay.showPopup'));
       expect(windowsVideoSource, contains('flutterViewId'));
       expect(windowsVideoSource, contains('FLUTTER_HOST_WINDOW'));

--- a/windows/runner/windows_native_video.cpp
+++ b/windows/runner/windows_native_video.cpp
@@ -72,6 +72,7 @@ HWND ResolveFlutterRegularHostWindow() {
 
 constexpr UINT_PTR kDetachedWindowSubclassId = 706;
 std::unordered_map<HWND, double> g_detached_window_aspect_ratios;
+std::unordered_map<HWND, RECT> g_picture_in_picture_restore_bounds;
 
 LRESULT CALLBACK DetachedWindowSubclassProc(HWND window,
                                             UINT message,
@@ -81,6 +82,7 @@ LRESULT CALLBACK DetachedWindowSubclassProc(HWND window,
                                             DWORD_PTR) {
   if (message == WM_NCDESTROY) {
     g_detached_window_aspect_ratios.erase(window);
+    g_picture_in_picture_restore_bounds.erase(window);
     ::RemoveWindowSubclass(window, DetachedWindowSubclassProc,
                            kDetachedWindowSubclassId);
     return ::DefSubclassProc(window, message, wparam, lparam);
@@ -167,6 +169,98 @@ void SetDetachedWindowClientSize(HWND window, double logical_width,
   ::SetWindowPos(window, nullptr, 0, 0, bounds.right - bounds.left,
                  bounds.bottom - bounds.top,
                  SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+}
+
+double ReadDouble(const flutter::EncodableMap& args,
+                  const char* key,
+                  double fallback);
+bool ReadBool(const flutter::EncodableMap& args,
+              const char* key,
+              bool fallback);
+
+std::string ReadString(const flutter::EncodableMap& args,
+                       const char* key,
+                       const std::string& fallback = "") {
+  const auto it = args.find(flutter::EncodableValue(key));
+  if (it == args.end()) {
+    return fallback;
+  }
+  if (const auto* value = std::get_if<std::string>(&it->second)) {
+    return *value;
+  }
+  return fallback;
+}
+
+void SetDetachedWindowPictureInPicture(
+    HWND window,
+    const flutter::EncodableMap& args) {
+  const bool enabled = ReadBool(args, "enabled", false);
+  if (!enabled) {
+    const auto restore_it = g_picture_in_picture_restore_bounds.find(window);
+    if (restore_it == g_picture_in_picture_restore_bounds.end()) {
+      return;
+    }
+    const RECT restore = restore_it->second;
+    g_picture_in_picture_restore_bounds.erase(restore_it);
+    ::SetWindowPos(window, nullptr, restore.left, restore.top,
+                   restore.right - restore.left, restore.bottom - restore.top,
+                   SWP_NOZORDER | SWP_NOACTIVATE);
+    return;
+  }
+
+  if (g_picture_in_picture_restore_bounds.find(window) ==
+      g_picture_in_picture_restore_bounds.end()) {
+    RECT current = {};
+    if (::GetWindowRect(window, &current)) {
+      g_picture_in_picture_restore_bounds[window] = current;
+    }
+  }
+
+  const HMONITOR monitor = ::MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST);
+  MONITORINFO monitor_info = {};
+  monitor_info.cbSize = sizeof(monitor_info);
+  if (monitor == nullptr || !::GetMonitorInfoW(monitor, &monitor_info)) {
+    return;
+  }
+  const RECT work = monitor_info.rcWork;
+  const double work_width = static_cast<double>(work.right - work.left);
+  const double work_height = static_cast<double>(work.bottom - work.top);
+  const double ratio = std::clamp(ReadDouble(args, "aspectRatio", 16.0 / 9.0),
+                                  0.5, 3.0);
+  const UINT dpi = ::GetDpiForWindow(window);
+  const double scale = dpi > 0 ? static_cast<double>(dpi) / 96.0 : 1.0;
+  const double margin = std::max(0.0, ReadDouble(args, "margin", 16.0) * scale);
+  const double available_width = std::max(1.0, work_width - margin * 2.0);
+  double client_height = std::min(work_height / 3.0,
+                                  std::max(1.0, work_height - margin * 2.0));
+  double client_width = client_height * ratio;
+  if (client_width > available_width) {
+    client_width = available_width;
+    client_height = client_width / ratio;
+  }
+  SetDetachedWindowClientSize(window, client_width / scale,
+                              client_height / scale);
+
+  RECT resized = {};
+  if (!::GetWindowRect(window, &resized)) {
+    return;
+  }
+  const int window_width = resized.right - resized.left;
+  const int window_height = resized.bottom - resized.top;
+  const std::string placement = ReadString(args, "placement", "topRight");
+  const int left = work.left + static_cast<int>(std::lround(margin));
+  const int right =
+      work.right - window_width - static_cast<int>(std::lround(margin));
+  const int top = work.top + static_cast<int>(std::lround(margin));
+  const int bottom =
+      work.bottom - window_height - static_cast<int>(std::lround(margin));
+  const bool place_left =
+      placement == "topLeft" || placement == "bottomLeft";
+  const bool place_bottom =
+      placement == "bottomLeft" || placement == "bottomRight";
+  ::SetWindowPos(window, nullptr, place_left ? left : right,
+                 place_bottom ? bottom : top, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 }
 constexpr UINT kRenderMessage = WM_APP + 0x4E56;
 
@@ -1133,6 +1227,18 @@ void WindowsNativeVideoPlugin::HandleDesktopWindowMethodCall(
     ::SetWindowPos(window, always_on_top ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0,
                    0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
     result->Success(flutter::EncodableValue(always_on_top));
+    return;
+  }
+  if (method == "setPictureInPictureMode") {
+    const bool enabled = ReadBool(*args, "enabled");
+    const std::string placement =
+        ReadString(*args, "placement", "topRight");
+    SetDetachedWindowPictureInPicture(window, *args);
+    LogNativeVideo(
+        "picture-in-picture enabled=" + std::to_string(enabled ? 1 : 0) +
+        " placement=" + placement +
+        " aspect=" + std::to_string(ReadDouble(*args, "aspectRatio")));
+    result->Success();
     return;
   }
   if (method == "startDragging") {


### PR DESCRIPTION
## What changed

- implement same-engine detached playback windows for desktop
- add frameless, aspect-ratio-locked playback windows with always-on-top support
- add configurable picture-in-picture placement and one-click PiP entry from the main player
- add keyboard shortcuts for detached-window and PiP switching
- add optional portrait external-player danmaku console windows, including a separate danmaku-list window
- restore the intended three-level danmaku outline behavior
- extend macOS, Windows, and Linux native window hosting support needed by the feature
- keep the main-window placeholder and player controls consistent with NipaPlay UI

## Why

Issue #706 requires moving the existing playback page into a real secondary window instead of recreating or hiding the main-window controls. The same-engine implementation preserves the active player state and avoids duplicate playback resources.

## Impact

Desktop users can move playback between the main and detached windows, use a compact always-on-top PiP mode, and optionally render the external-player danmaku console in dedicated windows.

Closes #706

## Validation

- Dart formatting completed
- `git diff --check` passed
- compilation and runtime tests were intentionally left to the requester, as requested during implementation