### PR TITLE
fix: 修复播放器 User-Agent 应用时序

### DIFF
--- a/lib/player_abstraction/abstract_player.dart
+++ b/lib/player_abstraction/abstract_player.dart
@@ -30,6 +30,13 @@ abstract class AbstractPlayer {
   String get media;
   set media(String value);
 
+  /// Opens [value] and completes when this adapter's open boundary is reached.
+  ///
+  /// Adapters with an asynchronous native open operation should override this.
+  Future<void> openMedia(String value) async {
+    media = value;
+  }
+
   PlayerMediaInfo get mediaInfo;
 
   List<int> get activeSubtitleTracks;
@@ -65,7 +72,7 @@ abstract class AbstractPlayer {
 
   /// 设置 HTTP User-Agent（播放器请求视频时使用）。默认空实现，各内核按需 override。
   /// 空字符串 [ua] = 用内核默认 UA。在打开媒体前调用。
-  void setUserAgent(String ua) {}
+  Future<void> setUserAgent(String ua) async {}
   Future<void> setVideoSurfaceSize({int? width, int? height});
 
   /// 跳转到指定索引的章节（使用 mpv 原生 `chapter` 属性，keyframe 对齐）。

--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -713,6 +713,11 @@ class ErikaPlayerAdapter
   }
 
   @override
+  Future<void> openMedia(String value) async {
+    media = value;
+  }
+
+  @override
   PlayerMediaInfo get mediaInfo => _mediaInfo;
 
   @override
@@ -962,7 +967,7 @@ class ErikaPlayerAdapter
   }
 
   @override
