### PR TITLE
build: consume Erika v0.1.5 prebuilts

### DIFF
--- a/.github/workflows/build-ohos.yml
+++ b/.github/workflows/build-ohos.yml
@@ -66,6 +66,8 @@ env:
   OHOS_SDK_NATIVE: /opt/harmonyos-tools/command-line-tools/sdk/default/openharmony/native
   RUSTUP_TOOLCHAIN: 1.93.0
   FVP_DEPS_LATEST: "0"
+  ERIKA_PREBUILT: "1"
+  ERIKA_PREBUILT_TAG: v0.1.5
 
 jobs:
   build:

--- a/.github/workflows/build-tvos.yml
+++ b/.github/workflows/build-tvos.yml
@@ -30,6 +30,10 @@ concurrency:
   group: build-tvos-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ERIKA_PREBUILT: "1"
+  ERIKA_PREBUILT_TAG: v0.1.5
+
 jobs:
   build:
     name: Build tvOS package

--- a/docs/HARMONYOS_MIGRATION_STATUS.md
+++ b/docs/HARMONYOS_MIGRATION_STATUS.md
@@ -221,7 +221,7 @@ git status --short
 | 能力 | 库或模块 | 当前处理 |
 | --- | --- | --- |
 | 播放器 | `fvp` | 使用 0.37.3 本地 fork，并兼容 API 18 的 `resourceManager` |
-| 播放器 | `erika_flutter` | 使用官方 `AimesSoft/Erika` v0.1.4；Erika Rust 内核使用 OHNativeWindow/wgpu、AVCodec 和 OHAudio |
+| 播放器 | `erika_flutter` | 使用官方 `AimesSoft/Erika` v0.1.5 及其预编译运行时；Erika Rust 内核使用 OHNativeWindow/wgpu、AVCodec 和 OHAudio |
 | 本地设置 | `shared_preferences` | 使用 OpenHarmony 实现 |
 | 应用目录 | `path_provider` | 使用 OpenHarmony 实现 |
 | SQLite | `sqflite` | 使用 OpenHarmony 实现 |

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -298,11 +298,11 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: "v0.1.4"
-      resolved-ref: "63b2b0bf26f51d0bbec62177ed820f6bd2a7baac"
+      ref: "v0.1.5"
+      resolved-ref: "8ceebbc97d946f45bbdc949f270ae77c3ce7829b"
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
-    version: "0.1.4"
+    version: "0.1.5"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -131,7 +131,7 @@ dependencies:
   erika_flutter:
     git:
       url: https://github.com/AimesSoft/Erika.git
-      ref: v0.1.4
+      ref: v0.1.5
       path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   mobile_scanner: ^7.2.0

--- a/pubspec_overrides.tvos.yaml
+++ b/pubspec_overrides.tvos.yaml
@@ -6,12 +6,11 @@
 # Pub replaces dependency_overrides as a complete section, so the shared
 # overrides from pubspec.yaml are repeated below the tvOS-specific entries.
 dependency_overrides:
-  # Apple TV requires the tvOS plugin and native Erika bridge added after
-  # v0.1.4. Pin the exact revision so release builds stay reproducible.
+  # Keep the tvOS plugin source aligned with its versioned prebuilt runtime.
   erika_flutter:
     git:
       url: https://github.com/AimesSoft/Erika.git
-      ref: 29f47da8e64ae9caacfd7317c2a6ad9d2d609e9b
+      ref: v0.1.5
       path: packages/erika_flutter
   # Shared repository overrides. Keep these keys aligned with pubspec.yaml.
   liquid_glass_widgets:


### PR DESCRIPTION
## What changed

- Upgrade `erika_flutter` to v0.1.5 and lock the refreshed release commit `8ceebbc97d946f45bbdc949f270ae77c3ce7829b`.
- Pin the tvOS dependency override to v0.1.5.
- Configure HarmonyOS and tvOS builds to consume the v0.1.5 prebuilt Erika runtimes.
- Update the HarmonyOS integration documentation.

## Why

The Erika v0.1.5 tag and release assets were refreshed. NipaPlay must resolve the matching source revision and avoid source-building Erika for HarmonyOS and tvOS CI.

## Validation

- Confirmed Erika `v0.1.5^{}` and `main` resolve to `8ceebbc97d946f45bbdc949f270ae77c3ce7829b`.
- Confirmed the refreshed HarmonyOS and tvOS release assets exist.
- Relevant Flutter analysis passed.
- YAML parsing and `git diff --check` passed.