### PR TITLE
Fix Erika resume seek and visual synchronization

### DIFF
--- a/lib/pages/desktop_player_window.dart
+++ b/lib/pages/desktop_player_window.dart
@@ -11,6 +11,7 @@ import 'package:nipaplay/providers/app_language_provider.dart';
 import 'package:nipaplay/services/desktop_player_window_service.dart';
 import 'package:nipaplay/utils/app_theme.dart';
 import 'package:nipaplay/utils/theme_notifier.dart';
+import 'package:nipaplay/utils/video_player_state.dart';
 import 'package:nipaplay/widgets/desktop_picture_in_picture_scope.dart';
 import 'package:provider/provider.dart';
 
@@ -26,6 +27,9 @@ class DesktopPlayerWindow extends StatelessWidget {
     final themeMode = context.watch<ThemeNotifier>().themeMode;
     final locale = context.watch<AppLanguageProvider>().locale;
     final windowController = DesktopMultiWindow.controllerOf(context);
+    final usesWindowHostedVideoSurface = context.select<VideoPlayerState, bool>(
+      (videoState) => videoState.player.usesWindowOverlayVideoSurface,
+    );
 
     return MaterialApp(
       title: 'NipaPlay 独立播放器',
@@ -57,7 +61,12 @@ class DesktopPlayerWindow extends StatelessWidget {
           return DesktopPictureInPictureScope(
             enabled: isPictureInPicture,
             child: ColoredBox(
-              color: Colors.black,
+              // Erika and the desktop HDR path render into a native surface
+              // hosted below Flutter. Keep this view transparent so the
+              // surface remains visible while Flutter controls stay above it.
+              color: usesWindowHostedVideoSurface
+                  ? Colors.transparent
+                  : Colors.black,
               child: Stack(
                 fit: StackFit.expand,
                 children: [

--- a/lib/player_abstraction/abstract_player.dart
+++ b/lib/player_abstraction/abstract_player.dart
@@ -8,6 +8,12 @@ abstract interface class AsyncDisposablePlayer {
   Future<void> disposeAsync();
 }
 
+/// Optional capability for backends whose native seek completes
+/// asynchronously across a platform bridge.
+abstract interface class AsyncSeekPlayer {
+  Future<void> seekAndWait({required int position});
+}
+
 abstract class AbstractPlayer {
   // Properties
   double get volume;
@@ -66,11 +72,11 @@ abstract class AbstractPlayer {
   /// 参考 REFERENCE/mpv/player/command.c:996 (queue_seek MPSEEK_CHAPTER)。
   /// 不支持章节的内核（mdk/erika）为空实现。
   Future<void> setChapter(int index);
-  
+
   // NEW DIRECT PLAYBACK METHODS
   /// 直接开始播放，绕过状态设置
   Future<void> playDirectly();
-  
+
   /// 直接暂停播放，绕过状态设置
   Future<void> pauseDirectly();
 

--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -424,7 +424,8 @@ class _NipaplayErikaWindowOverlayVideoViewState
   }
 }
 
-class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
+class ErikaPlayerAdapter
+    implements AbstractPlayer, AsyncDisposablePlayer, AsyncSeekPlayer {
   ErikaPlayerAdapter({
     PlayerErikaAndroidOutputMode androidOutputMode =
         PlayerErikaAndroidOutputMode.sdr,
@@ -703,12 +704,24 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
 
   @override
   void seek({required int position}) {
+    unawaited(
+      seekAndWait(position: position).catchError(
+        (Object error, StackTrace stackTrace) {
+          _lastNativeError = 'seek failed: $error';
+          debugPrint('[Erika] seek failed: $error');
+        },
+      ),
+    );
+  }
+
+  @override
+  Future<void> seekAndWait({required int position}) async {
     final clamped = position < 0 ? 0 : position;
     _lastPositionMs = clamped;
     _lastPositionUpdate = DateTime.now();
     _pendingSeekTargetMs = clamped;
     _seekFenceUntil = DateTime.now().add(const Duration(milliseconds: 1500));
-    unawaited(_player.seek(Duration(milliseconds: clamped)));
+    await _player.seek(Duration(milliseconds: clamped));
   }
 
   @override

--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -3,9 +3,10 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
 
+import 'package:desktop_multi_window/desktop_multi_window.dart';
+import 'package:erika_flutter/erika_flutter.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
-import 'package:erika_flutter/erika_flutter.dart';
 
 import './abstract_player.dart';
 import './player_data_models.dart';
@@ -158,6 +159,15 @@ class _ErikaDanmakuConfigPatch {
       value != null && !listEquals(value, previous);
 }
 
+bool get _erikaWindowOverlayTraceEnabled =>
+    !kIsWeb && Platform.environment['ERIKA_WINDOW_OVERLAY_TRACE'] == '1';
+
+void _traceErikaWindowOverlay(String message) {
+  if (_erikaWindowOverlayTraceEnabled) {
+    debugPrint('[NipaPlayErikaWindowOverlay] $message');
+  }
+}
+
 Rect _transformedGlobalRectOf(RenderBox box) {
   final topLeft = box.localToGlobal(Offset.zero);
   final topRight = box.localToGlobal(Offset(box.size.width, 0));
@@ -234,8 +244,12 @@ class _NipaplayErikaWindowOverlayVideoViewState
   Timer? _frameTimer;
   int _bindAttempts = 0;
   bool _isBound = false;
+  bool _bindInFlight = false;
   late final int _surfaceGeneration;
   String? _lastFrameSignature;
+  int? _flutterViewId;
+  bool _secondaryWindow = false;
+  int _targetRevision = 0;
 
   @override
   void initState() {
@@ -245,6 +259,14 @@ class _NipaplayErikaWindowOverlayVideoViewState
     widget.onPlatformViewIdChanged?.call(ErikaPlayer.windowOverlayViewId);
     _startFrameTimer();
     _scheduleAttach();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_captureWindowTarget()) {
+      _handleWindowTargetChanged();
+    }
   }
 
   @override
@@ -275,6 +297,7 @@ class _NipaplayErikaWindowOverlayVideoViewState
     _retryTimer?.cancel();
     _frameTimer?.cancel();
     widget.onPlatformViewIdChanged?.call(null);
+    widget.onFrameRectChanged?.call(null);
     unawaited(_hideOverlayFrame());
     unawaited(
       widget.player.detachWindowOverlay(generation: _surfaceGeneration),
@@ -304,17 +327,57 @@ class _NipaplayErikaWindowOverlayVideoViewState
   }
 
   Future<void> _attachOverlaySurface() async {
-    if (!mounted || _isBound || kIsWeb) {
+    if (!mounted || _isBound || _bindInFlight || kIsWeb) {
       return;
     }
 
+    final targetChanged = _captureWindowTarget();
+    if (targetChanged) {
+      _handleWindowTargetChanged();
+    }
+    final player = widget.player;
+    final targetRevision = _targetRevision;
+    final flutterViewId = _flutterViewId;
+    final secondaryWindow = _secondaryWindow;
+    var attachCurrentTargetAgain = false;
+    _bindInFlight = true;
     try {
-      await widget.player.attachWindowOverlay();
+      _traceErikaWindowOverlay(
+        'attach generation=$_surfaceGeneration revision=$targetRevision '
+        'flutterView=$flutterViewId secondary=$secondaryWindow',
+      );
+      await player.attachWindowOverlay(
+        flutterViewId: flutterViewId,
+        secondaryWindow: secondaryWindow,
+      );
+      if (!mounted ||
+          widget.player != player ||
+          _targetRevision != targetRevision ||
+          _flutterViewId != flutterViewId ||
+          _secondaryWindow != secondaryWindow) {
+        attachCurrentTargetAgain = mounted;
+        return;
+      }
+      _bindAttempts = 0;
       _isBound = true;
-      _scheduleFrameUpdate(force: true);
+      _traceErikaWindowOverlay(
+        'attached generation=$_surfaceGeneration revision=$targetRevision '
+        'flutterView=$flutterViewId secondary=$secondaryWindow',
+      );
     } catch (error) {
       debugPrint('NipaplayErikaWindowOverlayVideoView: bind failed: $error');
-      _scheduleRetry();
+      if (mounted && _targetRevision == targetRevision) {
+        _scheduleRetry();
+      } else {
+        attachCurrentTargetAgain = mounted;
+      }
+    } finally {
+      _bindInFlight = false;
+      if (attachCurrentTargetAgain) {
+        _scheduleAttach();
+      } else if (_isBound) {
+        _scheduleFrameUpdate(force: true);
+      }
     }
   }
 
@@ -366,6 +429,9 @@ class _NipaplayErikaWindowOverlayVideoViewState
       if (!box.hasSize || box.size.isEmpty) {
         return;
       }
+      if (_captureWindowTarget()) {
+        _handleWindowTargetChanged();
+      }
       nativeFrame = _transformedGlobalRectOf(box);
       flutterCutout = _screenRectToScaledFlutterRect(context, nativeFrame);
     } else {
@@ -378,21 +444,39 @@ class _NipaplayErikaWindowOverlayVideoViewState
       nativeFrame.top.toStringAsFixed(2),
       nativeFrame.width.toStringAsFixed(2),
       nativeFrame.height.toStringAsFixed(2),
+      _flutterViewId ?? -1,
+      _secondaryWindow,
     ].join('|');
     if (!force && signature == _lastFrameSignature) {
       return;
     }
     _lastFrameSignature = signature;
-    widget.onFrameRectChanged?.call(visible ? flutterCutout : null);
+    final flutterViewId = _flutterViewId;
+    final secondaryWindow = _secondaryWindow;
+    final targetRevision = _targetRevision;
+    _traceErikaWindowOverlay(
+      'frame generation=$_surfaceGeneration flutterView=$flutterViewId '
+      'secondary=$secondaryWindow visible=$visible rect=$nativeFrame',
+    );
 
     try {
       await widget.player.setWindowOverlayFrame(
         frame: nativeFrame,
         visible: visible,
         generation: _surfaceGeneration,
+        flutterViewId: flutterViewId,
+        secondaryWindow: secondaryWindow,
         debugLabel: widget.debugLabel,
       );
+      if (!mounted ||
+          _targetRevision != targetRevision ||
+          _flutterViewId != flutterViewId ||
+          _secondaryWindow != secondaryWindow) {
+        return;
+      }
+      widget.onFrameRectChanged?.call(visible ? flutterCutout : null);
     } catch (error) {
+      _lastFrameSignature = null;
       debugPrint(
         'NipaplayErikaWindowOverlayVideoView: frame update failed: $error',
       );
@@ -405,6 +489,8 @@ class _NipaplayErikaWindowOverlayVideoViewState
         frame: Rect.zero,
         visible: false,
         generation: _surfaceGeneration,
+        flutterViewId: _flutterViewId,
+        secondaryWindow: _secondaryWindow,
         debugLabel: widget.debugLabel,
       );
     } catch (error) {
@@ -412,6 +498,32 @@ class _NipaplayErikaWindowOverlayVideoViewState
         'NipaplayErikaWindowOverlayVideoView: hide overlay failed: $error',
       );
     }
+  }
+
+  bool _captureWindowTarget() {
+    final flutterViewId = View.maybeOf(context)?.viewId;
+    final secondaryWindow = DesktopMultiWindow.isSecondaryWindow(context);
+    if (_flutterViewId == flutterViewId &&
+        _secondaryWindow == secondaryWindow) {
+      return false;
+    }
+    _flutterViewId = flutterViewId;
+    _secondaryWindow = secondaryWindow;
+    _targetRevision += 1;
+    _traceErikaWindowOverlay(
+      'target generation=$_surfaceGeneration revision=$_targetRevision '
+      'flutterView=$_flutterViewId secondary=$_secondaryWindow',
+    );
+    return true;
+  }
+
+  void _handleWindowTargetChanged() {
+    _retryTimer?.cancel();
+    _bindAttempts = 0;
+    _isBound = false;
+    _lastFrameSignature = null;
+    _scheduleAttach();
+    _scheduleFrameUpdate(force: true);
   }
 
   @override

--- a/lib/player_abstraction/player_abstraction.dart
+++ b/lib/player_abstraction/player_abstraction.dart
@@ -1,7 +1,8 @@
 // Export all necessary enums, data models, and the abstract interface
 export './player_enums.dart' show PlayerPlaybackState, PlayerMediaType;
 export './player_data_models.dart';
-export './abstract_player.dart' show AbstractPlayer, AsyncDisposablePlayer;
+export './abstract_player.dart'
+    show AbstractPlayer, AsyncDisposablePlayer, AsyncSeekPlayer;
 export './player_factory.dart'
     show PlayerKernelType; // Export PlayerKernelType enum
 
@@ -134,6 +135,16 @@ class Player {
   Future<void> prepare() => _delegate.prepare();
 
   void seek({required int position}) => _delegate.seek(position: position);
+
+  Future<void> seekAndWait({required int position}) {
+    final delegate = _delegate;
+    if (delegate is core_player.AsyncSeekPlayer) {
+      return (delegate as core_player.AsyncSeekPlayer)
+          .seekAndWait(position: position);
+    }
+    delegate.seek(position: position);
+    return Future<void>.value();
+  }
 
   void dispose() {
     final future = _startDispose();
@@ -458,6 +469,7 @@ class Player {
     double? scrollDurationSeconds,
     double? trackGapRatio,
     double? outlineWidth,
+    int? shadowStyle,
     String? customFontFamily,
     String? customFontFilePath,
   }) async {
@@ -472,6 +484,7 @@ class Player {
         scrollDurationSeconds: scrollDurationSeconds,
         trackGapRatio: trackGapRatio,
         outlineWidth: outlineWidth,
+        shadowStyle: shadowStyle,
         customFontFamily: customFontFamily,
         customFontFilePath: customFontFilePath,
       );

--- a/lib/player_abstraction/player_abstraction.dart
+++ b/lib/player_abstraction/player_abstraction.dart
@@ -459,6 +459,13 @@ class Player {
     } catch (_) {}
   }
 
+  Future<void> setNativeDanmakuEnabled(bool enabled) async {
+    try {
+      final r = (_delegate as dynamic).setDanmakuEnabled(enabled);
+      if (r is Future) await r;
+    } catch (_) {}
+  }
+
   Future<void> setNativeDanmakuConfig({
     bool? enabled,
     double? opacity,

--- a/lib/services/desktop_player_window_service.dart
+++ b/lib/services/desktop_player_window_service.dart
@@ -64,6 +64,7 @@ class DesktopPlayerWindowService extends ChangeNotifier {
     _transitionInProgress = true;
     _tabChangeNotifier = context.read<TabChangeNotifier>();
     _attachVideoState(videoState);
+    _clearWindowHostedVideoCutout();
 
     // Register the destination FlutterView in the same frame. The GlobalKey
     // reparents the existing page instead of disposing it and rebuilding a
@@ -107,6 +108,10 @@ class DesktopPlayerWindowService extends ChangeNotifier {
   }
 
   Future<void> returnPlayerToMain() async {
+    // The detached FlutterView reports coordinates relative to its own
+    // window. Never let that rect become the main window's transparent cutout
+    // while the shared player subtree is being reparented.
+    _clearWindowHostedVideoCutout();
     final window = _activeWindow;
     if (window == null || window.isClosed) {
       _handleWindowClosed();
@@ -282,6 +287,9 @@ class DesktopPlayerWindowService extends ChangeNotifier {
 
   void _handleWindowClosed() {
     if (!_playerDetached && _activeWindow == null) return;
+    final videoState = _videoState;
+    _detachVideoState();
+    videoState?.setWindowHostedVideoRect(null);
     _activeWindow = null;
     _playerDetached = false;
     _transitionInProgress = false;
@@ -290,9 +298,12 @@ class DesktopPlayerWindowService extends ChangeNotifier {
     _alwaysOnTopBeforePictureInPicture = false;
     _lastWindowTitle = null;
     _lastAspectRatio = null;
-    _detachVideoState();
     _tabChangeNotifier?.changePage(AppPageIds.video);
     notifyListeners();
+  }
+
+  void _clearWindowHostedVideoCutout() {
+    _videoState?.setWindowHostedVideoRect(null);
   }
 
   void _attachVideoState(VideoPlayerState videoState) {

--- a/lib/themes/nipaplay/widgets/custom_scaffold.dart
+++ b/lib/themes/nipaplay/widgets/custom_scaffold.dart
@@ -336,65 +336,13 @@ class _WindowHostedVideoBackground extends StatelessWidget {
     return Selector<VideoPlayerState, Rect?>(
       selector: (_, videoState) => videoState.windowHostedVideoRect,
       builder: (context, videoUnderlayRect, child) {
-        return _WindowHostedVideoBlackBackground(
+        return BackgroundWithBlur(
           transparentCutout: videoUnderlayRect,
           child: child!,
         );
       },
       child: child,
     );
-  }
-}
-
-class _WindowHostedVideoBlackBackground extends StatelessWidget {
-  const _WindowHostedVideoBlackBackground({
-    required this.child,
-    required this.transparentCutout,
-  });
-
-  final Widget child;
-  final Rect? transparentCutout;
-
-  @override
-  Widget build(BuildContext context) {
-    final cutout = transparentCutout;
-    final background = cutout == null
-        ? const ColoredBox(color: Colors.black)
-        : ClipPath(
-            clipper: _RectCutoutClipper(cutout: cutout),
-            child: const ColoredBox(color: Colors.black),
-          );
-
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        Positioned.fill(child: background),
-        child,
-      ],
-    );
-  }
-}
-
-class _RectCutoutClipper extends CustomClipper<Path> {
-  const _RectCutoutClipper({required this.cutout});
-
-  final Rect cutout;
-
-  @override
-  Path getClip(Size size) {
-    final bounds = Offset.zero & size;
-    final effectiveCutout = cutout.intersect(bounds);
-    final path = Path()..fillType = PathFillType.evenOdd;
-    path.addRect(bounds);
-    if (!effectiveCutout.isEmpty) {
-      path.addRect(effectiveCutout);
-    }
-    return path;
-  }
-
-  @override
-  bool shouldReclip(covariant _RectCutoutClipper oldClipper) {
-    return oldClipper.cutout != cutout;
   }
 }
 

--- a/lib/themes/nipaplay/widgets/video_player_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_player_ui.dart
@@ -313,7 +313,13 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
     if (!mounted) {
       return;
     }
-    _videoPlayerStateInstance?.setWindowHostedVideoRect(rect);
+    // Rects are local to their FlutterView. The global VideoPlayerState value
+    // is consumed only by the main window background, so publishing a
+    // detached-window rect would punch a same-sized hole in the main window.
+    final isDetachedView = DesktopMultiWindow.isSecondaryWindow(context);
+    _videoPlayerStateInstance?.setWindowHostedVideoRect(
+      isDetachedView ? null : rect,
+    );
   }
 
   Widget _buildVideoSurfaceStage(VideoPlayerState videoState, int? textureId) {

--- a/lib/utils/video_player_state/video_player_state_danmaku.dart
+++ b/lib/utils/video_player_state/video_player_state_danmaku.dart
@@ -54,8 +54,10 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
     final fontFamily = danmakuFontFamily.isNotEmpty ? danmakuFontFamily : null;
     final fontPath =
         danmakuFontFilePath.isNotEmpty ? danmakuFontFilePath : null;
+    // Keep visibility out of the coalesced style patch. A queued, older
+    // visibility value could otherwise overwrite a newer direct toggle.
+    unawaited(player.setNativeDanmakuEnabled(_danmakuVisible));
     unawaited(player.setNativeDanmakuConfig(
-      enabled: _danmakuVisible,
       opacity: _danmakuOpacity,
       // actualDanmakuFontSize resolves the "0 = default" sentinel to the same
       // logical font size used by NipaPlay's DFM+ path; Erika uses the same
@@ -74,6 +76,21 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
       customFontFilePath: fontPath,
     ));
     _syncNativeDanmakuGlobalOffset();
+  }
+
+  // Slider changes should not resend unrelated layout fields. Besides reducing
+  // native work, this prevents a first opacity update from accidentally
+  // becoming a full layout revision when the adapter has no applied snapshot.
+  void _syncErikaDanmakuOpacity() {
+    if (!_erikaNativeDanmaku) return;
+    unawaited(player.setNativeDanmakuConfig(opacity: _danmakuOpacity));
+  }
+
+  void _syncErikaDanmakuFontSize() {
+    if (!_erikaNativeDanmaku) return;
+    unawaited(
+      player.setNativeDanmakuConfig(fontSize: actualDanmakuFontSize),
+    );
   }
 
   Future<DanmakuAutoLoadStrategy> _resolveDanmakuAutoLoadStrategy() async {

--- a/lib/utils/video_player_state/video_player_state_danmaku.dart
+++ b/lib/utils/video_player_state/video_player_state_danmaku.dart
@@ -69,6 +69,7 @@ extension VideoPlayerStateDanmaku on VideoPlayerState {
       scrollDurationSeconds: danmakuScrollDurationSeconds,
       trackGapRatio: _danmakuDfmPlusTrackGap,
       outlineWidth: _next2DanmakuOutlineWidth,
+      shadowStyle: _danmakuShadowStyle.index,
       customFontFamily: fontFamily,
       customFontFilePath: fontPath,
     ));

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -680,7 +680,12 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
               '← player.seek() does NOT update ptm/anchor fields');
         }
         // 先设置播放位置
-        player.seek(position: lastPosition);
+        // Erika's native seek crosses an asynchronous platform bridge and
+        // performs a frame-output barrier. Wait for that transition to finish
+        // before startup can issue play; otherwise a slow resume seek can race
+        // the first play command and leave the surface without a current frame
+        // until the user seeks again.
+        await player.seekAndWait(position: lastPosition);
         // ✅ Bug-8-2 修复：player.seek() 只调用底层 API，不更新锚点字段，
         // 导致 Ticker 首帧锚定到 playbackTimeMs=0 → 弹幕从头播放 + 回弹。
         // 手动更新所有锚点字段，与 seekTo() 保持一致。
@@ -690,8 +695,6 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
         _seekTargetMs = lastPosition.toDouble();
         _anchorSetBySeek = true;
         _lastRawPlayerMs = -1; // 保持 -1，让 Ticker 进入 seek 保护分支
-        // 等待一小段时间确保位置设置完成
-        await Future.delayed(const Duration(milliseconds: 100));
         // 更新状态
         _position = Duration(milliseconds: lastPosition);
         // duration 为 0 时避免除零产生 Infinity/NaN 落库

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -319,11 +319,14 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
 
   // 保存弹幕不透明度
   Future<void> setDanmakuOpacity(double opacity) async {
+    if (_danmakuOpacity == opacity) {
+      return;
+    }
     _danmakuOpacity = opacity;
+    _syncErikaDanmakuOpacity();
+    _notifyListeners();
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble(SettingsKeys.danmakuOpacity, opacity);
-    _syncErikaDanmakuConfig();
-    _notifyListeners();
   }
 
   // 获取映射后的弹幕不透明度
@@ -342,10 +345,15 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   void setDanmakuVisible(bool visible) async {
     if (_danmakuVisible != visible) {
       _danmakuVisible = visible;
+      // Visibility is latency-sensitive and Erika exposes a dedicated toggle.
+      // Start it before persistence, and bypass the coalesced full-config path
+      // so hiding cannot arrive together with a layout change and reset motion.
+      if (_erikaNativeDanmaku) {
+        unawaited(player.setNativeDanmakuEnabled(visible));
+      }
+      _notifyListeners();
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(SettingsKeys.danmakuVisible, visible);
-      _syncErikaDanmakuConfig();
-      _notifyListeners();
     }
   }
 
@@ -1380,11 +1388,10 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     if (_danmakuFontSize != fontSize) {
       _danmakuFontSize = fontSize;
       _scheduleDanmakuFontSizePersistence(immediate: commit);
-      _syncErikaDanmakuConfig();
+      _syncErikaDanmakuFontSize();
       _notifyListeners();
     } else if (commit) {
       _scheduleDanmakuFontSizePersistence(immediate: true);
-      _syncErikaDanmakuConfig();
     }
   }
 

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -1667,6 +1667,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
     _danmakuShadowStyle = style;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(SettingsKeys.danmakuShadowStyle, style.index);
+    _syncErikaDanmakuConfig();
     _notifyListeners();
   }
 

--- a/lib/widgets/macos_native_video_view.dart
+++ b/lib/widgets/macos_native_video_view.dart
@@ -295,6 +295,7 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
       'dispose state=${identityHashCode(this)} label=${widget.debugLabel}',
     );
     widget.onPlatformViewIdChanged?.call(null);
+    widget.onFrameRectChanged?.call(null);
     unawaited(_hideOverlayFrame());
     super.dispose();
   }
@@ -387,6 +388,7 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
 
     final Rect platformRect;
     final Rect? cutoutRect;
+    int? flutterViewId;
     if (visible) {
       if (!mounted) {
         return;
@@ -402,6 +404,7 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
       final origin = box.localToGlobal(Offset.zero);
       platformRect = _transformedGlobalRectOf(box);
       cutoutRect = origin & box.size;
+      flutterViewId = View.of(context).viewId;
     } else {
       platformRect = Rect.zero;
       cutoutRect = null;
@@ -413,8 +416,9 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
       platformRect.top.toStringAsFixed(2),
       platformRect.width.toStringAsFixed(2),
       platformRect.height.toStringAsFixed(2),
+      flutterViewId ?? -1,
     ].join('|');
-    if (signature == _lastFrameSignature) {
+    if (!force && signature == _lastFrameSignature) {
       return;
     }
     if (visible && _frameUpdateInFlight) {
@@ -423,7 +427,6 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
       return;
     }
     _lastFrameSignature = signature;
-    widget.onFrameRectChanged?.call(cutoutRect);
     if (!visible || force) {
       _logMacOSHdrExitTrace(
         'setOverlayFrame state=${identityHashCode(this)} visible=$visible force=$force rect=$platformRect label=${widget.debugLabel}',
@@ -436,7 +439,7 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
         'setOverlayFrame',
         <String, dynamic>{
           'viewId': _windowHostedPlatformSurfaceId,
-          'flutterViewId': View.of(context).viewId,
+          if (flutterViewId != null) 'flutterViewId': flutterViewId,
           'generation': _surfaceGeneration,
           'x': platformRect.left,
           'y': platformRect.top,
@@ -446,7 +449,14 @@ class _MacOSWindowNativeVideoOverlaySurfaceState
           if (widget.debugLabel != null) 'debugLabel': widget.debugLabel,
         },
       );
+      if (!mounted ||
+          (flutterViewId != null &&
+              View.maybeOf(context)?.viewId != flutterViewId)) {
+        return;
+      }
+      widget.onFrameRectChanged?.call(cutoutRect);
     } catch (error) {
+      _lastFrameSignature = null;
       debugPrint(
         'MacOSWindowNativeVideoOverlaySurface: frame update failed: $error',
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -231,6 +231,14 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  dart_ipc:
+    dependency: "direct main"
+    description:
+      name: dart_ipc
+      sha256: "6cad558cda5304017c1f581df4c96fd4f8e4ee212aae7bfa4357716236faa9ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   dbus:
     dependency: transitive
     description:

--- a/test/desktop_player_multiview_test.dart
+++ b/test/desktop_player_multiview_test.dart
@@ -160,6 +160,12 @@ void main() {
           File('windows/runner/windows_native_video.cpp').readAsStringSync();
       final nativeSurfaceSource =
           File('lib/widgets/macos_native_video_view.dart').readAsStringSync();
+      final videoPlayerUiSource = File(
+        'lib/themes/nipaplay/widgets/video_player_ui.dart',
+      ).readAsStringSync();
+      final erikaSurfaceSource = File(
+        'lib/player_abstraction/erika_player_adapter.dart',
+      ).readAsStringSync();
       final playerPageSource =
           File('lib/pages/play_video_page.dart').readAsStringSync();
       final detachedPlayerSource =
@@ -232,6 +238,11 @@ void main() {
       expect(playerPageSource, contains('Icons.push_pin_rounded'));
       expect(detachedPlayerSource, contains('_DetachedWindowDragRegion'));
       expect(detachedPlayerSource, contains('controller.startDragging()'));
+      expect(
+        detachedPlayerSource,
+        contains('usesWindowHostedVideoSurface'),
+      );
+      expect(detachedPlayerSource, contains('Colors.transparent'));
       expect(mainPlayerSlotSource, contains('VideoUploadUI('));
       expect(mainPlayerSlotSource, isNot(contains('FilledButton')));
       expect(tooltipSource, contains('createTooltipWindow'));
@@ -245,8 +256,32 @@ void main() {
       expect(contextMenuSource, contains('DesktopTransientOverlay.showPopup'));
       expect(windowsVideoSource, contains('flutterViewId'));
       expect(windowsVideoSource, contains('FLUTTER_HOST_WINDOW'));
-      expect(nativeSurfaceSource,
-          contains("'flutterViewId': View.of(context).viewId"));
+      expect(
+        nativeSurfaceSource,
+        contains("'flutterViewId': flutterViewId"),
+      );
+      expect(
+        nativeSurfaceSource,
+        contains('flutterViewId ?? -1'),
+      );
+      expect(
+        videoPlayerUiSource,
+        contains('DesktopMultiWindow.isSecondaryWindow(context)'),
+      );
+      expect(
+        videoPlayerUiSource,
+        contains('isDetachedView ? null : rect'),
+      );
+      expect(
+        serviceSource,
+        contains('_clearWindowHostedVideoCutout();'),
+      );
+      expect(
+        erikaSurfaceSource,
+        contains('DesktopMultiWindow.isSecondaryWindow(context)'),
+      );
+      expect(erikaSurfaceSource, contains('flutterViewId: flutterViewId'));
+      expect(erikaSurfaceSource, contains('secondaryWindow: secondaryWindow'));
       expect(
           File('lib/pages/desktop_pip_window_app.dart').existsSync(), isFalse);
     });

--- a/test/native_danmaku_visibility_test.dart
+++ b/test/native_danmaku_visibility_test.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/player_abstraction/player_abstraction.dart';
+
+class _NativeDanmakuDelegate extends Fake implements AbstractPlayer {
+  final List<bool> visibilityCalls = <bool>[];
+  final List<Map<String, Object?>> configCalls = <Map<String, Object?>>[];
+  Completer<void>? pendingCall;
+
+  bool get supportsNativeDanmaku => true;
+
+  Future<void> setDanmakuEnabled(bool enabled) {
+    visibilityCalls.add(enabled);
+    final completer = Completer<void>();
+    pendingCall = completer;
+    return completer.future;
+  }
+
+  Future<void> setDanmakuConfig({
+    bool? enabled,
+    double? opacity,
+    double? fontSize,
+    double? displayArea,
+    bool? mergeDuplicates,
+    bool? allowStacking,
+    double? scrollDurationSeconds,
+    double? trackGapRatio,
+    double? outlineWidth,
+    int? shadowStyle,
+    String? customFontFamily,
+    String? customFontFilePath,
+  }) async {
+    configCalls.add(<String, Object?>{
+      if (enabled != null) 'enabled': enabled,
+      if (opacity != null) 'opacity': opacity,
+      if (fontSize != null) 'fontSize': fontSize,
+      if (displayArea != null) 'displayArea': displayArea,
+      if (mergeDuplicates != null) 'mergeDuplicates': mergeDuplicates,
+      if (allowStacking != null) 'allowStacking': allowStacking,
+      if (scrollDurationSeconds != null)
+        'scrollDurationSeconds': scrollDurationSeconds,
+      if (trackGapRatio != null) 'trackGapRatio': trackGapRatio,
+      if (outlineWidth != null) 'outlineWidth': outlineWidth,
+      if (shadowStyle != null) 'shadowStyle': shadowStyle,
+      if (customFontFamily != null) 'customFontFamily': customFontFamily,
+      if (customFontFilePath != null)
+        'customFontFilePath': customFontFilePath,
+    });
+  }
+}
+
+void main() {
+  test('native danmaku visibility uses the dedicated immediate delegate call',
+      () async {
+    final delegate = _NativeDanmakuDelegate();
+    final player = Player.withDelegate(delegate);
+    var completed = false;
+
+    final update = player.setNativeDanmakuEnabled(false).then((_) {
+      completed = true;
+    });
+
+    expect(delegate.visibilityCalls, <bool>[false]);
+    expect(completed, isFalse);
+
+    delegate.pendingCall!.complete();
+    await update;
+    expect(completed, isTrue);
+  });
+
+  test('native danmaku style updates remain field-specific', () async {
+    final delegate = _NativeDanmakuDelegate();
+    final player = Player.withDelegate(delegate);
+
+    await player.setNativeDanmakuConfig(opacity: 0.4);
+    await player.setNativeDanmakuConfig(fontSize: 36.0);
+
+    expect(delegate.configCalls, <Map<String, Object?>>[
+      <String, Object?>{'opacity': 0.4},
+      <String, Object?>{'fontSize': 36.0},
+    ]);
+  });
+}

--- a/test/player_seek_completion_contract_test.dart
+++ b/test/player_seek_completion_contract_test.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/player_abstraction/player_abstraction.dart';
+
+class _ControlledSeekDelegate extends Fake
+    implements AbstractPlayer, AsyncSeekPlayer {
+  final Completer<void> seekCompleter = Completer<void>();
+  int? requestedPosition;
+
+  @override
+  Future<void> seekAndWait({required int position}) {
+    requestedPosition = position;
+    return seekCompleter.future;
+  }
+}
+
+class _SynchronousSeekDelegate extends Fake implements AbstractPlayer {
+  int? requestedPosition;
+
+  @override
+  void seek({required int position}) {
+    requestedPosition = position;
+  }
+}
+
+void main() {
+  test('Player forwards the asynchronous seek completion contract', () async {
+    final delegate = _ControlledSeekDelegate();
+    final player = Player.withDelegate(delegate);
+    var completed = false;
+
+    final seek = player.seekAndWait(position: 12345).then((_) {
+      completed = true;
+    });
+
+    expect(delegate.requestedPosition, 12345);
+    expect(completed, isFalse);
+
+    delegate.seekCompleter.complete();
+    await seek;
+    expect(completed, isTrue);
+  });
+
+  test('Player keeps the legacy synchronous seek behavior as fallback',
+      () async {
+    final delegate = _SynchronousSeekDelegate();
+    final player = Player.withDelegate(delegate);
+
+    await player.seekAndWait(position: 6789);
+
+    expect(delegate.requestedPosition, 6789);
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <battery_plus/battery_plus_windows_plugin.h>
 #include <charset_converter/charset_converter_plugin.h>
+#include <dart_ipc/dart_ipc_plugin_c_api.h>
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
 #include <erika_flutter/erika_flutter_plugin_c_api.h>
@@ -31,6 +32,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("BatteryPlusWindowsPlugin"));
   CharsetConverterPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("CharsetConverterPlugin"));
+  DartIpcPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("DartIpcPluginCApi"));
   DesktopDropPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DesktopDropPlugin"));
   DynamicColorPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   battery_plus
   charset_converter
+  dart_ipc
   desktop_drop
   dynamic_color
   erika_flutter


### PR DESCRIPTION
## Summary

- add an optional asynchronous seek-completion contract and use it when restoring playback with Erika
- propagate danmaku shadow-style changes to Erika immediately
- restore the blurred backdrop around window-hosted video while preserving the transparent video cutout
- sync the existing `dart_ipc` dependency into the lockfile and Windows generated plugin registration
- add coverage for asynchronous seek completion and the synchronous fallback

## Why

Erika seek crosses an asynchronous platform bridge and waits for a native frame-output barrier. Startup could issue `play` before the resume seek completed, leaving the video surface without a current frame until the user sought again. Danmaku shadow changes were also persisted without being forwarded to Erika, and window-hosted video had switched to a forced black background instead of the normal blurred backdrop.

## Impact

Resume playback now waits for backends that expose asynchronous seek completion, while existing synchronous backends keep their current behavior. Erika visual settings update immediately, and hosted-video surroundings use the standard blurred background again.

The local Erika checkout override used during development is intentionally excluded from this PR; the committed dependency remains the versioned Git source.

## Validation

- `flutter test test/player_seek_completion_contract_test.dart`
- repeated the same test from a clean worktree at commit `73faf335` using the committed remote Erika dependency (`v0.1.3`)
- targeted `flutter analyze` completed with no errors; it reported 50 pre-existing warning/info findings in the selected large source files