### PR TITLE
fix(ci): stabilize release platform builds

### DIFF
--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -424,12 +424,8 @@ runs:
 
             # 上传公证
             echo "☁️ 上传到 Apple 进行公证..."
-            SUBMISSION_ID=$(xcrun notarytool submit "$NOTARIZATION_ZIP" \
-              --apple-id "$APPLE_ID" \
-              --password "$APPLE_APP_PASSWORD" \
-              --team-id "$APPLE_TEAM_ID" \
-              --output-format json \
-              --wait | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))")
+            SUBMISSION_ID="$("$GITHUB_WORKSPACE/.github/workflows/scripts/submit-macos-notarization.sh" \
+              "$NOTARIZATION_ZIP")"
 
             if [ -z "$SUBMISSION_ID" ] || [ "$SUBMISSION_ID" = "null" ]; then
               echo "❌ 获取提交ID失败"
@@ -580,12 +576,8 @@ runs:
 
             if [ "$ENABLE_NOTARIZATION" = "true" ]; then
               echo "🔐 公证 macOS ${artifact_label} PKG..."
-              SUBMISSION_ID=$(xcrun notarytool submit "$pkg_name" \
-                --apple-id "$APPLE_ID" \
-                --password "$APPLE_APP_PASSWORD" \
-                --team-id "$APPLE_TEAM_ID" \
-                --output-format json \
-                --wait | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))")
+              SUBMISSION_ID="$("$GITHUB_WORKSPACE/.github/workflows/scripts/submit-macos-notarization.sh" \
+                "$pkg_name")"
 
               if [ -z "$SUBMISSION_ID" ] || [ "$SUBMISSION_ID" = "null" ]; then
                 echo "❌ 获取 PKG 公证提交ID失败"

--- a/.github/workflows/build-tvos.yml
+++ b/.github/workflows/build-tvos.yml
@@ -124,6 +124,65 @@ jobs:
             run tool/configure_flutter_dependencies.dart tvos
           "$FLUTTER_TVOS_ROOT/bin/flutter-tvos" pub get
 
+      - name: Keep Erika prebuilt path independent of Rust
+        shell: bash
+        run: |
+          set -euo pipefail
+          erika_root="$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+          from urllib.parse import unquote, urlparse
+
+          config_path = Path('.dart_tool/package_config.json').resolve()
+          config = json.loads(config_path.read_text(encoding='utf-8'))
+          package = next(
+              item for item in config['packages'] if item['name'] == 'erika_flutter'
+          )
+          uri = urlparse(package['rootUri'])
+          if uri.scheme == 'file':
+              root = Path(unquote(uri.path))
+          elif not uri.scheme:
+              root = (config_path.parent / unquote(uri.path)).resolve()
+          else:
+              raise SystemExit(f"Unsupported Erika package URI: {package['rootUri']}")
+          print(root)
+          PY
+          )"
+          podspec="$erika_root/tvos/erika_flutter.podspec"
+          test -f "$podspec"
+          python3 - "$podspec" <<'PY'
+          import sys
+          from pathlib import Path
+
+          path = Path(sys.argv[1])
+          source = path.read_text(encoding='utf-8')
+          old = '''if ! command -v rustup >/dev/null 2>&1; then
+            echo "error: rustup is required to build Erika for tvOS" >&2
+            exit 1
+          fi
+          if ! rustup run nightly rustc --version >/dev/null 2>&1; then
+            rustup toolchain install nightly --profile minimal --component rust-src
+          elif ! rustup component list --toolchain nightly --installed | grep -q '^rust-src'; then
+            rustup component add rust-src --toolchain nightly
+          fi
+          '''
+          new = '''if [ "${ERIKA_PREBUILT:-0}" != "1" ] || [ "${ERIKA_FORCE_SOURCE_BUILD:-0}" = "1" ]; then
+            if ! command -v rustup >/dev/null 2>&1; then
+              echo "error: rustup is required to build Erika for tvOS" >&2
+              exit 1
+            fi
+            if ! rustup run nightly rustc --version >/dev/null 2>&1; then
+              rustup toolchain install nightly --profile minimal --component rust-src
+            elif ! rustup component list --toolchain nightly --installed | grep -q '^rust-src'; then
+              rustup component add rust-src --toolchain nightly
+            fi
+          fi
+          '''
+          if source.count(old) != 1:
+              raise SystemExit('Unexpected Erika v0.1.5 tvOS podspec layout')
+          path.write_text(source.replace(old, new), encoding='utf-8')
+          PY
+
       - name: Build tvOS simulator application
         if: github.event_name == 'pull_request'
         shell: bash

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,7 +13,9 @@ on:
 jobs:
   build:
     name: Build Windows Package
