### PR TITLE
ci: relax macOS pod installation

### DIFF
--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -75,10 +75,10 @@ runs:
         export LC_ALL=zh_CN.UTF-8
         mkdir -p ~/.cocoapods
         echo 'source "https://cdn.cocoapods.org/"' > ~/.cocoapods/config
-        echo "Installing Pods from Podfile.lock (reusing a restored Pods cache when available)..."
-        if ! pod install --deployment; then
+        echo "Installing Pods (reusing a restored Pods cache when available)..."
+        if ! pod install; then
           echo "Initial pod install failed; refreshing the specs repository and retrying..."
-          pod install --deployment --repo-update
+          pod install --repo-update
         fi
         cd ..
 


### PR DESCRIPTION
## What changed

- remove CocoaPods `--deployment` mode from the macOS packaging action
- keep a normal `pod install` first attempt
- retry with `pod install --repo-update` only when the first attempt fails

## Why

The release run failed in all three macOS packaging jobs because `macos/Podfile.lock` did not yet contain several generated Flutter plugins. Deployment mode forbids updating the lockfile, so both the initial install and the repo-update retry exited before compilation.

This lets CocoaPods reconcile the generated plugin set during CI, matching the project's preferred level of lockfile strictness.

## Validation

- parsed the composite action YAML successfully
- checked the modified shell block with `bash -n`
- verified no `--deployment` invocation remains
- ran `git diff --check`