### PR TITLE
fix(ci): restore pinned Flutter checkout for tvOS

### DIFF
--- a/.github/workflows/build-tvos.yml
+++ b/.github/workflows/build-tvos.yml
@@ -89,6 +89,27 @@ jobs:
             origin \
             'refs/tags/${{ steps.project.outputs.flutter-tvos }}'
           git -C "$FLUTTER_TVOS_ROOT" checkout --detach --force FETCH_HEAD
+
+          # The cache restores flutter/bin/cache without the Flutter checkout.
+          # Recreate the pinned checkout in place so flutter-tvos can reuse the
+          # cached artifacts instead of rejecting flutter/ as a non-Git folder.
+          flutter_revision="$(tr -d '[:space:]' < \
+            "$FLUTTER_TVOS_ROOT/bin/internal/flutter.version")"
+          flutter_sdk_root="$FLUTTER_TVOS_ROOT/flutter"
+          mkdir -p "$flutter_sdk_root"
+          if [[ ! -d "$flutter_sdk_root/.git" ]]; then
+            git -C "$flutter_sdk_root" init
+            git -C "$flutter_sdk_root" remote add origin \
+              https://github.com/flutter/flutter.git
+          else
+            git -C "$flutter_sdk_root" remote set-url origin \
+              https://github.com/flutter/flutter.git
+          fi
+          git -C "$flutter_sdk_root" fetch --depth 1 origin "$flutter_revision"
+          git -C "$flutter_sdk_root" checkout --detach --force FETCH_HEAD
+          test "$(git -C "$flutter_sdk_root" rev-parse HEAD)" = \
+            "$flutter_revision"
+
           "$FLUTTER_TVOS_ROOT/bin/flutter-tvos" precache
           "$FLUTTER_TVOS_ROOT/bin/flutter-tvos" --version
 

--- a/.github/workflows/build-tvos.yml
+++ b/.github/workflows/build-tvos.yml
@@ -105,7 +105,10 @@ jobs:
             git -C "$flutter_sdk_root" remote set-url origin \
               https://github.com/flutter/flutter.git
           fi
-          git -C "$flutter_sdk_root" fetch --depth 1 origin "$flutter_revision"
+          # Flutter derives its SDK version from Git tags. Match the upstream
+          # flutter-tvos bootstrap so pub does not see 0.0.0-unknown.
+          git -C "$flutter_sdk_root" fetch \
+            --depth 1 --quiet --tags origin "$flutter_revision"
           git -C "$flutter_sdk_root" checkout --detach --force FETCH_HEAD
           test "$(git -C "$flutter_sdk_root" rev-parse HEAD)" = \
             "$flutter_revision"


### PR DESCRIPTION
## What changed

Reconstruct and pin the Flutter SDK Git checkout inside the restored `flutter-tvos` cache directory before invoking `flutter-tvos precache`, including the Git tags Flutter uses to derive its SDK version.

## Root cause

The workflow cached only `flutter-tvos/flutter/bin/cache`. Restoring that cache created a `flutter/` directory without `flutter/.git`, so the upstream launcher aborted with `flutter is not a git directory`. After reconstructing the checkout, Flutter was initially reported as `0.0.0-unknown` because its version tags were absent; pub then rejected every Flutter package constraint.

## Validation

The PR tvOS workflow passed end to end in run 30884230945:

- pinned flutter-tvos SDK installation
- Flutter 3.44.8 dependency resolution
- tvOS Simulator build
- simulator artifact preparation and upload

This fixes the same tvOS job failure seen in release run 30883242192.