### PR TITLE
fix: 修复连接 User-Agent 保存失败状态

### DIFF
--- a/lib/services/media_server_transport.dart
+++ b/lib/services/media_server_transport.dart
@@ -11,6 +11,7 @@ import 'media_server_transport_client_stub.dart'
 /// Sends Emby/Jellyfin HTTP requests through one configurable transport.
 class MediaServerTransport {
   static String? _connectionUserAgentCache;
+  static Future<void>? _connectionUserAgentSaveQueueTail;
 
   static const String defaultConnectionUserAgent = defaultNipaPlayUserAgent;
 
@@ -31,15 +32,34 @@ class MediaServerTransport {
   /// An empty value restores [defaultConnectionUserAgent].
   static Future<String> saveConnectionUserAgent(String userAgent) async {
     final sanitized = sanitizeHttpUserAgent(userAgent);
-    _connectionUserAgentCache = sanitized;
+    final previousSave = _connectionUserAgentSaveQueueTail;
+    final currentSave = Completer<void>();
+    final currentSaveFuture = currentSave.future;
+    _connectionUserAgentSaveQueueTail = currentSaveFuture;
     try {
+      if (previousSave != null) {
+        await previousSave;
+      }
       final preferences = await SharedPreferences.getInstance();
-      await preferences.setString(
+      _connectionUserAgentCache ??= sanitizeHttpUserAgent(
+        preferences.getString(SettingsKeys.mediaServerConnectionUserAgent) ??
+            '',
+      );
+      final saved = await preferences.setString(
         SettingsKeys.mediaServerConnectionUserAgent,
         sanitized,
       );
-    } catch (_) {}
-    return sanitized;
+      if (!saved) {
+        throw StateError('Failed to persist media-server User-Agent');
+      }
+      _connectionUserAgentCache = sanitized;
+      return sanitized;
+    } finally {
+      currentSave.complete();
+      if (identical(_connectionUserAgentSaveQueueTail, currentSaveFuture)) {
+        _connectionUserAgentSaveQueueTail = null;
+      }
+    }
   }
 
   /// Returns the stored value; an empty value means to use the app default.

--- a/lib/settings/widgets/media_server_connection_user_agent_setting.dart
+++ b/lib/settings/widgets/media_server_connection_user_agent_setting.dart
@@ -15,7 +15,17 @@ bool supportsMediaServerConnectionUserAgentSetting({bool isWeb = kIsWeb}) {
 }
 
 class MediaServerConnectionUserAgentSetting extends StatefulWidget {
-  const MediaServerConnectionUserAgentSetting({super.key});
+  const MediaServerConnectionUserAgentSetting({
+    super.key,
+    this.loadUserAgent,
+    this.saveUserAgent,
+  });
+
+  /// Overrides the persisted-value loader in tests or alternate hosts.
+  final Future<String> Function()? loadUserAgent;
+
+  /// Overrides the persisted-value writer in tests or alternate hosts.
+  final Future<String> Function(String userAgent)? saveUserAgent;
 
   @override
   State<MediaServerConnectionUserAgentSetting> createState() =>
@@ -61,7 +71,9 @@ class _MediaServerConnectionUserAgentSettingState
   }
 
   Future<void> _loadUserAgent() async {
-    final stored = await MediaServerServiceBase.getStoredConnectionUserAgent();
+    final loadUserAgent = widget.loadUserAgent ??
+        MediaServerServiceBase.getStoredConnectionUserAgent;
+    final stored = await loadUserAgent();
     if (!mounted) return;
     setState(() {
       _storedUserAgent = stored;
@@ -74,29 +86,50 @@ class _MediaServerConnectionUserAgentSettingState
     if (!mounted || input == null) return;
 
     setState(() => _isSaving = true);
-    final saved = await MediaServerServiceBase.saveConnectionUserAgent(input);
-    if (!mounted) return;
-    setState(() {
-      _storedUserAgent = saved;
-      _isSaving = false;
-    });
-    AdaptiveSnackBar.show(
-      context,
-      message: saved.isEmpty
-          ? _text(
-              context,
-              '已恢复默认连接 UA',
-              '已恢復預設連線 UA',
-              'Default connection UA restored.',
-            )
-          : _text(
-              context,
-              '连接 UA 已保存',
-              '連線 UA 已儲存',
-              'Connection UA saved.',
-            ),
-      type: AdaptiveSnackBarType.success,
-    );
+    try {
+      final saveUserAgent = widget.saveUserAgent ??
+          MediaServerServiceBase.saveConnectionUserAgent;
+      final saved = await saveUserAgent(input);
+      if (!mounted) return;
+      setState(() => _storedUserAgent = saved);
+      AdaptiveSnackBar.show(
+        context,
+        message: saved.isEmpty
+            ? _text(
+                context,
+                '已恢复默认连接 UA',
+                '已恢復預設連線 UA',
+                'Default connection UA restored.',
+              )
+            : _text(
+                context,
+                '连接 UA 已保存',
+                '連線 UA 已儲存',
+                'Connection UA saved.',
+              ),
+        type: AdaptiveSnackBarType.success,
+      );
+    } catch (error, stackTrace) {
+      debugPrint(
+        '[MediaServerConnectionUserAgentSetting] save failed: '
+        '$error\n$stackTrace',
+      );
+      if (!mounted) return;
+      AdaptiveSnackBar.show(
+        context,
+        message: _text(
+          context,
+          '连接 UA 保存失败',
+          '連線 UA 儲存失敗',
+          'Failed to save connection UA.',
+        ),
+        type: AdaptiveSnackBarType.error,
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
   }
 
   Future<String?> _showInputDialog() async {

--- a/test/media_server_image_loader_test.dart
+++ b/test/media_server_image_loader_test.dart
@@ -4,8 +4,11 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nipaplay/services/media_server_image_loader.dart';
 import 'package:nipaplay/services/media_server_service_base.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
   test('media-server image detection stays inside the registered base path',
       () {
     setMediaServerBaseUrl('test-emby', 'https://media.example/emby');

--- a/test/media_server_playback_sync_user_agent_test.dart
+++ b/test/media_server_playback_sync_user_agent_test.dart
@@ -10,8 +10,11 @@ import 'package:nipaplay/services/jellyfin_playback_sync_service.dart';
 import 'package:nipaplay/services/jellyfin_service.dart';
 import 'package:nipaplay/services/media_server_service_base.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
   test('Emby and Jellyfin playback sync use the configured User-Agent',
       () async {
     final embyRequests = <_RecordedRequest>[];
@@ -97,7 +100,8 @@ void main() {
     expect(embyRequests, hasLength(2));
     expect(jellyfinRequests, hasLength(2));
     expect(
-      [...embyRequests, ...jellyfinRequests].map((request) => request.userAgent),
+      [...embyRequests, ...jellyfinRequests]
+          .map((request) => request.userAgent),
       everyElement('SyncClient/4.0'),
     );
     expect(embyRequests.first.method, 'GET');

--- a/test/media_server_transport_test.dart
+++ b/test/media_server_transport_test.dart
@@ -1,29 +1,36 @@
 import 'dart:async';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
+import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/services/media_server_image_loader.dart';
 import 'package:nipaplay/services/media_server_transport.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  test('adds the app User-Agent unless the caller already supplied one',
-      () async {
-    final client = _RecordingClient();
-    final transport = MediaServerTransport.fromClient(client);
-    addTearDown(transport.close);
+  TestWidgetsFlutterBinding.ensureInitialized();
 
-    await transport.send(
-      http.Request('GET', Uri.parse('http://media.invalid/default')),
-      timeout: const Duration(seconds: 1),
-    );
-    await transport.send(
-      http.Request('GET', Uri.parse('http://media.invalid/explicit'))
-        ..headers['user-agent'] = 'ExplicitClient/3.0',
-      timeout: const Duration(seconds: 1),
-    );
+  test(
+    'adds the app User-Agent unless the caller already supplied one',
+    () async {
+      final client = _RecordingClient();
+      final transport = MediaServerTransport.fromClient(client);
+      addTearDown(transport.close);
 
-    expect(client.userAgents, ['NipaPlay/1.0', 'ExplicitClient/3.0']);
-  });
+      await transport.send(
+        http.Request('GET', Uri.parse('http://media.invalid/default')),
+        timeout: const Duration(seconds: 1),
+      );
+      await transport.send(
+        http.Request('GET', Uri.parse('http://media.invalid/explicit'))
+          ..headers['user-agent'] = 'ExplicitClient/3.0',
+        timeout: const Duration(seconds: 1),
+      );
+
+      expect(client.userAgents, ['NipaPlay/1.0', 'ExplicitClient/3.0']);
+    },
+  );
 
   test('closes its pending client only after a request times out', () async {
     final client = _StallingClient();
@@ -32,19 +39,13 @@ void main() {
     final targetUri = Uri.parse('http://media.invalid/slow');
 
     final responseFuture = transport.send(
-      http.Request(
-        'GET',
-        targetUri,
-      ),
+      http.Request('GET', targetUri),
       timeout: const Duration(milliseconds: 100),
     );
     expect(client.sentRequests, [('GET', targetUri)]);
     expect(client.isClosed, isFalse);
 
-    await expectLater(
-      responseFuture,
-      throwsA(isA<TimeoutException>()),
-    );
+    await expectLater(responseFuture, throwsA(isA<TimeoutException>()));
     expect(client.isClosed, isTrue);
   });
 
@@ -92,6 +93,55 @@ void main() {
     );
   });
 
+  test(
+    'connection User-Agent save failures are reported and keep the old UA',
+    () async {
+      const channel = MethodChannel('plugins.flutter.io/shared_preferences');
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      final persistenceError = PlatformException(
+        code: 'write-failed',
+        message: 'simulated persistence failure',
+      );
+      var failWrites = true;
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'getAll') {
+          return <String, Object>{
+            'flutter.${SettingsKeys.mediaServerConnectionUserAgent}':
+                'WorkingClient/1.0',
+          };
+        }
+        if (call.method == 'setString' && failWrites) {
+          throw persistenceError;
+        }
+        return true;
+      });
+      SharedPreferences.resetStatic();
+      addTearDown(() async {
+        failWrites = false;
+        await MediaServerTransport.saveConnectionUserAgent('');
+        messenger.setMockMethodCallHandler(channel, null);
+        SharedPreferences.resetStatic();
+      });
+
+      await expectLater(
+        MediaServerTransport.saveConnectionUserAgent('UnsavedClient/2.0'),
+        throwsA(
+          isA<PlatformException>()
+              .having((error) => error.code, 'code', persistenceError.code)
+              .having(
+                (error) => error.message,
+                'message',
+                persistenceError.message,
+              ),
+        ),
+      );
+      expect(
+        await MediaServerTransport.getStoredConnectionUserAgent(),
+        'WorkingClient/1.0',
+      );
+    },
+  );
 }
 
 class _StallingClient extends http.BaseClient {

--- a/test/unified_network_settings_widget_test.dart
+++ b/test/unified_network_settings_widget_test.dart
@@ -116,4 +116,43 @@ void main() {
     await tester.pump(const Duration(seconds: 5));
     await tester.pumpAndSettle();
   });
+
+  testWidgets(
+    'connection UA save failure keeps the old value and re-enables editing',
+    (tester) async {
+      var saveAttempts = 0;
+      await tester.pumpWidget(
+        buildApp(
+          MediaServerConnectionUserAgentSetting(
+            loadUserAgent: () async => 'WorkingClient/1.0',
+            saveUserAgent: (value) async {
+              saveAttempts++;
+              throw StateError('simulated write failure');
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final tile = find.text('连接 User-Agent（Jellyfin/Emby）');
+      await tester.tap(tile);
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byType(TextField).last,
+        'UnsavedClient/2.0',
+      );
+      await tester.tap(find.text('保存').last);
+      await tester.pumpAndSettle();
+
+      expect(saveAttempts, 1);
+      expect(find.text('WorkingClient/1.0'), findsOneWidget);
+      expect(find.text('连接 UA 保存失败'), findsOneWidget);
+
+      await tester.tap(tile);
+      await tester.pumpAndSettle();
+      expect(find.byType(TextField), findsWidgets);
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+    },
+  );
 }


### PR DESCRIPTION
## Summary

- 仅在持久化成功后更新连接 UA 缓存
- 串行保存并确保失败不会阻塞后续操作
- 保存失败时保留旧值、恢复编辑状态并显示错误提示

Refs #779