### PR TITLE
Update Erika for Windows SMTC build fix

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -298,8 +298,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: "v0.1.5"
-      resolved-ref: "8ceebbc97d946f45bbdc949f270ae77c3ce7829b"
+      ref: "9285a1fe556ffacb490481acfb1195005f1886d9"
+      resolved-ref: "9285a1fe556ffacb490481acfb1195005f1886d9"
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
     version: "0.1.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -131,7 +131,7 @@ dependencies:
   erika_flutter:
     git:
       url: https://github.com/AimesSoft/Erika.git
-      ref: v0.1.5
+      ref: 9285a1fe556ffacb490481acfb1195005f1886d9
       path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   mobile_scanner: ^7.2.0


### PR DESCRIPTION
Update Erika to merged PR #79 (`9285a1fe`) so Windows consumes the corrected SMTC C++ source. HarmonyOS and tvOS remain pinned to the v0.1.5 prebuilt artifacts.