### PR TITLE
fix(android): open Bangumi authorization in browser

### DIFF
--- a/lib/themes/nipaplay/pages/account/material_account_page.dart
+++ b/lib/themes/nipaplay/pages/account/material_account_page.dart
@@ -525,8 +525,11 @@ class _UnifiedAccountPageState extends State<UnifiedAccountPage>
       showMessage('授权链接为空');
       return;
     }
-    await _openExternalUrl(url, cannotOpenMessage: '无法打开Bangumi授权页面');
-    if (!mounted) return;
+    final opened = await _openExternalUrl(
+      url,
+      cannotOpenMessage: '无法打开Bangumi授权页面',
+    );
+    if (!opened || !mounted) return;
     showMessage('已在浏览器打开授权页，完成后点击“我已完成网页操作，刷新状态”。');
     unawaited(_tryAutoRefreshDandanBangumiStatus());
   }
@@ -543,8 +546,11 @@ class _UnifiedAccountPageState extends State<UnifiedAccountPage>
       showMessage('同步设置页面链接为空');
       return;
     }
-    await _openExternalUrl(url, cannotOpenMessage: '无法打开Bangumi同步设置页面');
-    if (!mounted) return;
+    final opened = await _openExternalUrl(
+      url,
+      cannotOpenMessage: '无法打开Bangumi同步设置页面',
+    );
+    if (!opened || !mounted) return;
     showMessage('已在浏览器打开同步设置页，网页内操作后请刷新状态或重新登录。');
     unawaited(_tryAutoRefreshDandanBangumiStatus());
   }
@@ -585,27 +591,31 @@ class _UnifiedAccountPageState extends State<UnifiedAccountPage>
     }
   }
 
-  Future<void> _openExternalUrl(
+  Future<bool> _openExternalUrl(
     String url, {
     String cannotOpenMessage = '无法打开链接',
   }) async {
     try {
       if (kIsWeb) {
         showMessage('请复制以下链接到浏览器中打开：$url');
-        return;
+        return false;
       }
       final uri = Uri.tryParse(url);
       if (uri == null) {
         showMessage('链接无效');
-        return;
+        return false;
       }
-      if (await canLaunchUrl(uri)) {
-        await launchUrl(uri, mode: LaunchMode.externalApplication);
-      } else {
+      final opened = await launchUrl(
+        uri,
+        mode: LaunchMode.externalApplication,
+      );
+      if (!opened) {
         showMessage(cannotOpenMessage);
       }
+      return opened;
     } catch (error) {
       showMessage('打开链接失败：$error');
+      return false;
     }
   }
 

--- a/test/bangumi_external_auth_launch_test.dart
+++ b/test/bangumi_external_auth_launch_test.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Bangumi auth launches directly and only reports real success', () {
+    final source = File(
+      'lib/themes/nipaplay/pages/account/material_account_page.dart',
+    ).readAsStringSync();
+
+    expect(source, isNot(contains('canLaunchUrl(uri)')));
+    expect(
+      source,
+      contains(
+        'final opened = await launchUrl(\n'
+        '        uri,\n'
+        '        mode: LaunchMode.externalApplication,\n'
+        '      );',
+      ),
+    );
+    expect(source, contains('if (!opened || !mounted) return;'));
+    expect(source, contains('return opened;'));
+  });
+}


### PR DESCRIPTION
## What changed

- launch Bangumi OAuth and management URLs directly with `LaunchMode.externalApplication`
- return and check the real `launchUrl` result before showing success or starting status polling
- add a regression test that prevents the Android package-visibility preflight from returning

## Root cause

On Android 11+, `canLaunchUrl` can return `false` when the browser intent is not exposed through package visibility, even though `launchUrl` itself can open the URL. The previous flow also ignored the open result and immediately replaced the failure message with a success message.

## Validation

- `flutter test test/bangumi_external_auth_launch_test.dart test/unified_app_architecture_test.dart` (64 tests passed)
- `flutter analyze lib/themes/nipaplay/pages/account/material_account_page.dart test/bangumi_external_auth_launch_test.dart` (no issues)

Closes #771