### PR TITLE
fix(player): restore Erika window overlay state on exit

### DIFF
--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -275,18 +275,33 @@ class _NipaplayErikaWindowOverlayVideoViewState
     _retryTimer?.cancel();
     _frameTimer?.cancel();
     widget.onPlatformViewIdChanged?.call(null);
-    unawaited(_hideOverlayFrame());
-    unawaited(
-      widget.player.detachWindowOverlay(generation: _surfaceGeneration),
-    );
+    // Clear the Flutter cutout synchronously. Native teardown is asynchronous,
+    // so leaving this rect behind makes the next page look transparent until a
+    // resize/fullscreen event happens to force another repaint.
+    widget.onFrameRectChanged?.call(null);
+    unawaited(_releaseOverlaySurface());
     super.dispose();
+  }
+
+  Future<void> _releaseOverlaySurface() async {
+    await _hideOverlayFrame();
+    try {
+      await widget.player.detachWindowOverlay(
+        generation: _surfaceGeneration,
+      );
+    } catch (error) {
+      debugPrint(
+        'NipaplayErikaWindowOverlayVideoView: detach overlay failed: $error',
+      );
+    }
   }
 
   void _startFrameTimer() {
     _frameTimer?.cancel();
-    final interval = defaultTargetPlatform == TargetPlatform.windows
-        ? const Duration(milliseconds: 16)
-        : const Duration(milliseconds: 250);
+    // The Windows plugin follows WM_MOVE/WM_SIZE natively. This timer is only a
+    // fallback for Flutter-only layout changes; polling at display refresh rate
+    // duplicates native window movement work and makes live dragging stutter.
+    const interval = Duration(milliseconds: 250);
     _frameTimer = Timer.periodic(
       interval,
       (_) => _scheduleFrameUpdate(),

--- a/lib/themes/nipaplay/widgets/video_player_ui.dart
+++ b/lib/themes/nipaplay/widgets/video_player_ui.dart
@@ -709,6 +709,10 @@ class _VideoPlayerUIState extends State<VideoPlayerUI>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    // The window-hosted video surface punches a transparent hole through the
+    // Flutter background. Always restore it before this route is removed, even
+    // if the native overlay's asynchronous detach races with player disposal.
+    _videoPlayerStateInstance?.setWindowHostedVideoRect(null);
     // <<< ADDED: Clear the callback to prevent memory leaks
     _videoPlayerStateInstance?.onSeriousPlaybackErrorAndShouldPop = null;
     _contextMenuController.dispose();


### PR DESCRIPTION
## Summary

- clear the Flutter transparent video cutout synchronously when the Erika overlay widget is disposed
- hide the native overlay before detaching it and handle asynchronous detach failures
- clear the hosted video rectangle when leaving the player route
- reduce the Windows fallback frame polling interval because native window messages already track movement and resize

Companion native fixes: AimesSoft/Erika#66.

## Validation

- `flutter analyze lib/player_abstraction/erika_player_adapter.dart lib/themes/nipaplay/widgets/video_player_ui.dart`
- full `flutter build windows --debug` against Erika PR #66 built from source
- live validation of player exit, return to homepage, fullscreen transitions, playback resume, and subtitle layout

Local Erika path overrides, lockfile updates, and generated plugin files used for source-build testing are intentionally excluded from this PR.