### PR TITLE
fix: align Cupertino glass control sizing across iOS versions

### DIFF
--- a/lib/themes/cupertino/pages/cupertino_main_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_main_page.dart
@@ -254,7 +254,7 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
       context,
     );
     final bottomInset = MediaQuery.viewPaddingOf(context).bottom;
-    final tabBarHeight = bottomInset > 0 ? 56.0 : 50.0;
+    final nativeTabBarHeight = bottomInset > 0 ? 56.0 : 50.0;
     final glassTabBarBottom = resolveGlassTabBarBottomOffset(
       viewPaddingBottom: bottomInset,
     );
@@ -313,7 +313,7 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
           onTap: _selectIndex,
           activeColor: activeColor,
           inactiveColor: inactiveColor,
-          height: tabBarHeight,
+          height: nativeTabBarHeight,
           items: _buildCupertinoItems(context, pages),
         );
 
@@ -355,7 +355,7 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
                     onTabSelected: _selectIndex,
                     horizontalPadding: 12,
                     verticalPadding: 0,
-                    barHeight: tabBarHeight,
+                    barHeight: cupertinoGlassTabBarHeight,
                     settings: glassTabBarSettings,
                     selectedIconColor: activeColor,
                     selectedLabelColor: activeColor,

--- a/lib/themes/cupertino/utils/cupertino_glass_navigation_insets.dart
+++ b/lib/themes/cupertino/utils/cupertino_glass_navigation_insets.dart
@@ -1,5 +1,8 @@
 const double _glassTabBarEdgeGap = 6.0;
 
+/// Height required by the fallback glass tab bar's icon-and-label layout.
+const double cupertinoGlassTabBarHeight = 64.0;
+
 /// Resolves the bottom offset for the floating liquid-glass tab bar.
 ///
 /// Keeps the entire system navigation inset unobstructed and adds a small,

