### PR TITLE
fix(ohos): keep remote sort dialog compatible with Flutter 3.35

### DIFF
--- a/lib/themes/nipaplay/widgets/network_media_library_view.dart
+++ b/lib/themes/nipaplay/widgets/network_media_library_view.dart
@@ -951,56 +951,20 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
                   ),
                   const SizedBox(height: 14),
                   Expanded(
-                    child: ListView.separated(
-                      scrollCacheExtent:
-                          ScrollCacheExtent.viewport(items.length.toDouble()),
-                      itemCount: items.length,
-                      separatorBuilder: (_, __) => const SizedBox(height: 8),
-                      itemBuilder: (context, index) {
-                        final item = items[index];
-                        final value = item.value;
-                        final description = value.description;
-                        return NipaplayLargeScreenFocusableAction(
-                          isSelected: item.isSelected,
-                          onActivate: () => Navigator.of(context).pop(value),
-                          borderRadius: BorderRadius.circular(8),
-                          padding: const EdgeInsets.all(14),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Row(
-                                children: [
-                                  Expanded(
-                                    child: Text(
-                                      item.title,
-                                      style: const TextStyle(
-                                        fontSize: 15,
-                                        fontWeight: FontWeight.w900,
-                                      ),
-                                    ),
-                                  ),
-                                  if (item.isSelected)
-                                    Icon(
-                                      Icons.check_rounded,
-                                      size: 18,
-                                      color: _accentColor,
-                                    ),
-                                ],
-                              ),
-                              if (description?.isNotEmpty == true) ...[
-                                const SizedBox(height: 4),
-                                Text(
-                                  description!,
-                                  style: TextStyle(
-                                    color: Colors.white.withValues(alpha: 0.62),
-                                    fontSize: 12,
-                                  ),
-                                ),
-                              ],
-                            ],
-                          ),
-                        );
-                      },
+                    child: SingleChildScrollView(
+                      child: Column(
+                        children: [
+                          for (var index = 0;
+                              index < items.length;
+                              index++) ...[
+                            if (index > 0) const SizedBox(height: 8),
+                            _buildLargeScreenRemoteSortItem(
+                              context,
+                              items[index],
+                            ),
+                          ],
+                        ],
+                      ),
                     ),
                   ),
                 ],
@@ -1013,6 +977,54 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
     if (selection != null) {
       _applyRemoteSortSelection(selection);
     }
+  }
+
+  Widget _buildLargeScreenRemoteSortItem(
+    BuildContext dialogContext,
+    DropdownMenuItemData<_RemoteSortSelection> item,
+  ) {
+    final value = item.value;
+    final description = value.description;
+    return NipaplayLargeScreenFocusableAction(
+      isSelected: item.isSelected,
+      onActivate: () => Navigator.of(dialogContext).pop(value),
+      borderRadius: BorderRadius.circular(8),
+      padding: const EdgeInsets.all(14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  item.title,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              if (item.isSelected)
+                Icon(
+                  Icons.check_rounded,
+                  size: 18,
+                  color: _accentColor,
+                ),
+            ],
+          ),
+          if (description?.isNotEmpty == true) ...[
+            const SizedBox(height: 4),
+            Text(
+              description!,
+              style: TextStyle(
+                color: Colors.white.withValues(alpha: 0.62),
+                fontSize: 12,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
   }
 
   Widget _buildLibrariesView(dynamic provider, dynamic service) {

--- a/test/large_screen_focusable_action_test.dart
+++ b/test/large_screen_focusable_action_test.dart
@@ -300,18 +300,21 @@ void main() {
         home: Scaffold(
           body: SizedBox(
             height: 180,
-            child: ListView.builder(
+            child: SingleChildScrollView(
               controller: scrollController,
-              scrollCacheExtent: const ScrollCacheExtent.viewport(20),
-              itemExtent: 60,
-              itemCount: 20,
-              itemBuilder: (context, index) {
-                return NipaplayLargeScreenFocusableAction(
-                  isSelected: index == 19,
-                  onActivate: () {},
-                  child: Text('Sort $index'),
-                );
-              },
+              child: Column(
+                children: List.generate(
+                  20,
+                  (index) => SizedBox(
+                    height: 60,
+                    child: NipaplayLargeScreenFocusableAction(
+                      isSelected: index == 19,
+                      onActivate: () {},
+                      child: Text('Sort $index'),
+                    ),
+                  ),
+                ),
+              ),
             ),
           ),
         ),
@@ -320,7 +323,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(scrollController.offset, greaterThan(0));
-    final viewport = tester.getRect(find.byType(ListView));
+    final viewport = tester.getRect(find.byType(SingleChildScrollView));
     final selected = tester.getRect(find.text('Sort 19'));
     expect(selected.top, greaterThanOrEqualTo(viewport.top));
     expect(selected.bottom, lessThanOrEqualTo(viewport.bottom));

--- a/test/mainline_flutter_compatibility_test.dart
+++ b/test/mainline_flutter_compatibility_test.dart
@@ -193,7 +193,8 @@ void main() {
     expect(
       workflow,
       matches(RegExp(r'apt-get install -y[\s\S]*?\bpython3\b')),
-      reason: 'The HarmonyOS dependency setup generates build metadata with Python.',
+      reason:
+          'The HarmonyOS dependency setup generates build metadata with Python.',
     );
     expect(
       workflow,
@@ -265,6 +266,16 @@ void main() {
       isEmpty,
       reason: 'Platform.isOhos is unavailable in upstream Dart.',
     );
+  });
+
+  test('application source avoids scroll APIs newer than HarmonyOS Flutter',
+      () {
+    final source = File(
+      'lib/themes/nipaplay/widgets/network_media_library_view.dart',
+    ).readAsStringSync();
+
+    expect(source, isNot(contains('ScrollCacheExtent')));
+    expect(source, isNot(contains('scrollCacheExtent:')));
   });
 }
 


### PR DESCRIPTION
## 修改内容

- 移除远程媒体库排序弹窗对 Flutter 3.41+ `ScrollCacheExtent` API 的依赖。
- 使用 `SingleChildScrollView + Column` 一次构建全部排序选项，保留选中项自动聚焦并滚入可视区的行为。
- 更新大屏焦点回归测试，并增加 HarmonyOS Flutter 兼容性检查，防止新 API 被重新引入。

## 问题原因

主线 Flutter 3.44.6 支持 `scrollCacheExtent`，但 HarmonyOS Flutter 3.35.8 的 `ListView.separated` 尚无该参数，导致 Release HAP 在 Dart AOT 阶段编译失败：

```text
No named parameter with the name 'scrollCacheExtent'
```

## 兼容性

- 不引入 HarmonyOS 专用运行时分支，同一份 Dart 代码兼容主线 Flutter 3.44.6 与 HarmonyOS Flutter 3.35.8。
- 排序项数量较少，一次构建不会带来可感知的性能影响。
- 保留 Windows/大屏场景下选中排序项自动获得焦点并滚入可视区的行为。

## 验证

- `flutter test --no-pub --reporter expanded test/large_screen_focusable_action_test.dart test/mainline_flutter_compatibility_test.dart`
  - 21 项测试全部通过。
- 使用 HarmonyOS Flutter 3.35.8 完成：
  - `flutter build hap --release --no-pub --no-codesign --target-platform ohos-arm64`
  - 成功生成 `entry-default-unsigned.hap`。
