### PR TITLE
feat: 增加 Windows HTTP 代理设置

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -32,6 +32,9 @@ class SettingsKeys {
   /// 自定义播放器请求视频的 User-Agent（空字符串 = 用内核默认 UA）。
   static const String customPlayerUA = 'custom_player_ua';
 
+  /// HTTP forward proxy endpoint shared by Dart requests and native players.
+  static const String playerHttpProxy = 'player_http_proxy';
+
   static const String autoCheckUpdatesInBackground =
       'auto_check_updates_in_background';
 

--- a/lib/player_abstraction/mdk_player_adapter_io.dart
+++ b/lib/player_abstraction/mdk_player_adapter_io.dart
@@ -7,6 +7,16 @@ import './player_data_models.dart';
 import 'dart:async';
 import 'package:nipaplay/utils/subtitle_font_loader.dart';
 
+@visibleForTesting
+void applyMdkHttpProxyProperties(
+  void Function(String key, String value) setter,
+  String httpProxy,
+) {
+  if (httpProxy.isEmpty) return;
+  setter('avformat.http_proxy', httpProxy);
+  setter('avio.http_proxy', httpProxy);
+}
+
 // Enum Converters
 PlayerPlaybackState _toPlayerPlaybackState(mdk.PlaybackState state) {
   if (state == mdk.PlaybackState.stopped) return PlayerPlaybackState.stopped;
@@ -56,7 +66,8 @@ mdk.MediaType _fromPlayerMediaType(PlayerMediaType type) {
   }
 }
 
-PlayerMediaInfo _toPlayerMediaInfo(mdk.MediaInfo mdkInfo, {int internalAudioTrackCount = 0}) {
+PlayerMediaInfo _toPlayerMediaInfo(mdk.MediaInfo mdkInfo,
+    {int internalAudioTrackCount = 0}) {
   return PlayerMediaInfo(
     duration: mdkInfo.duration,
     video: mdkInfo.video?.map((v) {
@@ -161,7 +172,8 @@ PlayerMediaInfo _toPlayerMediaInfo(mdk.MediaInfo mdkInfo, {int internalAudioTrac
         language: language ?? 'unknown',
         metadata: metadata,
         rawRepresentation: rawRepresentation,
-        isExternal: internalAudioTrackCount > 0 && trackIndex >= internalAudioTrackCount,
+        isExternal: internalAudioTrackCount > 0 &&
+            trackIndex >= internalAudioTrackCount,
       );
     }).toList(),
   );
@@ -176,8 +188,10 @@ class MdkPlayerAdapter implements AbstractPlayer {
   String? _activeVideoDecoder;
   String? _activeAudioDecoder;
   int _internalAudioTrackCount = 0; // 内部音频轨道数，用于区分外挂MKA轨道
+  final String _httpProxy;
 
-  MdkPlayerAdapter() {
+  MdkPlayerAdapter({String? httpProxy})
+      : _httpProxy = (httpProxy ?? '').trim() {
     _mdkPlayer = mdk.Player();
     _attachMdkEventListeners();
     _applyInitialSettings();
@@ -215,6 +229,7 @@ class MdkPlayerAdapter implements AbstractPlayer {
 
   void _applyInitialSettings() {
     try {
+      applyMdkHttpProxyProperties(_setStickyProperty, _httpProxy);
       _setStickyProperty('auto_load', '0');
       _setStickyProperty('subtitle', '1');
       // 重新应用播放速度设置
@@ -346,7 +361,8 @@ class MdkPlayerAdapter implements AbstractPlayer {
   }
 
   @override
-  PlayerMediaInfo get mediaInfo => _toPlayerMediaInfo(_mdkPlayer.mediaInfo, internalAudioTrackCount: _internalAudioTrackCount);
+  PlayerMediaInfo get mediaInfo => _toPlayerMediaInfo(_mdkPlayer.mediaInfo,
+      internalAudioTrackCount: _internalAudioTrackCount);
 
   @override
   List<int> get activeSubtitleTracks => _mdkPlayer.activeSubtitleTracks;

--- a/lib/player_abstraction/mdk_player_adapter_unsupported.dart
+++ b/lib/player_abstraction/mdk_player_adapter_unsupported.dart
@@ -5,7 +5,7 @@ import './player_data_models.dart';
 import 'dart:async';
 
 class MdkPlayerAdapter implements AbstractPlayer {
-  MdkPlayerAdapter();
+  MdkPlayerAdapter({String? httpProxy});
 
   @override
   double get volume => 1.0;

--- a/lib/player_abstraction/media_kit_player_adapter.dart
+++ b/lib/player_abstraction/media_kit_player_adapter.dart
@@ -14,12 +14,23 @@ import './abstract_player.dart';
 import './player_enums.dart';
 import './player_data_models.dart';
 
+@visibleForTesting
+void applyMediaKitNetworkOptions(
+  void Function(String key, String value) setter, {
+  required String userAgent,
+  String httpProxy = '',
+}) {
+  if (userAgent.isNotEmpty) setter('user-agent', userAgent);
+  if (httpProxy.isNotEmpty) setter('http-proxy', httpProxy);
+}
+
 /// MediaKit播放器适配器
 class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
   static bool _disableMpvLogs = false;
   static int? _cachedMacosMajor;
   static bool _macOSNativeVideoPreference = false;
   final String? _androidAudioOutput;
+  final String _httpProxy;
   static const int _defaultBufferSize = 32 * 1024 * 1024;
   static const String _hdrValidationFlag = 'NIPAPLAY_MACOS_HDR_VALIDATE';
   static const String _windowsHdrValidationFlag =
@@ -284,11 +295,15 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
   Media? _pendingPlatformMedia;
   bool _platformVideoSurfaceAvailable = true;
 
-  MediaKitPlayerAdapter({int? bufferSize, String? androidAudioOutput})
-      : _mpvDiagnosticsEnabled = _shouldEnableMpvDiagnostics(),
+  MediaKitPlayerAdapter({
+    int? bufferSize,
+    String? androidAudioOutput,
+    String? httpProxy,
+  })  : _mpvDiagnosticsEnabled = _shouldEnableMpvDiagnostics(),
         _enableHardwareAcceleration = !_shouldDisableHardwareAcceleration(),
         _prefersPlatformVideoSurface = _shouldUsePlatformNativeVideoSurface(),
         _androidAudioOutput = androidAudioOutput,
+        _httpProxy = (httpProxy ?? '').trim(),
         _player = Player(
           configuration: PlayerConfiguration(
             libass: true,
@@ -308,6 +323,11 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
     _applyPlatformHdrOutputOptions();
     _applyMpvDiagnosticOptions();
     _applyAndroidAudioOutput();
+    applyMediaKitNetworkOptions(
+      _setMpvPropertyOption,
+      userAgent: '',
+      httpProxy: _httpProxy,
+    );
     _bootstrapPlatformVideoSurface();
     if (!_prefersPlatformVideoSurface) {
       _controller = VideoController(

--- a/lib/player_abstraction/player_factory.dart
+++ b/lib/player_abstraction/player_factory.dart
@@ -7,6 +7,7 @@ import './player_data_models.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/foundation.dart'; // 用于 debugPrint
 import 'package:nipaplay/constants/settings_keys.dart';
+import 'package:nipaplay/services/app_http_proxy.dart';
 import 'package:nipaplay/utils/system_resource_monitor.dart'; // 导入系统资源监控器
 import 'dart:async'; // 导入dart:async库
 
@@ -18,6 +19,10 @@ enum PlayerKernelType {
   mediaKit, // 添加 media_kit 内核类型
   erika,
   // otherPlayer,
+}
+
+bool supportsPlayerHttpProxy(PlayerKernelType type) {
+  return type == PlayerKernelType.mdk || type == PlayerKernelType.mediaKit;
 }
 
 class PlayerFactory {
@@ -37,6 +42,7 @@ class PlayerFactory {
   static PlayerErikaAndroidOutputMode _cachedErikaAndroidOutputMode =
       PlayerErikaAndroidOutputMode.sdr;
   static String _cachedCustomPlayerUA = ''; // 自定义播放器 UA，空=用内核默认
+  static String _cachedHttpProxy = '';
   static String? _oneTimeUA; // 一次性 UA（仅下一次播放有效，不持久化，用后即清）
   static bool _hasLoadedSettings = false;
 
@@ -94,6 +100,9 @@ class PlayerFactory {
           _decodeErikaAndroidOutputMode(erikaAndroidOutputModeIndex);
       _cachedCustomPlayerUA =
           prefs.getString(SettingsKeys.customPlayerUA) ?? '';
+      _cachedHttpProxy =
+          (prefs.getString(SettingsKeys.playerHttpProxy) ?? '').trim();
+      AppHttpProxy.set(_cachedHttpProxy);
 
       _hasLoadedSettings = true;
     } catch (e) {
@@ -104,6 +113,8 @@ class PlayerFactory {
       _cachedAndroidAudioOutput = 'opensles';
       _cachedErikaAndroidOutputMode = PlayerErikaAndroidOutputMode.sdr;
       _cachedCustomPlayerUA = '';
+      _cachedHttpProxy = '';
+      AppHttpProxy.clear();
       MediaKitPlayerAdapter.setMacOSNativeVideoPreference(false);
       _hasLoadedSettings = true;
     }
@@ -119,6 +130,8 @@ class PlayerFactory {
       _cachedAndroidAudioOutput = 'opensles';
       _cachedErikaAndroidOutputMode = PlayerErikaAndroidOutputMode.sdr;
       _cachedCustomPlayerUA = '';
+      _cachedHttpProxy = '';
+      AppHttpProxy.clear();
       MediaKitPlayerAdapter.setMacOSNativeVideoPreference(false);
       _hasLoadedSettings = true;
 
@@ -151,6 +164,9 @@ class PlayerFactory {
             _decodeErikaAndroidOutputMode(erikaAndroidOutputModeIndex);
         _cachedCustomPlayerUA =
             prefs.getString(SettingsKeys.customPlayerUA) ?? '';
+        _cachedHttpProxy =
+            (prefs.getString(SettingsKeys.playerHttpProxy) ?? '').trim();
+        AppHttpProxy.set(_cachedHttpProxy);
       });
 
       debugPrint('[PlayerFactory] 同步设置临时默认值: MDK');
@@ -316,6 +332,24 @@ class PlayerFactory {
     }
   }
 
+  static String getHttpProxy() {
+    if (!_hasLoadedSettings) _loadSettingsSync();
+    return _cachedHttpProxy;
+  }
+
+  static Future<void> saveHttpProxy(String proxy) async {
+    final resolved = AppHttpProxy.validate(proxy)?.toString() ?? '';
+    final changed = resolved != _cachedHttpProxy;
+    final preferences = await SharedPreferences.getInstance();
+    await preferences.setString(SettingsKeys.playerHttpProxy, resolved);
+    _cachedHttpProxy = resolved;
+    AppHttpProxy.set(resolved);
+    final kernelType = _cachedKernelType ?? PlayerKernelType.mdk;
+    if (changed && !kIsWeb && supportsPlayerHttpProxy(kernelType)) {
+      _kernelChangeController.add(kernelType);
+    }
+  }
+
   // 创建播放器实例
   AbstractPlayer createPlayer({PlayerKernelType? kernelType}) {
     // 如果是Web平台，强制使用VideoPlayer
@@ -330,7 +364,7 @@ class PlayerFactory {
     switch (kernelType) {
       case PlayerKernelType.mdk:
         debugPrint('[PlayerFactory] 创建 MDK 播放器');
-        return MdkPlayerAdapter();
+        return MdkPlayerAdapter(httpProxy: getHttpProxy());
       case PlayerKernelType.videoPlayer:
         debugPrint('[PlayerFactory] 创建 Video Player 播放器');
         return VideoPlayerAdapter();
@@ -338,6 +372,7 @@ class PlayerFactory {
         return MediaKitPlayerAdapter(
           bufferSize: getPrecacheBufferSizeBytes(),
           androidAudioOutput: getAndroidAudioOutput(),
+          httpProxy: getHttpProxy(),
         );
       case PlayerKernelType.erika:
         debugPrint('[PlayerFactory] 创建 Erika 播放器');

--- a/lib/services/app_http_proxy.dart
+++ b/lib/services/app_http_proxy.dart
@@ -1,0 +1,38 @@
+class AppHttpProxy {
+  AppHttpProxy._();
+
+  static String _endpoint = '';
+
+  static Uri? validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return null;
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null ||
+        uri.scheme != 'http' ||
+        uri.host.isEmpty ||
+        uri.userInfo.isNotEmpty ||
+        (uri.path.isNotEmpty && uri.path != '/') ||
+        uri.hasQuery ||
+        uri.hasFragment) {
+      throw const FormatException('Unsupported HTTP proxy endpoint');
+    }
+    return uri;
+  }
+
+  static void set(String value) {
+    _endpoint = validate(value)?.toString() ?? '';
+  }
+
+  static void clear() => _endpoint = '';
+
+  static String findProxy(
+    Uri target,
+    String Function(Uri target) systemProxy,
+  ) {
+    final endpoint = validate(_endpoint);
+    if (endpoint == null) return systemProxy(target);
+    final port = endpoint.hasPort ? endpoint.port : 80;
+    return 'PROXY ${endpoint.host}:$port';
+  }
+}

--- a/lib/services/http_overrides_io.dart
+++ b/lib/services/http_overrides_io.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'certificate_trust_service.dart';
+import 'app_http_proxy.dart';
 import 'system_proxy_service.dart';
 
 /// 在非 Web 平台，为 Dart IO 网络栈设置证书例外规则
@@ -13,7 +14,10 @@ class NipaHttpOverrides extends HttpOverrides {
 
     // 仅在真正的 IO 环境下设置回调
     if (!kIsWeb) {
-      client.findProxy = SystemProxyService.instance.findProxy;
+      client.findProxy = (uri) => AppHttpProxy.findProxy(
+            uri,
+            SystemProxyService.instance.findProxy,
+          );
       client.badCertificateCallback =
           (X509Certificate cert, String host, int port) {
         try {

--- a/lib/settings/pages/network_settings_content.dart
+++ b/lib/settings/pages/network_settings_content.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/cupertino.dart' as cupertino;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/l10n/l10n.dart';
 import 'package:nipaplay/player_abstraction/player_factory.dart';
+import 'package:nipaplay/services/app_http_proxy.dart';
 import 'package:nipaplay/services/server_connectivity_service.dart';
 import 'package:nipaplay/settings/adaptive_settings_widgets.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_adaptive_platform_ui.dart';
@@ -11,6 +13,16 @@ import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:nipaplay/utils/network_settings.dart';
+
+bool supportsUnifiedHttpProxySetting({
+  required bool isWeb,
+  required TargetPlatform platform,
+}) {
+  if (isWeb) return false;
+  return platform == TargetPlatform.windows ||
+      platform == TargetPlatform.macOS ||
+      platform == TargetPlatform.linux;
+}
 
 class NetworkSettingsContent extends StatefulWidget {
   const NetworkSettingsContent({super.key});
@@ -150,6 +162,19 @@ class _NetworkSettingsContentState extends State<NetworkSettingsContent> {
               enabled: _persistentUAHasValue(),
               onTap: _resetPersistentUA,
             ),
+            if (_showHttpProxySetting)
+              AdaptiveSettingsTile<void>.card(
+                title: _text(
+                  context,
+                  '媒体服务器与播放器 HTTP 代理',
+                  '媒體伺服器與播放器 HTTP 代理',
+                  'Media Server & Player HTTP Proxy',
+                ),
+                subtitle: _httpProxySubtitle(context),
+                icon: Ionicons.git_network_outline,
+                phoneIcon: cupertino.CupertinoIcons.arrow_right_arrow_left,
+                onTap: _editHttpProxy,
+              ),
           ],
         ),
         const SizedBox(height: 16),
@@ -406,6 +431,33 @@ class _NetworkSettingsContentState extends State<NetworkSettingsContent> {
 
   bool _persistentUAHasValue() => PlayerFactory.getCustomPlayerUA().isNotEmpty;
 
+  bool get _showHttpProxySetting {
+    return supportsUnifiedHttpProxySetting(
+      isWeb: kIsWeb,
+      platform: defaultTargetPlatform,
+    );
+  }
+
+  String _httpProxySubtitle(BuildContext context) {
+    final proxy = PlayerFactory.getHttpProxy();
+    final supportedKernels = _text(
+      context,
+      '播放器代理仅支持 MDK/MediaKit 内核。',
+      '播放器代理僅支援 MDK/MediaKit 核心。',
+      'Player proxy is supported by MDK/MediaKit only.',
+    );
+    if (proxy.isEmpty) {
+      final disabled = _text(
+        context,
+        '未启用。仅支持 http:// 代理端点，可承载 HTTP/HTTPS 目标流量。',
+        '未啟用。僅支援 http:// 代理端點，可承載 HTTP/HTTPS 目標流量。',
+        'Disabled. Only http:// proxy endpoints are supported for HTTP/HTTPS targets.',
+      );
+      return '$disabled $supportedKernels';
+    }
+    return '$proxy\n$supportedKernels';
+  }
+
   Future<void> _editPersistentUA() async {
     final input = await _showUserAgentInputDialog();
     if (!mounted || input == null) return;
@@ -427,6 +479,90 @@ class _NetworkSettingsContentState extends State<NetworkSettingsContent> {
       context,
       message: _text(context, '已恢复默认 UA', '已恢復預設 UA', 'Default UA restored.'),
       type: AdaptiveSnackBarType.success,
+    );
+  }
+
+  Future<void> _editHttpProxy() async {
+    final input = await _showHttpProxyInputDialog();
+    if (!mounted || input == null) return;
+    try {
+      AppHttpProxy.validate(input);
+    } on FormatException {
+      AdaptiveSnackBar.show(
+        context,
+        message: _text(
+          context,
+          '请输入有效的 http:// 代理地址；不支持 HTTPS 代理端点或 SOCKS。',
+          '請輸入有效的 http:// 代理位址；不支援 HTTPS 代理端點或 SOCKS。',
+          'Enter a valid http:// proxy endpoint. HTTPS proxy endpoints and SOCKS are unsupported.',
+        ),
+        type: AdaptiveSnackBarType.error,
+      );
+      return;
+    }
+
+    await PlayerFactory.saveHttpProxy(input);
+    if (!mounted) return;
+    setState(() {});
+    AdaptiveSnackBar.show(
+      context,
+      message: input.isEmpty
+          ? _text(context, 'HTTP 代理已关闭', 'HTTP 代理已關閉', 'HTTP proxy disabled.')
+          : _text(context, 'HTTP 代理已保存并立即生效', 'HTTP 代理已儲存並立即生效',
+              'HTTP proxy saved and applied.'),
+      type: AdaptiveSnackBarType.success,
+    );
+  }
+
+  Future<String?> _showHttpProxyInputDialog() async {
+    final colorScheme = Theme.of(context).colorScheme;
+    var inputValue = PlayerFactory.getHttpProxy();
+    return BlurDialog.show<String>(
+      context: context,
+      title: _text(
+        context,
+        'HTTP 代理',
+        'HTTP 代理',
+        'HTTP Proxy',
+      ),
+      contentWidget: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            _text(
+              context,
+              '供 Emby/Jellyfin 请求与播放器网络流共用。留空关闭。',
+              '供 Emby/Jellyfin 請求與播放器網路串流共用。留空關閉。',
+              'Shared by Emby/Jellyfin requests and player network streams. Leave empty to disable.',
+            ),
+            style: TextStyle(
+              color: colorScheme.onSurface.withValues(alpha: 0.72),
+              fontSize: 13,
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            initialValue: inputValue,
+            onChanged: (value) => inputValue = value,
+            keyboardType: TextInputType.url,
+            autocorrect: false,
+            enableSuggestions: false,
+            decoration: const InputDecoration(
+              hintText: 'http://127.0.0.1:8000',
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        HoverScaleTextButton(
+          text: context.l10n.cancel,
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        HoverScaleTextButton(
+          text: context.l10n.save,
+          onPressed: () => Navigator.of(context).pop(inputValue.trim()),
+        ),
+      ],
     );
   }
 

--- a/test/app_http_proxy_test.dart
+++ b/test/app_http_proxy_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/services/app_http_proxy.dart';
+
+void main() {
+  tearDown(AppHttpProxy.clear);
+
+  test('manual HTTP proxy overrides the system proxy for all target schemes',
+      () {
+    AppHttpProxy.set('  http://127.0.0.1:8000  ');
+
+    expect(
+      AppHttpProxy.findProxy(
+        Uri.parse('http://media.example/video'),
+        (_) => 'DIRECT',
+      ),
+      'PROXY 127.0.0.1:8000',
+    );
+    expect(
+      AppHttpProxy.findProxy(
+        Uri.parse('https://media.example/video'),
+        (_) => 'DIRECT',
+      ),
+      'PROXY 127.0.0.1:8000',
+    );
+  });
+
+  test('empty manual proxy preserves system proxy behavior', () {
+    expect(
+      AppHttpProxy.findProxy(
+        Uri.parse('https://media.example/video'),
+        (_) => 'PROXY system.test:9000;DIRECT',
+      ),
+      'PROXY system.test:9000;DIRECT',
+    );
+  });
+
+  test('only plain HTTP forward proxy endpoints are accepted', () {
+    expect(AppHttpProxy.validate(''), isNull);
+    expect(
+      AppHttpProxy.validate('http://proxy.example:8080'),
+      Uri.parse('http://proxy.example:8080'),
+    );
+
+    for (final invalid in <String>[
+      'https://proxy.example:443',
+      'socks5://proxy.example:1080',
+      'http://proxy.example:8080/path',
+      'http://proxy.example:8080?mode=proxy',
+      'http://proxy.example:8080#fragment',
+      'http://',
+    ]) {
+      expect(
+        () => AppHttpProxy.validate(invalid),
+        throwsA(isA<FormatException>()),
+        reason: invalid,
+      );
+    }
+  });
+}

--- a/test/player_http_proxy_test.dart
+++ b/test/player_http_proxy_test.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
+import 'package:nipaplay/player_abstraction/mdk_player_adapter_io.dart';
+import 'package:nipaplay/player_abstraction/media_kit_player_adapter.dart';
+import 'package:nipaplay/player_abstraction/player_factory.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('only proxy-capable player kernels are rebuilt', () {
+    expect(supportsPlayerHttpProxy(PlayerKernelType.mdk), isTrue);
+    expect(supportsPlayerHttpProxy(PlayerKernelType.mediaKit), isTrue);
+    expect(supportsPlayerHttpProxy(PlayerKernelType.videoPlayer), isFalse);
+    expect(supportsPlayerHttpProxy(PlayerKernelType.erika), isFalse);
+  });
+
+  test('saving a proxy does not rebuild an unsupported player kernel',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    await PlayerFactory.initialize();
+    await PlayerFactory.saveKernelType(PlayerKernelType.videoPlayer);
+    var rebuilt = false;
+    final subscription = PlayerFactory.onKernelChanged.listen((_) {
+      rebuilt = true;
+    });
+    addTearDown(() async {
+      await subscription.cancel();
+      await PlayerFactory.saveKernelType(PlayerKernelType.mdk);
+      await PlayerFactory.saveHttpProxy('');
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    await PlayerFactory.saveHttpProxy('http://127.0.0.1:8000');
+    await pumpEventQueue();
+
+    expect(rebuilt, isFalse);
+  });
+
+  test('MDK applies the HTTP proxy to both FFmpeg option layers', () {
+    final applied = <(String, String)>[];
+
+    applyMdkHttpProxyProperties(
+      (key, value) => applied.add((key, value)),
+      'http://127.0.0.1:8000',
+    );
+
+    expect(applied, [
+      ('avformat.http_proxy', 'http://127.0.0.1:8000'),
+      ('avio.http_proxy', 'http://127.0.0.1:8000'),
+    ]);
+  });
+
+  test('MediaKit maps the HTTP proxy to the libmpv option', () {
+    final applied = <(String, String)>[];
+
+    applyMediaKitNetworkOptions(
+      (key, value) => applied.add((key, value)),
+      userAgent: '',
+      httpProxy: 'http://127.0.0.1:8000',
+    );
+
+    expect(applied, [('http-proxy', 'http://127.0.0.1:8000')]);
+  });
+
+  test('saving a proxy persists it and rebuilds the active kernel', () async {
+    SharedPreferences.setMockInitialValues({});
+    await PlayerFactory.initialize();
+    addTearDown(() async {
+      await PlayerFactory.saveHttpProxy('');
+      SharedPreferences.setMockInitialValues({});
+    });
+    final kernelChanged = PlayerFactory.onKernelChanged.first;
+
+    await PlayerFactory.saveHttpProxy('  http://127.0.0.1:8000  ');
+
+    expect(PlayerFactory.getHttpProxy(), 'http://127.0.0.1:8000');
+    final preferences = await SharedPreferences.getInstance();
+    expect(
+      preferences.getString(SettingsKeys.playerHttpProxy),
+      'http://127.0.0.1:8000',
+    );
+    expect(
+      await kernelChanged.timeout(const Duration(seconds: 1)),
+      PlayerKernelType.mdk,
+    );
+  });
+
+  test('initialization restores the persisted HTTP proxy', () async {
+    SharedPreferences.setMockInitialValues({
+      SettingsKeys.playerHttpProxy: '  http://127.0.0.1:8123  ',
+    });
+    addTearDown(() async {
+      await PlayerFactory.saveHttpProxy('');
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    await PlayerFactory.initialize();
+
+    expect(PlayerFactory.getHttpProxy(), 'http://127.0.0.1:8123');
+  });
+
+  test('PlayerFactory passes the proxy to MDK and MediaKit adapters', () {
+    final source = File(
+      'lib/player_abstraction/player_factory.dart',
+    ).readAsStringSync().replaceAll(RegExp(r'\s+'), ' ');
+
+    expect(
+      source,
+      contains('MdkPlayerAdapter(httpProxy: getHttpProxy())'),
+    );
+    expect(
+      source,
+      contains('MediaKitPlayerAdapter( bufferSize:'),
+    );
+    expect(
+      source,
+      contains('httpProxy: getHttpProxy()'),
+    );
+  });
+}

--- a/test/unified_http_proxy_settings_widget_test.dart
+++ b/test/unified_http_proxy_settings_widget_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
+import 'package:nipaplay/l10n/app_localizations.dart';
+import 'package:nipaplay/player_abstraction/player_factory.dart';
+import 'package:nipaplay/providers/appearance_settings_provider.dart';
+import 'package:nipaplay/services/app_http_proxy.dart';
+import 'package:nipaplay/settings/adaptive_settings_scope.dart';
+import 'package:nipaplay/settings/pages/network_settings_content.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('HTTP proxy setting is available on desktop native platforms only', () {
+    for (final platform in [
+      TargetPlatform.windows,
+      TargetPlatform.macOS,
+      TargetPlatform.linux,
+    ]) {
+      expect(
+        supportsUnifiedHttpProxySetting(isWeb: false, platform: platform),
+        isTrue,
+      );
+    }
+    for (final platform in [
+      TargetPlatform.android,
+      TargetPlatform.iOS,
+      TargetPlatform.fuchsia,
+    ]) {
+      expect(
+        supportsUnifiedHttpProxySetting(isWeb: false, platform: platform),
+        isFalse,
+      );
+    }
+    expect(
+      supportsUnifiedHttpProxySetting(
+        isWeb: true,
+        platform: TargetPlatform.windows,
+      ),
+      isFalse,
+    );
+  });
+
+  testWidgets('desktop network settings validate and save the HTTP proxy',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    try {
+      SharedPreferences.setMockInitialValues({});
+      await PlayerFactory.initialize();
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider(
+          create: (_) => AppearanceSettingsProvider(),
+          child: MaterialApp(
+            locale: const Locale('zh'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const AdaptiveSettingsScope(
+              style: AdaptiveSettingsStyle.desktopTablet,
+              child: NetworkSettingsContent(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final proxyTile = find.text('媒体服务器与播放器 HTTP 代理');
+      expect(proxyTile, findsOneWidget);
+      expect(
+        find.textContaining('播放器代理仅支持 MDK/MediaKit 内核'),
+        findsOneWidget,
+      );
+      await tester.ensureVisible(proxyTile);
+      await tester.tap(proxyTile);
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).last, 'https://proxy:443');
+      await tester.tap(find.text('保存').last);
+      await tester.pumpAndSettle();
+      expect(
+        find.text('请输入有效的 http:// 代理地址；不支持 HTTPS 代理端点或 SOCKS。'),
+        findsOneWidget,
+      );
+      var preferences = await SharedPreferences.getInstance();
+      expect(preferences.getString(SettingsKeys.playerHttpProxy), isNull);
+
+      await tester.pump(const Duration(seconds: 5));
+      await tester.ensureVisible(proxyTile);
+      await tester.tap(proxyTile);
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byType(TextField).last,
+        'http://127.0.0.1:8000',
+      );
+      await tester.tap(find.text('保存').last);
+      await tester.pumpAndSettle();
+
+      preferences = await SharedPreferences.getInstance();
+      expect(
+        preferences.getString(SettingsKeys.playerHttpProxy),
+        'http://127.0.0.1:8000',
+      );
+      expect(PlayerFactory.getHttpProxy(), 'http://127.0.0.1:8000');
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+      await PlayerFactory.saveHttpProxy('');
+      AppHttpProxy.clear();
+      SharedPreferences.setMockInitialValues({});
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- Windows 网络设置增加 HTTP 代理
- Dart 请求与 MDK、MediaKit 播放器共用代理配置

Refs #641