-  void setUserAgent(String ua) {
+  Future<void> setUserAgent(String ua) async {
     // erika_flutter 暂未暴露设置 HTTP User-Agent 的接口，留空实现。
   }
 

--- a/lib/player_abstraction/mdk_player_adapter_io.dart
+++ b/lib/player_abstraction/mdk_player_adapter_io.dart
@@ -370,6 +370,11 @@ class MdkPlayerAdapter implements AbstractPlayer {
   }
 
   @override
+  Future<void> openMedia(String value) async {
+    media = value;
+  }
+
+  @override
   PlayerMediaInfo get mediaInfo => _toPlayerMediaInfo(_mdkPlayer.mediaInfo,
       internalAudioTrackCount: _internalAudioTrackCount);
 
@@ -532,8 +537,8 @@ class MdkPlayerAdapter implements AbstractPlayer {
   }
 
   @override
-  void setUserAgent(String ua) {
-    applyMdkUserAgentProperties(setProperty, ua);
+  Future<void> setUserAgent(String ua) async {
+    applyMdkUserAgentProperties(_setStickyProperty, ua);
     debugPrint('MDK: 已设置 user-agent: ${ua.isEmpty ? "(默认)" : ua}');
   }
 

--- a/lib/player_abstraction/mdk_player_adapter_unsupported.dart
+++ b/lib/player_abstraction/mdk_player_adapter_unsupported.dart
@@ -31,6 +31,11 @@ class MdkPlayerAdapter implements AbstractPlayer {
   set media(String value) {}
 
   @override
+  Future<void> openMedia(String value) async {
+    media = value;
+  }
+
+  @override
   PlayerMediaInfo get mediaInfo => PlayerMediaInfo(duration: 0);
 
   @override
@@ -86,7 +91,7 @@ class MdkPlayerAdapter implements AbstractPlayer {
   void setProperty(String key, String value) {}
 
   @override
-  void setUserAgent(String ua) {}
+  Future<void> setUserAgent(String ua) async {}
 
   @override
   Future<void> setVideoSurfaceSize({int? width, int? height}) async {}

--- a/lib/player_abstraction/media_kit_player_adapter.dart
+++ b/lib/player_abstraction/media_kit_player_adapter.dart
@@ -1838,6 +1838,11 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
   }
 
   @override
+  Future<void> openMedia(String value) async {
+    media = value;
+  }
+
+  @override
   PlayerMediaInfo get mediaInfo => _mediaInfo;
 
   @override
@@ -2459,19 +2464,26 @@ class MediaKitPlayerAdapter implements AbstractPlayer, TickerProvider {
   }
 
   @override
-  void setUserAgent(String ua) {
+  Future<void> setUserAgent(String ua) async {
     try {
       // mpv 的 user-agent 属性，对所有 HTTP 请求生效。须在打开媒体前设置。
+      dynamic pendingUpdate;
       applyMediaKitUserAgentProperty(
-        (key, value) => unawaited(
-          (_player.platform as dynamic).setProperty(key, value),
+        (key, value) =>
+            pendingUpdate = (_player.platform as dynamic).setProperty(
+          key,
+          value,
         ),
         ua,
       );
+      if (pendingUpdate != null) {
+        await pendingUpdate;
+      }
       _properties['user-agent'] = ua;
       debugPrint('MediaKit: 已设置 user-agent: ${ua.isEmpty ? "(默认)" : ua}');
     } catch (e) {
       debugPrint('MediaKit: 设置 user-agent 失败: $e');
+      rethrow;
     }
   }
 

--- a/lib/player_abstraction/player_abstraction.dart
+++ b/lib/player_abstraction/player_abstraction.dart
@@ -36,6 +36,7 @@ enum MediaType { unknown, video, audio, subtitle }
 class Player {
   final core_player.AbstractPlayer _delegate;
   Future<void>? _disposeFuture;
+  Future<void>? _openQueueTail;
   bool _disposeErrorHandlerAttached = false;
 
   /// Factory constructor that allows `Player()` to be called.
@@ -93,6 +94,27 @@ class Player {
 
   String get media => _delegate.media;
   set media(String value) => _delegate.media = value;
+
+  Future<void> openMedia(String value) async {
+    final previousOpen = _openQueueTail;
+    final currentOpen = Completer<void>();
+    final currentOpenFuture = currentOpen.future;
+    _openQueueTail = currentOpenFuture;
+    try {
+      if (previousOpen != null) {
+        await previousOpen;
+      }
+      await PlayerFactory.runWithUserAgentForNextOpen(
+        setUserAgent: _delegate.setUserAgent,
+        openMedia: () => _delegate.openMedia(value),
+      );
+    } finally {
+      currentOpen.complete();
+      if (identical(_openQueueTail, currentOpenFuture)) {
+        _openQueueTail = null;
+      }
+    }
+  }
 
   PlayerMediaInfo get mediaInfo => _delegate.mediaInfo;
 
@@ -243,7 +265,7 @@ class Player {
       _delegate.setProperty(key, value);
 
   /// 设置 HTTP User-Agent（播放器请求视频时）。空字符串 = 用内核默认 UA。
-  void setUserAgent(String ua) => _delegate.setUserAgent(ua);
+  Future<void> setUserAgent(String ua) => _delegate.setUserAgent(ua);
 
   Future<void> setVideoSurfaceSize({int? width, int? height}) =>
       _delegate.setVideoSurfaceSize(width: width, height: height);

--- a/lib/player_abstraction/player_factory.dart
+++ b/lib/player_abstraction/player_factory.dart
@@ -44,6 +44,7 @@ class PlayerFactory {
   static String _cachedCustomPlayerUA = ''; // 自定义播放器 UA，空=用内核默认
   static String _cachedHttpProxy = '';
   static String? _oneTimeUA; // 一次性 UA（仅下一次播放有效，不持久化，用后即清）
+  static int _oneTimeUAGeneration = 0;
   static bool _hasLoadedSettings = false;
 
   // 添加一个StreamController来广播内核切换事件
@@ -199,6 +200,7 @@ class PlayerFactory {
   /// 优先级高于 [getCustomPlayerUA] 的持久 UA。空字符串清除一次性 UA。
   static void setOneTimeUA(String ua) {
     final resolved = ua.trim();
+    _oneTimeUAGeneration++;
     _oneTimeUA = resolved.isEmpty ? null : resolved;
   }
 
@@ -212,8 +214,35 @@ class PlayerFactory {
   /// 获取一次性 UA（不消费，供 UI 预填）。未设置返回 null。
   static String? getOneTimeUA() => _oneTimeUA;
 
-  static void applyUserAgentForNextOpen(void Function(String) setUserAgent) {
-    setUserAgent(consumeOneTimeUA() ?? getCustomPlayerUA());
+  static Future<void> applyUserAgentForNextOpen(
+    Future<void> Function(String) setUserAgent,
+  ) async {
+    await runWithUserAgentForNextOpen(
+      setUserAgent: setUserAgent,
+      openMedia: () async {},
+    );
+  }
+
+  static Future<void> runWithUserAgentForNextOpen({
+    required Future<void> Function(String) setUserAgent,
+    required Future<void> Function() openMedia,
+  }) async {
+    final reservedUserAgent = _oneTimeUA;
+    final reservationGeneration = _oneTimeUAGeneration;
+    if (reservedUserAgent != null) {
+      _oneTimeUA = null;
+    }
+    try {
+      await setUserAgent(reservedUserAgent ?? getCustomPlayerUA());
+      await openMedia();
+    } catch (_) {
+      if (reservedUserAgent != null &&
+          _oneTimeUAGeneration == reservationGeneration &&
+          _oneTimeUA == null) {
+        _oneTimeUA = reservedUserAgent;
+      }
+      rethrow;
+    }
   }
 
   static int _clampPrecacheBufferSizeMb(int value) {

--- a/lib/player_abstraction/video_player_adapter.dart
+++ b/lib/player_abstraction/video_player_adapter.dart
@@ -208,6 +208,11 @@ class VideoPlayerAdapter implements AbstractPlayer, TickerProvider {
     _createOrRebuildController();
   }
 
+  @override
+  Future<void> openMedia(String value) async {
+    media = value;
+  }
+
   void _disposeController() {
     try {
       if (_controller != null) {
@@ -821,7 +826,7 @@ class VideoPlayerAdapter implements AbstractPlayer, TickerProvider {
   }
 
   @override
-  void setUserAgent(String ua) {
+  Future<void> setUserAgent(String ua) async {
     // video_player 插件无设置 HTTP User-Agent 的能力，留空实现。
   }
 

--- a/lib/utils/video_player_state/video_player_state_player_setup.dart
+++ b/lib/utils/video_player_state/video_player_state_player_setup.dart
@@ -397,9 +397,7 @@ extension VideoPlayerStatePlayerSetup on VideoPlayerState {
 
       // 应用自定义 User-Agent（须在打开媒体前设置；空字符串 = 用内核默认 UA）。
       // 优先用一次性 UA（串流菜单设置，仅本次有效，用后即清），否则用持久 UA。
-      PlayerFactory.applyUserAgentForNextOpen(player.setUserAgent);
-
-      player.media = playUrl;
+      await player.openMedia(playUrl);
       await applyErikaUpscalerModeToCurrentPlayer();
 
       //debugPrint('4. 准备播放器...');

--- a/test/player_user_agent_open_contract_test.dart
+++ b/test/player_user_agent_open_contract_test.dart
@@ -1,31 +1,38 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:nipaplay/player_abstraction/abstract_player.dart';
 import 'package:nipaplay/player_abstraction/mdk_player_adapter_io.dart';
 import 'package:nipaplay/player_abstraction/media_kit_player_adapter.dart';
+import 'package:nipaplay/player_abstraction/player_abstraction.dart';
 import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('every player open applies and then clears a one-time User-Agent',
-      () async {
-    SharedPreferences.setMockInitialValues({});
-    await PlayerFactory.initialize();
-    final player = _UserAgentRecordingPlayer();
-    addTearDown(() {
-      PlayerFactory.setOneTimeUA('');
+  test(
+    'every player open applies and then clears a one-time User-Agent',
+    () async {
       SharedPreferences.setMockInitialValues({});
-    });
+      await PlayerFactory.initialize();
+      final player = _UserAgentRecordingPlayer();
+      addTearDown(() {
+        PlayerFactory.setOneTimeUA('');
+        SharedPreferences.setMockInitialValues({});
+      });
 
-    PlayerFactory.setOneTimeUA('OneTimeClient/1.0');
-    PlayerFactory.applyUserAgentForNextOpen(player.setUserAgent);
-    PlayerFactory.applyUserAgentForNextOpen(player.setUserAgent);
+      PlayerFactory.setOneTimeUA('OneTimeClient/1.0');
+      await Function.apply(PlayerFactory.applyUserAgentForNextOpen, [
+        player.setUserAgent,
+      ]);
+      await Function.apply(PlayerFactory.applyUserAgentForNextOpen, [
+        player.setUserAgent,
+      ]);
 
-    expect(player.userAgents, <String>['OneTimeClient/1.0', '']);
-  });
+      expect(player.userAgents, <String>['OneTimeClient/1.0', '']);
+    },
+  );
 
   test('empty User-Agent clears both native player option layers', () {
     final mdkApplied = <(String, String)>[];
@@ -46,16 +53,217 @@ void main() {
     expect(mediaKitApplied, <(String, String)>[('user-agent', '')]);
   });
 
-  test('stream setup does not issue an unconfigured HTTP preflight', () {
+  test('MDK User-Agent setter uses the error-propagating property path', () {
     final source = File(
-      'lib/utils/video_player_state/video_player_state_player_setup.dart',
+      'lib/player_abstraction/mdk_player_adapter_io.dart',
     ).readAsStringSync();
-
-    expect(source, isNot(contains('http.head(')));
-    expect(
+    final setter = _methodBody(
       source,
-      contains('PlayerFactory.applyUserAgentForNextOpen(player.setUserAgent);'),
+      'Future<void> setUserAgent(String ua)',
+      'void setProperty(String key, String value)',
     );
+
+    expect(
+      setter,
+      contains('applyMdkUserAgentProperties(_setStickyProperty, ua)'),
+    );
+    expect(setter, isNot(contains('applyMdkUserAgentProperties(setProperty')));
+  });
+
+  test(
+    'initializePlayer delegates its only media open to the ordered boundary',
+    () {
+      final source = File(
+        'lib/utils/video_player_state/video_player_state_player_setup.dart',
+      ).readAsStringSync();
+      final initializePlayer = _methodBody(
+        source,
+        'Future<void> initializePlayer(',
+        'void _startBackgroundDanmakuLoading(',
+      );
+
+      expect(initializePlayer, isNot(contains('http.head(')));
+      expect(initializePlayer, contains('await player.openMedia(playUrl);'));
+      expect(
+        RegExp(r'\bplayer\.openMedia\(playUrl\)').allMatches(initializePlayer),
+        hasLength(1),
+      );
+      expect(initializePlayer, isNot(contains('player.media = playUrl;')));
+    },
+  );
+
+  test(
+    'player open waits until an asynchronous User-Agent setter completes',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      await PlayerFactory.initialize();
+      final setterMayComplete = Completer<void>();
+      final events = <String>[];
+
+      final result = Function.apply(PlayerFactory.applyUserAgentForNextOpen, [
+        (String userAgent) async {
+          events.add('setter-start:$userAgent');
+          await setterMayComplete.future;
+          events.add('setter-complete');
+        },
+      ]);
+
+      if (result is! Future<void>) {
+        fail('applyUserAgentForNextOpen must expose asynchronous completion');
+      }
+      var applyCompleted = false;
+      result.then((_) => applyCompleted = true);
+      await Future<void>.delayed(Duration.zero);
+      expect(applyCompleted, isFalse);
+
+      setterMayComplete.complete();
+      await result;
+
+      expect(applyCompleted, isTrue);
+      expect(events, <String>['setter-start:', 'setter-complete']);
+    },
+  );
+
+  test(
+    'media-open boundary waits for User-Agent before opening media',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      await PlayerFactory.initialize();
+      final setterMayComplete = Completer<void>();
+      final delegate = _OrderedMediaOpenPlayer(setterMayComplete);
+      final player = Player.withDelegate(delegate);
+
+      final open = player.openMedia('https://media.example/video.mkv');
+
+      await Future<void>.delayed(Duration.zero);
+      expect(delegate.events, <String>['setter-start:']);
+
+      setterMayComplete.complete();
+      await open;
+
+      expect(delegate.events, <String>[
+        'setter-start:',
+        'setter-complete',
+        'media-open:https://media.example/video.mkv',
+      ]);
+    },
+  );
+
+  test('media-open boundary awaits the delegate open operation', () async {
+    SharedPreferences.setMockInitialValues({});
+    await PlayerFactory.initialize();
+    final delegate = _AwaitableMediaOpenPlayer();
+    final player = Player.withDelegate(delegate);
+    var completed = false;
+
+    final open = player
+        .openMedia('https://media.example/awaitable.mkv')
+        .whenComplete(() => completed = true);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(completed, isFalse);
+    expect(delegate.events, <String>[
+      'setter:',
+      'open-start:https://media.example/awaitable.mkv',
+    ]);
+
+    delegate.openMayComplete.complete();
+    await open;
+    expect(delegate.events, <String>[
+      'setter:',
+      'open-start:https://media.example/awaitable.mkv',
+      'open-complete',
+    ]);
+  });
+
+  test(
+    'failed User-Agent application preserves one-time UA and does not open',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      await PlayerFactory.initialize();
+      PlayerFactory.setOneTimeUA('RetryClient/1.0');
+      addTearDown(() => PlayerFactory.setOneTimeUA(''));
+      final delegate = _FailingUserAgentPlayer();
+      final player = Player.withDelegate(delegate);
+
+      await expectLater(
+        player.openMedia('https://media.example/failing.mkv'),
+        throwsStateError,
+      );
+
+      expect(delegate.openedMedia, isEmpty);
+      expect(PlayerFactory.getOneTimeUA(), 'RetryClient/1.0');
+
+      delegate.failUserAgent = false;
+      await player.openMedia('https://media.example/retry.mkv');
+      expect(delegate.openedMedia, <String>[
+        'https://media.example/retry.mkv',
+      ]);
+      expect(PlayerFactory.getOneTimeUA(), isNull);
+    },
+  );
+
+  test('concurrent media opens are serialized in invocation order', () async {
+    SharedPreferences.setMockInitialValues({});
+    await PlayerFactory.initialize();
+    final delegate = _SequencedMediaOpenPlayer();
+    final player = Player.withDelegate(delegate);
+
+    final firstOpen = player.openMedia('https://media.example/first.mkv');
+    await Future<void>.delayed(Duration.zero);
+    final secondOpen = player.openMedia('https://media.example/second.mkv');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(delegate.events, <String>['setter-start:']);
+
+    delegate.setterCompletions.single.complete();
+    await Future<void>.delayed(Duration.zero);
+    expect(delegate.events, <String>[
+      'setter-start:',
+      'setter-complete',
+      'media-open:https://media.example/first.mkv',
+      'setter-start:',
+    ]);
+
+    delegate.setterCompletions.last.complete();
+    await Future.wait<void>([firstOpen, secondOpen]);
+    expect(delegate.events, <String>[
+      'setter-start:',
+      'setter-complete',
+      'media-open:https://media.example/first.mkv',
+      'setter-start:',
+      'setter-complete',
+      'media-open:https://media.example/second.mkv',
+    ]);
+  });
+
+  test('one-time User-Agent is reserved by only one player', () async {
+    SharedPreferences.setMockInitialValues({});
+    await PlayerFactory.initialize();
+    PlayerFactory.setOneTimeUA('SingleUseClient/1.0');
+    addTearDown(() => PlayerFactory.setOneTimeUA(''));
+    final firstDelegate = _BlockingUserAgentPlayer();
+    final secondDelegate = _BlockingUserAgentPlayer();
+    final firstPlayer = Player.withDelegate(firstDelegate);
+    final secondPlayer = Player.withDelegate(secondDelegate);
+
+    final firstOpen = firstPlayer.openMedia('https://media.example/first.mkv');
+    await firstDelegate.setterStarted.future.timeout(
+      const Duration(seconds: 1),
+    );
+    final secondOpen = secondPlayer.openMedia(
+      'https://media.example/second.mkv',
+    );
+    await secondDelegate.setterStarted.future.timeout(
+      const Duration(seconds: 1),
+    );
+
+    expect(firstDelegate.userAgents, <String>['SingleUseClient/1.0']);
+    expect(secondDelegate.userAgents, <String>['']);
+
+    firstDelegate.setterMayComplete.complete();
+    secondDelegate.setterMayComplete.complete();
+    await Future.wait<void>([firstOpen, secondOpen]);
   });
 }
 
@@ -63,5 +271,116 @@ class _UserAgentRecordingPlayer extends Fake implements AbstractPlayer {
   final List<String> userAgents = <String>[];
 
   @override
-  void setUserAgent(String ua) => userAgents.add(ua);
+  Future<void> setUserAgent(String ua) async => userAgents.add(ua);
+}
+
+class _OrderedMediaOpenPlayer extends Fake implements AbstractPlayer {
+  _OrderedMediaOpenPlayer(this.setterMayComplete);
+
+  final Completer<void> setterMayComplete;
+  final List<String> events = <String>[];
+
+  @override
+  Future<void> setUserAgent(String ua) async {
+    events.add('setter-start:$ua');
+    await setterMayComplete.future;
+    events.add('setter-complete');
+  }
+
+  @override
+  set media(String value) => events.add('media-open:$value');
+
+  @override
+  Future<void> openMedia(String value) async {
+    media = value;
+  }
+}
+
+class _FailingUserAgentPlayer extends Fake implements AbstractPlayer {
+  final List<String> openedMedia = <String>[];
+  bool failUserAgent = true;
+
+  @override
+  Future<void> setUserAgent(String ua) async {
+    if (failUserAgent) {
+      throw StateError('simulated User-Agent failure');
+    }
+  }
+
+  @override
+  set media(String value) => openedMedia.add(value);
+
+  @override
+  Future<void> openMedia(String value) async {
+    media = value;
+  }
+}
+
+class _AwaitableMediaOpenPlayer extends Fake implements AbstractPlayer {
+  final Completer<void> openMayComplete = Completer<void>();
+  final List<String> events = <String>[];
+
+  @override
+  Future<void> setUserAgent(String ua) async => events.add('setter:$ua');
+
+  @override
+  Future<void> openMedia(String value) async {
+    events.add('open-start:$value');
+    await openMayComplete.future;
+    events.add('open-complete');
+  }
+
+  @override
+  set media(String value) => events.add('legacy-media-setter:$value');
+}
+
+class _SequencedMediaOpenPlayer extends Fake implements AbstractPlayer {
+  final List<String> events = <String>[];
+  final List<Completer<void>> setterCompletions = <Completer<void>>[];
+
+  @override
+  Future<void> setUserAgent(String ua) async {
+    events.add('setter-start:$ua');
+    final completion = Completer<void>();
+    setterCompletions.add(completion);
+    await completion.future;
+    events.add('setter-complete');
+  }
+
+  @override
+  set media(String value) => events.add('media-open:$value');
+
+  @override
+  Future<void> openMedia(String value) async {
+    media = value;
+  }
+}
+
+class _BlockingUserAgentPlayer extends Fake implements AbstractPlayer {
+  final Completer<void> setterStarted = Completer<void>();
+  final Completer<void> setterMayComplete = Completer<void>();
+  final List<String> userAgents = <String>[];
+
+  @override
+  Future<void> setUserAgent(String ua) async {
+    userAgents.add(ua);
+    setterStarted.complete();
+    await setterMayComplete.future;
+  }
+
+  @override
+  set media(String value) {}
+
+  @override
+  Future<void> openMedia(String value) async {
+    media = value;
+  }
+}
+
+String _methodBody(String source, String startMarker, String endMarker) {
+  final start = source.indexOf(startMarker);
+  final end = source.indexOf(endMarker, start);
+  expect(start, greaterThanOrEqualTo(0), reason: 'missing $startMarker');
+  expect(end, greaterThan(start), reason: 'missing $endMarker');
+  return source.substring(start, end);
 }


### PR DESCRIPTION
## Summary

- 在打开媒体前等待播放器 User-Agent 设置完成
- 串行处理同一播放器的打开请求，并原子消费一次性 UA
- 设置或打开失败时保留一次性 UA，供后续重试

Refs #779