### PR TITLE
fix(settings): remove duplicate home controls from general

### DIFF
--- a/lib/settings/pages/general_settings_content.dart
+++ b/lib/settings/pages/general_settings_content.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/l10n/l10n.dart';
-import 'package:nipaplay/providers/home_sections_settings_provider.dart';
 import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
 import 'package:nipaplay/services/desktop_exit_preferences.dart';
 import 'package:nipaplay/services/desktop_picture_in_picture_preferences.dart';
@@ -18,7 +17,6 @@ import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
-import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 const String defaultPageIndexKey = 'default_page_index';
@@ -73,7 +71,6 @@ class _GeneralSettingsContentState extends State<GeneralSettingsContent> {
 
   @override
   Widget build(BuildContext context) {
-    final homeSections = context.watch<HomeSectionsSettingsProvider>();
     final children = <Widget>[];
 
     if (globals.isDesktop) {
@@ -285,43 +282,6 @@ class _GeneralSettingsContentState extends State<GeneralSettingsContent> {
             dropdownKey: _defaultPageDropdownKey,
           ),
           const AutoUpdateSettingTile(),
-        ],
-      ),
-    );
-
-    children.add(const SizedBox(height: 16));
-    children.add(
-      AdaptiveSettingsDragList<HomeSectionType>(
-        items: [
-          for (final section in homeSections.orderedSections)
-            AdaptiveSettingsDragListItem<HomeSectionType>(
-              value: section,
-              title: section.title,
-              subtitle: homeSections.isSectionEnabled(section)
-                  ? _text(context, '显示在首页', '顯示在首頁', 'Shown on Home')
-                  : _text(context, '已隐藏', '已隱藏', 'Hidden'),
-              icon: Ionicons.home_outline,
-              phoneIcon: cupertino.CupertinoIcons.square_grid_2x2,
-              enabled: homeSections.isSectionEnabled(section),
-            ),
-        ],
-        onReorder: homeSections.reorderSections,
-        onEnabledChanged: (section, value) {
-          homeSections.setSectionEnabled(section, value);
-        },
-      ),
-    );
-    children.add(const SizedBox(height: 8));
-    children.add(
-      AdaptiveSettingsSection(
-        children: [
-          AdaptiveSettingsTile<void>.card(
-            title: context.l10n.restoreDefaults,
-            subtitle: context.l10n.restoreDefaultsSubtitle,
-            icon: Ionicons.refresh_outline,
-            phoneIcon: cupertino.CupertinoIcons.refresh,
-            onTap: homeSections.restoreDefaults,
-          ),
         ],
       ),
     );

--- a/test/unified_app_architecture_test.dart
+++ b/test/unified_app_architecture_test.dart
@@ -621,6 +621,9 @@ void main() {
     final appearance = File(
       'lib/settings/pages/appearance_settings_content.dart',
     ).readAsStringSync();
+    final general = File(
+      'lib/settings/pages/general_settings_content.dart',
+    ).readAsStringSync();
 
     expect(appearance, isNot(contains('AnimeDetailDisplayMode')));
     expect(appearance, isNot(contains('RecentWatchingStyle')));
@@ -628,6 +631,10 @@ void main() {
     expect(appearance, isNot(contains('_recentStyleDropdownKey')));
     expect(appearance, contains('AdaptiveSettingsDragList<HomeSectionType>'));
     expect(appearance, contains('onReorder: homeSections.reorderSections'));
+    expect(general, isNot(contains('HomeSectionsSettingsProvider')));
+    expect(
+        general, isNot(contains('AdaptiveSettingsDragList<HomeSectionType>')));
+    expect(general, isNot(contains('homeSections.restoreDefaults')));
   });
 
   test('danmaku workflows share one data service and adaptive presentation',


### PR DESCRIPTION
## What changed

- Removed the duplicated Home content visibility and ordering controls from General settings.
- Removed the duplicated restore-defaults action from General settings.
- Kept the canonical controls in Appearance settings unchanged.
- Removed the now-unused Home sections provider dependency from General settings.
- Added an architecture assertion preventing the duplicate controls from returning.

## Why

The mobile Home content switches and reorder UI were rendered in both General and Appearance settings because both pages independently consumed the same `HomeSectionsSettingsProvider`.

## Impact

Mobile users now see these controls only under Appearance settings. Existing saved visibility and ordering preferences are unaffected.

## Validation

- `flutter test --no-pub test/unified_app_architecture_test.dart test/poster_blur_and_fast_playback_test.dart`
- 68 tests passed
- Targeted Dart analysis passed with no issues