--- a/lib/themes/cupertino/widgets/cupertino_bottom_sheet.dart
+++ b/lib/themes/cupertino/widgets/cupertino_bottom_sheet.dart
@@ -380,7 +380,7 @@ class CupertinoBottomSheet extends StatelessWidget {
 
     if (PlatformInfo.isIOS26OrHigher()) {
       return SizedBox.square(
-        dimension: _closeButtonSize,
+        dimension: _nativeHeaderButtonSize,
         child: AdaptiveButton.sfSymbol(
           useSmoothRectangleBorder: false,
           onPressed: onPressed,
@@ -396,7 +396,7 @@ class CupertinoBottomSheet extends StatelessWidget {
     }
 
     return SizedBox.square(
-      dimension: _closeButtonSize,
+      dimension: _fallbackHeaderButtonSize,
       child: _buildFallbackHeaderButton(
         context,
         label: '返回',
@@ -417,8 +417,8 @@ class CupertinoBottomSheet extends StatelessWidget {
 
     if (PlatformInfo.isIOS26OrHigher()) {
       return SizedBox(
-        width: _closeButtonSize,
-        height: _closeButtonSize,
+        width: _nativeHeaderButtonSize,
+        height: _nativeHeaderButtonSize,
         child: AdaptiveButton.sfSymbol(
           useSmoothRectangleBorder: false,
           onPressed: onPressedCallback,
@@ -430,8 +430,8 @@ class CupertinoBottomSheet extends StatelessWidget {
     }
 
     return SizedBox(
-      width: _closeButtonSize,
-      height: _closeButtonSize,
+      width: _fallbackHeaderButtonSize,
+      height: _fallbackHeaderButtonSize,
       child: _buildFallbackHeaderButton(
         context,
         label: '关闭',
@@ -458,8 +458,8 @@ class CupertinoBottomSheet extends StatelessWidget {
       label: label,
       icon: Icon(icon, size: iconSize, color: iconColor),
       onTap: onPressed,
-      width: _closeButtonSize,
-      height: _closeButtonSize,
+      width: _fallbackHeaderButtonSize,
+      height: _fallbackHeaderButtonSize,
       iconSize: iconSize,
       useOwnLayer: true,
       quality: GlassQuality.standard,
@@ -491,7 +491,10 @@ class CupertinoBottomSheet extends StatelessWidget {
   );
 
   static const double _closeButtonPadding = 12;
-  static const double _closeButtonSize = 40;
+  static const double _nativeHeaderButtonSize = 40;
+  // Native Liquid Glass paints outside its 40pt layout box. The fallback
+  // does not, so its visible circle needs the standard 44pt tap diameter.
+  static const double _fallbackHeaderButtonSize = 44;
   static const double _floatingContentTopInsetWithClose = 44;
   static const double _floatingContentTopInset = 28;
   static const double _contentTopInsetWithClose = 28;

--- a/lib/themes/cupertino/widgets/cupertino_glass_button_group.dart
+++ b/lib/themes/cupertino/widgets/cupertino_glass_button_group.dart
@@ -24,6 +24,14 @@ class CupertinoGlassButtonGroup extends StatelessWidget {
   final List<CupertinoGlassButtonGroupItem> items;
   final double buttonSize;
 
+  // UIKit's iOS 26 glass chrome paints a few points beyond the platform
+  // view's logical bounds. The Flutter fallback stays strictly inside its
+  // bounds, so give its shell a little more room to preserve the same visual
+  // size while keeping the icon size unchanged.
+  static const double _fallbackHeightExpansion = 4;
+  static const double _fallbackItemWidthExpansion = 6;
+  static const double _iconSize = 19;
+
   @override
   Widget build(BuildContext context) {
     if (items.isEmpty) return const SizedBox.shrink();
@@ -49,6 +57,9 @@ class CupertinoGlassButtonGroup extends StatelessWidget {
       );
     }
 
+    final fallbackHeight = buttonSize + _fallbackHeightExpansion;
+    final fallbackItemWidth = buttonSize + _fallbackItemWidthExpansion;
+
     return GlassButtonGroup.icons(
       useOwnLayer: true,
       quality: GlassQuality.standard,
@@ -66,9 +77,12 @@ class CupertinoGlassButtonGroup extends StatelessWidget {
               backerColor: Color(0x14FFFFFF),
             )
           : null,
-      borderRadius: buttonSize / 2,
-      iconSize: 19,
-      itemPadding: EdgeInsets.all((buttonSize - 19) / 2),
+      borderRadius: fallbackHeight / 2,
+      iconSize: _iconSize,
+      itemPadding: EdgeInsets.symmetric(
+        horizontal: (fallbackItemWidth - _iconSize) / 2,
+        vertical: (fallbackHeight - _iconSize) / 2,
+      ),
       items: [
         for (final item in items)
           GlassButtonGroupItem(

--- a/packages/adaptive_platform_ui/lib/src/widgets/ios26/ios26_button_group.dart
+++ b/packages/adaptive_platform_ui/lib/src/widgets/ios26/ios26_button_group.dart
@@ -44,6 +44,11 @@ class IOS26ButtonGroup extends StatefulWidget {
 }
 
 class _IOS26ButtonGroupState extends State<IOS26ButtonGroup> {
+  // UIToolbar's shared Liquid Glass background paints beyond the platform
+  // view's item bounds on iOS 26. Keep that native chrome inside the Flutter
+  // layout box so right-aligned groups cannot be clipped by the screen edge.
+  static const double _nativeChromeHorizontalOutset = 12;
+
   static int _nextId = 0;
 
   late final int _id = _nextId++;
@@ -59,19 +64,31 @@ class _IOS26ButtonGroupState extends State<IOS26ButtonGroup> {
 
   @override
   Widget build(BuildContext context) {
-    final size = Size(widget.itemWidth * widget.items.length, widget.height);
     if (widget.items.isEmpty) return const SizedBox.shrink();
+    final contentSize = Size(
+      widget.itemWidth * widget.items.length,
+      widget.height,
+    );
+    final layoutSize = Size(
+      contentSize.width + (_nativeChromeHorizontalOutset * 2),
+      contentSize.height,
+    );
     if (kIsWeb || !Platform.isIOS || !ios26NativeViewRouteIsCurrent(context)) {
-      return SizedBox.fromSize(size: size);
+      return SizedBox.fromSize(size: layoutSize);
     }
 
-    return SizedBox.fromSize(
-      size: size,
-      child: UiKitView(
-        viewType: 'adaptive_platform_ui/ios26_button_group',
-        creationParams: <String, Object>{'id': _id, 'items': _itemsParams()},
-        creationParamsCodec: const StandardMessageCodec(),
-        onPlatformViewCreated: _onPlatformViewCreated,
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: _nativeChromeHorizontalOutset,
+      ),
+      child: SizedBox.fromSize(
+        size: contentSize,
+        child: UiKitView(
+          viewType: 'adaptive_platform_ui/ios26_button_group',
+          creationParams: <String, Object>{'id': _id, 'items': _itemsParams()},
+          creationParamsCodec: const StandardMessageCodec(),
+          onPlatformViewCreated: _onPlatformViewCreated,
+        ),
       ),
     );
   }

--- a/packages/adaptive_platform_ui/test/ios26_button_group_test.dart
+++ b/packages/adaptive_platform_ui/test/ios26_button_group_test.dart
@@ -1,0 +1,46 @@
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('reserves room for native Liquid Glass chrome', (tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: IOS26ButtonGroup(
+            height: 44,
+            itemWidth: 44,
+            items: const [
+              IOS26ButtonGroupItem(label: 'More', sfSymbol: 'ellipsis'),
+              IOS26ButtonGroupItem(label: 'Theme', sfSymbol: 'moon.fill'),
+              IOS26ButtonGroupItem(
+                label: 'Settings',
+                sfSymbol: 'gearshape.fill',
+              ),
+            ],
+            onPressed: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.getSize(find.byType(IOS26ButtonGroup)),
+      const Size((44 * 3) + 24, 44),
+    );
+  });
+
+  testWidgets('empty groups remain collapsed', (tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: IOS26ButtonGroup(items: const [], onPressed: (_) {}),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(IOS26ButtonGroup)), Size.zero);
+  });
+}

--- a/test/cupertino_glass_button_size_test.dart
+++ b/test/cupertino_glass_button_size_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
+import 'package:nipaplay/themes/cupertino/widgets/cupertino_glass_button_group.dart';
+
+void main() {
+  testWidgets('fallback toolbar group matches native glass visual size', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoGlassButtonGroup(
+            buttonSize: 44,
+            items: [
+              CupertinoGlassButtonGroupItem(
+                label: '更多',
+                icon: CupertinoIcons.ellipsis,
+                onPressed: () {},
+              ),
+              CupertinoGlassButtonGroupItem(
+                label: '设置',
+                icon: CupertinoIcons.gear,
+                onPressed: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(GlassButtonGroup)), const Size(100, 48));
+  });
+
+  testWidgets('fallback bottom sheet header button uses 44pt circle', (
+    tester,
+  ) async {
+    final controller = CupertinoBottomSheetPageController(rootTitle: '菜单');
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoBottomSheet(
+          pageController: controller,
+          child: const SizedBox.expand(),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(GlassButton)), const Size.square(44));
+  });
+}

--- a/test/cupertino_glass_navigation_insets_test.dart
+++ b/test/cupertino_glass_navigation_insets_test.dart
@@ -2,6 +2,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nipaplay/themes/cupertino/utils/cupertino_glass_navigation_insets.dart';
 
 void main() {
+  test('fallback glass tab bar keeps its designed content height', () {
+    expect(cupertinoGlassTabBarHeight, 64);
+  });
+
   group('resolveGlassTabBarBottomOffset', () {
     test('fully clears Android three-button navigation', () {
       expect(


### PR DESCRIPTION
## What changed

- reserve horizontal layout room for the iOS 26 native toolbar's Liquid Glass chrome so right-aligned actions are not clipped
- restore the fallback glass tab bar to its designed 64pt height
- enlarge pre-iOS 26 fallback toolbar and bottom-sheet glass shells to match the native visual size
- add widget tests for native chrome outsets and fallback control dimensions

## Root cause

UIKit's iOS 26 Liquid Glass chrome paints beyond the platform view's logical bounds. The right-aligned native toolbar was therefore clipped at the screen edge, while Flutter fallback controls stayed strictly inside their nominal bounds and appeared smaller. The fallback tab bar was also being forced below its designed content height.

## User impact

The top-right toolbar stays fully visible on iOS 26, and the fallback toolbar, bottom-sheet buttons, and bottom navigation have consistent spacing and visual sizing on older iOS versions.

## Validation

- 68 relevant app and architecture tests passed
- 202 `adaptive_platform_ui` package tests passed
- post-rebase sizing tests passed (7 app + 2 package)
- targeted analysis for all changed Dart files: no issues
- verified interactively in iOS 26 and iOS 18 simulators
