### PR TITLE
ci: publish HarmonyOS and Apple TV sideload packages

### DIFF
--- a/.github/workflows/build-tvos.yml
+++ b/.github/workflows/build-tvos.yml
@@ -8,7 +8,7 @@ on:
         description: Application version from pubspec.yaml
         value: ${{ jobs.build.outputs.version }}
       artifact-name:
-        description: Uploaded tvOS simulator application
+        description: Uploaded tvOS build artifact
         value: ${{ jobs.build.outputs.artifact-name }}
   pull_request:
     paths:
@@ -32,12 +32,12 @@ concurrency:
 
 jobs:
   build:
-    name: Build tvOS simulator app
+    name: Build tvOS package
     runs-on: macos-26
     timeout-minutes: 120
     outputs:
       version: ${{ steps.project.outputs.version }}
-      artifact-name: release-tvOS-simulator
+      artifact-name: ${{ steps.artifact.outputs.name }}
     steps:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
@@ -96,29 +96,100 @@ jobs:
             run tool/configure_flutter_dependencies.dart tvos
           "$FLUTTER_TVOS_ROOT/bin/flutter-tvos" pub get
 
-      - name: Build unsigned tvOS simulator app
+      - name: Build tvOS simulator application
+        if: github.event_name == 'pull_request'
         shell: bash
         run: |
           set -euo pipefail
           "$FLUTTER_TVOS_ROOT/bin/flutter-tvos" \
-            build tvos --simulator --debug
+            build tvos --simulator --debug --no-pub
 
-      - name: Locate tvOS application
-        id: artifact
+      - name: Build unsigned tvOS device application
+        if: github.event_name != 'pull_request'
         shell: bash
         run: |
           set -euo pipefail
