### PR TITLE
test: 防止 Emby 排序退化为串行分页

### DIFF
--- a/test/emby_last_content_added_sort_test.dart
+++ b/test/emby_last_content_added_sort_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -87,5 +88,83 @@ void main() {
     expect(itemsRequest.queryParameters['SortBy'], sortBy);
     expect(itemsRequest.queryParameters['SortOrder'], 'Descending');
     expect(itemsRequest.queryParameters['Limit'], '37');
+  });
+
+  test('large Emby sorts do not split into serial requests', () async {
+    SharedPreferences.setMockInitialValues({});
+    const totalItems = 201;
+    final itemRequests = <Uri>[];
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((request) async {
+      request.response.headers.contentType = ContentType.json;
+      if (request.uri.path == '/emby/Users/test-user/Items/library-id') {
+        request.response.write('{"CollectionType":"tvshows"}');
+      } else if (request.uri.path == '/emby/Items') {
+        itemRequests.add(request.uri);
+        final startIndex =
+            int.tryParse(request.uri.queryParameters['StartIndex'] ?? '') ?? 0;
+        final requestedLimit =
+            int.tryParse(request.uri.queryParameters['Limit'] ?? '') ??
+                totalItems;
+        final remaining = totalItems - startIndex;
+        final count = remaining <= 0
+            ? 0
+            : (remaining < requestedLimit ? remaining : requestedLimit);
+        request.response.write(
+          jsonEncode({
+            'Items': [
+              for (var index = 0; index < count; index++)
+                {
+                  'Id': 'item-${startIndex + index}',
+                  'Name': 'Item ${startIndex + index}',
+                  'Type': 'Series',
+                  'DateCreated': '2026-01-01T00:00:00Z',
+                },
+            ],
+            'TotalRecordCount': totalItems,
+          }),
+        );
+      } else {
+        request.response.statusCode = HttpStatus.notFound;
+        request.response.write('{}');
+      }
+      await request.response.close();
+    });
+
+    final service = EmbyService.instance;
+    final previousServerUrl = service.serverUrl;
+    final previousUserId = service.userId;
+    final previousAccessToken = service.accessToken;
+    final previousConnected = service.isConnected;
+    final previousProfile = service.currentProfile;
+    addTearDown(() async {
+      await server.close(force: true);
+      service.currentProfile = previousProfile;
+      service.serverUrl = previousServerUrl;
+      service.userId = previousUserId;
+      service.accessToken = previousAccessToken;
+      service.isConnected = previousConnected;
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    service.currentProfile = null;
+    service.serverUrl = 'http://${server.address.address}:${server.port}';
+    service.userId = 'test-user';
+    service.accessToken = 'test-token';
+    service.isConnected = true;
+
+    final items = await service.getLatestMediaItemsByLibrary(
+      'library-id',
+      limit: 99999,
+      sortBy: sortBy,
+      sortOrder: 'Descending',
+    );
+
+    expect(items, hasLength(totalItems));
+    expect(itemRequests, hasLength(1));
+    expect(itemRequests.single.queryParameters['StartIndex'], isNull);
+    expect(itemRequests.single.queryParameters['Limit'], '99999');
+    expect(itemRequests.single.queryParameters['SortBy'], sortBy);
+    expect(itemRequests.single.queryParameters['SortOrder'], 'Descending');
   });
 }


### PR DESCRIPTION
## Summary

- 为大型 Emby 排序请求增加 HTTP 回归测试
- 验证 `Limit=99999` 时仅发出一次 `/Items` 请求
- 防止重新引入每 200 条串行分页造成界面长时间卡住

当前上游的一次请求实现本身正确；问题来自未合并的 #800 被带入自定义 Windows 集成分支。本 PR 固化正确行为。

Refs #777