### PR TITLE
Fix:batch danmaku match optimize

### DIFF
--- a/lib/pages/shortcuts_settings_page.dart
+++ b/lib/pages/shortcuts_settings_page.dart
@@ -376,8 +376,7 @@ class _ShortcutsSettingsPageState extends State<ShortcutsSettingsPage> {
               _stopRecording();
             },
             child: const Text('取消',
-                locale: Locale("zh", "CN"),
-                style: TextStyle(color: Colors.white70)),
+                locale: Locale("zh", "CN")),
           ),
           HoverScaleTextButton(
             onPressed: () {
@@ -386,8 +385,7 @@ class _ShortcutsSettingsPageState extends State<ShortcutsSettingsPage> {
               _stopRecording();
             },
             child: const Text('替换',
-                locale: Locale("zh", "CN"),
-                style: TextStyle(color: Colors.white)),
+                locale: Locale("zh", "CN")),
           ),
         ],
       );

--- a/lib/settings/pages/developer_options_settings_content.dart
+++ b/lib/settings/pages/developer_options_settings_content.dart
@@ -634,7 +634,6 @@ XDG缓存目录: $cacheDir
           child: const Text(
             '取消',
             locale: Locale('zh-Hans', 'zh'),
-            style: TextStyle(color: Colors.white70),
           ),
           onPressed: () => Navigator.of(context).pop(false),
         ),
@@ -792,7 +791,6 @@ XDG_CACHE_HOME: $xdgCacheHome
           child: const Text(
             '取消',
             locale: Locale('zh-Hans', 'zh'),
-            style: TextStyle(color: Colors.white70),
           ),
           onPressed: () => Navigator.of(context).pop(false),
         ),

--- a/lib/settings/pages/plugin_settings_content.dart
+++ b/lib/settings/pages/plugin_settings_content.dart
@@ -414,7 +414,6 @@ class _PluginSettingsContentState extends State<PluginSettingsContent> {
         HoverScaleTextButton(
           child: Text(
             context.l10n.cancel,
-            style: const TextStyle(color: Colors.white70),
           ),
           onPressed: () => Navigator.of(context).pop(),
         ),

--- a/lib/themes/nipaplay/pages/settings/backup_restore_page.dart
+++ b/lib/themes/nipaplay/pages/settings/backup_restore_page.dart
@@ -274,11 +274,11 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
       actions: [
         HoverScaleTextButton(
           onPressed: () => Navigator.pop(context, false),
-          child: const Text('取消', style: TextStyle(color: Colors.white70)),
+          child: const Text('取消'),
         ),
         HoverScaleTextButton(
           onPressed: () => Navigator.pop(context, true),
-          child: const Text('确认', style: TextStyle(color: Colors.white)),
+          child: const Text('确认'),
         ),
       ],
     );
@@ -399,11 +399,11 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
         actions: [
           HoverScaleTextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: const Text('取消', style: TextStyle(color: Colors.white70)),
+            child: const Text('取消'),
           ),
           HoverScaleTextButton(
             onPressed: () => Navigator.pop(context, true),
-            child: const Text('确认', style: TextStyle(color: Colors.white)),
+            child: const Text('确认'),
           ),
         ],
       );
@@ -708,7 +708,7 @@ class _BackupSelectionDialogState extends State<_BackupSelectionDialog> {
                 HoverScaleTextButton(
                   onPressed: () => Navigator.of(context).pop(),
                   child:
-                      const Text('取消', style: TextStyle(color: Colors.white70)),
+                      const Text('取消'),
                 ),
                 const SizedBox(width: 16),
                 HoverScaleTextButton(
@@ -722,7 +722,7 @@ class _BackupSelectionDialogState extends State<_BackupSelectionDialog> {
                         }
                       : null,
                   child:
-                      const Text('确定', style: TextStyle(color: Colors.white)),
+                      const Text('确定'),
                 ),
               ],
             ),
@@ -1005,7 +1005,7 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
                 HoverScaleTextButton(
                   onPressed: () => Navigator.of(context).pop(),
                   child:
-                      const Text('取消', style: TextStyle(color: Colors.white70)),
+                      const Text('取消'),
                 ),
                 const SizedBox(width: 16),
                 HoverScaleTextButton(
@@ -1019,7 +1019,7 @@ class _RestoreSelectionDialogState extends State<_RestoreSelectionDialog> {
                         }
                       : null,
                   child:
-                      const Text('确定', style: TextStyle(color: Colors.white)),
+                      const Text('确定'),
                 ),
               ],
             ),

