### PR TITLE
修复 iOS Erika window-overlay 白屏并兼容 Flutter 3.44

### DIFF
--- a/lib/pages/play_video_page.dart
+++ b/lib/pages/play_video_page.dart
@@ -547,19 +547,22 @@ class _PlayVideoPageState extends State<PlayVideoPage> {
               (constraints.maxWidth / _phonePortraitUiDesignWidth)
                   .clamp(0.35, 0.72)
                   .toDouble();
+          final playerStage = _buildPlayerStage(
+            videoState,
+            portraitUiScale: portraitUiScale,
+          );
           return Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               SizedBox(
                 height: stageHeight,
                 child: ClipRect(
-                  child: ColoredBox(
-                    color: Colors.black,
-                    child: _buildPlayerStage(
-                      videoState,
-                      portraitUiScale: portraitUiScale,
-                    ),
-                  ),
+                  child: videoState.player.usesWindowOverlayVideoSurface
+                      ? playerStage
+                      : ColoredBox(
+                          color: Colors.black,
+                          child: playerStage,
+                        ),
                 ),
               ),
               Expanded(

--- a/lib/settings/adaptive_settings_widgets.dart
+++ b/lib/settings/adaptive_settings_widgets.dart
@@ -1141,23 +1141,26 @@ class AdaptiveSettingsPage extends material.StatelessWidget {
         cupertino.CupertinoColors.systemGroupedBackground,
         context,
       );
-      return material.ColoredBox(
-        color: backgroundColor,
-        child: material.SafeArea(
-          top: false,
-          bottom: false,
-          child: material.ListView(
-            physics: const cupertino.BouncingScrollPhysics(
-              parent: material.AlwaysScrollableScrollPhysics(),
+      return material.Material(
+        type: material.MaterialType.transparency,
+        child: material.ColoredBox(
+          color: backgroundColor,
+          child: material.SafeArea(
+            top: false,
+            bottom: false,
+            child: material.ListView(
+              physics: const cupertino.BouncingScrollPhysics(
+                parent: material.AlwaysScrollableScrollPhysics(),
+              ),
+              padding: material.EdgeInsets.fromLTRB(
+                cupertinoHorizontalPadding,
+                64,
+                cupertinoHorizontalPadding,
+                cupertinoBottomPadding +
+                    material.MediaQuery.viewPaddingOf(context).bottom,
+              ),
+              children: children,
             ),
-            padding: material.EdgeInsets.fromLTRB(
-              cupertinoHorizontalPadding,
-              64,
-              cupertinoHorizontalPadding,
-              cupertinoBottomPadding +
-                  material.MediaQuery.viewPaddingOf(context).bottom,
-            ),
-            children: children,
           ),
         ),
       );

--- a/lib/themes/cupertino/pages/cupertino_main_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_main_page.dart
@@ -270,7 +270,14 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
             videoState.isFullscreen;
         final isBottomNavigationVisible =
             bottomBar.isBottomBarVisible && !isFullscreenPlayback;
+        final useWindowHostedVideoUnderlay =
+            selectedPage.id == AppPageIds.video &&
+                videoState.hasVideo &&
+                videoState.player.usesWindowOverlayVideoSurface;
         final body = BackgroundWithBlur(
+          transparentCutout: useWindowHostedVideoUnderlay
+              ? videoState.windowHostedVideoRect
+              : null,
           child: CupertinoPageActionsScope(
             controller: _pageActionsController,
             child: AppNavigationScope(
@@ -321,6 +328,8 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
           return AdaptiveScaffold(
             minimizeBehavior: TabBarMinimizeBehavior.never,
             enableBlur: true,
+            backgroundColor:
+                useWindowHostedVideoUnderlay ? const Color(0x00000000) : null,
             body: body,
             bottomNavigationBar: isBottomNavigationVisible
                 ? AdaptiveBottomNavigationBar(

--- a/lib/themes/nipaplay/widgets/nipaplay_window.dart
+++ b/lib/themes/nipaplay/widgets/nipaplay_window.dart
@@ -218,7 +218,12 @@ class _NipaplayWindowScaffoldState extends State<NipaplayWindowScaffold> {
 
   @override
   Widget build(BuildContext context) {
-    if (widget.embedded) return widget.child;
+    if (widget.embedded) {
+      return Material(
+        type: MaterialType.transparency,
+        child: widget.child,
+      );
+    }
 
     final appearanceSettings = context.watch<AppearanceSettingsProvider>();
     final bool useFilledScreenLayout = appearanceSettings.windowDisplayMode ==

--- a/packages/adaptive_platform_ui/lib/src/widgets/adaptive_scaffold.dart
+++ b/packages/adaptive_platform_ui/lib/src/widgets/adaptive_scaffold.dart
@@ -69,6 +69,7 @@ class AdaptiveScaffold extends StatefulWidget {
     this.floatingActionButton,
     this.minimizeBehavior = TabBarMinimizeBehavior.automatic,
     this.enableBlur = true,
+    this.backgroundColor,
   });
 
   /// App bar configuration
@@ -92,6 +93,12 @@ class AdaptiveScaffold extends StatefulWidget {
   /// Enable Liquid Glass blur effect behind tab bar (iOS 26+ only)
   /// When enabled, content behind the tab bar will be blurred
   final bool enableBlur;
+
+  /// Background color used by the platform scaffold.
+  ///
+  /// Leave null to use the platform theme default. A transparent color is
+  /// useful when the body exposes a window-hosted native underlay.
+  final Color? backgroundColor;
 
   @override
   State<AdaptiveScaffold> createState() => _AdaptiveScaffoldState();
@@ -163,6 +170,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
         leading: widget.appBar?.leading,
         minimizeBehavior: widget.minimizeBehavior,
         enableBlur: widget.enableBlur,
+        backgroundColor: widget.backgroundColor,
         children: childrenList,
       );
     }
@@ -373,6 +381,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
         }
 
         return CupertinoPageScaffold(
+          backgroundColor: widget.backgroundColor,
           navigationBar: navigationBar,
           child: bodyWidget,
         );
@@ -448,7 +457,11 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
         );
       }
 
-      return CupertinoPageScaffold(navigationBar: navigationBar, child: body);
+      return CupertinoPageScaffold(
+        backgroundColor: widget.backgroundColor,
+        navigationBar: navigationBar,
+        child: body,
+      );
     }
 
     // Android - Use NavigationBar if destinations provided
@@ -541,6 +554,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
       }
 
       return Scaffold(
+        backgroundColor: widget.backgroundColor,
         appBar: appBar,
         body: widget.body ?? const SizedBox.shrink(),
         bottomNavigationBar: bottomNavBar,
@@ -591,6 +605,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
     }
 
     return Scaffold(
+      backgroundColor: widget.backgroundColor,
       appBar: appBar,
       body: widget.body ?? const SizedBox.shrink(),
       floatingActionButton: widget.floatingActionButton,

--- a/packages/adaptive_platform_ui/lib/src/widgets/ios26/ios26_scaffold.dart
+++ b/packages/adaptive_platform_ui/lib/src/widgets/ios26/ios26_scaffold.dart
@@ -15,6 +15,7 @@ class IOS26Scaffold extends StatefulWidget {
     this.leading,
     this.minimizeBehavior = TabBarMinimizeBehavior.automatic,
     this.enableBlur = true,
+    this.backgroundColor,
     required this.children,
   });
 
@@ -24,6 +25,7 @@ class IOS26Scaffold extends StatefulWidget {
   final Widget? leading;
   final TabBarMinimizeBehavior minimizeBehavior;
   final bool enableBlur;
+  final Color? backgroundColor;
   final List<Widget> children;
 
   @override
@@ -212,6 +214,7 @@ class _IOS26ScaffoldState extends State<IOS26Scaffold>
         widget.bottomNavigationBar!.items!.isNotEmpty;
 
     return CupertinoPageScaffold(
+      backgroundColor: widget.backgroundColor,
       child: hasBottomNav
           ? NotificationListener<ScrollNotification>(
               onNotification: _handleScrollNotification,

--- a/packages/adaptive_platform_ui/test/adaptive_snackbar_pickers_test.dart
+++ b/packages/adaptive_platform_ui/test/adaptive_snackbar_pickers_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart'
+    show CupertinoApp, CupertinoPageScaffold;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 
@@ -371,6 +373,38 @@ void main() {
   });
 
   group('AdaptiveScaffold', () {
+    testWidgets('forwards a transparent Cupertino scaffold background', (
+      WidgetTester tester,
+    ) async {
+      PlatformInfo.setPlatformOverride(PlatformOverride.ios, iosVersion: 18);
+      addTearDown(PlatformInfo.clearPlatformOverride);
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: AdaptiveScaffold(
+            backgroundColor: const Color(0x00000000),
+            body: const Text('Transparent body'),
+            bottomNavigationBar: AdaptiveBottomNavigationBar(
+              items: const [
+                AdaptiveNavigationDestination(icon: Icons.home, label: 'Home'),
+                AdaptiveNavigationDestination(
+                  icon: Icons.search,
+                  label: 'Search',
+                ),
+              ],
+              selectedIndex: 0,
+              onTap: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      final scaffold = tester.widget<CupertinoPageScaffold>(
+        find.byType(CupertinoPageScaffold),
+      );
+      expect(scaffold.backgroundColor, const Color(0x00000000));
+    });
+
     testWidgets('creates scaffold with body', (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(home: AdaptiveScaffold(body: Text('Scaffold Body'))),

--- a/test/settings/adaptive_settings_widgets_test.dart
+++ b/test/settings/adaptive_settings_widgets_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/settings/adaptive_settings_scope.dart';
+import 'package:nipaplay/settings/adaptive_settings_widgets.dart';
+
+void main() {
+  testWidgets('phone settings page provides a Material ancestor',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AdaptiveSettingsScope(
+          style: AdaptiveSettingsStyle.phone,
+          child: AdaptiveSettingsPage(
+            children: [
+              Chip(label: Text('Selected library')),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Selected library'), findsOneWidget);
+  });
+}

--- a/test/widgets/nipaplay_window_test.dart
+++ b/test/widgets/nipaplay_window_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
+
+void main() {
+  testWidgets('embedded window provides a Material ancestor', (tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: NipaplayWindowScaffold(
+          embedded: true,
+          child: InkWell(
+            onTap: () {},
+            child: const Text('Tap target'),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Tap target'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## 修改内容

- 补齐 iOS Erika `window-overlay` 在 Flutter 手机 UI 中的透明显示通路。
- Cupertino 手机主页面根据 Erika 上报的原生视频区域，对 `BackgroundWithBlur` 执行透明挖孔；该逻辑同时适用于横屏和竖屏。
- 为 `AdaptiveScaffold` / `IOS26Scaffold` 增加可选背景色透传，在 window-hosted 视频激活时避免默认 `CupertinoPageScaffold` 背景覆盖原生视频。
- 竖屏播放器区域不再无条件绘制黑色 `ColoredBox`；非 window-overlay 播放器仍保留原有黑色舞台背景。
- 为手机设置页和嵌入式窗口补充透明 `Material` 祖先，兼容 Flutter 3.44 对 Material 组件层级的检查。
- 增加 scaffold 背景透传和 Material 祖先的 widget 回归测试。

## 根因

Erika 的 iOS 视频画面由 window-hosted 原生 Metal 图层承载，位于 Flutter 内容下方。只要 Flutter 页面层级中仍存在不透明背景，即使原生图层已经正确解码和渲染，用户看到的也会是白屏或黑屏。

Nipa UI 重构后的播放页面存在多层遮挡：

1. 手机主页面的 `BackgroundWithBlur` 会覆盖整个 Flutter 页面，没有为 Erika 上报的视频 rect 留出透明区域。
2. iOS 26 在显示底部导航时，`AdaptiveScaffold` 会创建带默认浅色背景的 `CupertinoPageScaffold`。
3. 竖屏播放器舞台还额外包了一层固定黑色 `ColoredBox`。

因此横屏和竖屏最初都可能被 Flutter 背景遮挡。横屏全屏隐藏底部导航后会绕过第 2 层 scaffold，所以透明通路恢复后横屏先正常；竖屏仍保留底部导航和专用播放器舞台，需要继续移除第 2、3 层遮挡。

真机诊断确认 Erika 的 VideoToolbox 解码、CVPixelBuffer 零拷贝、Metal 渲染和 overlay frame 坐标均正常，所以问题不在 Erika 解码器或渲染器。

## 影响

- 修复 iOS 真机 Erika 在横屏和竖屏播放路径中被 Flutter UI 背景覆盖而出现的白屏/黑屏。
- 保持 Erika 现有 `window-overlay` 架构，不切换为嵌入式 `UiKitView`。
- 不修改 Erika 源码，也不影响 media-kit 播放路径。
- 普通页面和非 window-overlay 播放器继续使用原有主题及黑色播放器背景。

## 验证

- iPhone 14 Pro / iOS 26.5.2 真机：Erika 横屏、竖屏播放均正常。
- 真机诊断：硬件解码、零拷贝与 Metal 渲染持续增长，`importFailures=0`、`renderFailures=0`。
- `flutter test test/settings/adaptive_settings_widgets_test.dart test/widgets/nipaplay_window_test.dart`
- `flutter test packages/adaptive_platform_ui/test/adaptive_snackbar_pickers_test.dart --plain-name AdaptiveScaffold`
- 静态分析无 error/warning；仅保留主线已有的 info 级 deprecated/const 提示。