-    runs-on: windows-latest
+    # Keep the release build on the VS 2022 SDK until Erika's Windows SMTC
+    # bridge supports the C++/WinRT projection shipped by VS 2026.
+    runs-on: windows-2022
     outputs:
       version: ${{ steps.setup.outputs.version }}
       artifact-name: release-Windows-x64

--- a/.github/workflows/scripts/submit-macos-notarization.sh
+++ b/.github/workflows/scripts/submit-macos-notarization.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+artifact_path="${1:?Usage: submit-macos-notarization.sh <artifact>}"
+max_attempts="${NOTARY_SUBMIT_ATTEMPTS:-3}"
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  set +e
+  output="$(xcrun notarytool submit "$artifact_path" \
+    --apple-id "$APPLE_ID" \
+    --password "$APPLE_APP_PASSWORD" \
+    --team-id "$APPLE_TEAM_ID" \
+    --output-format json \
+    --wait 2>&1)"
+  status=$?
+  set -e
+
+  submission_id=""
+  if [[ $status -eq 0 && -n "$output" ]]; then
+    submission_id="$(printf '%s' "$output" | python3 -c \
+      'import json, sys; print(json.load(sys.stdin).get("id", ""))' \
+      2>/dev/null || true)"
+  fi
+
+  if [[ -n "$submission_id" && "$submission_id" != "null" ]]; then
+    printf '%s\n' "$submission_id"
+    exit 0
+  fi
+
+  printf 'notarytool submission attempt %d/%d failed (exit %d).\n' \
+    "$attempt" "$max_attempts" "$status" >&2
+  if [[ -n "$output" ]]; then
+    printf '%s\n' "$output" >&2
+  else
+    printf 'notarytool returned no output.\n' >&2
+  fi
+
+  if ((attempt < max_attempts)); then
+    sleep $((attempt * 15))
+  fi
+done
+
+exit 1

--- a/pubspec_overrides.ohos.yaml
+++ b/pubspec_overrides.ohos.yaml
@@ -43,7 +43,7 @@ dependency_overrides:
       path: packages/url_launcher/url_launcher
   package_info_plus:
     git:
-      url: https://gitee.com/openharmony-sig/flutter_plus_plugins.git
+      url: https://gitcode.com/openharmony-sig/flutter_plus_plugins.git
       ref: br_package_info_plus-v8.1.0_ohos
       path: packages/package_info_plus/package_info_plus
   # The tvOS registrant packages are native-only, but their current metadata
@@ -61,7 +61,7 @@ dependency_overrides:
       ref: br_v7.1.4_ohos
   wakelock_plus:
     git:
-      url: https://gitee.com/openharmony-sig/fluttertpc_wakelock_plus.git
+      url: https://gitcode.com/openharmony-sig/fluttertpc_wakelock_plus.git
       ref: br_wakelock_plus_1.2.8_ohos
       path: wakelock_plus
   wakelock_plus_platform_interface: 1.3.0


### PR DESCRIPTION
## Summary

- pin the Windows release build to the VS 2022 runner while Erika v0.1.5's SMTC bridge is incompatible with VS 2026
- ensure the tvOS v0.1.5 prebuilt path does not require a nightly Rust toolchain
- move HarmonyOS plugin mirrors from Gitee to GitCode
- retry macOS notarytool submissions while preserving the real failure output

## Failure addressed

- Release run: https://github.com/AimesSoft/NipaPlay-Reload/actions/runs/30885297687
- Windows: Erika SMTC C++ compile errors on windows-2025-vs2026
- tvOS: nightly Rust DNS failure before the prebuilt download
- HarmonyOS: gitee.com DNS failure
- macOS Universal: empty notarytool response masked by JSONDecodeError

## Validation

- parsed changed workflow/action YAML
- checked embedded tvOS shell syntax
- checked notarization helper with bash -n
- git diff --check