--- a/lib/themes/nipaplay/widgets/batch_danmaku_dialog.dart
+++ b/lib/themes/nipaplay/widgets/batch_danmaku_dialog.dart
@@ -19,18 +19,23 @@ class BatchDanmakuMatchDialog extends StatefulWidget {
   final List<String> filePaths;
   final String? initialSearchKeyword;
   final bool embedded;
+  /// 当用户切换"包括子文件夹"勾选项时调用，返回新的文件列表。
+  /// 为 null 时表示不支持切换（如远程媒体库）。
+  final Future<List<String>> Function(bool includeSubfolders)? onIncludeSubfoldersChanged;
 
   const BatchDanmakuMatchDialog({
     super.key,
     required this.filePaths,
     this.initialSearchKeyword,
     this.embedded = false,
+    this.onIncludeSubfoldersChanged,
   });
 
   static Future<Map<String, dynamic>?> show(
     BuildContext context, {
     required List<String> filePaths,
     String? initialSearchKeyword,
+    Future<List<String>> Function(bool includeSubfolders)? onIncludeSubfoldersChanged,
   }) {
     final enableAnimation = Provider.of<AppearanceSettingsProvider>(
       context,
@@ -45,6 +50,7 @@ class BatchDanmakuMatchDialog extends StatefulWidget {
         child: BatchDanmakuMatchDialog(
           filePaths: filePaths,
           initialSearchKeyword: initialSearchKeyword,
+          onIncludeSubfoldersChanged: onIncludeSubfoldersChanged,
           embedded: true,
         ),
       );
@@ -57,6 +63,7 @@ class BatchDanmakuMatchDialog extends StatefulWidget {
       child: BatchDanmakuMatchDialog(
         filePaths: filePaths,
         initialSearchKeyword: initialSearchKeyword,
+        onIncludeSubfoldersChanged: onIncludeSubfoldersChanged,
       ),
     );
   }
@@ -86,6 +93,8 @@ class _BatchDanmakuMatchDialogState extends State<BatchDanmakuMatchDialog>
   final Set<int> _selectedEpisodeIds = {};
 
   late final List<_FileItem> _files;
+  bool _includeSubfolders = false;
+  bool _isReloadingFiles = false;
 
   @override
   String get hotkeyDisableReason => 'batch_danmaku_dialog';
@@ -329,6 +338,35 @@ class _BatchDanmakuMatchDialogState extends State<BatchDanmakuMatchDialog>
         return a.displayName.compareTo(b.displayName);
       });
     });
