### PR TITLE
fix(ios): use native kernel dropdowns on iOS 26

### DIFF
--- a/lib/settings/adaptive_settings_widgets.dart
+++ b/lib/settings/adaptive_settings_widgets.dart
@@ -1,7 +1,12 @@
 import 'dart:async';
 
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart'
-    show PlatformInfo;
+    show
+        AdaptivePopupMenuButton,
+        AdaptivePopupMenuEntry,
+        AdaptivePopupMenuItem,
+        PlatformInfo,
+        PopupButtonStyle;
 import 'package:flutter/cupertino.dart' as cupertino;
 import 'package:flutter/material.dart' as material;
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
@@ -33,6 +38,7 @@ class AdaptiveSettingsTile<T> extends material.StatelessWidget {
     this.dropdownItems,
     this.onDropdownChanged,
     this.dropdownKey,
+    this.useNativeIOS26Dropdown = false,
     this.switchValue,
     this.onSwitchChanged,
     this.hideNativeIOS26Switch = false,
@@ -61,6 +67,7 @@ class AdaptiveSettingsTile<T> extends material.StatelessWidget {
     required List<DropdownMenuItemData<T>> items,
     required FutureOr<void> Function(T value) onChanged,
     material.GlobalKey? dropdownKey,
+    bool useNativeIOS26Dropdown = false,
   }) {
     return AdaptiveSettingsTile<T>._(
       key: key,
@@ -73,6 +80,7 @@ class AdaptiveSettingsTile<T> extends material.StatelessWidget {
       dropdownItems: items,
       onDropdownChanged: onChanged,
       dropdownKey: dropdownKey,
+      useNativeIOS26Dropdown: useNativeIOS26Dropdown,
     );
   }
 
@@ -219,6 +227,11 @@ class AdaptiveSettingsTile<T> extends material.StatelessWidget {
   final List<DropdownMenuItemData<T>>? dropdownItems;
   final FutureOr<void> Function(T value)? onDropdownChanged;
   final material.GlobalKey? dropdownKey;
+
+  /// Uses the native UIKit popup menu on iOS 26 and later.
+  ///
+  /// Other platforms and earlier iOS versions keep the shared bottom sheet.
+  final bool useNativeIOS26Dropdown;
   final bool? switchValue;
   final material.ValueChanged<bool>? onSwitchChanged;
 
@@ -393,6 +406,28 @@ class AdaptiveSettingsTile<T> extends material.StatelessWidget {
     }
     final label =
         selected?.title ?? (items.isNotEmpty ? items.first.title : '');
+    if (useNativeIOS26Dropdown && usesNativeIOS26SettingsControls) {
+      return AdaptivePopupMenuButton.text<T>(
+        label: label,
+        items: <AdaptivePopupMenuEntry>[
+          for (final item in items)
+            AdaptivePopupMenuItem<T>(
+              label: item.title,
+              value: item.value,
+              enabled: item.enabled,
+              icon: item.isSelected ? 'checkmark' : null,
+            ),
+        ],
+        onSelected: (index, _) {
+          if (index < 0 || index >= items.length || !items[index].enabled) {
+            return;
+          }
+          onDropdownChanged?.call(items[index].value);
+        },
+        shrinkWrap: true,
+        buttonStyle: PopupButtonStyle.plain,
+      );
+    }
     return cupertino.CupertinoButton(
       padding: material.EdgeInsets.zero,
       minimumSize: material.Size.zero,

--- a/lib/settings/pages/danmaku_settings_content.dart
+++ b/lib/settings/pages/danmaku_settings_content.dart
@@ -758,6 +758,7 @@ class _DanmakuSettingsContentState extends State<DanmakuSettingsContent> {
                   _saveDanmakuRenderEngineSettings(value);
                 },
                 dropdownKey: _danmakuRenderEngineDropdownKey,
+                useNativeIOS26Dropdown: true,
               ),
               Divider(
                   color: colorScheme.onSurface.withValues(alpha: 0.12),

--- a/lib/settings/pages/player_settings_content.dart
+++ b/lib/settings/pages/player_settings_content.dart
@@ -375,6 +375,7 @@ class _PlayerSettingsContentState extends State<PlayerSettingsContent> {
                   _savePlayerKernelSettings(kernelType);
                 },
                 dropdownKey: _playerKernelDropdownKey,
+                useNativeIOS26Dropdown: true,
               ),
               Divider(
                   color: colorScheme.onSurface.withValues(alpha: 0.12),

--- a/test/settings/adaptive_settings_widgets_test.dart
+++ b/test/settings/adaptive_settings_widgets_test.dart
@@ -1,7 +1,12 @@
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+import 'package:adaptive_platform_ui/src/widgets/ios26/ios26_popup_menu_button.dart'
+    show IOS26PopupMenuButton;
+import 'package:flutter/cupertino.dart' as cupertino;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nipaplay/settings/adaptive_settings_scope.dart';
 import 'package:nipaplay/settings/adaptive_settings_widgets.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
 
 void main() {
   testWidgets('phone settings page provides a Material ancestor',
@@ -21,5 +26,85 @@ void main() {
 
     expect(tester.takeException(), isNull);
     expect(find.text('Selected library'), findsOneWidget);
+  });
+
+  testWidgets('opted-in iOS 26 dropdown uses the native popup menu',
+      (tester) async {
+    String? selectedValue;
+    PlatformInfo.setPlatformOverride(PlatformOverride.ios, iosVersion: 26);
+    addTearDown(PlatformInfo.clearPlatformOverride);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AdaptiveSettingsScope(
+          style: AdaptiveSettingsStyle.phone,
+          child: AdaptiveSettingsTile<String>.dropdown(
+            title: 'Kernel',
+            items: [
+              DropdownMenuItemData(
+                title: 'MDK',
+                value: 'mdk',
+                isSelected: true,
+              ),
+              DropdownMenuItemData(title: 'MediaKit', value: 'media-kit'),
+            ],
+            onChanged: (value) => selectedValue = value,
+            useNativeIOS26Dropdown: true,
+          ),
+        ),
+      ),
+    );
+
+    final popupFinder = find.byWidgetPredicate(
+      (widget) => widget is IOS26PopupMenuButton<String>,
+    );
+    expect(popupFinder, findsOneWidget);
+
+    final popup = tester.widget<IOS26PopupMenuButton<String>>(popupFinder);
+    expect(popup.buttonLabel, 'MDK');
+    expect(
+      (popup.items.first as AdaptivePopupMenuItem<String>).icon,
+      'checkmark',
+    );
+
+    popup.onSelected(
+      1,
+      popup.items[1] as AdaptivePopupMenuItem<String>,
+    );
+    expect(selectedValue, 'media-kit');
+  });
+
+  testWidgets('iOS 18 opted-in dropdown keeps the bottom-sheet button',
+      (tester) async {
+    PlatformInfo.setPlatformOverride(PlatformOverride.ios, iosVersion: 18);
+    addTearDown(PlatformInfo.clearPlatformOverride);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AdaptiveSettingsScope(
+          style: AdaptiveSettingsStyle.phone,
+          child: AdaptiveSettingsTile<String>.dropdown(
+            title: 'Kernel',
+            items: [
+              DropdownMenuItemData(
+                title: 'MDK',
+                value: 'mdk',
+                isSelected: true,
+              ),
+            ],
+            onChanged: (_) {},
+            useNativeIOS26Dropdown: true,
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byWidgetPredicate(
+        (widget) => widget is IOS26PopupMenuButton<String>,
+      ),
+      findsNothing,
+    );
+    expect(find.byType(cupertino.CupertinoButton), findsOneWidget);
   });
 }

--- a/test/unified_app_architecture_test.dart
+++ b/test/unified_app_architecture_test.dart
@@ -525,16 +525,20 @@ void main() {
     expect(notification, isNot(contains('AppAccentColors.current')));
   });
 
-  test('phone modal choices all use the shared Cupertino bottom sheet', () {
+  test('phone modal choices use shared adapters instead of direct popups', () {
     final dartFiles = Directory('lib')
         .listSync(recursive: true)
         .whereType<File>()
         .where((file) => file.path.endsWith('.dart'))
         .where(
-          (file) => !_portablePath(file.path).endsWith(
-            'themes/cupertino/widgets/cupertino_bottom_sheet.dart',
-          ),
-        );
+      (file) {
+        final path = _portablePath(file.path);
+        return !path.endsWith(
+              'themes/cupertino/widgets/cupertino_bottom_sheet.dart',
+            ) &&
+            !path.endsWith('settings/adaptive_settings_widgets.dart');
+      },
+    );
     final directPopupUsers = <String>[];
     for (final file in dartFiles) {
       final source = file.readAsStringSync();
@@ -551,6 +555,34 @@ void main() {
         'lib/themes/cupertino/widgets/cupertino_modal_popup.dart',
       ).existsSync(),
       isFalse,
+    );
+  });
+
+  test('iOS 26 kernel selectors opt into native dropdown menus', () {
+    final player = File(
+      'lib/settings/pages/player_settings_content.dart',
+    ).readAsStringSync();
+    final danmaku = File(
+      'lib/settings/pages/danmaku_settings_content.dart',
+    ).readAsStringSync();
+
+    expect(
+      player,
+      matches(
+        RegExp(
+          r'title: "播放器内核",[\s\S]*?'
+          r'useNativeIOS26Dropdown: true,',
+        ),
+      ),
+    );
+    expect(
+      danmaku,
+      matches(
+        RegExp(
+          r"title: '弹幕渲染引擎',[\s\S]*?"
+          r'useNativeIOS26Dropdown: true,',
+        ),
+      ),
     );
   });
 


### PR DESCRIPTION
## What changed

- Added an opt-in native iOS 26 dropdown path to adaptive settings tiles.
- Enabled the native UIKit popup menu for the player-kernel and danmaku-kernel selectors.
- Kept the existing Cupertino bottom-sheet selector on iOS 18 and other platforms.
- Added widget and architecture coverage for the native/fallback behavior.

## Why

Phone dropdown settings always opened the shared bottom sheet, so iOS 26 users saw an upward modal selector instead of the platform-native dropdown menu already available in the app.

## Impact

iOS 26 and later now use the native `UIButton`/`UIMenu` control for these two kernel settings, including a checkmark for the current option. Existing behavior is unchanged elsewhere.

## Validation

- `flutter test --no-pub test/settings/adaptive_settings_widgets_test.dart test/unified_app_architecture_test.dart`
- 65 tests passed
- Targeted Dart analysis reported no new errors