### PR TITLE
Use Erika v0.1.5 prebuilts on Android and iOS

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -33,8 +33,8 @@ jobs:
     env:
       FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
       FVP_DEPS_LATEST: 1
-      # The integration commit is newer than the v0.1.3 native bundle.
-      ERIKA_PREBUILT: "0"
+      ERIKA_PREBUILT: "1"
+      ERIKA_PREBUILT_TAG: v0.1.5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -61,8 +61,8 @@ jobs:
     env:
       FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
       FVP_DEPS_LATEST: 1
-      # The integration commit is newer than the v0.1.3 native bundle.
-      ERIKA_PREBUILT: "0"
+      ERIKA_PREBUILT: "1"
+      ERIKA_PREBUILT_TAG: v0.1.5
     steps:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer


### PR DESCRIPTION
Android and iOS both have v0.1.5 native release assets. Remove the stale v0.1.3 source-build override and pin both workflows to the v0.1.5 prebuilts. Linux does not integrate Erika.