### PR TITLE
fix(windows): 修复 Flutter 更新后的弹窗卡死

### DIFF
--- a/lib/media_library/adaptive_media_library_controls.dart
+++ b/lib/media_library/adaptive_media_library_controls.dart
@@ -24,6 +24,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/nipaplay_main_tab_bar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/shared_remote_library_view.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
 import 'package:nipaplay/utils/globals.dart' as globals;
+import 'package:nipaplay/widgets/in_view_dialog.dart';
 
 class AdaptiveMediaLibraryScaffold extends material.StatelessWidget {
   const AdaptiveMediaLibraryScaffold({
@@ -628,7 +629,7 @@ Future<List<String>?> showAdaptiveMediaLibrarySectionOrder(
     );
   }
 
-  return material.showDialog<List<String>>(
+  return showInViewDialog<List<String>>(
     context: context,
     builder: (dialogContext) {
       final viewport = material.MediaQuery.sizeOf(dialogContext);

--- a/lib/services/emby_dandanplay_matcher.dart
+++ b/lib/services/emby_dandanplay_matcher.dart
@@ -15,6 +15,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/blur_button.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/tvos_remote_text_input_scope.dart';
 import 'package:nipaplay/utils/remote_media_fetcher.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
+import 'package:nipaplay/widgets/in_view_dialog.dart';
 import 'package:provider/provider.dart';
 
 /// 负责将Emby媒体与DandanPlay的内容匹配，以获取弹幕和元数据
@@ -382,7 +383,7 @@ class EmbyDandanplayMatcher {
         // 显示匹配对话框，让用户手动选择
         debugPrint(
             '显示选择对话框 (有  [38;5;246m [48;5;236m${animeMatches.length} [0m 个预搜索候选项)');
-        final dialogResult = await showDialog<Map<String, dynamic>>(
+        final dialogResult = await showInViewDialog<Map<String, dynamic>>(
           context: context,
           barrierDismissible: false, // Make it modal, like Jellyfin's
           builder: (context) => AnimeMatchDialog(
@@ -494,7 +495,7 @@ class EmbyDandanplayMatcher {
       // 自动选择模式下，如果预搜索为空，则回退弹窗让用户手动搜索
       if (selectedMatch == null && showMatchDialog && autoPickOnHashFail) {
         debugPrint('自动选择失败（无候选项），回退弹幕匹配弹窗');
-        final dialogResult = await showDialog<Map<String, dynamic>>(
+        final dialogResult = await showInViewDialog<Map<String, dynamic>>(
           context: context,
           barrierDismissible: false,
           builder: (context) => AnimeMatchDialog(

--- a/lib/services/jellyfin_dandanplay_matcher.dart
+++ b/lib/services/jellyfin_dandanplay_matcher.dart
@@ -15,6 +15,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/blur_button.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/tvos_remote_text_input_scope.dart';
 import 'package:nipaplay/utils/remote_media_fetcher.dart';
 import 'package:nipaplay/providers/settings_provider.dart';
+import 'package:nipaplay/widgets/in_view_dialog.dart';
 import 'package:provider/provider.dart';
 
 /// 负责将Jellyfin媒体与DandanPlay的内容匹配，以获取弹幕和元数据
@@ -361,7 +362,7 @@ class JellyfinDandanplayMatcher {
       if (showMatchDialog && !autoPickOnHashFail) {
         // 总是显示对话框让用户选择或跳过，使其成为阻塞操作
         // 即使没有找到匹配，也要显示对话框，让用户能手动搜索
-        final result = await showDialog<Map<String, dynamic>>(
+        final result = await showInViewDialog<Map<String, dynamic>>(
           context: context,
           barrierDismissible: false, // 设置为 false 使对话框成为模态对话框，阻止背景交互
           builder: (context) => AnimeMatchDialog(
@@ -394,7 +395,7 @@ class JellyfinDandanplayMatcher {
       // 自动选择模式下，如果预搜索为空，则回退弹窗让用户手动搜索
       if (selectedMatch == null && showMatchDialog && autoPickOnHashFail) {
         debugPrint('自动选择失败（无候选项），回退弹幕匹配弹窗');
-        final result = await showDialog<Map<String, dynamic>>(
+        final result = await showInViewDialog<Map<String, dynamic>>(
           context: context,
           barrierDismissible: false,
           builder: (context) => AnimeMatchDialog(

--- a/lib/themes/nipaplay/widgets/large_screen_focusable_action.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_focusable_action.dart
@@ -27,16 +27,18 @@ class NipaplayLargeScreenFocusableAction extends StatefulWidget {
     this.onActivate,
     this.focusNode,
     this.autofocus = false,
+    this.isSelected,
     this.borderRadius = BorderRadius.zero,
     this.padding,
     this.style = const NipaplayLargeScreenFocusableStyle(),
     this.focusScale = 1.0,
-  });
+  }) : assert(isSelected == null || onActivate != null);
 
   final Widget child;
   final VoidCallback? onActivate;
   final FocusNode? focusNode;
   final bool autofocus;
+  final bool? isSelected;
   final BorderRadius borderRadius;
   final EdgeInsetsGeometry? padding;
   final NipaplayLargeScreenFocusableStyle style;
@@ -58,10 +60,13 @@ class _NipaplayLargeScreenFocusableActionState
   Widget build(BuildContext context) {
     final isDarkMode = Theme.of(context).brightness == Brightness.dark;
     final style = widget.style;
+    final isSelected = widget.isSelected == true;
     final Color idleOverlay =
         isDarkMode ? style.idleBackgroundDark : style.idleBackgroundLight;
-    final bool isActive = _isFocused || _isHovered;
-    final Color backgroundColor = idleOverlay;
+    final bool isActive = _isFocused || _isHovered || isSelected;
+    final Color backgroundColor = isSelected
+        ? AppAccentColors.current.withValues(alpha: isDarkMode ? 0.16 : 0.1)
+        : idleOverlay;
     final Color contentColor =
         isDarkMode ? style.contentColorDark : style.contentColorLight;
 
@@ -98,10 +103,19 @@ class _NipaplayLargeScreenFocusableActionState
       ),
     );
 
-    return FocusableActionDetector(
+    final focusableAction = FocusableActionDetector(
       focusNode: widget.focusNode,
-      autofocus: widget.autofocus,
+      autofocus: widget.autofocus || isSelected,
       enabled: widget.onActivate != null,
+      onFocusChange: (value) {
+        if (value && widget.isSelected == true) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) {
+              Scrollable.ensureVisible(context, alignment: 0.5);
+            }
+          });
+        }
+      },
       onShowFocusHighlight: (value) {
         if (_isFocused == value) return;
         setState(() {
@@ -132,6 +146,15 @@ class _NipaplayLargeScreenFocusableActionState
         onTap: widget.onActivate,
         child: buttonSurface,
       ),
+    );
+
+    if (widget.isSelected == null) {
+      return focusableAction;
+    }
+    return Semantics(
+      button: true,
+      selected: widget.isSelected,
+      child: focusableAction,
     );
   }
 }

--- a/lib/themes/nipaplay/widgets/network_media_library_view.dart
+++ b/lib/themes/nipaplay/widgets/network_media_library_view.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/cupertino.dart' as cupertino;
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 import 'package:nipaplay/models/jellyfin_model.dart';
 import 'package:nipaplay/models/emby_model.dart';
@@ -28,6 +29,7 @@ import 'package:nipaplay/media_library/adaptive_media_library_primitives.dart';
 import 'package:nipaplay/app/app_display_surface.dart';
 import 'package:nipaplay/app/app_display_surface_scope.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
+import 'package:nipaplay/widgets/in_view_dialog.dart';
 
 enum NetworkMediaServerType { jellyfin, emby }
 
@@ -928,7 +930,7 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
       currentSortSettings['sortBy']!,
       currentSortSettings['sortOrder']!,
     );
-    final selection = await showDialog<_RemoteSortSelection>(
+    final selection = await showInViewDialog<_RemoteSortSelection>(
       context: context,
       barrierColor: Colors.black.withValues(alpha: 0.54),
       builder: (context) {
@@ -950,6 +952,8 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
                   const SizedBox(height: 14),
                   Expanded(
                     child: ListView.separated(
+                      scrollCacheExtent:
+                          ScrollCacheExtent.viewport(items.length.toDouble()),
                       itemCount: items.length,
                       separatorBuilder: (_, __) => const SizedBox(height: 8),
                       itemBuilder: (context, index) {
@@ -957,19 +961,31 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
                         final value = item.value;
                         final description = value.description;
                         return NipaplayLargeScreenFocusableAction(
-                          autofocus: index == 0,
+                          isSelected: item.isSelected,
                           onActivate: () => Navigator.of(context).pop(value),
                           borderRadius: BorderRadius.circular(8),
                           padding: const EdgeInsets.all(14),
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              Text(
-                                item.title,
-                                style: const TextStyle(
-                                  fontSize: 15,
-                                  fontWeight: FontWeight.w900,
-                                ),
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: Text(
+                                      item.title,
+                                      style: const TextStyle(
+                                        fontSize: 15,
+                                        fontWeight: FontWeight.w900,
+                                      ),
+                                    ),
+                                  ),
+                                  if (item.isSelected)
+                                    Icon(
+                                      Icons.check_rounded,
+                                      size: 18,
+                                      color: _accentColor,
+                                    ),
+                                ],
                               ),
                               if (description?.isNotEmpty == true) ...[
                                 const SizedBox(height: 4),

--- a/lib/widgets/in_view_dialog.dart
+++ b/lib/widgets/in_view_dialog.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// Shows a Material dialog without letting Flutter Windowing promote it to a
+/// separate native window on Windows.
+Future<T?> showInViewDialog<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool barrierDismissible = true,
+  Color? barrierColor,
+  String? barrierLabel,
+  bool useSafeArea = true,
+  bool useRootNavigator = true,
+  RouteSettings? routeSettings,
+  Offset? anchorPoint,
+  bool? requestFocus,
+}) {
+  if (kIsWeb || defaultTargetPlatform != TargetPlatform.windows) {
+    return showDialog<T>(
+      context: context,
+      builder: builder,
+      barrierDismissible: barrierDismissible,
+      barrierColor: barrierColor,
+      barrierLabel: barrierLabel,
+      useSafeArea: useSafeArea,
+      useRootNavigator: useRootNavigator,
+      routeSettings: routeSettings,
+      anchorPoint: anchorPoint,
+      requestFocus: requestFocus,
+    );
+  }
+
+  final navigator = Navigator.of(
+    context,
+    rootNavigator: useRootNavigator,
+  );
+  final themes = InheritedTheme.capture(
+    from: context,
+    to: navigator.context,
+  );
+  final textDirection = Directionality.of(context);
+  final themeData = Theme.of(context);
+  final mediaQueryData = MediaQuery.of(context);
+  final resolvedBarrierColor = barrierColor ??
+      DialogTheme.of(context).barrierColor ??
+      Theme.of(context).dialogTheme.barrierColor ??
+      Colors.black54;
+  final resolvedBarrierLabel = barrierLabel ??
+      MaterialLocalizations.of(context).modalBarrierDismissLabel;
+
+  return navigator.push<T>(
+    RawDialogRoute<T>(
+      settings: routeSettings,
+      requestFocus: requestFocus,
+      anchorPoint: anchorPoint,
+      traversalEdgeBehavior: TraversalEdgeBehavior.closedLoop,
+      transitionDuration: const Duration(milliseconds: 150),
+      barrierDismissible: barrierDismissible,
+      barrierColor: resolvedBarrierColor,
+      barrierLabel: resolvedBarrierLabel,
+      pageBuilder: (dialogContext, animation, secondaryAnimation) {
+        Widget dialog = themes.wrap(Builder(builder: builder));
+        if (useSafeArea) {
+          dialog = SafeArea(child: dialog);
+        }
+        return Directionality(
+          textDirection: textDirection,
+          child: Theme(
+            data: themeData,
+            child: MediaQuery(
+              data: mediaQueryData,
+              child: dialog,
+            ),
+          ),
+        );
+      },
+    ),
+  );
+}

--- a/test/in_view_dialog_test.dart
+++ b/test/in_view_dialog_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/widgets/in_view_dialog.dart';
+
+void main() {
+  testWidgets('Windows dialogs stay inside the current Flutter view',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    final observer = _RecordingNavigatorObserver();
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorObservers: <NavigatorObserver>[observer],
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showInViewDialog<void>(
+              context: context,
+              builder: (context) => AlertDialog(
+                title: const Text('In-view dialog'),
+                actions: <Widget>[
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('Close'),
+                  ),
+                ],
+              ),
+            ),
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('In-view dialog'), findsOneWidget);
+    expect(observer.lastPushedRoute, isA<RawDialogRoute<void>>());
+    expect(observer.lastPushedRoute, isNot(isA<DialogRoute<void>>()));
+
+    await tester.tap(find.text('Close'));
+    await tester.pumpAndSettle();
+    expect(find.text('In-view dialog'), findsNothing);
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+}
+
+class _RecordingNavigatorObserver extends NavigatorObserver {
+  Route<dynamic>? lastPushedRoute;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    lastPushedRoute = route;
+    super.didPush(route, previousRoute);
+  }
+}

--- a/test/large_screen_focusable_action_test.dart
+++ b/test/large_screen_focusable_action_test.dart
@@ -1,4 +1,7 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_focusable_action.dart';
@@ -218,5 +221,108 @@ void main() {
     await tester.pump();
     await tester.sendKeyEvent(LogicalKeyboardKey.select);
     expect(lowerActivationCount, 1);
+  });
+
+  testWidgets('selected action is focused and exposes selection feedback',
+      (tester) async {
+    final otherFocusNode = FocusNode();
+    addTearDown(otherFocusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              NipaplayLargeScreenFocusableAction(
+                isSelected: true,
+                onActivate: () {},
+                child: const Text('Current sort'),
+              ),
+              NipaplayLargeScreenFocusableAction(
+                focusNode: otherFocusNode,
+                onActivate: () {},
+                child: const Text('Other sort'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final label = find.text('Current sort');
+    expect(Focus.of(tester.element(label)).hasFocus, isTrue);
+
+    final semantics = tester.getSemantics(label);
+    expect(semantics.flagsCollection.isSelected, ui.Tristate.isTrue);
+
+    otherFocusNode.requestFocus();
+    await tester.pumpAndSettle();
+
+    final selectedAction = find.ancestor(
+      of: label,
+      matching: find.byType(NipaplayLargeScreenFocusableAction),
+    );
+    final surface = tester.widget<AnimatedContainer>(
+      find.descendant(
+        of: selectedAction,
+        matching: find.byType(AnimatedContainer),
+      ),
+    );
+    final decoration = surface.decoration! as BoxDecoration;
+    final foregroundDecoration = surface.foregroundDecoration! as BoxDecoration;
+    expect(decoration.color, isNot(const Color(0x08000000)));
+    expect(foregroundDecoration.border!.top.color, isNot(Colors.transparent));
+  });
+
+  testWidgets('default action has no selection semantics', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NipaplayLargeScreenFocusableAction(
+          onActivate: () {},
+          child: const Text('Regular action'),
+        ),
+      ),
+    );
+
+    final semantics = tester.getSemantics(find.text('Regular action'));
+    expect(semantics.flagsCollection.isSelected, ui.Tristate.none);
+    expect(semantics.flagsCollection.isButton, isFalse);
+  });
+
+  testWidgets('selected action scrolls into view when initially offscreen',
+      (tester) async {
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 180,
+            child: ListView.builder(
+              controller: scrollController,
+              scrollCacheExtent: const ScrollCacheExtent.viewport(20),
+              itemExtent: 60,
+              itemCount: 20,
+              itemBuilder: (context, index) {
+                return NipaplayLargeScreenFocusableAction(
+                  isSelected: index == 19,
+                  onActivate: () {},
+                  child: Text('Sort $index'),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, greaterThan(0));
+    final viewport = tester.getRect(find.byType(ListView));
+    final selected = tester.getRect(find.text('Sort 19'));
+    expect(selected.top, greaterThanOrEqualTo(viewport.top));
+    expect(selected.bottom, lessThanOrEqualTo(viewport.bottom));
   });
 }


### PR DESCRIPTION
## Summary

- 修复 Flutter 3.44.6 更新后 Windows Windowing 将部分弹窗提升为隐藏原生窗口，导致界面看似卡死的问题
- 将媒体库排序、Emby/Jellyfin 排序及手动匹配弹窗保留在当前 Flutter 主视图
- 恢复 Emby/Jellyfin 排序当前选项的高亮、勾选、焦点和自动滚动定位
- 添加 Windows 弹窗路由与大屏排序选中状态测试

Refs #795