+  }
+
+  Future<void> _onIncludeSubfoldersChanged(bool value) async {
+    if (widget.onIncludeSubfoldersChanged == null) return;
+    setState(() {
+      _includeSubfolders = value;
+      _isReloadingFiles = true;
+    });
+    try {
+      final newPaths = await widget.onIncludeSubfoldersChanged!(value);
+      if (!mounted) return;
+      setState(() {
+        _files
+          ..clear()
+          ..addAll(
+            newPaths.map(
+              (path) => _FileItem(path: path, displayName: _displayNameFromPath(path)),
+            ),
+          );
+        _sortFilesByEpisodeNumber();
+        _isReloadingFiles = false;
+      });
+      _autoSelectEpisodesToMatchFileCount();
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _isReloadingFiles = false;
+      });
+    }
   }
 
   void _confirmAndClose() {
@@ -751,21 +789,63 @@ class _BatchDanmakuMatchDialogState extends State<BatchDanmakuMatchDialog>
     final windowHeight = MediaQuery.of(context).size.height;
     final panelHeight = windowHeight * 0.4; // 占窗口高度的40%
 
+    // 构建"包括子文件夹"勾选项
+    Widget? subfolderCheckbox;
+    if (widget.onIncludeSubfoldersChanged != null) {
+      subfolderCheckbox = Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 18,
+            height: 18,
+            child: AdaptiveMediaCheckbox(
+              value: _includeSubfolders,
+              onChanged: _isReloadingFiles ? null : _onIncludeSubfoldersChanged,
+            ),
+          ),
+          SizedBox(width: 4),
+          GestureDetector(
+            onTap: _isReloadingFiles ? null : () => _onIncludeSubfoldersChanged(!_includeSubfolders),
+            child: Text(
+              '包括子文件夹',
+              style: TextStyle(color: _subTextColor, fontSize: 12),
+            ),
+          ),
+        ],
+      );
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _buildSectionTitle(
           '待匹配文件',
-          trailing: Text(
-            '已选 $_selectedFileCount/${_files.length}',
-            style: TextStyle(color: _subTextColor, fontSize: 12),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (subfolderCheckbox != null) ...[
+                subfolderCheckbox,
+                SizedBox(width: 12),
+              ],
+              Text(
+                '已选 $_selectedFileCount/${_files.length}',
+                style: TextStyle(color: _subTextColor, fontSize: 12),
+              ),
+            ],
           ),
         ),
         SizedBox(height: 8),
         Container(
           height: panelHeight,
           decoration: _panelDecoration(),
-          child: ReorderableListView.builder(
+          child: _isReloadingFiles
+              ? Center(
+                  child: AdaptiveMediaActivityIndicator(
+                    size: 18,
+                    color: _accentColor,
+                  ),
+                )
+              : ReorderableListView.builder(
             shrinkWrap: true,
             padding: const EdgeInsets.all(12),
             itemCount: _files.length,

--- a/lib/themes/nipaplay/widgets/library_management_tab.dart
+++ b/lib/themes/nipaplay/widgets/library_management_tab.dart
@@ -225,6 +225,8 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
   bool _isMountedDirectoryLoading = false;
   String? _mountedDirectoryError;
   int _mountedDirectoryLoadGeneration = 0;
+  /// 缓存子文件夹下一层的视频文件数量（仅本地目录，key 为文件夹路径）
+  final Map<String, int> _childVideoCountCache = {};
   bool get _isRemoteMode =>
       kIsWeb &&
       (widget.section == LibraryManagementSection.webdav ||
@@ -2836,34 +2838,44 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
     ScanService? scanService,
   ) {
     if (entry.isDirectory) {
-      return [
+      final actions = [
         UnifiedLibraryManagementAction(
           label: '打开文件夹',
           icon: LibraryManagementIcon.browse,
           onPressed: () => _openMountedDirectory(entry),
         ),
-        UnifiedLibraryManagementAction(
-          label: '自定义媒体信息',
-          icon: LibraryManagementIcon.info,
-          onPressed: () => unawaited(
-            _showMountedCustomMediaInfo(location, entry),
-          ),
-        ),
-        UnifiedLibraryManagementAction(
-          label: '批量匹配弹幕',
-          icon: LibraryManagementIcon.subtitles,
-          onPressed: () => unawaited(
-            _showMountedBatchMatch(location, entry),
-          ),
-        ),
-        UnifiedLibraryManagementAction(
-          label: location.type == _MountedLibraryType.local ? '扫描文件夹' : '刮削文件夹',
-          icon: LibraryManagementIcon.scan,
-          onPressed: () => unawaited(
-            _scanMountedDirectory(location, entry, scanService),
-          ),
-        ),
       ];
+
+      // 仅当下一层有2+视频文件时才显示"自定义媒体信息"和"批量匹配弹幕"
+      final childVideoCount = _countChildVideoFiles(entry);
+      if (childVideoCount >= 2) {
+        actions.addAll([
+          UnifiedLibraryManagementAction(
+            label: '自定义媒体信息',
+            icon: LibraryManagementIcon.info,
+            onPressed: () => unawaited(
+              _showMountedCustomMediaInfo(location, entry),
+            ),
+          ),
+          UnifiedLibraryManagementAction(
+            label: '批量匹配弹幕',
+            icon: LibraryManagementIcon.subtitles,
+            onPressed: () => unawaited(
+              _showMountedBatchMatch(location, entry),
+            ),
+          ),
+        ]);
+      }
+
+      actions.add(UnifiedLibraryManagementAction(
+        label: location.type == _MountedLibraryType.local ? '扫描文件夹' : '刮削文件夹',
+        icon: LibraryManagementIcon.scan,
+        onPressed: () => unawaited(
+          _scanMountedDirectory(location, entry, scanService),
+        ),
+      ));
+
+      return actions;
     }
 
     return [
@@ -2882,6 +2894,80 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
         ),
       ),
     ];
+  }
+
+  /// 统计文件夹下一层（不含子文件夹）的视频文件数量。
+  int _countChildVideoFiles(_MountedLibraryEntry dirEntry) {
+    return _childVideoCountCache[dirEntry.path] ?? 0;
+  }
+
+  /// 统计子文件夹下一层的视频文件数量并填充缓存（本地同步，远程异步）。
+  Future<void> _fillChildVideoCounts(
+      _MountedLibraryLocation location, List<_MountedLibraryEntry> entries) async {
+    final dirEntries = entries.where((e) => e.isDirectory).toList();
+    if (dirEntries.isEmpty) return;
+
+    switch (location.type) {
+      case _MountedLibraryType.local:
+        // 本地目录同步扫描
+        for (final dirEntry in dirEntries) {
+          try {
+            final directory = io.Directory(dirEntry.path);
+            if (!directory.existsSync()) continue;
+            int count = 0;
+            for (final entity
+                in directory.listSync(recursive: false, followLinks: false)) {
+              if (entity is io.File) {
+                final ext = p.extension(entity.path).toLowerCase();
+                if (_batchMatchVideoExtensions.contains(ext)) {
+                  count++;
+                }
+              }
+            }
+            _childVideoCountCache[dirEntry.path] = count;
+          } catch (_) {
+            _childVideoCountCache[dirEntry.path] = 0;
+          }
+        }
+      case _MountedLibraryType.webdav:
+        // WebDAV 异步扫描（并行）
+        final results = await Future.wait(
+          dirEntries.map((dirEntry) async {
+            try {
+              final files = await WebDAVService.instance
+                  .listDirectory(location.webdavConnection!, dirEntry.path);
+              final count = files
+                  .where((f) => !f.isDirectory && WebDAVService.instance.isVideoFile(f.name))
+                  .length;
+              return (dirEntry.path, count);
+            } catch (_) {
+              return (dirEntry.path, 0);
+            }
+          }),
+        );
+        for (final (path, count) in results) {
+          _childVideoCountCache[path] = count;
+        }
+      case _MountedLibraryType.smb:
+        // SMB 异步扫描（并行）
+        final results = await Future.wait(
+          dirEntries.map((dirEntry) async {
+            try {
+              final files = await SMBService.instance
+                  .listDirectory(location.smbConnection!, dirEntry.path);
+              final count = files
+                  .where((f) => !f.isDirectory && SMBService.instance.isVideoFile(f.name))
+                  .length;
+              return (dirEntry.path, count);
+            } catch (_) {
+              return (dirEntry.path, 0);
+            }
+          }),
+        );
+        for (final (path, count) in results) {
+          _childVideoCountCache[path] = count;
+        }
+    }
   }
 
   void _mountLibrary(_MountedLibraryLocation location) {
@@ -2976,6 +3062,15 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
         final comparison = a.name.toLowerCase().compareTo(b.name.toLowerCase());
         return _sortOption == 1 ? -comparison : comparison;
       });
+      if (!mounted ||
+          generation != _mountedDirectoryLoadGeneration ||
+          _mountedLocation != location ||
+          _currentMountedPath != path) {
+        return;
+      }
+      // 统计子文件夹下一层的视频数量
+      await _fillChildVideoCounts(location, entries);
+
       if (!mounted ||
           generation != _mountedDirectoryLoadGeneration ||
           _mountedLocation != location ||
@@ -3081,27 +3176,36 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
     _MountedLibraryLocation location,
     _MountedLibraryEntry entry,
   ) async {
-    final filePaths = await _collectMountedVideoPaths(location, entry.path);
+    // 默认只收集下一级目录的视频
+    final filePaths = await _collectMountedVideoPaths(
+      location, entry.path, recursive: false,
+    );
     if (!mounted) return;
     await _showBatchDanmakuMatchDialog(
       entry.path,
       filePaths,
       initialSearchKeyword: entry.name,
       onSuccessRefresh: () => setState(() {}),
+      onIncludeSubfoldersChanged: (includeSubfolders) async {
+        return _collectMountedVideoPaths(
+          location, entry.path, recursive: includeSubfolders,
+        );
+      },
     );
   }
 
   Future<List<String>> _collectMountedVideoPaths(
     _MountedLibraryLocation location,
-    String path,
-  ) async {
+    String path, {
+    bool recursive = true,
+  }) async {
     switch (location.type) {
       case _MountedLibraryType.local:
         final result = <String>[];
         final directory = io.Directory(path);
         if (!await directory.exists()) return result;
         await for (final entity
-            in directory.list(recursive: true, followLinks: false)) {
+            in directory.list(recursive: recursive, followLinks: false)) {
           if (entity is io.File &&
               _batchMatchVideoExtensions
                   .contains(p.extension(entity.path).toLowerCase())) {
@@ -3113,6 +3217,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
         final files = await _getWebDAVVideoFiles(
           location.webdavConnection!,
           path,
+          recursive: recursive,
         );
         return files
             .map((file) => WebDAVService.instance.getFileUrl(
@@ -3121,7 +3226,10 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
                 ))
             .toList();
       case _MountedLibraryType.smb:
-        final files = await _getSMBVideoFiles(location.smbConnection!, path);
+        final files = await _getSMBVideoFiles(
+          location.smbConnection!, path,
+          recursive: recursive,
+        );
         return files
             .map((file) => SMBProxyService.instance.buildStreamUrl(
                   location.smbConnection!,
@@ -4180,6 +4288,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
     List<String> filePaths, {
     String? initialSearchKeyword,
     void Function()? onSuccessRefresh,
+    Future<List<String>> Function(bool includeSubfolders)? onIncludeSubfoldersChanged,
   }) async {
     if (filePaths.isEmpty) {
       BlurSnackBar.show(context, '未找到可匹配的视频文件');
@@ -4190,6 +4299,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
       context,
       filePaths: filePaths,
       initialSearchKeyword: initialSearchKeyword ?? p.basename(folderPath),
+      onIncludeSubfoldersChanged: onIncludeSubfoldersChanged,
     );
 
     if (!mounted || result == null) return;
@@ -5877,9 +5987,9 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
     }
   }
 
-  // 递归获取WebDAV文件夹中的视频文件
+  // 获取WebDAV文件夹中的视频文件
   Future<List<WebDAVFile>> _getWebDAVVideoFiles(
-      WebDAVConnection connection, String folderPath) async {
+      WebDAVConnection connection, String folderPath, {bool recursive = true}) async {
     final List<WebDAVFile> videoFiles = [];
 
     try {
@@ -5889,8 +5999,10 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
       for (final file in files) {
         if (file.isDirectory) {
           // 递归获取子文件夹中的视频文件
-          final subFiles = await _getWebDAVVideoFiles(connection, file.path);
-          videoFiles.addAll(subFiles);
+          if (recursive) {
+            final subFiles = await _getWebDAVVideoFiles(connection, file.path, recursive: true);
+            videoFiles.addAll(subFiles);
+          }
         } else {
           // 检查是否为视频文件
           if (WebDAVService.instance.isVideoFile(file.name)) {
@@ -6093,15 +6205,17 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
   }
 
   Future<List<SMBFileEntry>> _getSMBVideoFiles(
-      SMBConnection connection, String folderPath) async {
+      SMBConnection connection, String folderPath, {bool recursive = true}) async {
     final List<SMBFileEntry> videoFiles = [];
     try {
       final files =
           await SMBService.instance.listDirectory(connection, folderPath);
       for (final file in files) {
         if (file.isDirectory) {
-          final nested = await _getSMBVideoFiles(connection, file.path);
-          videoFiles.addAll(nested);
+          if (recursive) {
+            final nested = await _getSMBVideoFiles(connection, file.path, recursive: true);
+            videoFiles.addAll(nested);
+          }
         } else if (SMBService.instance.isVideoFile(file.name)) {
           videoFiles.add(file);
         }

--- a/lib/themes/nipaplay/widgets/library_management_tab.dart
+++ b/lib/themes/nipaplay/widgets/library_management_tab.dart
@@ -595,8 +595,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
           actions: <Widget>[
             HoverScaleTextButton(
               child: const Text("知道了",
-                  locale: Locale("zh-Hans", "zh"),
-                  style: TextStyle(color: Colors.white70)),
+                  locale: Locale("zh-Hans", "zh")),
               onPressed: () {
                 Navigator.of(context).pop();
               },
@@ -726,8 +725,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
       actions: <Widget>[
         HoverScaleTextButton(
           child: const Text('取消',
-              locale: Locale("zh-Hans", "zh"),
-              style: TextStyle(color: Colors.white70)),
+              locale: Locale("zh-Hans", "zh")),
           onPressed: () {
             Navigator.of(context).pop(false);
           },
@@ -1389,8 +1387,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
           HoverScaleTextButton(
             onPressed: () => Navigator.of(context).pop(),
             child: const Text('取消',
-                locale: Locale("zh-Hans", "zh"),
-                style: TextStyle(color: Colors.white54)),
+                locale: Locale("zh-Hans", "zh")),
           ),
         ],
       ),
@@ -1554,8 +1551,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
       actions: <Widget>[
         HoverScaleTextButton(
           child: const Text('取消',
-              locale: Locale("zh-Hans", "zh"),
-              style: TextStyle(color: Colors.white70)),
+              locale: Locale("zh-Hans", "zh")),
           onPressed: () {
             Navigator.of(context).pop(false);
           },
@@ -1625,8 +1621,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
           actions: <Widget>[
             HoverScaleTextButton(
               child: const Text('关闭',
-                  locale: Locale("zh-Hans", "zh"),
-                  style: TextStyle(color: Colors.white70)),
+                  locale: Locale("zh-Hans", "zh")),
               onPressed: () {
                 Navigator.of(context).pop();
               },
@@ -4206,8 +4201,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
       actions: <Widget>[
         HoverScaleTextButton(
           child: const Text('取消',
-              locale: Locale("zh-Hans", "zh"),
-              style: TextStyle(color: Colors.white70)),
+              locale: Locale("zh-Hans", "zh")),
           onPressed: () => Navigator.of(context).pop(false),
         ),
         HoverScaleTextButton(
@@ -4237,8 +4231,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
       actions: <Widget>[
         HoverScaleTextButton(
           child: const Text('取消',
-              locale: Locale("zh-Hans", "zh"),
-              style: TextStyle(color: Colors.white70)),
+              locale: Locale("zh-Hans", "zh")),
           onPressed: () => Navigator.of(context).pop(false),
         ),
         HoverScaleTextButton(
@@ -4703,8 +4696,7 @@ class _LibraryManagementTabState extends State<LibraryManagementTab> {
       actions: <Widget>[
         HoverScaleTextButton(
           child: const Text('取消',
-              locale: Locale("zh-Hans", "zh"),
-              style: TextStyle(color: Colors.white70)),
+              locale: Locale("zh-Hans", "zh")),
           onPressed: () {
             Navigator.of(context).pop(false);
           },

--- a/lib/utils/video_player_state/video_player_state_danmaku.dart
+++ b/lib/utils/video_player_state/video_player_state_danmaku.dart
@@ -540,6 +540,18 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
       };
       _danmakuTrackEnabled[finalTrackName] = true;
 
+      // 触发弹幕加载完成事件，通知插件（在合并之前，以便插件可以修改数据）
+      if (!canContinue()) return;
+      _notifyPluginDanmakuLoaded(parsedDanmaku);
+
+      // 检查插件是否修改了弹幕数据
+      final pluginModified = _pluginService?.pendingDanmakuData;
+      if (pluginModified != null && pluginModified.isNotEmpty) {
+        _danmakuTracks[finalTrackName]!['danmakuList'] = pluginModified;
+        _danmakuTracks[finalTrackName]!['count'] = pluginModified.length;
+        _pluginService?.updateDanmakuData(null);
+      }
+
       // 重新计算合并后的弹幕列表
       if (!canContinue()) return;
       _updateMergedDanmakuList();


### PR DESCRIPTION
## Summary

- 规范化了批量匹配弹幕和自定义媒体按钮的出现机制：仅当下级目录中有视频文件时显示
- 批量匹配弹幕菜单默认不包含子文件夹内的视频，如有需求可勾选“包括子文件夹”勾选项
- 扩展插件系统中 danmakuloaded 事件的作用域：对本地载入的弹幕也生效
- 修复了多处存在的日间模式下弹窗的“确定”和“取消”按钮文字均为白色不可见的问题
