### PR TITLE
fix: 修复播放器恢复默认 User-Agent

### DIFF
--- a/lib/player_abstraction/mdk_player_adapter_io.dart
+++ b/lib/player_abstraction/mdk_player_adapter_io.dart
@@ -12,6 +12,7 @@ void applyMdkUserAgentProperties(
   void Function(String key, String value) setter,
   String userAgent,
 ) {
+  if (userAgent.isEmpty) return;
   setter('avformat.user_agent', userAgent);
   setter('avio.user_agent', userAgent);
 }

--- a/lib/player_abstraction/media_kit_player_adapter.dart
+++ b/lib/player_abstraction/media_kit_player_adapter.dart
@@ -19,6 +19,7 @@ void applyMediaKitUserAgentProperty(
   void Function(String key, String value) setter,
   String userAgent,
 ) {
+  if (userAgent.isEmpty) return;
   setter('user-agent', userAgent);
 }
 

--- a/lib/player_abstraction/player_factory.dart
+++ b/lib/player_abstraction/player_factory.dart
@@ -25,6 +25,11 @@ bool supportsPlayerHttpProxy(PlayerKernelType type) {
   return type == PlayerKernelType.mdk || type == PlayerKernelType.mediaKit;
 }
 
+/// Whether [type] exposes a native HTTP User-Agent option.
+bool supportsNativePlayerUserAgent(PlayerKernelType type) {
+  return type == PlayerKernelType.mdk || type == PlayerKernelType.mediaKit;
+}
+
 class PlayerFactory {
   static const String _playerKernelTypeKey = 'player_kernel_type';
   static const String _precacheBufferSizeKey = 'player_precache_buffer_size_mb';
@@ -322,17 +327,35 @@ class PlayerFactory {
   }
 
   /// 保存自定义播放器 User-Agent。空字符串表示用内核默认 UA。
-  /// 即时生效于"下一次打开视频"（当前正在播放的视频不会重新请求）。
+  ///
+  /// 新值用于下一次打开视频；从自定义值恢复默认值时，会重建当前原生
+  /// 播放器内核，以移除已写入该内核实例的 UA 覆盖。
   static Future<void> saveCustomPlayerUA(String ua) async {
     final resolved = ua.trim();
     try {
+      if (!_hasLoadedSettings) {
+        await initialize();
+      }
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(SettingsKeys.customPlayerUA, resolved);
+      final previous = _cachedCustomPlayerUA;
+      final saved =
+          await prefs.setString(SettingsKeys.customPlayerUA, resolved);
+      if (!saved) {
+        throw StateError('Failed to persist custom player User-Agent');
+      }
       _cachedCustomPlayerUA = resolved;
+      final kernelType = _cachedKernelType ?? PlayerKernelType.mdk;
+      if (previous.isNotEmpty &&
+          resolved.isEmpty &&
+          !kIsWeb &&
+          supportsNativePlayerUserAgent(kernelType)) {
+        _kernelChangeController.add(kernelType);
+      }
       debugPrint('[PlayerFactory] 已保存自定义播放器 UA: '
           '${resolved.isEmpty ? "(空=默认)" : resolved}');
     } catch (e) {
       debugPrint('[PlayerFactory] 保存自定义播放器 UA 出错: $e');
+      rethrow;
     }
   }
 

--- a/test/player_user_agent_open_contract_test.dart
+++ b/test/player_user_agent_open_contract_test.dart
@@ -1,7 +1,9 @@
+import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:nipaplay/player_abstraction/abstract_player.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/player_abstraction/mdk_player_adapter_io.dart';
 import 'package:nipaplay/player_abstraction/media_kit_player_adapter.dart';
 import 'package:nipaplay/player_abstraction/player_factory.dart';
@@ -10,41 +12,112 @@ import 'package:shared_preferences/shared_preferences.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('every player open applies and then clears a one-time User-Agent',
-      () async {
-    SharedPreferences.setMockInitialValues({});
-    await PlayerFactory.initialize();
-    final player = _UserAgentRecordingPlayer();
-    addTearDown(() {
-      PlayerFactory.setOneTimeUA('');
-      SharedPreferences.setMockInitialValues({});
-    });
+  test(
+    'default restore initializes the kernel and later write failures surface',
+    () async {
+      const channel = MethodChannel('plugins.flutter.io/shared_preferences');
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      var failWrites = false;
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'getAll') {
+          return <String, Object>{
+            'flutter.player_kernel_type': PlayerKernelType.mediaKit.index,
+            'flutter.${SettingsKeys.customPlayerUA}': 'CustomClient/1.0',
+          };
+        }
+        if (call.method == 'setString' && failWrites) {
+          throw PlatformException(
+            code: 'write-failed',
+            message: 'simulated persistence failure',
+          );
+        }
+        return true;
+      });
+      SharedPreferences.resetStatic();
+      final kernelChanged = Completer<PlayerKernelType>();
+      final subscription = PlayerFactory.onKernelChanged.listen((event) {
+        if (!kernelChanged.isCompleted) kernelChanged.complete(event);
+      });
+      addTearDown(() async {
+        await subscription.cancel();
+        messenger.setMockMethodCallHandler(channel, null);
+        SharedPreferences.resetStatic();
+      });
 
-    PlayerFactory.setOneTimeUA('OneTimeClient/1.0');
-    PlayerFactory.applyUserAgentForNextOpen(player.setUserAgent);
-    PlayerFactory.applyUserAgentForNextOpen(player.setUserAgent);
+      await PlayerFactory.saveCustomPlayerUA('');
 
-    expect(player.userAgents, <String>['OneTimeClient/1.0', '']);
-  });
+      expect(
+        await kernelChanged.future.timeout(const Duration(milliseconds: 250)),
+        PlayerKernelType.mediaKit,
+      );
 
