### PR TITLE
修复 CI 的 Unix IPC 测试环境

### DIFF
--- a/.github/workflows/release-ci-smoke.yml
+++ b/.github/workflows/release-ci-smoke.yml
@@ -19,6 +19,11 @@ on:
         required: true
         type: boolean
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     branches:
       - main
     paths:
@@ -49,7 +54,10 @@ concurrency:
 jobs:
   validate:
     name: Analyze and Test
-    if: github.event_name == 'pull_request' || inputs.run_validation
+    if: >-
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false) ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_validation)
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/lib/models/external_player_session/mpv_session.dart
+++ b/lib/models/external_player_session/mpv_session.dart
@@ -323,13 +323,18 @@ class MpvSession extends ChangeNotifier implements ExternalPlayerLaunchSession {
 
   /// 连接到 mpv 的 IPC 端点.
   ///
-  /// 使用 dart_ipc 实现跨平台 IPC 连接:
-  /// - Linux/macOS: Unix Domain Socket
-  /// - Windows: 命名管道 (Named Pipe)
+  /// - Linux/macOS: 直接使用 Dart 的 Unix Domain Socket
+  /// - Windows: 使用 dart_ipc 的命名管道 (Named Pipe)
   ///
   /// mpv 的 --input-ipc-server 在 Windows 上接受命名管道路径 (如 \\.\pipe\xxx).
   static Future<Socket> _connectToIpc(String path) async {
-    return await connect(path).timeout(const Duration(milliseconds: 500));
+    final connection = Platform.isWindows
+        ? connect(path)
+        : Socket.connect(
+            InternetAddress(path, type: InternetAddressType.unix),
+            0,
+          );
+    return await connection.timeout(const Duration(milliseconds: 500));
   }
 
   Future<void> _setMpvPaused(bool paused) async {


### PR DESCRIPTION
## 修改内容

- Linux 和 macOS 的 mpv IPC 直接使用 Dart Unix Domain Socket，仅 Windows 保留 `dart_ipc` 命名管道实现。
- `Release CI Smoke` 补充 `ready_for_review` 触发，并跳过 Draft PR，同时保留手动运行的 `run_validation` 开关。

## 根因

`dart_ipc 1.0.1` 在 `flutter test` 中不会注册 Linux/macOS Dart plugin，默认实现因此错误落到 MethodChannel，触发 `MissingPluginException`，导致 6 个外部播放器 IPC 测试超时。该失败已存在于合入 main 的 #770，与 #774 的 iOS overlay 改动无关。

## 验证

- `flutter test --no-pub test/external_player_console_service_test.dart --reporter expanded`：23/23 通过。
- `flutter test --no-pub --reporter compact`：185/185 通过。
- `flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings lib`：退出码 0。
- Workflow YAML 解析通过。