-          app_path="$(find build/tvos -type d -name '*.app' -print -quit)"
+          unsigned_config="$RUNNER_TEMP/NipaPlay-tvOS-unsigned.xcconfig"
+          printf '%s\n' \
+            'CODE_SIGNING_ALLOWED = NO' \
+            'CODE_SIGNING_REQUIRED = NO' \
+            'CODE_SIGN_IDENTITY =' \
+            'DEVELOPMENT_TEAM =' \
+            'PROVISIONING_PROFILE_SPECIFIER =' \
+            > "$unsigned_config"
+
+          XCODE_XCCONFIG_FILE="$unsigned_config" \
+            "$FLUTTER_TVOS_ROOT/bin/flutter-tvos" \
+            build tvos --release --no-pub
+
+      - name: Prepare tvOS artifact
+        id: artifact
+        shell: bash
+        env:
+          VERSION: ${{ steps.project.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            app_path="$(find build/tvos -path '*-appletvsimulator/*.app' -type d -print -quit)"
+            if [[ -z "$app_path" ]]; then
+              echo "No tvOS simulator .app was produced." >&2
+              find build -maxdepth 5 -print
+              exit 1
+            fi
+            echo "name=release-tvOS-simulator" >> "$GITHUB_OUTPUT"
+            echo "path=$app_path" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          app_path="$(find build/tvos/Release-appletvos -maxdepth 1 -type d -name '*.app' -print -quit)"
           if [[ -z "$app_path" ]]; then
-            echo "No tvOS .app was produced." >&2
+            echo "No tvOS device .app was produced." >&2
             find build -maxdepth 5 -print
             exit 1
           fi
-          echo "path=$app_path" >> "$GITHUB_OUTPUT"
+
+          executable_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app_path/Info.plist")"
+          executable="$app_path/$executable_name"
+          if ! lipo -archs "$executable" | tr ' ' '\n' | grep -qx arm64; then
+            echo "tvOS device executable is not arm64: $(lipo -archs "$executable")" >&2
+            exit 1
+          fi
+          if ! xcrun vtool -show-build "$executable" | grep -q 'platform TVOS'; then
+            echo "tvOS package does not target physical Apple TV devices." >&2
+            xcrun vtool -show-build "$executable" || true
+            exit 1
+          fi
+
+          mkdir -p dist/Payload
+          /usr/bin/ditto "$app_path" "dist/Payload/$(basename "$app_path")"
+          ipa_name="NipaPlay-${VERSION}-tvOS-arm64-sideload.ipa"
+          (
+            cd dist
+            /usr/bin/ditto -c -k --keepParent Payload "$ipa_name"
+          )
+          test -s "dist/$ipa_name"
+          shasum -a 256 "dist/$ipa_name" > dist/SHA256SUMS-tvOS
+
+          echo "name=release-tvOS-sideload" >> "$GITHUB_OUTPUT"
+          echo "path=dist/$ipa_name" >> "$GITHUB_OUTPUT"
 
       - name: Upload tvOS simulator application
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: release-tvOS-simulator
           path: ${{ steps.artifact.outputs.path }}
           if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload tvOS sideload package
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-tvOS-sideload
+          path: |
+            ${{ steps.artifact.outputs.path }}
+            dist/SHA256SUMS-tvOS
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,9 +104,38 @@ jobs:
     if: needs.Gatekeeper.outputs.triggered == 'true'
     uses: ./.github/workflows/build-linux.yml
 
+  Build-HarmonyOS:
+    name: Build HarmonyOS sideload package
+    needs: Gatekeeper
+    if: needs.Gatekeeper.outputs.triggered == 'true'
+    uses: ./.github/workflows/build-ohos.yml
+    with:
+      sign_hap: true
+    secrets:
+      OHOS_SIGNING_CERT_BASE64: ${{ secrets.OHOS_SIGNING_CERT_BASE64 }}
+      OHOS_SIGNING_PROFILE_BASE64: ${{ secrets.OHOS_SIGNING_PROFILE_BASE64 }}
+      OHOS_SIGNING_KEYSTORE_BASE64: ${{ secrets.OHOS_SIGNING_KEYSTORE_BASE64 }}
+      OHOS_SIGNING_KEY_ALIAS: ${{ secrets.OHOS_SIGNING_KEY_ALIAS }}
+      OHOS_SIGNING_KEYSTORE_PASSWORD: ${{ secrets.OHOS_SIGNING_KEYSTORE_PASSWORD }}
+      OHOS_SIGNING_KEY_PASSWORD: ${{ secrets.OHOS_SIGNING_KEY_PASSWORD }}
+
+  Build-tvOS:
+    name: Build Apple TV sideload package
+    needs: Gatekeeper
+    if: needs.Gatekeeper.outputs.triggered == 'true'
+    uses: ./.github/workflows/build-tvos.yml
+
   Publish:
     name: Publish Release
-    needs: [Gatekeeper, Build-Android, Build-iOS, Build-macOS, Build-Windows, Build-Linux]
+    needs:
+      - Gatekeeper
+      - Build-Android
+      - Build-iOS
+      - Build-macOS
+      - Build-Windows
+      - Build-Linux
+      - Build-HarmonyOS
+      - Build-tvOS
     if: needs.Gatekeeper.outputs.triggered == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -390,7 +419,7 @@ jobs:
           name: Release v${{ needs.Build-Android.outputs.version }}
           bodyFile: "release_notes.md"
           allowUpdates: true
-          artifacts: /tmp/artifacts/release-Android/*.apk,/tmp/artifacts/release-iOS/*.ipa,/tmp/artifacts/release-macOS-*/*.dmg,/tmp/artifacts/release-macOS-*/*.zip,/tmp/artifacts/release-macOS-*/*.pkg,/tmp/artifacts/release-Windows-x64/*.zip,/tmp/artifacts/release-Windows-x64/*.exe,/tmp/artifacts/release-Windows-x64/*.msix,/tmp/artifacts/release-Linux-amd64/*.deb,/tmp/artifacts/release-Linux-amd64/*.AppImage,/tmp/artifacts/release-Linux-amd64/*.tar.gz,/tmp/artifacts/release-Linux-amd64/*.rpm,/tmp/artifacts/release-Linux-arm64/*.deb,/tmp/artifacts/release-Linux-arm64/*.tar.gz,/tmp/artifacts/release-Linux-arm64/*.rpm
+          artifacts: /tmp/artifacts/release-Android/*.apk,/tmp/artifacts/release-iOS/*.ipa,/tmp/artifacts/release-macOS-*/*.dmg,/tmp/artifacts/release-macOS-*/*.zip,/tmp/artifacts/release-macOS-*/*.pkg,/tmp/artifacts/release-Windows-x64/*.zip,/tmp/artifacts/release-Windows-x64/*.exe,/tmp/artifacts/release-Windows-x64/*.msix,/tmp/artifacts/release-Linux-amd64/*.deb,/tmp/artifacts/release-Linux-amd64/*.AppImage,/tmp/artifacts/release-Linux-amd64/*.tar.gz,/tmp/artifacts/release-Linux-amd64/*.rpm,/tmp/artifacts/release-Linux-arm64/*.deb,/tmp/artifacts/release-Linux-arm64/*.tar.gz,/tmp/artifacts/release-Linux-arm64/*.rpm,/tmp/artifacts/release-HarmonyOS-signed/*.hap,/tmp/artifacts/release-tvOS-sideload/*.ipa
           artifactErrorsFailBuild: true
           replacesArtifacts: true
           token: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}

--- a/docs/TVOS_DEVELOPMENT.md
+++ b/docs/TVOS_DEVELOPMENT.md
@@ -86,6 +86,9 @@ fixed to the Erika kernel through the tvOS dependency profile; Media Kit, MDK,
 file pickers, URL launcher, and camera-based features remain hidden where they
 do not have usable tvOS implementations.
 
-The CI workflow builds an unsigned simulator app. App Store or physical-device
-artifacts require Apple signing credentials and should be added as a separate
-release step rather than embedding a personal team in the project.
+Pull-request CI builds an unsigned simulator app. Manual and reusable release
+runs build an unsigned arm64 device IPA for sideloading tools to re-sign with
+the user's Apple developer identity. This keeps personal teams and provisioning
+profiles out of the project while still producing a physical Apple TV package.
+App Store or directly installable device-specific artifacts continue to require
+Apple signing credentials and a matching tvOS provisioning profile.

--- a/test/mainline_flutter_compatibility_test.dart
+++ b/test/mainline_flutter_compatibility_test.dart
@@ -198,6 +198,37 @@ void main() {
     expect(workflow, isNot(contains('.ohos/config')));
   });
 
+  test('release CI publishes HarmonyOS and Apple TV sideload packages', () {
+    final releaseWorkflow =
+        File('.github/workflows/main.yml').readAsStringSync();
+    final tvOSWorkflow =
+        File('.github/workflows/build-tvos.yml').readAsStringSync();
+
+    expect(
+        releaseWorkflow, contains('uses: ./.github/workflows/build-ohos.yml'));
+    expect(
+        releaseWorkflow, contains('uses: ./.github/workflows/build-tvos.yml'));
+    expect(releaseWorkflow, contains('sign_hap: true'));
+    expect(releaseWorkflow, contains('Build-HarmonyOS'));
+    expect(releaseWorkflow, contains('Build-tvOS'));
+    expect(
+      releaseWorkflow,
+      contains('/tmp/artifacts/release-HarmonyOS-signed/*.hap'),
+    );
+    expect(
+      releaseWorkflow,
+      contains('/tmp/artifacts/release-tvOS-sideload/*.ipa'),
+    );
+
+    expect(tvOSWorkflow, contains("github.event_name == 'pull_request'"));
+    expect(tvOSWorkflow, contains('CODE_SIGNING_ALLOWED = NO'));
+    expect(tvOSWorkflow, contains('build tvos --release --no-pub'));
+    expect(tvOSWorkflow, contains('build/tvos/Release-appletvos'));
+    expect(tvOSWorkflow, contains("grep -q 'platform TVOS'"));
+    expect(tvOSWorkflow, contains('release-tvOS-sideload'));
+    expect(tvOSWorkflow, contains('tvOS-arm64-sideload.ipa'));
+  });
+
   test('application source does not require custom Platform APIs', () {
     final incompatibleFiles = Directory('lib')
         .listSync(recursive: true)


### PR DESCRIPTION
## Summary

- add the signed HarmonyOS arm64 HAP job to the modular release workflow
- add an unsigned arm64 Apple TV device IPA for sideloading tools to re-sign
- keep pull-request tvOS validation on the simulator and verify release binaries target physical tvOS devices
- publish both new package types with the existing release artifacts

## Validation

- actionlint .github/workflows/build-tvos.yml .github/workflows/build-ohos.yml
- flutter test --no-pub test/mainline_flutter_compatibility_test.dart
- git diff --check

## Release prerequisites

- HarmonyOS publishing requires all six OHOS_SIGNING_* Actions secrets; the signed profile must include the target device.
- The Apple TV IPA is intentionally unsigned and must be re-signed by the sideloading tool with the user developer identity.