-  test('empty User-Agent clears both native player option layers', () {
+      failWrites = true;
+      await expectLater(
+        PlayerFactory.saveCustomPlayerUA('UnsavedClient/2.0'),
+        throwsA(
+          isA<PlatformException>().having(
+            (error) => error.code,
+            'code',
+            'write-failed',
+          ),
+        ),
+      );
+    },
+  );
+
+  test('default User-Agent does not write an empty native option override', () {
     final mdkApplied = <(String, String)>[];
     applyMdkUserAgentProperties(
       (key, value) => mdkApplied.add((key, value)),
       '',
     );
-    expect(mdkApplied, <(String, String)>[
-      ('avformat.user_agent', ''),
-      ('avio.user_agent', ''),
-    ]);
+    expect(mdkApplied, isEmpty);
 
     final mediaKitApplied = <(String, String)>[];
     applyMediaKitUserAgentProperty(
       (key, value) => mediaKitApplied.add((key, value)),
       '',
     );
-    expect(mediaKitApplied, <(String, String)>[('user-agent', '')]);
+    expect(mediaKitApplied, isEmpty);
   });
+
+  test(
+    'restoring the default User-Agent requests the active native kernel',
+    () async {
+      addTearDown(() async {
+        await PlayerFactory.saveCustomPlayerUA('');
+        SharedPreferences.setMockInitialValues({});
+      });
+
+      for (final kernel in <PlayerKernelType>[
+        PlayerKernelType.mdk,
+        PlayerKernelType.mediaKit,
+      ]) {
+        SharedPreferences.setMockInitialValues({
+          'player_kernel_type': kernel.index,
+        });
+        await PlayerFactory.initialize();
+        await PlayerFactory.saveCustomPlayerUA('CustomClient/1.0');
+
+        final kernelChanged = Completer<PlayerKernelType>();
+        final subscription = PlayerFactory.onKernelChanged.listen((event) {
+          if (!kernelChanged.isCompleted) kernelChanged.complete(event);
+        });
+        try {
+          await PlayerFactory.saveCustomPlayerUA('');
+          expect(
+            await kernelChanged.future.timeout(
+              const Duration(milliseconds: 250),
+            ),
+            kernel,
+          );
+        } finally {
+          await subscription.cancel();
+        }
+      }
+    },
+  );
 
   test('stream setup does not issue an unconfigured HTTP preflight', () {
     final source = File(
@@ -57,11 +130,4 @@ void main() {
       contains('PlayerFactory.applyUserAgentForNextOpen(player.setUserAgent);'),
     );
   });
-}
-
-class _UserAgentRecordingPlayer extends Fake implements AbstractPlayer {
-  final List<String> userAgents = <String>[];
-
-  @override
-  void setUserAgent(String ua) => userAgents.add(ua);
 }


### PR DESCRIPTION
## Summary

- 恢复默认值时不再向原生播放器写入空 UA 覆盖
- 重建当前 MDK 或 MediaKit 内核以移除已应用的自定义 UA
- 初始化持久化状态并传播保存错误

Refs #779