### PR TITLE
fix: 完善 Windows HTTP 代理地址校验

### DIFF
--- a/lib/services/app_http_proxy.dart
+++ b/lib/services/app_http_proxy.dart
@@ -8,14 +8,24 @@ class AppHttpProxy {
     if (trimmed.isEmpty) return null;
 
     final uri = Uri.tryParse(trimmed);
+    final schemeSeparator = trimmed.indexOf('://');
+    final rawAuthority = schemeSeparator < 0
+        ? ''
+        : trimmed.substring(schemeSeparator + 3).split(RegExp(r'[/#?]')).first;
     if (uri == null ||
         uri.scheme != 'http' ||
         uri.host.isEmpty ||
         uri.userInfo.isNotEmpty ||
+        rawAuthority.endsWith(':') ||
         (uri.path.isNotEmpty && uri.path != '/') ||
         uri.hasQuery ||
         uri.hasFragment) {
       throw const FormatException('Unsupported HTTP proxy endpoint');
+    }
+    final port = uri.hasPort ? uri.port : 80;
+    if (port < 1 || port > 65535) {
+      throw const FormatException(
+          'HTTP proxy port must be between 1 and 65535');
     }
     return uri;
   }
@@ -33,6 +43,8 @@ class AppHttpProxy {
     final endpoint = validate(_endpoint);
     if (endpoint == null) return systemProxy(target);
     final port = endpoint.hasPort ? endpoint.port : 80;
-    return 'PROXY ${endpoint.host}:$port';
+    final host =
+        endpoint.host.contains(':') ? '[${endpoint.host}]' : endpoint.host;
+    return 'PROXY $host:$port';
   }
 }

--- a/test/app_http_proxy_test.dart
+++ b/test/app_http_proxy_test.dart
@@ -4,25 +4,27 @@ import 'package:nipaplay/services/app_http_proxy.dart';
 void main() {
   tearDown(AppHttpProxy.clear);
 
-  test('manual HTTP proxy overrides the system proxy for all target schemes',
-      () {
-    AppHttpProxy.set('  http://127.0.0.1:8000  ');
+  test(
+    'manual HTTP proxy overrides the system proxy for all target schemes',
+    () {
+      AppHttpProxy.set('  http://127.0.0.1:8000  ');
 
-    expect(
-      AppHttpProxy.findProxy(
-        Uri.parse('http://media.example/video'),
-        (_) => 'DIRECT',
-      ),
-      'PROXY 127.0.0.1:8000',
-    );
-    expect(
-      AppHttpProxy.findProxy(
-        Uri.parse('https://media.example/video'),
-        (_) => 'DIRECT',
-      ),
-      'PROXY 127.0.0.1:8000',
-    );
-  });
+      expect(
+        AppHttpProxy.findProxy(
+          Uri.parse('http://media.example/video'),
+          (_) => 'DIRECT',
+        ),
+        'PROXY 127.0.0.1:8000',
+      );
+      expect(
+        AppHttpProxy.findProxy(
+          Uri.parse('https://media.example/video'),
+          (_) => 'DIRECT',
+        ),
+        'PROXY 127.0.0.1:8000',
+      );
+    },
+  );
 
   test('empty manual proxy preserves system proxy behavior', () {
     expect(
@@ -40,10 +42,21 @@ void main() {
       AppHttpProxy.validate('http://proxy.example:8080'),
       Uri.parse('http://proxy.example:8080'),
     );
+    expect(
+      AppHttpProxy.validate('http://proxy.example:1'),
+      Uri.parse('http://proxy.example:1'),
+    );
+    expect(
+      AppHttpProxy.validate('http://proxy.example:65535'),
+      Uri.parse('http://proxy.example:65535'),
+    );
 
     for (final invalid in <String>[
       'https://proxy.example:443',
       'socks5://proxy.example:1080',
+      'http://proxy.example:',
+      'http://proxy.example:0',
+      'http://proxy.example:65536',
       'http://proxy.example:8080/path',
       'http://proxy.example:8080?mode=proxy',
       'http://proxy.example:8080#fragment',
@@ -55,5 +68,17 @@ void main() {
         reason: invalid,
       );
     }
+  });
+
+  test('IPv6 proxy endpoints use bracketed HttpClient proxy syntax', () {
+    AppHttpProxy.set('http://[::1]:8888');
+
+    expect(
+      AppHttpProxy.findProxy(
+        Uri.parse('https://media.example/video'),
+        (_) => 'DIRECT',
+      ),
+      'PROXY [::1]:8888',
+    );
   });
 }


### PR DESCRIPTION
## Summary

- 仅接受带有效端口的 HTTP forward proxy 地址
- 拒绝 HTTPS、SOCKS、路径、查询参数和越界端口
- 正确生成 IPv6 代理语法

Refs #780