### PR TITLE
ci: Windows 仅上传便携程序目录

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -49,19 +49,21 @@ jobs:
       
       - name: Clean flutter pub cache
         run: flutter pub cache clean
-      
+
+      - name: Verify portable Windows artifact
+        shell: pwsh
+        run: |
+          $portableDirs = @(Get-ChildItem "build/windows" -Directory -Filter "NipaPlay_*_Windows_x64")
+          if ($portableDirs.Count -ne 1) {
+            throw "Expected exactly one portable Windows directory, found $($portableDirs.Count)"
+          }
+          if (-not (Test-Path (Join-Path $portableDirs[0].FullName "NipaPlay.exe"))) {
+            throw "Portable Windows directory does not contain NipaPlay.exe"
+          }
+
       - name: Upload Windows Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: release-Windows-x64
-          path: |
-            build/windows/*
-            !build/windows/symbols-windows
-
-      - name: Upload Dart debug symbols (for de-obfuscating crash stacks)
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: dart-symbols-Windows
-          path: build/symbols-windows/
-          if-no-files-found: warn
+          path: build/windows/NipaPlay_*_Windows_x64/
+          if-no-files-found: error

--- a/test/windows_portable_artifact_workflow_test.dart
+++ b/test/windows_portable_artifact_workflow_test.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _step(String workflow, String name) {
+  final marker = '      - name: $name';
+  final start = workflow.indexOf(marker);
+  expect(start, isNonNegative, reason: 'Missing workflow step: $name');
+  final next = workflow.indexOf('\n      - name: ', start + marker.length);
+  return workflow.substring(start, next < 0 ? workflow.length : next);
+}
+
+void main() {
+  test('Windows workflow uploads only the directly runnable folder', () {
+    final workflow =
+        File('.github/workflows/build-windows.yml').readAsStringSync();
+    final verification = _step(workflow, 'Verify portable Windows artifact');
+    final upload = _step(workflow, 'Upload Windows Artifacts');
+
+    expect(
+      verification,
+      matches(
+        RegExp(
+          r'if\s*\(\s*-not\s*\(\s*Test-Path[\s\S]*?NipaPlay\.exe'
+          r'[\s\S]*?\)\s*\)',
+        ),
+      ),
+    );
+    expect(verification, contains('throw'));
+    expect(upload, contains('uses: actions/upload-artifact@v4'));
+    expect(
+      upload,
+      matches(
+        RegExp(
+          r'^\s+path: build/windows/NipaPlay_\*_Windows_x64/\s*$',
+          multiLine: true,
+        ),
+      ),
+    );
+    expect(
+      RegExp(r'actions/upload-artifact@v4').allMatches(workflow),
+      hasLength(1),
+    );
+    expect(upload, isNot(contains('path: |')));
+    expect(
+        RegExp(r'^\s+path:', multiLine: true).allMatches(upload), hasLength(1));
+    expect(workflow, isNot(contains('dart-symbols-Windows')));
+  });
+}


### PR DESCRIPTION
## Summary

- Windows artifact 仅上传可直接运行的程序目录
- 上传前检查 NipaPlay.exe，并排除中间文件和调试符号