### PR TITLE
fix: 恢复媒体库分区排序回调语义

### DIFF
--- a/lib/media_library/adaptive_media_library_controls.dart
+++ b/lib/media_library/adaptive_media_library_controls.dart
@@ -539,7 +539,7 @@ class _MediaLibrarySectionOrderEditorState
           child: material.ReorderableListView.builder(
             buildDefaultDragHandles: false,
             itemCount: _sections.length,
-            onReorder: _reorder,
+            onReorderItem: _reorder,
             itemBuilder: (context, index) {
               final section = _sections[index];
               return material.Padding(

--- a/test/media_library_section_order_test.dart
+++ b/test/media_library_section_order_test.dart
@@ -428,6 +428,11 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('媒体库排序'), findsOneWidget);
+    final reorderableList = tester.widget<ReorderableListView>(
+      find.byType(ReorderableListView),
+    );
+    expect(reorderableList.onReorderItem, isNotNull);
+    expect(reorderableList.onReorder, isNull);
     for (final section in _sections) {
       expect(find.text(section.label), findsWidgets);
     }


### PR DESCRIPTION
## Summary

- 将媒体库分区排序恢复为 Flutter 3.44 的 `onReorderItem` 回调
- 避免 `onReorder` 未调整目标索引导致的重排异常
- 增加回归断言，防止回调再次退化

该实现与已验证正常的旧版 `37696cf2` 一致。

Refs #776