### PR TITLE
完善桌面排行榜与平板设置体验

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -47,9 +47,6 @@ class SettingsKeys {
 
   static const String showRemoteAccessQrCode = 'show_remote_access_qr_code';
 
-  static const String labsEnableLargeScreenMode =
-      'labs_enable_large_screen_mode';
-
   static const String labsShowRemoteAccessQrCode =
       'labs_show_remote_access_qr_code';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1112,6 +1112,7 @@ class MainPageState extends State<MainPage>
   bool _hotkeysAreRegistered = false;
   VideoPlayerState? _videoPlayerState;
   AppearanceSettingsProvider? _appearanceSettingsProvider;
+  LabsSettingsProvider? _labsSettingsProvider;
 
   // Static method to find MainPageState from context
   static MainPageState? of(BuildContext context) {
@@ -1356,6 +1357,7 @@ class MainPageState extends State<MainPage>
     _useLargeScreenLayout = await LargeScreenModePreferences.load(
       defaultValue: globals.isTelevision,
     );
+    _syncLargeScreenHotkeySuppression();
     final initialIndex = _getInitialTabIndex();
 
     if (mounted) {
@@ -1456,6 +1458,19 @@ class MainPageState extends State<MainPage>
       _appearanceSettingsProvider = newAppearanceSettingsProvider;
     }
 
+    final newLabsSettingsProvider =
+        Provider.of<LabsSettingsProvider>(context, listen: false);
+    if (newLabsSettingsProvider != _labsSettingsProvider) {
+      _labsSettingsProvider?.removeListener(
+        _syncLargeScreenHotkeySuppression,
+      );
+      _labsSettingsProvider = newLabsSettingsProvider;
+      _labsSettingsProvider?.addListener(
+        _syncLargeScreenHotkeySuppression,
+      );
+      _syncLargeScreenHotkeySuppression();
+    }
+
     // 初始化对话框尺寸管理器 - 只初始化一次
     if (!globals.DialogSizes.isInitialized) {
       final screenSize = MediaQuery.of(context).size;
@@ -1480,7 +1495,11 @@ class MainPageState extends State<MainPage>
 
   @override
   void dispose() {
+    HotkeyService().setLargeScreenModeActive(false);
     DesktopPlayerWindowService.instance.removeListener(_manageHotkeys);
+    _labsSettingsProvider?.removeListener(
+      _syncLargeScreenHotkeySuppression,
+    );
     _tabChangeNotifier
         ?.removeListener(_onTabChangeRequested); // Temporarily remove
     _webdavQuickAccessProvider?.removeListener(_onWebDAVSettingsChanged);
@@ -1540,6 +1559,14 @@ class MainPageState extends State<MainPage>
     await windowManager.close();
   }
 
+  void _syncLargeScreenHotkeySuppression() {
+    final isLargeScreenModeActive = globals.isTelevision ||
+        (globals.isDesktopOrTablet &&
+            (_labsSettingsProvider?.enableLargeScreenMode ?? false) &&
+            _useLargeScreenLayout);
+    HotkeyService().setLargeScreenModeActive(isLargeScreenModeActive);
+  }
+
   Future<void> _toggleLargeScreenLayout() async {
     final labsSettings = context.read<LabsSettingsProvider>();
     if (!labsSettings.enableLargeScreenMode && !_useLargeScreenLayout) {
@@ -1549,6 +1576,7 @@ class MainPageState extends State<MainPage>
     setState(() {
       _useLargeScreenLayout = nextValue;
     });
+    _syncLargeScreenHotkeySuppression();
     try {
       await LargeScreenModePreferences.save(nextValue);
     } catch (e) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1112,7 +1112,6 @@ class MainPageState extends State<MainPage>
   bool _hotkeysAreRegistered = false;
   VideoPlayerState? _videoPlayerState;
   AppearanceSettingsProvider? _appearanceSettingsProvider;
-  LabsSettingsProvider? _labsSettingsProvider;
 
   // Static method to find MainPageState from context
   static MainPageState? of(BuildContext context) {
@@ -1394,7 +1393,7 @@ class MainPageState extends State<MainPage>
         _initializeHotkeys();
       }
 
-      if (_useLargeScreenLayout && _isLabsLargeScreenModeEnabled()) {
+      if (_useLargeScreenLayout) {
         unawaited(_syncDesktopFullScreenWithLargeScreenMode(true));
       }
     });
@@ -1458,19 +1457,6 @@ class MainPageState extends State<MainPage>
       _appearanceSettingsProvider = newAppearanceSettingsProvider;
     }
 
-    final newLabsSettingsProvider =
-        Provider.of<LabsSettingsProvider>(context, listen: false);
-    if (newLabsSettingsProvider != _labsSettingsProvider) {
-      _labsSettingsProvider?.removeListener(
-        _syncLargeScreenHotkeySuppression,
-      );
-      _labsSettingsProvider = newLabsSettingsProvider;
-      _labsSettingsProvider?.addListener(
-        _syncLargeScreenHotkeySuppression,
-      );
-      _syncLargeScreenHotkeySuppression();
-    }
-
     // 初始化对话框尺寸管理器 - 只初始化一次
     if (!globals.DialogSizes.isInitialized) {
       final screenSize = MediaQuery.of(context).size;
@@ -1497,9 +1483,6 @@ class MainPageState extends State<MainPage>
   void dispose() {
     HotkeyService().setLargeScreenModeActive(false);
     DesktopPlayerWindowService.instance.removeListener(_manageHotkeys);
-    _labsSettingsProvider?.removeListener(
-      _syncLargeScreenHotkeySuppression,
-    );
     _tabChangeNotifier
         ?.removeListener(_onTabChangeRequested); // Temporarily remove
     _webdavQuickAccessProvider?.removeListener(_onWebDAVSettingsChanged);
@@ -1561,17 +1544,11 @@ class MainPageState extends State<MainPage>
 
   void _syncLargeScreenHotkeySuppression() {
     final isLargeScreenModeActive = globals.isTelevision ||
-        (globals.isDesktopOrTablet &&
-            (_labsSettingsProvider?.enableLargeScreenMode ?? false) &&
-            _useLargeScreenLayout);
+        (globals.isDesktopOrTablet && _useLargeScreenLayout);
     HotkeyService().setLargeScreenModeActive(isLargeScreenModeActive);
   }
 
   Future<void> _toggleLargeScreenLayout() async {
-    final labsSettings = context.read<LabsSettingsProvider>();
-    if (!labsSettings.enableLargeScreenMode && !_useLargeScreenLayout) {
-      return;
-    }
     final nextValue = !_useLargeScreenLayout;
     setState(() {
       _useLargeScreenLayout = nextValue;
@@ -1600,13 +1577,6 @@ class MainPageState extends State<MainPage>
     } catch (e) {
       debugPrint('[MainPageState] 切换大屏幕模式全屏状态失败: $e');
     }
-  }
-
-  bool _isLabsLargeScreenModeEnabled() {
-    if (!mounted) {
-      return false;
-    }
-    return context.read<LabsSettingsProvider>().enableLargeScreenMode;
   }
 
   ThemeMode _nextThemeMode() {
@@ -1718,16 +1688,14 @@ class MainPageState extends State<MainPage>
 
   @override
   void onWindowEvent(String eventName) {
-    if (eventName == 'leave-full-screen' &&
-        _useLargeScreenLayout &&
-        _isLabsLargeScreenModeEnabled()) {
+    if (eventName == 'leave-full-screen' && _useLargeScreenLayout) {
       unawaited(_syncDesktopFullScreenWithLargeScreenMode(true));
     }
   }
 
   @override
   void onWindowLeaveFullScreen() {
-    if (_useLargeScreenLayout && _isLabsLargeScreenModeEnabled()) {
+    if (_useLargeScreenLayout) {
       unawaited(_syncDesktopFullScreenWithLargeScreenMode(true));
     }
   }
@@ -1746,13 +1714,12 @@ class MainPageState extends State<MainPage>
         AppDisplaySurfaceScope.of(context) == AppDisplaySurface.television;
     final bool canUseLargeScreenLayout =
         globals.isDesktopOrTablet || isTelevisionSurface;
-    final bool labsEnableLargeScreenMode =
-        context.watch<LabsSettingsProvider>().enableLargeScreenMode;
-    final bool allowLargeScreenControls = labsEnableLargeScreenMode;
+    final bool allowLargeScreenControls = shouldOfferLargeScreenModeControl(
+      isDesktopOrTablet: globals.isDesktopOrTablet,
+      isTelevisionSurface: isTelevisionSurface,
+    );
     final bool isLargeScreenLayoutActive = isTelevisionSurface ||
-        (canUseLargeScreenLayout &&
-            allowLargeScreenControls &&
-            _useLargeScreenLayout);
+        (canUseLargeScreenLayout && _useLargeScreenLayout);
     final double baseTopPadding = isMac ? 10 : 4;
     final double baseRightPadding = isMac ? 20 : 10;
     final double topPadding =

--- a/lib/pages/dashboard_home_page.dart
+++ b/lib/pages/dashboard_home_page.dart
@@ -30,6 +30,8 @@ import 'package:nipaplay/models/bangumi_model.dart';
 import 'package:nipaplay/models/trending_bangumi.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/horizontal_anime_card.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/horizontal_anime_skeleton.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/cached_network_image_widget.dart';

--- a/lib/providers/labs_settings_provider.dart
+++ b/lib/providers/labs_settings_provider.dart
@@ -1,46 +1,25 @@
 import 'package:flutter/foundation.dart';
 import 'package:nipaplay/constants/settings_keys.dart';
 import 'package:nipaplay/utils/settings_storage.dart';
-import 'package:nipaplay/utils/globals.dart' as globals;
 
 class LabsSettingsProvider extends ChangeNotifier {
   LabsSettingsProvider() {
     _loadSettings();
   }
 
-  bool _enableLargeScreenMode = false;
   bool _enableErikaPlayerKernel = false;
   bool _isLoaded = false;
 
-  // Television layouts are a first-class mode rather than an experimental
-  // feature. Desktop and tablet devices still use the separate preference.
-  bool get enableLargeScreenMode =>
-      globals.isTelevision || _enableLargeScreenMode;
   bool get enableErikaPlayerKernel => _enableErikaPlayerKernel;
   bool get isLoaded => _isLoaded;
 
   Future<void> _loadSettings() async {
-    _enableLargeScreenMode = await SettingsStorage.loadBool(
-      SettingsKeys.labsEnableLargeScreenMode,
-      defaultValue: false,
-    );
     _enableErikaPlayerKernel = await SettingsStorage.loadBool(
       SettingsKeys.labsEnableErikaPlayerKernel,
       defaultValue: false,
     );
     _isLoaded = true;
     notifyListeners();
-  }
-
-  Future<void> setEnableLargeScreenMode(bool enabled) async {
-    if (globals.isTelevision) return;
-    if (_enableLargeScreenMode == enabled) return;
-    _enableLargeScreenMode = enabled;
-    notifyListeners();
-    await SettingsStorage.saveBool(
-      SettingsKeys.labsEnableLargeScreenMode,
-      enabled,
-    );
   }
 
   Future<void> setEnableErikaPlayerKernel(bool enabled) async {

--- a/lib/settings/adaptive_settings_widgets.dart
+++ b/lib/settings/adaptive_settings_widgets.dart
@@ -13,7 +13,6 @@ import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:nipaplay/settings/adaptive_settings_scope.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_adaptive_platform_ui.dart'
     show AdaptiveSlider, AdaptiveSwitch;
-import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_group_card.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_settings_tile.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
@@ -40,7 +39,6 @@ class AdaptiveSettingsTile<T> extends material.StatelessWidget {
     this.dropdownItems,
     this.onDropdownChanged,
     this.dropdownKey,
-    this.useNativeIOS26Dropdown = false,
     this.switchValue,
     this.onSwitchChanged,
     this.hideNativeIOS26Switch = false,
@@ -69,7 +67,6 @@ class AdaptiveSettingsTile<T> extends material.StatelessWidget {
     required List<DropdownMenuItemData<T>> items,
     required FutureOr<void> Function(T value) onChanged,
     material.GlobalKey? dropdownKey,
-    bool useNativeIOS26Dropdown = false,
   }) {
     return AdaptiveSettingsTile<T>._(
       key: key,
@@ -82,7 +79,6 @@ class AdaptiveSettingsTile<T> extends material.StatelessWidget {
       dropdownItems: items,
       onDropdownChanged: onChanged,
       dropdownKey: dropdownKey,
-      useNativeIOS26Dropdown: useNativeIOS26Dropdown,
     );
   }
 
@@ -230,10 +226,6 @@ class AdaptiveSettingsTile<T> extends material.StatelessWidget {
   final FutureOr<void> Function(T value)? onDropdownChanged;
   final material.GlobalKey? dropdownKey;
 
-  /// Uses the native UIKit popup menu on iOS 26 and later.
-  ///
-  /// Other platforms and earlier iOS versions keep the shared bottom sheet.
-  final bool useNativeIOS26Dropdown;
   final bool? switchValue;
   final material.ValueChanged<bool>? onSwitchChanged;
 
@@ -408,9 +400,12 @@ class AdaptiveSettingsTile<T> extends material.StatelessWidget {
     }
     final label =
         selected?.title ?? (items.isNotEmpty ? items.first.title : '');
-    if (useNativeIOS26Dropdown && usesNativeIOS26SettingsControls) {
-      return AdaptivePopupMenuButton.text<T>(
-        label: label,
+    final trigger = _PhoneMenuChip(label: label);
+    if (items.isEmpty) {
+      return trigger;
+    }
+    if (usesNativeIOS26SettingsControls) {
+      return AdaptivePopupMenuButton.widget<T>(
         items: <AdaptivePopupMenuEntry>[
           for (final item in items)
             AdaptivePopupMenuItem<T>(
@@ -426,35 +421,16 @@ class AdaptiveSettingsTile<T> extends material.StatelessWidget {
           }
           onDropdownChanged?.call(items[index].value);
         },
-        shrinkWrap: true,
         buttonStyle: PopupButtonStyle.plain,
+        child: trigger,
       );
     }
-    return cupertino.CupertinoButton(
-      padding: material.EdgeInsets.zero,
-      minimumSize: material.Size.zero,
-      onPressed: items.isEmpty
-          ? null
-          : () async {
-              final selectedIndex =
-                  await CupertinoBottomSheet.showSelection<int>(
-                context: context,
-                title: title,
-                options: [
-                  for (final entry in items.asMap().entries)
-                    CupertinoBottomSheetOption(
-                      label: entry.value.title,
-                      value: entry.key,
-                      selected: entry.value.isSelected,
-                      enabled: entry.value.enabled,
-                    ),
-                ],
-              );
-              if (selectedIndex != null) {
-                onDropdownChanged?.call(items[selectedIndex].value);
-              }
-            },
-      child: _PhoneMenuChip(label: label),
+    return BlurDropdown<T>(
+      dropdownKey: dropdownKey ?? material.GlobalKey(),
+      items: items,
+      onItemSelected: (value) => onDropdownChanged?.call(value),
+      controlBuilder: (context, selectedLabel) =>
+          _PhoneMenuChip(label: selectedLabel),
     );
   }
 

--- a/lib/settings/pages/appearance_settings_content.dart
+++ b/lib/settings/pages/appearance_settings_content.dart
@@ -346,7 +346,7 @@ class _AppearanceSettingsContentState extends State<AppearanceSettingsContent> {
           ),
         ],
       ),
-      if (globals.isPhone) ...[
+      if (!globals.isTelevision) ...[
         const SizedBox(height: 16),
         AdaptiveSettingsDragList<HomeSectionType>(
           items: [

--- a/lib/settings/pages/danmaku_settings_content.dart
+++ b/lib/settings/pages/danmaku_settings_content.dart
@@ -769,7 +769,6 @@ class _DanmakuSettingsContentState extends State<DanmakuSettingsContent> {
                   _saveDanmakuRenderEngineSettings(value);
                 },
                 dropdownKey: _danmakuRenderEngineDropdownKey,
-                useNativeIOS26Dropdown: true,
               ),
               Divider(
                   color: colorScheme.onSurface.withValues(alpha: 0.12),

--- a/lib/settings/pages/developer_options_settings_content.dart
+++ b/lib/settings/pages/developer_options_settings_content.dart
@@ -21,6 +21,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_window.dart';
 import 'package:nipaplay/utils/build_info.dart';
+import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/linux_storage_migration.dart';
 import 'package:nipaplay/utils/platform_utils.dart' as platform;
 import 'package:nipaplay/utils/video_player_state.dart';
@@ -140,13 +141,14 @@ class DeveloperOptionsSettingsContent extends StatelessWidget {
                   value: devOptions.enableFileLog,
                   onChanged: (value) => _setFileLog(context, devOptions, value),
                 ),
-                AdaptiveSettingsTile<void>.card(
-                  title: l10n.openLogDirectoryTitle,
-                  subtitle: l10n.openLogDirectorySubtitle,
-                  icon: Ionicons.folder_open_outline,
-                  phoneIcon: cupertino.CupertinoIcons.folder_open,
-                  onTap: () => _openLogDirectory(context),
-                ),
+                if (!globals.isTablet)
+                  AdaptiveSettingsTile<void>.card(
+                    title: l10n.openLogDirectoryTitle,
+                    subtitle: l10n.openLogDirectorySubtitle,
+                    icon: Ionicons.folder_open_outline,
+                    phoneIcon: cupertino.CupertinoIcons.folder_open,
+                    onTap: () => _openLogDirectory(context),
+                  ),
                 AdaptiveSettingsTile<void>.card(
                   title: l10n.terminalOutput,
                   subtitle: l10n.terminalOutputSubtitle,

--- a/lib/settings/pages/labs_settings_content.dart
+++ b/lib/settings/pages/labs_settings_content.dart
@@ -25,21 +25,6 @@ class LabsSettingsContent extends StatelessWidget {
             AdaptiveSettingsSection(
               dividerIndent: 56,
               children: [
-                if (!globals.isTelevision)
-                  AdaptiveSettingsTile.toggle(
-                    title:
-                        _text(context, '大屏幕模式', '大螢幕模式', 'Large Screen Mode'),
-                    subtitle: _text(
-                      context,
-                      '开启后，桌面和平板布局右上角显示大屏幕模式按钮',
-                      '開啟後，桌面和平板布局右上角顯示大螢幕模式按鈕',
-                      'Show the large-screen mode button in the desktop and tablet layout.',
-                    ),
-                    icon: Ionicons.tv_outline,
-                    phoneIcon: cupertino.CupertinoIcons.tv,
-                    value: labsSettings.enableLargeScreenMode,
-                    onChanged: labsSettings.setEnableLargeScreenMode,
-                  ),
                 if (PlayerFactory.isErikaKernelSupported &&
                     !globals.isTelevision)
                   AdaptiveSettingsTile.toggle(

--- a/lib/settings/pages/player_settings_content.dart
+++ b/lib/settings/pages/player_settings_content.dart
@@ -384,7 +384,6 @@ class _PlayerSettingsContentState extends State<PlayerSettingsContent> {
                   _savePlayerKernelSettings(kernelType);
                 },
                 dropdownKey: _playerKernelDropdownKey,
-                useNativeIOS26Dropdown: true,
               ),
               Divider(
                   color: colorScheme.onSurface.withValues(alpha: 0.12),

--- a/lib/settings/unified_settings_entries.dart
+++ b/lib/settings/unified_settings_entries.dart
@@ -346,7 +346,6 @@ List<UnifiedSettingEntry> _buildUnifiedSettingEntryDefinitions() {
       visible: (context, surface) =>
           surface == UnifiedSettingsSurface.desktopTablet &&
           !globals.isPhone &&
-          !globals.isTablet &&
           !globals.isTelevision,
     ),
     UnifiedSettingEntry(
@@ -407,6 +406,7 @@ List<UnifiedSettingEntry> _buildUnifiedSettingEntryDefinitions() {
       visible: (context, surface) =>
           surface == UnifiedSettingsSurface.desktopTablet &&
           !globals.isPhone &&
+          !globals.isTablet &&
           !globals.isTelevision,
     ),
     UnifiedSettingEntry(

--- a/lib/settings/unified_settings_entries.dart
+++ b/lib/settings/unified_settings_entries.dart
@@ -346,6 +346,7 @@ List<UnifiedSettingEntry> _buildUnifiedSettingEntryDefinitions() {
       visible: (context, surface) =>
           surface == UnifiedSettingsSurface.desktopTablet &&
           !globals.isPhone &&
+          !globals.isTablet &&
           !globals.isTelevision,
     ),
     UnifiedSettingEntry(
@@ -393,7 +394,7 @@ List<UnifiedSettingEntry> _buildUnifiedSettingEntryDefinitions() {
       icon: Ionicons.open_outline,
       phoneIcon: cupertino.CupertinoIcons.square_arrow_up,
       contentType: UnifiedSettingContentType.externalPlayer,
-      visible: (context, surface) => !globals.isTelevision,
+      visible: (context, surface) => !globals.isTelevision && !globals.isTablet,
     ),
     UnifiedSettingEntry(
       id: UnifiedSettingEntryIds.shortcuts,

--- a/lib/themes/cupertino/pages/cupertino_main_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_main_page.dart
@@ -10,13 +10,13 @@ import 'package:nipaplay/providers/webdav_quick_access_provider.dart';
 import 'package:nipaplay/services/external_player_console_service.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_adaptive_platform_ui.dart';
 import 'package:nipaplay/themes/cupertino/cupertino_imports.dart';
+import 'package:nipaplay/themes/cupertino/utils/cupertino_bottom_navigation_style.dart';
 import 'package:nipaplay/themes/cupertino/utils/cupertino_glass_navigation_insets.dart';
 import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_app_page_actions.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_page_actions_scope.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_bounce_wrapper.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/background_with_blur.dart';
-import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/tab_change_notifier.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
@@ -248,10 +248,9 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
     final pages = _pages;
     final selectedIndex = _selectedIndex;
     final selectedPage = pages[selectedIndex];
-    final activeColor = AppAccentColors.current;
-    final inactiveColor = CupertinoDynamicColor.resolve(
-      CupertinoColors.inactiveGray,
-      context,
+    final bottomNavigationForegroundColor =
+        resolveCupertinoBottomNavigationForegroundColor(
+      CupertinoTheme.brightnessOf(context),
     );
     final bottomInset = MediaQuery.viewPaddingOf(context).bottom;
     final nativeTabBarHeight = bottomInset > 0 ? 56.0 : 50.0;
@@ -323,8 +322,8 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
         final cupertinoTabBar = CupertinoTabBar(
           currentIndex: selectedIndex,
           onTap: _selectIndex,
-          activeColor: activeColor,
-          inactiveColor: inactiveColor,
+          activeColor: bottomNavigationForegroundColor,
+          inactiveColor: bottomNavigationForegroundColor,
           height: nativeTabBarHeight,
           items: _buildCupertinoItems(context, pages),
         );
@@ -339,8 +338,8 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
             bottomNavigationBar: isBottomNavigationVisible
                 ? AdaptiveBottomNavigationBar(
                     useNativeBottomBar: bottomBar.useNativeBottomBar,
-                    selectedItemColor: activeColor,
-                    unselectedItemColor: inactiveColor,
+                    selectedItemColor: bottomNavigationForegroundColor,
+                    unselectedItemColor: bottomNavigationForegroundColor,
                     cupertinoTabBar: cupertinoTabBar,
                     items: _buildNativeItems(context, pages),
                     selectedIndex: selectedIndex,
@@ -371,10 +370,10 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
                     verticalPadding: 0,
                     barHeight: cupertinoGlassTabBarHeight,
                     settings: glassTabBarSettings,
-                    selectedIconColor: activeColor,
-                    selectedLabelColor: activeColor,
-                    unselectedIconColor: inactiveColor,
-                    unselectedLabelColor: inactiveColor,
+                    selectedIconColor: bottomNavigationForegroundColor,
+                    selectedLabelColor: bottomNavigationForegroundColor,
+                    unselectedIconColor: bottomNavigationForegroundColor,
+                    unselectedLabelColor: bottomNavigationForegroundColor,
                     quality: GlassQuality.standard,
                   ),
                 ),

--- a/lib/themes/cupertino/pages/cupertino_main_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_main_page.dart
@@ -17,6 +17,7 @@ import 'package:nipaplay/themes/cupertino/widgets/cupertino_app_page_actions.dar
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_page_actions_scope.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_bounce_wrapper.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/background_with_blur.dart';
+import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
 import 'package:nipaplay/utils/tab_change_notifier.dart';
 import 'package:nipaplay/utils/video_player_state.dart';
@@ -248,9 +249,9 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
     final pages = _pages;
     final selectedIndex = _selectedIndex;
     final selectedPage = pages[selectedIndex];
-    final bottomNavigationForegroundColor =
-        resolveCupertinoBottomNavigationForegroundColor(
-      CupertinoTheme.brightnessOf(context),
+    final bottomNavigationColors = resolveCupertinoBottomNavigationColors(
+      brightness: CupertinoTheme.brightnessOf(context),
+      accentColor: AppAccentColors.current,
     );
     final bottomInset = MediaQuery.viewPaddingOf(context).bottom;
     final nativeTabBarHeight = bottomInset > 0 ? 56.0 : 50.0;
@@ -322,8 +323,8 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
         final cupertinoTabBar = CupertinoTabBar(
           currentIndex: selectedIndex,
           onTap: _selectIndex,
-          activeColor: bottomNavigationForegroundColor,
-          inactiveColor: bottomNavigationForegroundColor,
+          activeColor: bottomNavigationColors.selected,
+          inactiveColor: bottomNavigationColors.unselected,
           height: nativeTabBarHeight,
           items: _buildCupertinoItems(context, pages),
         );
@@ -338,8 +339,8 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
             bottomNavigationBar: isBottomNavigationVisible
                 ? AdaptiveBottomNavigationBar(
                     useNativeBottomBar: bottomBar.useNativeBottomBar,
-                    selectedItemColor: bottomNavigationForegroundColor,
-                    unselectedItemColor: bottomNavigationForegroundColor,
+                    selectedItemColor: bottomNavigationColors.selected,
+                    unselectedItemColor: bottomNavigationColors.unselected,
                     cupertinoTabBar: cupertinoTabBar,
                     items: _buildNativeItems(context, pages),
                     selectedIndex: selectedIndex,
@@ -370,10 +371,10 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
                     verticalPadding: 0,
                     barHeight: cupertinoGlassTabBarHeight,
                     settings: glassTabBarSettings,
-                    selectedIconColor: bottomNavigationForegroundColor,
-                    selectedLabelColor: bottomNavigationForegroundColor,
-                    unselectedIconColor: bottomNavigationForegroundColor,
-                    unselectedLabelColor: bottomNavigationForegroundColor,
+                    selectedIconColor: bottomNavigationColors.selected,
+                    selectedLabelColor: bottomNavigationColors.selected,
+                    unselectedIconColor: bottomNavigationColors.unselected,
+                    unselectedLabelColor: bottomNavigationColors.unselected,
                     quality: GlassQuality.standard,
                   ),
                 ),

--- a/lib/themes/cupertino/pages/cupertino_main_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_main_page.dart
@@ -258,6 +258,11 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
     final glassTabBarBottom = resolveGlassTabBarBottomOffset(
       viewPaddingBottom: bottomInset,
     );
+    final usesNativeIOS26Toolbar = PlatformInfo.isIOS26OrHigher();
+    final pageActionsTrailingOffset = resolvePageActionsTrailingOffset(
+      viewPaddingRight: MediaQuery.paddingOf(context).right,
+      usesNativeIOS26Toolbar: usesNativeIOS26Toolbar,
+    );
     final glassTabBarSettings =
         CupertinoTheme.brightnessOf(context) == Brightness.light
             ? _lightPhoneNavigationGlassSettings
@@ -304,7 +309,7 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
                   ),
                   Positioned(
                     top: MediaQuery.paddingOf(context).top + 4,
-                    right: 12 + MediaQuery.paddingOf(context).right,
+                    right: pageActionsTrailingOffset,
                     child: CupertinoAppPageActions(
                       actionIds: selectedPage.actionIds,
                     ),
@@ -324,7 +329,7 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
           items: _buildCupertinoItems(context, pages),
         );
 
-        if (PlatformInfo.isIOS26OrHigher()) {
+        if (usesNativeIOS26Toolbar) {
           return AdaptiveScaffold(
             minimizeBehavior: TabBarMinimizeBehavior.never,
             enableBlur: true,

--- a/lib/themes/cupertino/pages/cupertino_main_page.dart
+++ b/lib/themes/cupertino/pages/cupertino_main_page.dart
@@ -261,7 +261,7 @@ class _CupertinoMainPageState extends State<CupertinoMainPage> {
     final usesNativeIOS26Toolbar = PlatformInfo.isIOS26OrHigher();
     final pageActionsTrailingOffset = resolvePageActionsTrailingOffset(
       viewPaddingRight: MediaQuery.paddingOf(context).right,
-      usesNativeIOS26Toolbar: usesNativeIOS26Toolbar,
+      iosMajorVersion: PlatformInfo.iOSVersion,
     );
     final glassTabBarSettings =
         CupertinoTheme.brightnessOf(context) == Brightness.light

--- a/lib/themes/cupertino/utils/cupertino_bottom_navigation_style.dart
+++ b/lib/themes/cupertino/utils/cupertino_bottom_navigation_style.dart
@@ -1,8 +1,24 @@
 import 'package:flutter/cupertino.dart';
 
-/// Returns the high-contrast foreground shared by every bottom-navigation item.
-Color resolveCupertinoBottomNavigationForegroundColor(Brightness brightness) {
-  return brightness == Brightness.light
-      ? CupertinoColors.black
-      : CupertinoColors.white;
+class CupertinoBottomNavigationColors {
+  const CupertinoBottomNavigationColors({
+    required this.selected,
+    required this.unselected,
+  });
+
+  final Color selected;
+  final Color unselected;
+}
+
+/// Keeps the selected item accented while maximizing inactive-item contrast.
+CupertinoBottomNavigationColors resolveCupertinoBottomNavigationColors({
+  required Brightness brightness,
+  required Color accentColor,
+}) {
+  return CupertinoBottomNavigationColors(
+    selected: accentColor,
+    unselected: brightness == Brightness.light
+        ? CupertinoColors.black
+        : CupertinoColors.white,
+  );
 }

--- a/lib/themes/cupertino/utils/cupertino_bottom_navigation_style.dart
+++ b/lib/themes/cupertino/utils/cupertino_bottom_navigation_style.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/cupertino.dart';
+
+/// Returns the high-contrast foreground shared by every bottom-navigation item.
+Color resolveCupertinoBottomNavigationForegroundColor(Brightness brightness) {
+  return brightness == Brightness.light
+      ? CupertinoColors.black
+      : CupertinoColors.white;
+}

--- a/lib/themes/cupertino/utils/cupertino_glass_navigation_insets.dart
+++ b/lib/themes/cupertino/utils/cupertino_glass_navigation_insets.dart
@@ -1,6 +1,6 @@
 const double _glassTabBarEdgeGap = 6.0;
 const double _pageActionsEdgeGap = 12.0;
-const double _nativeIOS26PageActionsExtraTrailingGap = 8.0;
+const double _nativeIOS26PageActionsExtraTrailingGap = 16.0;
 
 /// Height required by the fallback glass tab bar's icon-and-label layout.
 const double cupertinoGlassTabBarHeight = 64.0;

--- a/lib/themes/cupertino/utils/cupertino_glass_navigation_insets.dart
+++ b/lib/themes/cupertino/utils/cupertino_glass_navigation_insets.dart
@@ -1,6 +1,6 @@
 const double _glassTabBarEdgeGap = 6.0;
 const double _pageActionsEdgeGap = 12.0;
-const double _nativeIOS26PageActionsExtraTrailingGap = 16.0;
+const double _ios27PageActionsExtraTrailingGap = 16.0;
 
 /// Height required by the fallback glass tab bar's icon-and-label layout.
 const double cupertinoGlassTabBarHeight = 64.0;
@@ -17,13 +17,13 @@ double resolveGlassTabBarBottomOffset({
 
 /// Resolves the trailing offset for the floating page-action toolbar.
 ///
-/// Native iOS 26 Liquid Glass chrome extends farther toward the screen edge
-/// than the fallback toolbar, so it needs a little more visual breathing room.
+/// iOS 27 Liquid Glass chrome extends farther toward the screen edge than the
+/// other toolbar implementations, so only that release gets an extra inset.
 double resolvePageActionsTrailingOffset({
   required double viewPaddingRight,
-  required bool usesNativeIOS26Toolbar,
+  required int iosMajorVersion,
 }) {
   return viewPaddingRight +
       _pageActionsEdgeGap +
-      (usesNativeIOS26Toolbar ? _nativeIOS26PageActionsExtraTrailingGap : 0);
+      (iosMajorVersion == 27 ? _ios27PageActionsExtraTrailingGap : 0);
 }

--- a/lib/themes/cupertino/utils/cupertino_glass_navigation_insets.dart
+++ b/lib/themes/cupertino/utils/cupertino_glass_navigation_insets.dart
@@ -1,4 +1,6 @@
 const double _glassTabBarEdgeGap = 6.0;
+const double _pageActionsEdgeGap = 12.0;
+const double _nativeIOS26PageActionsExtraTrailingGap = 8.0;
 
 /// Height required by the fallback glass tab bar's icon-and-label layout.
 const double cupertinoGlassTabBarHeight = 64.0;
@@ -11,4 +13,17 @@ double resolveGlassTabBarBottomOffset({
   required double viewPaddingBottom,
 }) {
   return viewPaddingBottom + _glassTabBarEdgeGap;
+}
+
+/// Resolves the trailing offset for the floating page-action toolbar.
+///
+/// Native iOS 26 Liquid Glass chrome extends farther toward the screen edge
+/// than the fallback toolbar, so it needs a little more visual breathing room.
+double resolvePageActionsTrailingOffset({
+  required double viewPaddingRight,
+  required bool usesNativeIOS26Toolbar,
+}) {
+  return viewPaddingRight +
+      _pageActionsEdgeGap +
+      (usesNativeIOS26Toolbar ? _nativeIOS26PageActionsExtraTrailingGap : 0);
 }

--- a/lib/themes/nipaplay/widgets/anime_card.dart
+++ b/lib/themes/nipaplay/widgets/anime_card.dart
@@ -203,8 +203,10 @@ class _AnimeCardState extends State<AnimeCard> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final settings = context.watch<AppearanceSettingsProvider>();
     final bool enableBlur = settings.enableWidgetBlurEffect;
+    final titleColor = theme.colorScheme.onSurface.withValues(alpha: 0.9);
 
     final Widget imageCard = Container(
       decoration: BoxDecoration(
@@ -303,12 +305,12 @@ class _AnimeCardState extends State<AnimeCard> {
             padding: const EdgeInsets.symmetric(horizontal: 2.0),
             child: Text(
               widget.name,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    fontSize: 13,
-                    height: 1.3,
-                    color: Colors.white.withValues(alpha: 0.9),
-                    fontWeight: FontWeight.w500,
-                  ),
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontSize: 13,
+                height: 1.3,
+                color: titleColor,
+                fontWeight: FontWeight.w500,
+              ),
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
               textAlign: TextAlign.left,

--- a/lib/themes/nipaplay/widgets/blur_dropdown.dart
+++ b/lib/themes/nipaplay/widgets/blur_dropdown.dart
@@ -14,16 +14,23 @@ class _BlurDropdownGlobalState {
   static int expandedCount = 0;
 }
 
+typedef BlurDropdownControlBuilder = Widget Function(
+  BuildContext context,
+  String selectedLabel,
+);
+
 class BlurDropdown<T> extends StatefulWidget {
   final GlobalKey dropdownKey;
   final List<DropdownMenuItemData<T>> items;
   final FutureOr<void> Function(T value) onItemSelected;
+  final BlurDropdownControlBuilder? controlBuilder;
 
   const BlurDropdown({
     super.key,
     required this.dropdownKey,
     required this.items,
     required this.onItemSelected,
+    this.controlBuilder,
   });
 
   static bool get isAnyExpanded => _BlurDropdownGlobalState.expandedCount > 0;
@@ -196,67 +203,83 @@ class _BlurDropdownState<T> extends State<BlurDropdown<T>>
     final bgColor =
         isDark ? Colors.white.withValues(alpha: 0.12) : Colors.white;
 
-    final control = Container(
-      height: 40,
-      decoration: BoxDecoration(
-        color: bgColor,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: (_isDropdownOpen ||
-                  (isLargeScreenModeActive && _isControlFocused))
-              ? activeColor
-              : idleBorderColor,
-          width: (_isDropdownOpen ||
-                  (isLargeScreenModeActive && _isControlFocused))
-              ? 1.5
-              : 1,
-        ),
-      ),
-      padding: const EdgeInsets.symmetric(horizontal: 12),
-      child: Row(
-        key: widget.dropdownKey,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          GestureDetector(
-            onTap: () {
-              if (_isSelecting || _animationController.isAnimating) {
-                return;
-              }
-              if (_isDropdownOpen) {
-                _closeDropdown(restoreControlFocus: true);
-              } else {
-                _openDropdown(
-                  requestMenuFocus: isLargeScreenModeActive,
-                );
-              }
-            },
+    void toggleDropdown() {
+      if (_isSelecting || _animationController.isAnimating) {
+        return;
+      }
+      if (_isDropdownOpen) {
+        _closeDropdown(restoreControlFocus: true);
+      } else {
+        _openDropdown(requestMenuFocus: isLargeScreenModeActive);
+      }
+    }
+
+    final customControl = widget.controlBuilder?.call(
+      context,
+      _getSelectedItemText(),
+    );
+    final control = customControl != null
+        ? GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: toggleDropdown,
             child: MouseRegion(
               cursor: SystemMouseCursors.click,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    _getSelectedItemText(),
-                    style: getTitleTextStyle(context),
-                  ),
-                  const SizedBox(width: 10),
-                  RotationTransition(
-                    turns: Tween(begin: 0.0, end: 0.5)
-                        .animate(_animationController),
-                    child: Icon(
-                      Ionicons.chevron_down_outline,
-                      color: _isDropdownOpen
-                          ? activeColor
-                          : (isDark ? Colors.white : Colors.black87),
-                    ),
-                  ),
-                ],
+              child: KeyedSubtree(
+                key: widget.dropdownKey,
+                child: customControl,
               ),
             ),
-          ),
-        ],
-      ),
-    );
+          )
+        : Container(
+            height: 40,
+            decoration: BoxDecoration(
+              color: bgColor,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: (_isDropdownOpen ||
+                        (isLargeScreenModeActive && _isControlFocused))
+                    ? activeColor
+                    : idleBorderColor,
+                width: (_isDropdownOpen ||
+                        (isLargeScreenModeActive && _isControlFocused))
+                    ? 1.5
+                    : 1,
+              ),
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              key: widget.dropdownKey,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                GestureDetector(
+                  onTap: toggleDropdown,
+                  child: MouseRegion(
+                    cursor: SystemMouseCursors.click,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          _getSelectedItemText(),
+                          style: getTitleTextStyle(context),
+                        ),
+                        const SizedBox(width: 10),
+                        RotationTransition(
+                          turns: Tween(begin: 0.0, end: 0.5)
+                              .animate(_animationController),
+                          child: Icon(
+                            Ionicons.chevron_down_outline,
+                            color: _isDropdownOpen
+                                ? activeColor
+                                : (isDark ? Colors.white : Colors.black87),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
 
     if (!isLargeScreenModeActive) {
       return control;

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -1178,7 +1178,7 @@ class _NipaplayFullTrendingViewState extends State<_NipaplayFullTrendingView> {
         final centerWidth = 210.0 * scale;
         final gap = 18.0 * scale;
         return SizedBox(
-          height: 326,
+          height: 390,
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.end,
@@ -1278,11 +1278,12 @@ class _NipaplayRankingCardState extends State<_NipaplayRankingCard> {
     final secondaryColor = Theme.of(context).colorScheme.onSurfaceVariant;
     return SizedBox(
       width: widget.width,
-      height: widget.height,
+      height: (widget.height ?? 304) + 64,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Expanded(
+          SizedBox(
+            height: widget.height ?? 304,
             child: ClipRRect(
               borderRadius: BorderRadius.circular(5),
               child: Stack(

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -143,7 +143,7 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
                   fontWeight: FontWeight.bold,
                 ),
               ),
-              const SizedBox(width: 8),
+              const SizedBox(width: 16),
               _buildScrollButton(
                 icon: Icons.tune_rounded,
                 onTap: () => _showTrendingFilter(cupertinoStyle: false),

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -1121,7 +1121,7 @@ class _NipaplayFullTrendingViewState extends State<_NipaplayFullTrendingView> {
         SliverToBoxAdapter(child: _buildPodium(items.take(3).toList())),
         if (items.length > 3)
           SliverPadding(
-            padding: const EdgeInsets.fromLTRB(20, 0, 20, 24),
+            padding: const EdgeInsets.fromLTRB(20, 20, 20, 24),
             sliver: SliverGrid(
               gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
                 maxCrossAxisExtent: 180,

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -829,12 +829,8 @@ class _NipaplayTrendingFilterControlsState
               ),
             ),
           ),
-          Expanded(
-            child: Align(
-              alignment: Alignment.centerLeft,
-              child: control,
-            ),
-          ),
+          const SizedBox(width: 8),
+          control,
         ],
       );
     }

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -337,7 +337,6 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
                           ],
                         ),
                       ),
-                      const Divider(height: 1),
                       Padding(
                         padding: const EdgeInsets.fromLTRB(24, 22, 24, 16),
                         child: _NipaplayTrendingFilterControls(
@@ -353,7 +352,6 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
                           }),
                         ),
                       ),
-                      const Divider(height: 1),
                       Padding(
                         padding: const EdgeInsets.fromLTRB(20, 12, 20, 16),
                         child: Row(
@@ -1059,7 +1057,6 @@ class _NipaplayFullTrendingViewState extends State<_NipaplayFullTrendingView> {
             ],
           ),
         ),
-        const Divider(height: 1),
         Padding(
           padding: const EdgeInsets.fromLTRB(24, 12, 24, 11),
           child: _NipaplayTrendingFilterControls(
@@ -1070,7 +1067,6 @@ class _NipaplayFullTrendingViewState extends State<_NipaplayFullTrendingView> {
             onScopeChanged: _changeScope,
           ),
         ),
-        const Divider(height: 1),
         Padding(
           padding: const EdgeInsets.fromLTRB(24, 8, 24, 7),
           child: Row(

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -943,10 +943,11 @@ class _NipaplayTrendingFilterControlsState
           );
         }
         return Row(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Expanded(child: fields.first),
-            const SizedBox(width: 30),
-            Expanded(child: fields.last),
+            fields.first,
+            const SizedBox(width: 20),
+            fields.last,
           ],
         );
       },

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -19,11 +19,22 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
   }
 
   Future<void> _loadTrending({bool forceRefresh = false}) async {
-    if (!mounted) return;
-    final query = _currentTrendingQuery;
+    await _loadTrendingQuery(
+      _currentTrendingQuery,
+      forceRefresh: forceRefresh,
+    );
+  }
+
+  Future<TrendingBangumiResult?> _loadTrendingQuery(
+    TrendingBangumiQuery query, {
+    bool forceRefresh = false,
+  }) async {
+    if (!mounted) return null;
     final key = query.cacheKey;
-    if (_trendingLoadingKeys.contains(key)) return;
-    if (!forceRefresh && _trendingResults.containsKey(key)) return;
+    if (_trendingLoadingKeys.contains(key)) return _trendingResults[key];
+    if (!forceRefresh && _trendingResults.containsKey(key)) {
+      return _trendingResults[key];
+    }
 
     _updateTrendingState(() {
       _trendingLoadingKeys.add(key);
@@ -42,7 +53,7 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
         filterAdultContent: filterAdultContent,
         limit: 50,
       );
-      if (!mounted) return;
+      if (!mounted) return null;
       _updateTrendingState(() {
         _trendingResults[key] = result;
         _trendingLoadingKeys.remove(key);
@@ -51,8 +62,9 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
         }
       });
       _resetTrendingScroll();
+      return result;
     } catch (error) {
-      if (!mounted) return;
+      if (!mounted) return null;
       _updateTrendingState(() {
         _trendingLoadingKeys.remove(key);
         if (_currentTrendingQuery.cacheKey == key) {
@@ -60,11 +72,16 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
         }
       });
       debugPrint('加载排行榜失败: $error');
+      return _trendingResults[key];
     }
   }
 
-  void _applyTrendingQuery(TrendingBangumiQuery query) {
-    if (_currentTrendingQuery.cacheKey == query.cacheKey) return;
+  Future<TrendingBangumiResult?> _applyTrendingQuery(
+    TrendingBangumiQuery query,
+  ) async {
+    if (_currentTrendingQuery.cacheKey == query.cacheKey) {
+      return _currentTrendingResult;
+    }
     _updateTrendingState(() {
       _trendingKind = query.kind;
       _trendingPeriod = query.period;
@@ -72,7 +89,7 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
       _trendingError = null;
     });
     _resetTrendingScroll();
-    unawaited(_loadTrending());
+    return _loadTrendingQuery(query);
   }
 
   void _resetTrendingScroll() {
@@ -86,23 +103,11 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
   }
 
   String _trendingMetric(TrendingBangumiItem item) {
-    if (_trendingKind == TrendingRankingKind.allRising) {
-      final rate = item.heatGrowthRate;
-      if (rate != null && rate.isNotEmpty) return '增长 $rate';
-      final delta = item.heatDelta;
-      if (delta != null && delta.isNotEmpty) return '热度 +$delta';
-    }
-    final heat = item.heat;
-    return heat == null || heat.isEmpty ? '热度统计中' : '热度 $heat';
+    return _formatTrendingMetric(item, _trendingKind);
   }
 
   String? _trendingDateLabel(TrendingSummary? summary) {
-    if (summary == null) return null;
-    final from = summary.dateFrom;
-    final to = summary.dateTo;
-    if (from != null && to != null) return '$from — $to';
-    final latest = summary.latestDataDate;
-    return latest == null ? null : '数据截至 $latest';
+    return _formatTrendingDateLabel(summary);
   }
 
   String get _trendingSelectionLabel =>
@@ -296,276 +301,59 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
         context: context,
         child: Builder(
           builder: (windowContext) {
-            final isDark =
-                Theme.of(windowContext).brightness == Brightness.dark;
             return NipaplayWindowScaffold(
               backgroundImageUrl: null,
-              backgroundColor: isDark
-                  ? Colors.black.withValues(alpha: 0.56)
-                  : const Color(0xFFF4F5F8).withValues(alpha: 0.68),
-              backdropBlurSigma: 34,
-              borderColor: isDark
-                  ? Colors.white.withValues(alpha: 0.16)
-                  : Colors.white.withValues(alpha: 0.78),
-              maxWidth: 640,
-              maxHeightFactor: 0.68,
+              maxWidth: 520,
+              maxHeightFactor: 0.58,
               onClose: () => Navigator.of(windowContext).pop(),
               child: StatefulBuilder(
                 builder: (sheetContext, setModalState) {
                   final theme = Theme.of(sheetContext);
-                  final isDark = theme.brightness == Brightness.dark;
                   final secondaryColor = theme.colorScheme.onSurfaceVariant;
-                  final groupColor = isDark
-                      ? Colors.white.withValues(alpha: 0.065)
-                      : Colors.white.withValues(alpha: 0.44);
-                  final groupBorder = isDark
-                      ? Colors.white.withValues(alpha: 0.09)
-                      : Colors.black.withValues(alpha: 0.055);
-
-                  Widget optionButton({
-                    required String label,
-                    required bool selected,
-                    required VoidCallback onTap,
-                    IconData? icon,
-                  }) {
-                    final accent = AppAccentColors.current;
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: Material(
-                            color: Colors.transparent,
-                            borderRadius: BorderRadius.circular(11),
-                            clipBehavior: Clip.antiAlias,
-                            child: InkWell(
-                              onTap: onTap,
-                              child: AnimatedContainer(
-                                duration: const Duration(milliseconds: 160),
-                                curve: Curves.easeOut,
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 10,
-                                  vertical: 13,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: selected
-                                      ? accent.withValues(
-                                          alpha: isDark ? 0.22 : 0.14,
-                                        )
-                                      : isDark
-                                          ? Colors.white
-                                              .withValues(alpha: 0.035)
-                                          : Colors.white
-                                              .withValues(alpha: 0.30),
-                                  borderRadius: BorderRadius.circular(11),
-                                  border: Border.all(
-                                    color: selected
-                                        ? accent.withValues(alpha: 0.72)
-                                        : groupBorder,
-                                  ),
-                                ),
-                                child: Row(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    if (icon != null) ...[
-                                      Icon(
-                                        icon,
-                                        size: 18,
-                                        color:
-                                            selected ? accent : secondaryColor,
-                                      ),
-                                      const SizedBox(width: 7),
-                                    ],
-                                    Flexible(
-                                      child: Text(
-                                        label,
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: TextStyle(
-                                          fontSize: 13,
-                                          fontWeight: selected
-                                              ? FontWeight.w700
-                                              : FontWeight.w600,
-                                          color: selected
-                                              ? accent
-                                              : theme.colorScheme.onSurface,
-                                        ),
-                                      ),
-                                    ),
-                                    if (selected) ...[
-                                      const SizedBox(width: 6),
-                                      Icon(
-                                        Icons.check_rounded,
-                                        size: 16,
-                                        color: accent,
-                                      ),
-                                    ],
-                                  ],
-                                ),
-                              ),
-                            )),
-                      ),
-                    );
-                  }
-
-                  Widget optionGroup({
-                    required String title,
-                    required String subtitle,
-                    required List<Widget> options,
-                  }) {
-                    return Container(
-                      padding: const EdgeInsets.fromLTRB(14, 12, 14, 14),
-                      decoration: BoxDecoration(
-                        color: groupColor,
-                        borderRadius: BorderRadius.circular(15),
-                        border: Border.all(color: groupBorder),
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            children: [
-                              Text(
-                                title,
-                                style: const TextStyle(
-                                  fontSize: 13,
-                                  fontWeight: FontWeight.w700,
-                                ),
-                              ),
-                              const SizedBox(width: 8),
-                              Expanded(
-                                child: Text(
-                                  subtitle,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(
-                                    color: secondaryColor,
-                                    fontSize: 11,
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 10),
-                          Row(children: options),
-                        ],
-                      ),
-                    );
-                  }
-
-                  IconData iconForKind(TrendingRankingKind kind) =>
-                      switch (kind) {
-                        TrendingRankingKind.allHot =>
-                          Icons.local_fire_department_rounded,
-                        TrendingRankingKind.allRising =>
-                          Icons.trending_up_rounded,
-                        TrendingRankingKind.newAnimeHot =>
-                          Icons.auto_awesome_rounded,
-                      };
 
                   return Column(
+                    mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       Padding(
-                        padding: const EdgeInsets.fromLTRB(52, 14, 24, 14),
-                        child: Row(
+                        padding: const EdgeInsets.fromLTRB(52, 16, 44, 14),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Container(
-                              width: 38,
-                              height: 38,
-                              decoration: BoxDecoration(
-                                color: AppAccentColors.current
-                                    .withValues(alpha: 0.14),
-                                borderRadius: BorderRadius.circular(11),
-                              ),
-                              child: Icon(
-                                Icons.leaderboard_rounded,
-                                size: 21,
-                                color: AppAccentColors.current,
+                            Text(
+                              '排行榜设置',
+                              style: theme.textTheme.titleLarge?.copyWith(
+                                fontWeight: FontWeight.w700,
                               ),
                             ),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    '排行榜设置',
-                                    style: theme.textTheme.titleLarge?.copyWith(
-                                      fontWeight: FontWeight.w700,
-                                    ),
-                                  ),
-                                  const SizedBox(height: 2),
-                                  Text(
-                                    '选择首页预览和完整榜单的统计方式',
-                                    style: TextStyle(
-                                      color: secondaryColor,
-                                      fontSize: 12,
-                                    ),
-                                  ),
-                                ],
+                            const SizedBox(height: 3),
+                            Text(
+                              '选择首页预览和完整榜单的统计方式',
+                              style: TextStyle(
+                                color: secondaryColor,
+                                fontSize: 12,
                               ),
                             ),
                           ],
                         ),
                       ),
-                      Divider(height: 1, color: groupBorder),
-                      Expanded(
-                        child: ListView(
-                          padding: const EdgeInsets.fromLTRB(20, 18, 20, 12),
-                          children: [
-                            optionGroup(
-                              title: '榜单类型',
-                              subtitle: '决定热度的统计维度',
-                              options: [
-                                for (final kind in TrendingRankingKind.values)
-                                  optionButton(
-                                    label: kind.label,
-                                    icon: iconForKind(kind),
-                                    selected: selectedKind == kind,
-                                    onTap: () => setModalState(() {
-                                      selectedKind = kind;
-                                    }),
-                                  ),
-                              ],
-                            ),
-                            const SizedBox(height: 14),
-                            optionGroup(
-                              title: selectedKind ==
-                                      TrendingRankingKind.newAnimeHot
-                                  ? '季度范围'
-                                  : '统计周期',
-                              subtitle: selectedKind ==
-                                      TrendingRankingKind.newAnimeHot
-                                  ? '切换当前季度或上一季度'
-                                  : '切换榜单覆盖的时间长度',
-                              options: selectedKind ==
-                                      TrendingRankingKind.newAnimeHot
-                                  ? [
-                                      for (final scope
-                                          in TrendingNewAnimeScope.values)
-                                        optionButton(
-                                          label: scope.label,
-                                          selected: selectedScope == scope,
-                                          onTap: () => setModalState(() {
-                                            selectedScope = scope;
-                                          }),
-                                        ),
-                                    ]
-                                  : [
-                                      for (final period
-                                          in TrendingPeriod.values)
-                                        optionButton(
-                                          label: period.label,
-                                          selected: selectedPeriod == period,
-                                          onTap: () => setModalState(() {
-                                            selectedPeriod = period;
-                                          }),
-                                        ),
-                                    ],
-                            ),
-                          ],
+                      const Divider(height: 1),
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(24, 22, 24, 16),
+                        child: _NipaplayTrendingFilterControls(
+                          query: selectedQuery(),
+                          onKindChanged: (kind) => setModalState(() {
+                            selectedKind = kind;
+                          }),
+                          onPeriodChanged: (period) => setModalState(() {
+                            selectedPeriod = period;
+                          }),
+                          onScopeChanged: (scope) => setModalState(() {
+                            selectedScope = scope;
+                          }),
                         ),
                       ),
-                      Divider(height: 1, color: groupBorder),
+                      const Divider(height: 1),
                       Padding(
                         padding: const EdgeInsets.fromLTRB(20, 12, 20, 16),
                         child: Row(
@@ -581,18 +369,25 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
                                 ),
                               ),
                             ),
-                            TextButton(
+                            HoverScaleTextButton(
+                              text: '取消',
                               onPressed: () =>
                                   Navigator.of(windowContext).pop(),
-                              child: const Text('取消'),
                             ),
-                            const SizedBox(width: 8),
-                            FilledButton.icon(
+                            const SizedBox(width: 12),
+                            HoverScaleTextButton(
                               onPressed: () => Navigator.of(windowContext).pop(
                                 selectedQuery(),
                               ),
-                              icon: const Icon(Icons.check_rounded, size: 18),
-                              label: const Text('应用'),
+                              idleColor: AppAccentColors.current,
+                              child: const Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(Icons.check_rounded, size: 17),
+                                  SizedBox(width: 5),
+                                  Text('应用'),
+                                ],
+                              ),
                             ),
                           ],
                         ),
@@ -608,7 +403,7 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
     }
 
     if (result != null && mounted) {
-      _applyTrendingQuery(result);
+      await _applyTrendingQuery(result);
     }
   }
 
@@ -625,19 +420,16 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _buildFullTrendingListSummary(
-              result.summary,
-              cupertinoStyle: true,
-            ),
+            _buildCupertinoFullTrendingListSummary(result.summary),
             Expanded(
               child: ListView.separated(
                 padding: const EdgeInsets.only(bottom: 24),
                 itemCount: items.length,
                 separatorBuilder: (_, __) => const SizedBox(height: 1),
-                itemBuilder: (sheetContext, index) => _buildFullTrendingRow(
+                itemBuilder: (sheetContext, index) =>
+                    _buildCupertinoFullTrendingRow(
                   sheetContext,
                   items[index],
-                  cupertinoStyle: true,
                 ),
               ),
             ),
@@ -651,86 +443,21 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
       context: context,
       child: Builder(
         builder: (windowContext) {
-          final theme = Theme.of(windowContext);
-          final isDark = theme.brightness == Brightness.dark;
-          final dividerColor = isDark
-              ? Colors.white.withValues(alpha: 0.09)
-              : Colors.black.withValues(alpha: 0.055);
           return NipaplayWindowScaffold(
             backgroundImageUrl: null,
-            backgroundColor: isDark
-                ? Colors.black.withValues(alpha: 0.56)
-                : const Color(0xFFF4F5F8).withValues(alpha: 0.68),
-            backdropBlurSigma: 34,
-            borderColor: isDark
-                ? Colors.white.withValues(alpha: 0.16)
-                : Colors.white.withValues(alpha: 0.78),
-            maxWidth: 820,
-            maxHeightFactor: 0.88,
+            maxWidth: 1120,
+            maxHeightFactor: 0.92,
             onClose: () => Navigator.of(windowContext).pop(),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(52, 14, 24, 14),
-                  child: Row(
-                    children: [
-                      Container(
-                        width: 38,
-                        height: 38,
-                        decoration: BoxDecoration(
-                          color:
-                              AppAccentColors.current.withValues(alpha: 0.14),
-                          borderRadius: BorderRadius.circular(11),
-                        ),
-                        child: Icon(
-                          Icons.format_list_numbered_rounded,
-                          size: 21,
-                          color: AppAccentColors.current,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              '完整排行榜',
-                              style: theme.textTheme.titleLarge?.copyWith(
-                                fontWeight: FontWeight.w700,
-                              ),
-                            ),
-                            const SizedBox(height: 2),
-                            Text(
-                              '$_trendingSelectionLabel  ·  ${items.length} 部作品',
-                              style: TextStyle(
-                                color: theme.colorScheme.onSurfaceVariant,
-                                fontSize: 12,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                Divider(height: 1, color: dividerColor),
-                _buildFullTrendingListSummary(
-                  result.summary,
-                  cupertinoStyle: false,
-                ),
-                Expanded(
-                  child: ListView.builder(
-                    padding: const EdgeInsets.only(bottom: 20),
-                    itemCount: items.length,
-                    itemBuilder: (sheetContext, index) => _buildFullTrendingRow(
-                      sheetContext,
-                      items[index],
-                      cupertinoStyle: false,
-                    ),
-                  ),
-                ),
-              ],
+            child: _NipaplayFullTrendingView(
+              initialQuery: _currentTrendingQuery,
+              initialResult: result,
+              onQueryChanged: _applyTrendingQuery,
+              onAnimeSelected: (anime) {
+                Navigator.of(windowContext).pop();
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (mounted) _showAnimeDetail(anime);
+                });
+              },
             ),
           );
         },
@@ -738,87 +465,36 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
     );
   }
 
-  Widget _buildFullTrendingListSummary(
-    TrendingSummary summary, {
-    required bool cupertinoStyle,
-  }) {
-    final secondaryColor = cupertinoStyle
-        ? cupertino.CupertinoDynamicColor.resolve(
-            cupertino.CupertinoColors.secondaryLabel,
-            context,
-          )
-        : Theme.of(context).colorScheme.onSurfaceVariant;
-    final labels = <(IconData, String)>[
-      (Icons.tune_rounded, _trendingSelectionLabel),
-      if (_trendingDateLabel(summary) case final date?)
-        (Icons.calendar_today_rounded, date),
-      (
-        Icons.movie_filter_outlined,
-        '共 ${_currentTrendingResult?.items.length ?? 0} 条',
-      ),
-      (Icons.cloud_outlined, '数据来源：弹弹play开放弹幕网络'),
+  Widget _buildCupertinoFullTrendingListSummary(TrendingSummary summary) {
+    final secondaryColor = cupertino.CupertinoDynamicColor.resolve(
+      cupertino.CupertinoColors.secondaryLabel,
+      context,
+    );
+    final labels = <String>[
+      _trendingSelectionLabel,
+      if (_trendingDateLabel(summary) case final date?) date,
+      '共 ${_currentTrendingResult?.items.length ?? 0} 条',
+      '数据来源：弹弹play开放弹幕网络',
     ];
-    if (cupertinoStyle) {
-      return Padding(
-        padding: const EdgeInsets.fromLTRB(20, 8, 20, 14),
-        child: Text(
-          labels.map((item) => item.$2).join('  ·  '),
-          style: TextStyle(fontSize: 12, color: secondaryColor),
-        ),
-      );
-    }
-
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     return Padding(
-      padding: const EdgeInsets.fromLTRB(20, 14, 20, 12),
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        children: [
-          for (final (icon, label) in labels)
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-              decoration: BoxDecoration(
-                color: isDark
-                    ? Colors.white.withValues(alpha: 0.065)
-                    : Colors.white.withValues(alpha: 0.42),
-                borderRadius: BorderRadius.circular(999),
-                border: Border.all(
-                  color: isDark
-                      ? Colors.white.withValues(alpha: 0.09)
-                      : Colors.black.withValues(alpha: 0.05),
-                ),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(icon, size: 13, color: secondaryColor),
-                  const SizedBox(width: 5),
-                  Text(
-                    label,
-                    style: TextStyle(fontSize: 11, color: secondaryColor),
-                  ),
-                ],
-              ),
-            ),
-        ],
+      padding: const EdgeInsets.fromLTRB(20, 8, 20, 14),
+      child: Text(
+        labels.join('  ·  '),
+        style: TextStyle(fontSize: 12, color: secondaryColor),
       ),
     );
   }
 
-  Widget _buildFullTrendingRow(
+  Widget _buildCupertinoFullTrendingRow(
     BuildContext sheetContext,
-    TrendingBangumiItem item, {
-    required bool cupertinoStyle,
-  }) {
+    TrendingBangumiItem item,
+  ) {
     final anime = item.anime;
     final title = anime.nameCn.isNotEmpty ? anime.nameCn : anime.name;
-    final secondaryColor = cupertinoStyle
-        ? cupertino.CupertinoDynamicColor.resolve(
-            cupertino.CupertinoColors.secondaryLabel,
-            sheetContext,
-          )
-        : Theme.of(sheetContext).colorScheme.onSurfaceVariant;
+    final secondaryColor = cupertino.CupertinoDynamicColor.resolve(
+      cupertino.CupertinoColors.secondaryLabel,
+      sheetContext,
+    );
     final rankColor = item.rank > 0 && item.rank <= 3
         ? AppAccentColors.current
         : secondaryColor;
@@ -905,31 +581,10 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
       ),
     );
 
-    if (cupertinoStyle) {
-      return GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: openDetails,
-        child: content,
-      );
-    }
-    final isDark = Theme.of(sheetContext).brightness == Brightness.dark;
-    final highlighted = item.rank > 0 && item.rank <= 3;
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 3),
-      child: Material(
-        color: highlighted
-            ? AppAccentColors.current.withValues(alpha: isDark ? 0.09 : 0.055)
-            : isDark
-                ? Colors.white.withValues(alpha: 0.035)
-                : Colors.white.withValues(alpha: 0.30),
-        borderRadius: BorderRadius.circular(12),
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          onTap: openDetails,
-          hoverColor: AppAccentColors.current.withValues(alpha: 0.08),
-          child: content,
-        ),
-      ),
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: openDetails,
+      child: content,
     );
   }
 
@@ -1105,6 +760,701 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
                     },
                   ),
           ),
+      ],
+    );
+  }
+}
+
+String _formatTrendingMetric(
+  TrendingBangumiItem item,
+  TrendingRankingKind kind,
+) {
+  if (kind == TrendingRankingKind.allRising) {
+    final rate = item.heatGrowthRate;
+    if (rate != null && rate.isNotEmpty) return '增长 $rate';
+    final delta = item.heatDelta;
+    if (delta != null && delta.isNotEmpty) return '热度 +$delta';
+  }
+  final heat = item.heat;
+  return heat == null || heat.isEmpty ? '热度统计中' : '热度 $heat';
+}
+
+String? _formatTrendingDateLabel(TrendingSummary? summary) {
+  if (summary == null) return null;
+  final from = summary.dateFrom;
+  final to = summary.dateTo;
+  if (from != null && to != null) return '$from — $to';
+  final latest = summary.latestDataDate;
+  return latest == null ? null : '数据截至 $latest';
+}
+
+class _NipaplayTrendingFilterControls extends StatefulWidget {
+  const _NipaplayTrendingFilterControls({
+    required this.query,
+    required this.onKindChanged,
+    required this.onPeriodChanged,
+    required this.onScopeChanged,
+    this.compact = false,
+  });
+
+  final TrendingBangumiQuery query;
+  final ValueChanged<TrendingRankingKind> onKindChanged;
+  final ValueChanged<TrendingPeriod> onPeriodChanged;
+  final ValueChanged<TrendingNewAnimeScope> onScopeChanged;
+  final bool compact;
+
+  @override
+  State<_NipaplayTrendingFilterControls> createState() =>
+      _NipaplayTrendingFilterControlsState();
+}
+
+class _NipaplayTrendingFilterControlsState
+    extends State<_NipaplayTrendingFilterControls> {
+  final GlobalKey _kindDropdownKey = GlobalKey();
+  final GlobalKey _dimensionDropdownKey = GlobalKey();
+
+  Widget _buildField({
+    required String label,
+    required Widget control,
+    bool horizontal = false,
+  }) {
+    if (horizontal) {
+      return Row(
+        children: [
+          SizedBox(
+            width: 72,
+            child: Text(
+              label,
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: control,
+            ),
+          ),
+        ],
+      );
+    }
+
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            label,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        control,
+      ],
+    );
+  }
+
+  Widget _buildKindDropdown() {
+    return BlurDropdown<TrendingRankingKind>(
+      dropdownKey: _kindDropdownKey,
+      items: [
+        for (final kind in TrendingRankingKind.values)
+          DropdownMenuItemData<TrendingRankingKind>(
+            title: kind.label,
+            value: kind,
+            isSelected: widget.query.kind == kind,
+          ),
+      ],
+      onItemSelected: widget.onKindChanged,
+    );
+  }
+
+  Widget _buildDimensionDropdown() {
+    if (widget.query.kind == TrendingRankingKind.newAnimeHot) {
+      return BlurDropdown<TrendingNewAnimeScope>(
+        dropdownKey: _dimensionDropdownKey,
+        items: [
+          for (final scope in TrendingNewAnimeScope.values)
+            DropdownMenuItemData<TrendingNewAnimeScope>(
+              title: scope.label,
+              value: scope,
+              isSelected: widget.query.scope == scope,
+            ),
+        ],
+        onItemSelected: widget.onScopeChanged,
+      );
+    }
+
+    return BlurDropdown<TrendingPeriod>(
+      dropdownKey: _dimensionDropdownKey,
+      items: [
+        for (final period in TrendingPeriod.values)
+          DropdownMenuItemData<TrendingPeriod>(
+            title: period.label,
+            value: period,
+            isSelected: widget.query.period == period,
+          ),
+      ],
+      onItemSelected: widget.onPeriodChanged,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.compact) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildField(label: '榜单类型', control: _buildKindDropdown()),
+          const SizedBox(height: 20),
+          _buildField(
+            label: widget.query.kind == TrendingRankingKind.newAnimeHot
+                ? '季度范围'
+                : '统计周期',
+            control: _buildDimensionDropdown(),
+          ),
+        ],
+      );
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final fields = [
+          _buildField(
+            label: '榜单类型',
+            control: _buildKindDropdown(),
+            horizontal: true,
+          ),
+          _buildField(
+            label: widget.query.kind == TrendingRankingKind.newAnimeHot
+                ? '季度范围'
+                : '统计周期',
+            control: _buildDimensionDropdown(),
+            horizontal: true,
+          ),
+        ];
+        if (constraints.maxWidth < 680) {
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              fields.first,
+              const SizedBox(height: 10),
+              fields.last,
+            ],
+          );
+        }
+        return Row(
+          children: [
+            Expanded(child: fields.first),
+            const SizedBox(width: 30),
+            Expanded(child: fields.last),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _NipaplayFullTrendingView extends StatefulWidget {
+  const _NipaplayFullTrendingView({
+    required this.initialQuery,
+    required this.initialResult,
+    required this.onQueryChanged,
+    required this.onAnimeSelected,
+  });
+
+  final TrendingBangumiQuery initialQuery;
+  final TrendingBangumiResult initialResult;
+  final Future<TrendingBangumiResult?> Function(TrendingBangumiQuery query)
+      onQueryChanged;
+  final ValueChanged<BangumiAnime> onAnimeSelected;
+
+  @override
+  State<_NipaplayFullTrendingView> createState() =>
+      _NipaplayFullTrendingViewState();
+}
+
+class _NipaplayFullTrendingViewState extends State<_NipaplayFullTrendingView> {
+  late TrendingBangumiQuery _query;
+  late TrendingBangumiResult _result;
+  bool _loading = false;
+  int _requestId = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _query = widget.initialQuery;
+    _result = widget.initialResult;
+  }
+
+  Future<void> _changeQuery(TrendingBangumiQuery query) async {
+    if (query.cacheKey == _query.cacheKey) return;
+    final requestId = ++_requestId;
+    setState(() {
+      _query = query;
+      _loading = true;
+    });
+    final result = await widget.onQueryChanged(query);
+    if (!mounted || requestId != _requestId) return;
+    setState(() {
+      if (result != null) _result = result;
+      _loading = false;
+    });
+  }
+
+  void _changeKind(TrendingRankingKind kind) {
+    _changeQuery(TrendingBangumiQuery(
+      kind: kind,
+      period: _query.period,
+      scope: _query.scope,
+    ));
+  }
+
+  void _changePeriod(TrendingPeriod period) {
+    _changeQuery(TrendingBangumiQuery(
+      kind: _query.kind,
+      period: period,
+      scope: _query.scope,
+    ));
+  }
+
+  void _changeScope(TrendingNewAnimeScope scope) {
+    _changeQuery(TrendingBangumiQuery(
+      kind: _query.kind,
+      period: _query.period,
+      scope: scope,
+    ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final secondaryColor = theme.colorScheme.onSurfaceVariant;
+    final items = _result.items;
+    final dateLabel = _formatTrendingDateLabel(_result.summary);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(52, 16, 44, 12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '完整排行榜',
+                style: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 3),
+              Text(
+                '${_query.kind.label}  ·  ${_query.dimensionLabel}  ·  '
+                '共 ${items.length} 部',
+                style: TextStyle(color: secondaryColor, fontSize: 12),
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 12, 24, 11),
+          child: _NipaplayTrendingFilterControls(
+            query: _query,
+            compact: true,
+            onKindChanged: _changeKind,
+            onPeriodChanged: _changePeriod,
+            onScopeChanged: _changeScope,
+          ),
+        ),
+        const Divider(height: 1),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 8, 24, 7),
+          child: Row(
+            children: [
+              if (dateLabel != null) ...[
+                Text(
+                  dateLabel,
+                  style: TextStyle(color: secondaryColor, fontSize: 11),
+                ),
+                const SizedBox(width: 14),
+              ],
+              Expanded(
+                child: Text(
+                  '数据来源：弹弹play开放弹幕网络',
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(color: secondaryColor, fontSize: 11),
+                ),
+              ),
+              AnimatedOpacity(
+                duration: const Duration(milliseconds: 120),
+                opacity: _loading ? 1 : 0,
+                child: Text(
+                  '正在更新榜单…',
+                  style: TextStyle(
+                    color: AppAccentColors.current,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: AnimatedOpacity(
+            duration: const Duration(milliseconds: 140),
+            opacity: _loading ? 0.58 : 1,
+            child: _buildRankingContent(items),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildRankingContent(List<TrendingBangumiItem> items) {
+    if (items.isEmpty) {
+      return const Center(child: Text('暂无排行榜数据'));
+    }
+
+    return CustomScrollView(
+      key: ValueKey(_query.cacheKey),
+      slivers: [
+        SliverToBoxAdapter(child: _buildPodium(items.take(3).toList())),
+        if (items.length > 3)
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 24),
+            sliver: SliverGrid(
+              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                maxCrossAxisExtent: 180,
+                mainAxisExtent: 285,
+                crossAxisSpacing: 14,
+                mainAxisSpacing: 18,
+              ),
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  final item = items[index + 3];
+                  return _NipaplayRankingCard(
+                    item: item,
+                    kind: _query.kind,
+                    onTap: () => widget.onAnimeSelected(item.anime),
+                  );
+                },
+                childCount: items.length - 3,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildPodium(List<TrendingBangumiItem> items) {
+    final byRank = <int, TrendingBangumiItem>{
+      for (final item in items) item.rank: item,
+    };
+    final first = byRank[1] ?? (items.isNotEmpty ? items.first : null);
+    final second = byRank[2] ?? (items.length > 1 ? items[1] : null);
+    final third = byRank[3] ?? (items.length > 2 ? items[2] : null);
+
+    Widget slot(
+      TrendingBangumiItem? item, {
+      required double width,
+      required double height,
+    }) {
+      if (item == null) return SizedBox(width: width, height: height);
+      return _NipaplayRankingCard(
+        item: item,
+        kind: _query.kind,
+        featured: true,
+        width: width,
+        height: height,
+        onTap: () => widget.onAnimeSelected(item.anime),
+      );
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final availableWidth = math.max(300.0, constraints.maxWidth - 40);
+        final scale = math.min(1.0, availableWidth / 650);
+        final sideWidth = 178.0 * scale;
+        final centerWidth = 210.0 * scale;
+        final gap = 18.0 * scale;
+        return SizedBox(
+          height: 326,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              slot(second, width: sideWidth, height: 250 * scale),
+              SizedBox(width: gap),
+              slot(first, width: centerWidth, height: 304 * scale),
+              SizedBox(width: gap),
+              slot(third, width: sideWidth, height: 238 * scale),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _NipaplayRankingCard extends StatefulWidget {
+  const _NipaplayRankingCard({
+    required this.item,
+    required this.kind,
+    required this.onTap,
+    this.featured = false,
+    this.width,
+    this.height,
+  });
+
+  final TrendingBangumiItem item;
+  final TrendingRankingKind kind;
+  final VoidCallback onTap;
+  final bool featured;
+  final double? width;
+  final double? height;
+
+  @override
+  State<_NipaplayRankingCard> createState() => _NipaplayRankingCardState();
+}
+
+class _NipaplayRankingCardState extends State<_NipaplayRankingCard> {
+  bool _hovered = false;
+
+  Color _rankColor(BuildContext context) {
+    return switch (widget.item.rank) {
+      1 => const Color(0xFFFFC400),
+      2 => const Color(0xFF718099),
+      3 => const Color(0xFFC56D38),
+      _ => Theme.of(context).brightness == Brightness.dark
+          ? const Color(0xCC1B1B1B)
+          : const Color(0xCC26313A),
+    };
+  }
+
+  Widget _buildRankBadge(BuildContext context) {
+    final rank = widget.item.rank;
+    final featuredRank = widget.featured && rank > 0 && rank <= 3;
+    return Container(
+      constraints: BoxConstraints(minWidth: featuredRank ? 39 : 31),
+      padding: EdgeInsets.symmetric(
+        horizontal: featuredRank ? 8 : 6,
+        vertical: featuredRank ? 5 : 4,
+      ),
+      decoration: BoxDecoration(
+        color: _rankColor(context),
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(8),
+          bottomRight: Radius.circular(8),
+        ),
+      ),
+      child: Text(
+        featuredRank ? 'TOP\n$rank' : (rank > 0 ? '#$rank' : '—'),
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          color: Colors.white,
+          height: featuredRank ? 1.05 : 1,
+          fontSize: featuredRank ? 12 : 11,
+          fontWeight: FontWeight.w800,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final child =
+        widget.featured ? _buildFeaturedCard(context) : _buildGridCard(context);
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: widget.onTap,
+        child: AnimatedScale(
+          duration: const Duration(milliseconds: 150),
+          curve: Curves.easeOutCubic,
+          scale: _hovered ? 1.025 : 1,
+          child: child,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFeaturedCard(BuildContext context) {
+    final anime = widget.item.anime;
+    final title = anime.nameCn.isNotEmpty ? anime.nameCn : anime.name;
+    return SizedBox(
+      width: widget.width,
+      height: widget.height,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(8),
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            CachedNetworkImageWidget(
+              imageUrl: anime.imageUrl,
+              fit: BoxFit.cover,
+              memCacheWidth: ((widget.width ?? 210) * 2).round(),
+              memCacheHeight: ((widget.height ?? 304) * 2).round(),
+            ),
+            const DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  stops: [0.42, 1],
+                  colors: [Colors.transparent, Color(0xE6000000)],
+                ),
+              ),
+            ),
+            Positioned(top: 0, left: 0, child: _buildRankBadge(context)),
+            Positioned(
+              left: 10,
+              right: 9,
+              bottom: 9,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 14,
+                      height: 1.16,
+                      fontWeight: FontWeight.w700,
+                      shadows: [Shadow(blurRadius: 3, color: Colors.black)],
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      if (anime.rating case final rating?) ...[
+                        Text(
+                          '评分 ${rating.toStringAsFixed(1)}',
+                          style: const TextStyle(
+                            color: Colors.white70,
+                            fontSize: 11,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                      ],
+                      Expanded(
+                        child: Text(
+                          _formatTrendingMetric(widget.item, widget.kind),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: Color(0xFFFFA726),
+                            fontSize: 11,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                      Icon(
+                        anime.isFavorited == true
+                            ? Icons.favorite_rounded
+                            : Icons.favorite_border_rounded,
+                        color: Colors.white,
+                        size: 17,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGridCard(BuildContext context) {
+    final anime = widget.item.anime;
+    final title = anime.nameCn.isNotEmpty ? anime.nameCn : anime.name;
+    final secondaryColor = Theme.of(context).colorScheme.onSurfaceVariant;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Expanded(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                CachedNetworkImageWidget(
+                  imageUrl: anime.imageUrl,
+                  fit: BoxFit.cover,
+                  memCacheWidth: 360,
+                  memCacheHeight: 440,
+                ),
+                Positioned(top: 0, left: 0, child: _buildRankBadge(context)),
+                Positioned(
+                  top: 5,
+                  right: 5,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 6,
+                      vertical: 3,
+                    ),
+                    decoration: BoxDecoration(
+                      color: const Color(0xD91B1B1B),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: Text(
+                      _formatTrendingMetric(widget.item, widget.kind),
+                      maxLines: 1,
+                      style: const TextStyle(
+                        color: Color(0xFFFFA726),
+                        fontSize: 10,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 7),
+        Text(
+          title,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(
+            fontSize: 12,
+            height: 1.18,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Row(
+          children: [
+            Text(
+              anime.rating == null
+                  ? '暂无评分'
+                  : '评分 ${anime.rating!.toStringAsFixed(1)}',
+              style: TextStyle(color: secondaryColor, fontSize: 10),
+            ),
+            const Spacer(),
+            Icon(
+              anime.isFavorited == true
+                  ? Icons.favorite_rounded
+                  : Icons.favorite_border_rounded,
+              color: anime.isFavorited == true
+                  ? AppAccentColors.current
+                  : secondaryColor,
+              size: 15,
+            ),
+          ],
+        ),
       ],
     );
   }

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -143,7 +143,7 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
                   fontWeight: FontWeight.bold,
                 ),
               ),
-              const SizedBox(width: 16),
+              const SizedBox(width: 32),
               _buildScrollButton(
                 icon: Icons.tune_rounded,
                 onTap: () => _showTrendingFilter(cupertinoStyle: false),

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -126,6 +126,7 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Row(
+            mainAxisSize: MainAxisSize.min,
             children: [
               Text(
                 '排行榜',
@@ -137,7 +138,7 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
                   fontWeight: FontWeight.bold,
                 ),
               ),
-              const Spacer(),
+              const SizedBox(width: 8),
               _buildScrollButton(
                 icon: Icons.tune_rounded,
                 onTap: () => _showTrendingFilter(cupertinoStyle: false),

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -841,7 +841,8 @@ class _NipaplayTrendingFilterControlsState
 
     return Row(
       children: [
-        Expanded(
+        SizedBox(
+          width: 88,
           child: Text(
             label,
             style: const TextStyle(
@@ -850,6 +851,7 @@ class _NipaplayTrendingFilterControlsState
             ),
           ),
         ),
+        const SizedBox(width: 16),
         control,
       ],
     );

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -451,10 +451,7 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
               initialResult: result,
               onQueryChanged: _applyTrendingQuery,
               onAnimeSelected: (anime) {
-                Navigator.of(windowContext).pop();
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  if (mounted) _showAnimeDetail(anime);
-                });
+                if (mounted) _showAnimeDetail(anime);
               },
             ),
           );
@@ -498,10 +495,7 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
         : secondaryColor;
 
     void openDetails() {
-      Navigator.of(sheetContext).pop();
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) _showAnimeDetail(anime);
-      });
+      if (mounted) _showAnimeDetail(anime);
     }
 
     final content = Padding(

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -1218,8 +1218,6 @@ class _NipaplayRankingCard extends StatefulWidget {
 }
 
 class _NipaplayRankingCardState extends State<_NipaplayRankingCard> {
-  bool _hovered = false;
-
   Color _rankColor(BuildContext context) {
     return switch (widget.item.rank) {
       1 => const Color(0xFFFFC400),
@@ -1243,8 +1241,8 @@ class _NipaplayRankingCardState extends State<_NipaplayRankingCard> {
       decoration: BoxDecoration(
         color: _rankColor(context),
         borderRadius: const BorderRadius.only(
-          topLeft: Radius.circular(8),
-          bottomRight: Radius.circular(8),
+          topLeft: Radius.circular(5),
+          bottomRight: Radius.circular(5),
         ),
       ),
       child: Text(
@@ -1266,17 +1264,10 @@ class _NipaplayRankingCardState extends State<_NipaplayRankingCard> {
         widget.featured ? _buildFeaturedCard(context) : _buildGridCard(context);
     return MouseRegion(
       cursor: SystemMouseCursors.click,
-      onEnter: (_) => setState(() => _hovered = true),
-      onExit: (_) => setState(() => _hovered = false),
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: widget.onTap,
-        child: AnimatedScale(
-          duration: const Duration(milliseconds: 150),
-          curve: Curves.easeOutCubic,
-          scale: _hovered ? 1.025 : 1,
-          child: child,
-        ),
+        child: child,
       ),
     );
   }
@@ -1284,89 +1275,74 @@ class _NipaplayRankingCardState extends State<_NipaplayRankingCard> {
   Widget _buildFeaturedCard(BuildContext context) {
     final anime = widget.item.anime;
     final title = anime.nameCn.isNotEmpty ? anime.nameCn : anime.name;
+    final secondaryColor = Theme.of(context).colorScheme.onSurfaceVariant;
     return SizedBox(
       width: widget.width,
       height: widget.height,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(8),
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            CachedNetworkImageWidget(
-              imageUrl: anime.imageUrl,
-              fit: BoxFit.cover,
-              memCacheWidth: ((widget.width ?? 210) * 2).round(),
-              memCacheHeight: ((widget.height ?? 304) * 2).round(),
-            ),
-            const DecoratedBox(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  stops: [0.42, 1],
-                  colors: [Colors.transparent, Color(0xE6000000)],
-                ),
-              ),
-            ),
-            Positioned(top: 0, left: 0, child: _buildRankBadge(context)),
-            Positioned(
-              left: 10,
-              right: 9,
-              bottom: 9,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(5),
+              child: Stack(
+                fit: StackFit.expand,
                 children: [
-                  Text(
-                    title,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontSize: 14,
-                      height: 1.16,
-                      fontWeight: FontWeight.w700,
-                      shadows: [Shadow(blurRadius: 3, color: Colors.black)],
-                    ),
+                  CachedNetworkImageWidget(
+                    imageUrl: anime.imageUrl,
+                    fit: BoxFit.cover,
+                    memCacheWidth: ((widget.width ?? 210) * 2).round(),
+                    memCacheHeight: ((widget.height ?? 304) * 2).round(),
                   ),
-                  const SizedBox(height: 4),
-                  Row(
-                    children: [
-                      if (anime.rating case final rating?) ...[
-                        Text(
-                          '评分 ${rating.toStringAsFixed(1)}',
-                          style: const TextStyle(
-                            color: Colors.white70,
-                            fontSize: 11,
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                      ],
-                      Expanded(
-                        child: Text(
-                          _formatTrendingMetric(widget.item, widget.kind),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            color: Color(0xFFFFA726),
-                            fontSize: 11,
-                            fontWeight: FontWeight.w700,
-                          ),
-                        ),
-                      ),
-                      Icon(
-                        anime.isFavorited == true
-                            ? Icons.favorite_rounded
-                            : Icons.favorite_border_rounded,
-                        color: Colors.white,
-                        size: 17,
-                      ),
-                    ],
-                  ),
+                  Positioned(top: 0, left: 0, child: _buildRankBadge(context)),
                 ],
               ),
             ),
-          ],
-        ),
+          ),
+          const SizedBox(height: 7),
+          Text(
+            title,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontSize: 14,
+              height: 1.16,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Row(
+            children: [
+              if (anime.rating case final rating?)
+                Text(
+                  '评分 ${rating.toStringAsFixed(1)}',
+                  style: TextStyle(color: secondaryColor, fontSize: 11),
+                ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  _formatTrendingMetric(widget.item, widget.kind),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: AppAccentColors.current,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              Icon(
+                anime.isFavorited == true
+                    ? Icons.favorite_rounded
+                    : Icons.favorite_border_rounded,
+                color: anime.isFavorited == true
+                    ? AppAccentColors.current
+                    : secondaryColor,
+                size: 17,
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }
@@ -1380,7 +1356,7 @@ class _NipaplayRankingCardState extends State<_NipaplayRankingCard> {
       children: [
         Expanded(
           child: ClipRRect(
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: BorderRadius.circular(5),
             child: Stack(
               fit: StackFit.expand,
               children: [
@@ -1391,29 +1367,6 @@ class _NipaplayRankingCardState extends State<_NipaplayRankingCard> {
                   memCacheHeight: 440,
                 ),
                 Positioned(top: 0, left: 0, child: _buildRankBadge(context)),
-                Positioned(
-                  top: 5,
-                  right: 5,
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 6,
-                      vertical: 3,
-                    ),
-                    decoration: BoxDecoration(
-                      color: const Color(0xD91B1B1B),
-                      borderRadius: BorderRadius.circular(999),
-                    ),
-                    child: Text(
-                      _formatTrendingMetric(widget.item, widget.kind),
-                      maxLines: 1,
-                      style: const TextStyle(
-                        color: Color(0xFFFFA726),
-                        fontSize: 10,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ),
-                ),
               ],
             ),
           ),
@@ -1438,7 +1391,19 @@ class _NipaplayRankingCardState extends State<_NipaplayRankingCard> {
                   : '评分 ${anime.rating!.toStringAsFixed(1)}',
               style: TextStyle(color: secondaryColor, fontSize: 10),
             ),
-            const Spacer(),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                _formatTrendingMetric(widget.item, widget.kind),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: AppAccentColors.current,
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
             Icon(
               anime.isFavorited == true
                   ? Icons.favorite_rounded

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart
@@ -143,7 +143,7 @@ extension _DashboardHomePageTrending on _DashboardHomePageState {
                   fontWeight: FontWeight.bold,
                 ),
               ),
-              const SizedBox(width: 32),
+              const SizedBox(width: 48),
               _buildScrollButton(
                 icon: Icons.tune_rounded,
                 onTap: () => _showTrendingFilter(cupertinoStyle: false),

--- a/lib/themes/nipaplay/widgets/large_screen_mode_actions.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_mode_actions.dart
@@ -7,6 +7,13 @@ import 'package:nipaplay/utils/app_accent_color.dart';
 
 const double kNipaplayWindowCaptionHeight = WindowControlButtons.buttonHeight;
 
+bool shouldOfferLargeScreenModeControl({
+  required bool isDesktopOrTablet,
+  required bool isTelevisionSurface,
+}) {
+  return isDesktopOrTablet && !isTelevisionSurface;
+}
+
 class NipaplayLargeScreenModeActionsOverlay extends StatelessWidget {
   const NipaplayLargeScreenModeActionsOverlay({
     super.key,

--- a/lib/utils/hotkey_service.dart
+++ b/lib/utils/hotkey_service.dart
@@ -10,6 +10,19 @@ import 'video_player_state.dart';
 import 'danmaku_dialog_manager.dart'; // 导入弹幕对话框管理器
 import 'package:nipaplay/services/desktop_player_window_service.dart';
 
+@visibleForTesting
+bool shouldBlockDesktopHotkeys({
+  required bool isLargeScreenModeActive,
+  required bool hasActiveOverlay,
+  required bool isEditableTextFocused,
+  required bool playerHotkeysSuppressed,
+}) {
+  return isLargeScreenModeActive ||
+      hasActiveOverlay ||
+      isEditableTextFocused ||
+      playerHotkeysSuppressed;
+}
+
 /// 热键管理服务，用于替代Flutter内部的键盘事件处理
 class HotkeyService extends ChangeNotifier {
   static final HotkeyService _instance = HotkeyService._internal();
@@ -48,6 +61,9 @@ class HotkeyService extends ChangeNotifier {
   // 上下文，用于访问Provider
   BuildContext? _context;
 
+  // 大屏幕模式拥有独立的焦点与遥控输入层，激活时必须屏蔽全部旧热键。
+  bool _isLargeScreenModeActive = false;
+
   // overlay 计数器，>0 时表示有对话框/overlay 在视频播放界面上方
   static int _overlayCount = 0;
 
@@ -73,6 +89,22 @@ class HotkeyService extends ChangeNotifier {
   Timer? _longPressTimer;
   bool _isForwardKeyPressed = false;
   bool _isSpeedBoostActive = false;
+
+  void setLargeScreenModeActive(bool isActive) {
+    if (_isLargeScreenModeActive == isActive) {
+      return;
+    }
+    _isLargeScreenModeActive = isActive;
+    if (!isActive) {
+      return;
+    }
+
+    _isForwardKeyPressed = false;
+    _longPressTimer?.cancel();
+    if (_isSpeedBoostActive) {
+      _stopSpeedBoost();
+    }
+  }
 
   // 初始化热键服务
   Future<void> initialize(BuildContext context) async {
@@ -287,7 +319,7 @@ class HotkeyService extends ChangeNotifier {
       await hotKeyManager.register(
         hotKey,
         keyDownHandler: (HotKey hotKey) {
-          if (_shouldBlockHotkeyInTextInput()) {
+          if (_shouldBlockHotkey()) {
             return;
           }
           ////debugPrint('[HotkeyService] 热键触发: $description ($keyString)');
@@ -310,19 +342,17 @@ class HotkeyService extends ChangeNotifier {
     return focusedContext.widget is EditableText;
   }
 
-  bool _shouldBlockHotkeyInTextInput() {
-    if (hasActiveOverlay) {
+  bool _shouldBlockHotkey() {
+    if (_isLargeScreenModeActive) {
       return true;
     }
-    if (_isEditableTextFocused()) {
-      return true;
-    }
-    // 播放器内菜单打开时禁用热键
     final videoState = _getVideoPlayerState();
-    if (videoState != null && videoState.hotkeysSuppressed) {
-      return true;
-    }
-    return false;
+    return shouldBlockDesktopHotkeys(
+      isLargeScreenModeActive: false,
+      hasActiveOverlay: hasActiveOverlay,
+      isEditableTextFocused: _isEditableTextFocused(),
+      playerHotkeysSuppressed: videoState?.hotkeysSuppressed ?? false,
+    );
   }
 
   bool _isShiftPressed() {
@@ -883,13 +913,13 @@ class HotkeyService extends ChangeNotifier {
       await hotKeyManager.register(
         hotKey,
         keyDownHandler: (HotKey hotKey) {
-          if (_shouldBlockHotkeyInTextInput()) {
+          if (_shouldBlockHotkey()) {
             return;
           }
           _handleForwardKeyDown();
         },
         keyUpHandler: (HotKey hotKey) {
-          if (_shouldBlockHotkeyInTextInput()) {
+          if (_shouldBlockHotkey()) {
             return;
           }
           _handleForwardKeyUp();
@@ -903,7 +933,7 @@ class HotkeyService extends ChangeNotifier {
   }
 
   void _handleForwardKeyDown() {
-    if (_shouldBlockHotkeyInTextInput()) {
+    if (_shouldBlockHotkey()) {
       return;
     }
     _isForwardKeyPressed = true;
@@ -936,7 +966,7 @@ class HotkeyService extends ChangeNotifier {
     }
 
     // block 检查仅影响"短按快进"逻辑（倍速已在上面的分支中处理）
-    if (_shouldBlockHotkeyInTextInput()) {
+    if (_shouldBlockHotkey()) {
       return;
     }
     // 如果没有触发倍速（短按），执行快进
@@ -962,7 +992,7 @@ class HotkeyService extends ChangeNotifier {
   }
 
   void _handleEscape() {
-    if (_shouldBlockHotkeyInTextInput()) {
+    if (_shouldBlockHotkey()) {
       return;
     }
     final windowService = DesktopPlayerWindowService.instance;

--- a/test/cupertino_bottom_navigation_style_test.dart
+++ b/test/cupertino_bottom_navigation_style_test.dart
@@ -3,17 +3,25 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nipaplay/themes/cupertino/utils/cupertino_bottom_navigation_style.dart';
 
 void main() {
-  test('bottom navigation uses pure black in light mode', () {
-    expect(
-      resolveCupertinoBottomNavigationForegroundColor(Brightness.light),
-      const Color(0xFF000000),
+  const accentColor = Color(0xFF40C7FF);
+
+  test('light mode keeps selected accent and uses black when unselected', () {
+    final colors = resolveCupertinoBottomNavigationColors(
+      brightness: Brightness.light,
+      accentColor: accentColor,
     );
+
+    expect(colors.selected, accentColor);
+    expect(colors.unselected, const Color(0xFF000000));
   });
 
-  test('bottom navigation uses pure white in dark mode', () {
-    expect(
-      resolveCupertinoBottomNavigationForegroundColor(Brightness.dark),
-      const Color(0xFFFFFFFF),
+  test('dark mode keeps selected accent and uses white when unselected', () {
+    final colors = resolveCupertinoBottomNavigationColors(
+      brightness: Brightness.dark,
+      accentColor: accentColor,
     );
+
+    expect(colors.selected, accentColor);
+    expect(colors.unselected, const Color(0xFFFFFFFF));
   });
 }

--- a/test/cupertino_bottom_navigation_style_test.dart
+++ b/test/cupertino_bottom_navigation_style_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/themes/cupertino/utils/cupertino_bottom_navigation_style.dart';
+
+void main() {
+  test('bottom navigation uses pure black in light mode', () {
+    expect(
+      resolveCupertinoBottomNavigationForegroundColor(Brightness.light),
+      const Color(0xFF000000),
+    );
+  });
+
+  test('bottom navigation uses pure white in dark mode', () {
+    expect(
+      resolveCupertinoBottomNavigationForegroundColor(Brightness.dark),
+      const Color(0xFFFFFFFF),
+    );
+  });
+}

--- a/test/cupertino_glass_navigation_insets_test.dart
+++ b/test/cupertino_glass_navigation_insets_test.dart
@@ -43,4 +43,36 @@ void main() {
       );
     });
   });
+
+  group('resolvePageActionsTrailingOffset', () {
+    test('moves the native iOS 26 toolbar eight points inward', () {
+      expect(
+        resolvePageActionsTrailingOffset(
+          viewPaddingRight: 0,
+          usesNativeIOS26Toolbar: true,
+        ),
+        20,
+      );
+    });
+
+    test('preserves the safe area while moving the native toolbar inward', () {
+      expect(
+        resolvePageActionsTrailingOffset(
+          viewPaddingRight: 6,
+          usesNativeIOS26Toolbar: true,
+        ),
+        26,
+      );
+    });
+
+    test('keeps the fallback toolbar at its original offset', () {
+      expect(
+        resolvePageActionsTrailingOffset(
+          viewPaddingRight: 6,
+          usesNativeIOS26Toolbar: false,
+        ),
+        18,
+      );
+    });
+  });
 }

--- a/test/cupertino_glass_navigation_insets_test.dart
+++ b/test/cupertino_glass_navigation_insets_test.dart
@@ -45,13 +45,13 @@ void main() {
   });
 
   group('resolvePageActionsTrailingOffset', () {
-    test('moves the native iOS 26 toolbar eight points inward', () {
+    test('moves the native iOS 26 toolbar sixteen points inward', () {
       expect(
         resolvePageActionsTrailingOffset(
           viewPaddingRight: 0,
           usesNativeIOS26Toolbar: true,
         ),
-        20,
+        28,
       );
     });
 
@@ -61,7 +61,7 @@ void main() {
           viewPaddingRight: 6,
           usesNativeIOS26Toolbar: true,
         ),
-        26,
+        34,
       );
     });
 

--- a/test/cupertino_glass_navigation_insets_test.dart
+++ b/test/cupertino_glass_navigation_insets_test.dart
@@ -45,31 +45,41 @@ void main() {
   });
 
   group('resolvePageActionsTrailingOffset', () {
-    test('moves the native iOS 26 toolbar sixteen points inward', () {
+    test('moves the iOS 27 toolbar sixteen points inward', () {
       expect(
         resolvePageActionsTrailingOffset(
           viewPaddingRight: 0,
-          usesNativeIOS26Toolbar: true,
+          iosMajorVersion: 27,
         ),
         28,
       );
     });
 
-    test('preserves the safe area while moving the native toolbar inward', () {
+    test('preserves the safe area while moving the iOS 27 toolbar inward', () {
       expect(
         resolvePageActionsTrailingOffset(
           viewPaddingRight: 6,
-          usesNativeIOS26Toolbar: true,
+          iosMajorVersion: 27,
         ),
         34,
       );
     });
 
-    test('keeps the fallback toolbar at its original offset', () {
+    test('keeps the iOS 26 toolbar at its original offset', () {
       expect(
         resolvePageActionsTrailingOffset(
           viewPaddingRight: 6,
-          usesNativeIOS26Toolbar: false,
+          iosMajorVersion: 26,
+        ),
+        18,
+      );
+    });
+
+    test('does not apply the workaround to versions after iOS 27', () {
+      expect(
+        resolvePageActionsTrailingOffset(
+          viewPaddingRight: 6,
+          iosMajorVersion: 28,
         ),
         18,
       );

--- a/test/hotkey_service_policy_test.dart
+++ b/test/hotkey_service_policy_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/utils/hotkey_service.dart';
+
+void main() {
+  test('large-screen mode blocks the complete desktop hotkey set', () {
+    expect(
+      shouldBlockDesktopHotkeys(
+        isLargeScreenModeActive: true,
+        hasActiveOverlay: false,
+        isEditableTextFocused: false,
+        playerHotkeysSuppressed: false,
+      ),
+      isTrue,
+    );
+  });
+
+  test('desktop hotkeys remain available after leaving large-screen mode', () {
+    expect(
+      shouldBlockDesktopHotkeys(
+        isLargeScreenModeActive: false,
+        hasActiveOverlay: false,
+        isEditableTextFocused: false,
+        playerHotkeysSuppressed: false,
+      ),
+      isFalse,
+    );
+  });
+
+  test('existing overlay, text input, and player guards remain active', () {
+    for (final blockedState in <List<bool>>[
+      <bool>[true, false, false],
+      <bool>[false, true, false],
+      <bool>[false, false, true],
+    ]) {
+      expect(
+        shouldBlockDesktopHotkeys(
+          isLargeScreenModeActive: false,
+          hasActiveOverlay: blockedState[0],
+          isEditableTextFocused: blockedState[1],
+          playerHotkeysSuppressed: blockedState[2],
+        ),
+        isTrue,
+      );
+    }
+  });
+}

--- a/test/large_screen_mode_actions_test.dart
+++ b/test/large_screen_mode_actions_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/l10n/app_localizations.dart';
+import 'package:nipaplay/themes/nipaplay/widgets/large_screen_mode_actions.dart';
+
+void main() {
+  test('large-screen mode control is permanent on desktop and tablet', () {
+    expect(
+      shouldOfferLargeScreenModeControl(
+        isDesktopOrTablet: true,
+        isTelevisionSurface: false,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldOfferLargeScreenModeControl(
+        isDesktopOrTablet: false,
+        isTelevisionSurface: false,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldOfferLargeScreenModeControl(
+        isDesktopOrTablet: true,
+        isTelevisionSurface: true,
+      ),
+      isFalse,
+    );
+  });
+
+  testWidgets('inactive large-screen mode control stays at the top right',
+      (tester) async {
+    var toggleCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Stack(
+          children: [
+            NipaplayLargeScreenModeActionsOverlay(
+              isDarkMode: false,
+              isLargeScreenLayoutActive: false,
+              topPadding: 12,
+              rightPadding: 16,
+              showWindowsButtons: false,
+              isMaximized: false,
+              onToggleLargeScreen: () => toggleCount += 1,
+              onToggleThemeFromOrigin: (_) async {},
+              onOpenSettings: () {},
+              onMinimize: () {},
+              onMaximizeRestore: () {},
+              onClose: () {},
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final toggle = find.byType(LargeScreenModeToggleIconButton);
+    expect(toggle, findsOneWidget);
+    final positioned = tester.widget<Positioned>(
+      find.ancestor(of: toggle, matching: find.byType(Positioned)),
+    );
+    expect(positioned.top, 12);
+    expect(positioned.right, 16);
+
+    await tester.tap(toggle);
+    expect(toggleCount, 1);
+  });
+}

--- a/test/settings/adaptive_settings_widgets_test.dart
+++ b/test/settings/adaptive_settings_widgets_test.dart
@@ -1,7 +1,6 @@
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:adaptive_platform_ui/src/widgets/ios26/ios26_popup_menu_button.dart'
     show IOS26PopupMenuButton;
-import 'package:flutter/cupertino.dart' as cupertino;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nipaplay/settings/adaptive_settings_scope.dart';
@@ -28,7 +27,7 @@ void main() {
     expect(find.text('Selected library'), findsOneWidget);
   });
 
-  testWidgets('opted-in iOS 26 dropdown uses the native popup menu',
+  testWidgets('every iOS 26 dropdown uses the native menu and shared trigger',
       (tester) async {
     String? selectedValue;
     PlatformInfo.setPlatformOverride(PlatformOverride.ios, iosVersion: 26);
@@ -49,7 +48,6 @@ void main() {
               DropdownMenuItemData(title: 'MediaKit', value: 'media-kit'),
             ],
             onChanged: (value) => selectedValue = value,
-            useNativeIOS26Dropdown: true,
           ),
         ),
       ),
@@ -61,7 +59,9 @@ void main() {
     expect(popupFinder, findsOneWidget);
 
     final popup = tester.widget<IOS26PopupMenuButton<String>>(popupFinder);
-    expect(popup.buttonLabel, 'MDK');
+    expect(popup.child, isNotNull);
+    expect(popup.buttonLabel, isNull);
+    expect(find.text('MDK'), findsOneWidget);
     expect(
       (popup.items.first as AdaptivePopupMenuItem<String>).icon,
       'checkmark',
@@ -74,8 +74,9 @@ void main() {
     expect(selectedValue, 'media-kit');
   });
 
-  testWidgets('iOS 18 opted-in dropdown keeps the bottom-sheet button',
+  testWidgets('iOS 18 dropdown uses the NipaPlay menu with shared trigger',
       (tester) async {
+    String? selectedValue;
     PlatformInfo.setPlatformOverride(PlatformOverride.ios, iosVersion: 18);
     addTearDown(PlatformInfo.clearPlatformOverride);
 
@@ -91,9 +92,9 @@ void main() {
                 value: 'mdk',
                 isSelected: true,
               ),
+              DropdownMenuItemData(title: 'MediaKit', value: 'media-kit'),
             ],
-            onChanged: (_) {},
-            useNativeIOS26Dropdown: true,
+            onChanged: (value) => selectedValue = value,
           ),
         ),
       ),
@@ -105,6 +106,16 @@ void main() {
       ),
       findsNothing,
     );
-    expect(find.byType(cupertino.CupertinoButton), findsOneWidget);
+    expect(find.byType(BlurDropdown<String>), findsOneWidget);
+    expect(find.text('MDK'), findsOneWidget);
+    expect(find.text('MediaKit'), findsNothing);
+
+    await tester.tap(find.text('MDK'));
+    await tester.pumpAndSettle();
+    expect(find.text('MediaKit'), findsOneWidget);
+
+    await tester.tap(find.text('MediaKit'));
+    await tester.pumpAndSettle();
+    expect(selectedValue, 'media-kit');
   });
 }

--- a/test/television_media_library_test.dart
+++ b/test/television_media_library_test.dart
@@ -199,8 +199,9 @@ void main() {
       isTrue,
     );
   });
-  testWidgets('television collection renders a focusable poster grid',
+  testWidgets('desktop large-screen collection uses light theme card text',
       (tester) async {
+    final lightTheme = ThemeData.light();
     final item = WatchHistoryItem(
       animeId: 42,
       animeName: '测试番剧',
@@ -216,20 +217,24 @@ void main() {
       ChangeNotifierProvider<AppearanceSettingsProvider>(
         create: (_) => AppearanceSettingsProvider(),
         child: MaterialApp(
+          theme: lightTheme,
           home: AppDisplaySurfaceScope(
-            surface: AppDisplaySurface.television,
-            child: SizedBox(
-              width: 1280,
-              height: 720,
-              child: AdaptiveMediaCollectionItems(
-                source: UnifiedMediaLibrarySource.local,
-                sourceLabel: '本地媒体库',
-                isLoading: false,
-                items: <WatchHistoryItem>[item],
-                allHistory: <WatchHistoryItem>[item],
-                details: const {},
-                onRefresh: () async {},
-                onTap: (_) {},
+            surface: AppDisplaySurface.desktopTablet,
+            child: NipaplayLargeScreenModeScope(
+              isActive: true,
+              child: SizedBox(
+                width: 1280,
+                height: 720,
+                child: AdaptiveMediaCollectionItems(
+                  source: UnifiedMediaLibrarySource.local,
+                  sourceLabel: '本地媒体库',
+                  isLoading: false,
+                  items: <WatchHistoryItem>[item],
+                  allHistory: <WatchHistoryItem>[item],
+                  details: const {},
+                  onRefresh: () async {},
+                  onTap: (_) {},
+                ),
               ),
             ),
           ),
@@ -249,6 +254,11 @@ void main() {
     expect(
       find.byType(NipaplayLargeScreenFocusableAction),
       findsOneWidget,
+    );
+    final title = tester.widget<Text>(find.text('测试番剧'));
+    expect(
+      title.style?.color,
+      lightTheme.colorScheme.onSurface.withValues(alpha: 0.9),
     );
   });
 

--- a/test/trending_bangumi_test.dart
+++ b/test/trending_bangumi_test.dart
@@ -20,7 +20,7 @@ void main() {
     );
 
     expect(desktopSection, contains('mainAxisSize: MainAxisSize.min'));
-    expect(desktopSection, contains('const SizedBox(width: 8)'));
+    expect(desktopSection, contains('const SizedBox(width: 16)'));
     expect(desktopSection, isNot(contains('const Spacer()')));
   });
 

--- a/test/trending_bangumi_test.dart
+++ b/test/trending_bangumi_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -9,6 +10,20 @@ import 'package:nipaplay/services/trending_bangumi_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  test('desktop ranking actions stay beside the section title', () {
+    final source = File(
+      'lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart',
+    ).readAsStringSync();
+    final desktopSection = source.substring(
+      source.indexOf('Widget _buildTrendingSection()'),
+      source.indexOf('Widget _buildTrendingErrorState()'),
+    );
+
+    expect(desktopSection, contains('mainAxisSize: MainAxisSize.min'));
+    expect(desktopSection, contains('const SizedBox(width: 8)'));
+    expect(desktopSection, isNot(contains('const Spacer()')));
+  });
+
   group('TrendingBangumiQuery', () {
     test('builds all supported endpoint paths', () {
       expect(

--- a/test/trending_bangumi_test.dart
+++ b/test/trending_bangumi_test.dart
@@ -20,7 +20,7 @@ void main() {
     );
 
     expect(desktopSection, contains('mainAxisSize: MainAxisSize.min'));
-    expect(desktopSection, contains('const SizedBox(width: 16)'));
+    expect(desktopSection, contains('const SizedBox(width: 32)'));
     expect(desktopSection, isNot(contains('const Spacer()')));
   });
 

--- a/test/trending_bangumi_test.dart
+++ b/test/trending_bangumi_test.dart
@@ -20,7 +20,7 @@ void main() {
     );
 
     expect(desktopSection, contains('mainAxisSize: MainAxisSize.min'));
-    expect(desktopSection, contains('const SizedBox(width: 32)'));
+    expect(desktopSection, contains('const SizedBox(width: 48)'));
     expect(desktopSection, isNot(contains('const Spacer()')));
   });
 

--- a/test/trending_bangumi_test.dart
+++ b/test/trending_bangumi_test.dart
@@ -24,6 +24,20 @@ void main() {
     expect(desktopSection, isNot(contains('const Spacer()')));
   });
 
+  test('desktop ranking windows use plain NipaPlay dropdown layouts', () {
+    final source = File(
+      'lib/themes/nipaplay/widgets/dashboard_home_page_trending.dart',
+    ).readAsStringSync();
+
+    expect(source, isNot(contains('backdropBlurSigma: 34')));
+    expect(source, contains('class _NipaplayTrendingFilterControls'));
+    expect(source, contains('BlurDropdown<TrendingRankingKind>'));
+    expect(source, contains('class _NipaplayFullTrendingView'));
+    expect(source, contains('compact: true'));
+    expect(source, contains('crossAxisAlignment: CrossAxisAlignment.end'));
+    expect(source, contains('SliverGridDelegateWithMaxCrossAxisExtent'));
+  });
+
   group('TrendingBangumiQuery', () {
     test('builds all supported endpoint paths', () {
       expect(

--- a/test/tvos_large_screen_adaptation_policy_test.dart
+++ b/test/tvos_large_screen_adaptation_policy_test.dart
@@ -3,6 +3,25 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('large screen mode is a permanent feature outside labs', () {
+    final main = File('lib/main.dart').readAsStringSync();
+    final labs = File(
+      'lib/settings/pages/labs_settings_content.dart',
+    ).readAsStringSync();
+    final labsProvider = File(
+      'lib/providers/labs_settings_provider.dart',
+    ).readAsStringSync();
+    final settingsKeys = File(
+      'lib/constants/settings_keys.dart',
+    ).readAsStringSync();
+
+    expect(main, contains('shouldOfferLargeScreenModeControl('));
+    expect(main, isNot(contains('_isLabsLargeScreenModeEnabled')));
+    expect(labs, isNot(contains('enableLargeScreenMode')));
+    expect(labsProvider, isNot(contains('enableLargeScreenMode')));
+    expect(settingsKeys, isNot(contains('labsEnableLargeScreenMode')));
+  });
+
   test('televisions remove controls that require touch or desktop access', () {
     final scaffold = File(
       'lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart',
@@ -31,7 +50,7 @@ void main() {
       scaffold,
       contains('globals.isTelevision || usePlayerContextPanel'),
     );
-    expect(labs, contains('if (!globals.isTelevision)'));
+    expect(labs, isNot(contains('enableLargeScreenMode')));
     expect(plugins, contains('if (!globals.isTelevision)'));
     expect(remote, contains('if (!globals.isTelevision)'));
     expect(remote, contains('if (!globals.isTelevision &&'));

--- a/test/unified_app_architecture_test.dart
+++ b/test/unified_app_architecture_test.dart
@@ -559,7 +559,11 @@ void main() {
     );
   });
 
-  test('iOS 26 kernel selectors opt into native dropdown menus', () {
+  test('phone setting selectors share native and NipaPlay dropdown routing',
+      () {
+    final adaptive = File(
+      'lib/settings/adaptive_settings_widgets.dart',
+    ).readAsStringSync();
     final player = File(
       'lib/settings/pages/player_settings_content.dart',
     ).readAsStringSync();
@@ -567,24 +571,14 @@ void main() {
       'lib/settings/pages/danmaku_settings_content.dart',
     ).readAsStringSync();
 
-    expect(
-      player,
-      matches(
-        RegExp(
-          r'title: "播放器内核",[\s\S]*?'
-          r'useNativeIOS26Dropdown: true,',
-        ),
-      ),
-    );
-    expect(
-      danmaku,
-      matches(
-        RegExp(
-          r"title: '弹幕渲染引擎',[\s\S]*?"
-          r'useNativeIOS26Dropdown: true,',
-        ),
-      ),
-    );
+    expect(adaptive, contains('if (usesNativeIOS26SettingsControls)'));
+    expect(adaptive, contains('AdaptivePopupMenuButton.widget<T>'));
+    expect(adaptive, contains('return BlurDropdown<T>('));
+    expect(adaptive, contains('final trigger = _PhoneMenuChip(label: label)'));
+    expect(adaptive, isNot(contains('CupertinoBottomSheet.showSelection')));
+    expect(adaptive, isNot(contains('useNativeIOS26Dropdown')));
+    expect(player, isNot(contains('useNativeIOS26Dropdown')));
+    expect(danmaku, isNot(contains('useNativeIOS26Dropdown')));
   });
 
   test('shared host selection has one model and adaptive renderers', () {

--- a/test/unified_app_architecture_test.dart
+++ b/test/unified_app_architecture_test.dart
@@ -618,7 +618,8 @@ void main() {
     expect(qr, contains('MobileScanner('));
   });
 
-  test('obsolete appearance modes are removed and phone sections reorder', () {
+  test('appearance settings expose home section ordering outside television',
+      () {
     final appearance = File(
       'lib/settings/pages/appearance_settings_content.dart',
     ).readAsStringSync();
@@ -630,6 +631,14 @@ void main() {
     expect(appearance, isNot(contains('RecentWatchingStyle')));
     expect(appearance, isNot(contains('_detailModeDropdownKey')));
     expect(appearance, isNot(contains('_recentStyleDropdownKey')));
+    expect(
+      appearance,
+      contains(
+        RegExp(
+          r'if \(!globals\.isTelevision\) \.\.\.\[[\s\S]*?AdaptiveSettingsDragList<HomeSectionType>',
+        ),
+      ),
+    );
     expect(appearance, contains('AdaptiveSettingsDragList<HomeSectionType>'));
     expect(appearance, contains('onReorder: homeSections.reorderSections'));
     expect(general, isNot(contains('HomeSectionsSettingsProvider')));


### PR DESCRIPTION
## 变更内容

- 修复大屏模式快捷键拦截、排行榜卡片样式与完整排行榜交互。
- 重做桌面排行榜设置与完整榜单窗口，支持排序下拉、前三名展示和海报网格。
- 优化排行榜间距、卡片文本、主题色和详情返回行为。
- 平板隐藏外部调用、快捷键及开发者设置中的打开日志路径。
- 更新 iOS/macOS Pod 锁文件。

## 验证

- `flutter test --no-pub test/trending_bangumi_test.dart`
- 相关 Dart 文件静态分析通过。