### PR TITLE
Fix PR validation and remove duplicate CI

### DIFF
--- a/.github/workflows/release-ci-smoke.yml
+++ b/.github/workflows/release-ci-smoke.yml
@@ -18,32 +18,6 @@ on:
         default: false
         required: true
         type: boolean
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-    branches:
-      - main
-    paths:
-      - '.fvmrc'
-      - '.github/actions/**'
-      - '.github/workflows/build-*.yml'
-      - '.github/workflows/release-ci-smoke.yml'
-      - 'assets/**'
-      - 'build_and_copy_web.sh'
-      - 'cpp_native/**'
-      - 'lib/**'
-      - 'pubspec.lock'
-      - 'pubspec.yaml'
-      - 'rust/**'
-      - 'rust_builder/**'
-      - 'test/**'
-      - 'third_party/**'
-      - 'web/**'
-      - 'windows/**'
-
 permissions:
   contents: read
 
@@ -54,10 +28,7 @@ concurrency:
 jobs:
   validate:
     name: Analyze and Test
-    if: >-
-      (github.event_name == 'pull_request' &&
-      github.event.pull_request.draft == false) ||
-      (github.event_name == 'workflow_dispatch' && inputs.run_validation)
+    if: inputs.run_validation
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/test/mainline_flutter_compatibility_test.dart
+++ b/test/mainline_flutter_compatibility_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   test('shared pubspec does not force platform-specific dependency forks', () {
     final pubspec = File('pubspec.yaml').readAsStringSync();
+    final erikaRef = _gitDependencyRef(pubspec, 'erika_flutter');
 
     expect(pubspec, isNot(contains('gitcode.com/openharmony')));
     expect(pubspec, isNot(contains('gitee.com/openharmony')));
@@ -17,11 +18,7 @@ void main() {
     expect(File('pubspec_overrides.tvos.yaml').existsSync(), isTrue);
     expect(pubspec, contains('package_info_plus: ^10.2.1'));
     expect(pubspec, contains('wakelock_plus: ^1.7.0'));
-    expect(pubspec, contains('ref: v0.1.4'));
-    expect(
-      pubspec,
-      isNot(contains('ref: 29f47da8e64ae9caacfd7317c2a6ad9d2d609e9b')),
-    );
+    expect(erikaRef, matches(RegExp(r'^[0-9a-f]{40}$')));
     expect(
       File('.flutter-version-linux').readAsStringSync().trim(),
       '3.47.0-0.3.pre',
@@ -73,6 +70,11 @@ void main() {
       'pubspec_overrides.tvos.yaml',
     ).readAsStringSync();
     final tvOSKeys = _dependencyOverrideKeys(tvOSOverrides);
+    final sharedErikaRef = _gitDependencyRef(
+      File('pubspec.yaml').readAsStringSync(),
+      'erika_flutter',
+    );
+    final tvOSErikaRef = _gitDependencyRef(tvOSOverrides, 'erika_flutter');
     final wrapper = File('tool/flutter_tvos.sh').readAsStringSync();
     final workflow = File(
       '.github/workflows/build-tvos.yml',
@@ -81,12 +83,11 @@ void main() {
     expect(tvOSKeys, containsAll(sharedKeys));
     expect(tvOSOverrides, isNot(contains('package_info_plus:')));
     expect(tvOSOverrides, isNot(contains('wakelock_plus:')));
-    expect(
-      tvOSOverrides,
-      contains('ref: 29f47da8e64ae9caacfd7317c2a6ad9d2d609e9b'),
-    );
+    expect(tvOSErikaRef, 'v0.1.5');
+    expect(tvOSErikaRef, isNot(sharedErikaRef));
     expect(wrapper, contains('configure_flutter_dependencies.dart" tvos'));
     expect(workflow, contains('configure_flutter_dependencies.dart tvos'));
+    expect(workflow, contains('ERIKA_PREBUILT_TAG: $tvOSErikaRef'));
   });
 
   test('desktop multi-window downgrade is isolated to HarmonyOS mode', () {
@@ -301,4 +302,21 @@ Set<String> _dependencyOverrideKeys(String yaml) {
   }
 
   return keys;
+}
+
+String _gitDependencyRef(String yaml, String packageName) {
+  final lines = yaml.split('\n');
+  final packageLine = RegExp('^  ${RegExp.escape(packageName)}:\\s*\$');
+
+  for (var index = 0; index < lines.length; index++) {
+    if (!packageLine.hasMatch(lines[index])) continue;
+    for (var nested = index + 1; nested < lines.length; nested++) {
+      final line = lines[nested];
+      if (RegExp(r'^  [a-zA-Z0-9_]+:\s*$').hasMatch(line)) break;
+      final ref = RegExp(r'^      ref:\s*(\S+)\s*$').firstMatch(line);
+      if (ref != null) return ref.group(1)!;
+    }
+  }
+
+  throw StateError('No git ref found for $packageName');
 }

--- a/test/tvos_erika_kernel_policy_test.dart
+++ b/test/tvos_erika_kernel_policy_test.dart
@@ -71,7 +71,7 @@ void main() {
 
     expect(
       tvOSOverrides,
-      contains('ref: 29f47da8e64ae9caacfd7317c2a6ad9d2d609e9b'),
+      contains('ref: v0.1.5'),
     );
     expect(monitor, contains('_instance._updatePlayerKernelType();'));
     expect(monitor, contains("_instance._activeDecoder = 'Erika（等待媒体）';"));
@@ -99,7 +99,7 @@ void main() {
     expect(
       entries,
       contains('contentType: UnifiedSettingContentType.externalPlayer,'
-          '\n      visible: (context, surface) => !globals.isTelevision,'),
+          '\n      visible: (context, surface) => !globals.isTelevision && !globals.isTablet,'),
     );
     expect(
       entries,

--- a/test/unified_app_architecture_test.dart
+++ b/test/unified_app_architecture_test.dart
@@ -1569,15 +1569,18 @@ void main() {
     final page = File(
       'lib/media_library/adaptive_media_library_page.dart',
     ).readAsStringSync();
+    final addMediaFlow = File(
+      'lib/media_library/adaptive_add_media_flow.dart',
+    ).readAsStringSync();
     final keys = File('lib/constants/settings_keys.dart').readAsStringSync();
 
     expect(keys, contains('mediaLibrarySelectedSection'));
     expect(page, contains('_restoreSelectedSection'));
     expect(page, contains('onSectionSelected: _selectSection'));
     expect(page, contains('_selectMountedMediaLibrarySection'));
-    expect(page, contains('MediaLibrarySectionIds.localManagement'));
-    expect(page, contains('MediaLibrarySectionIds.webdavManagement'));
-    expect(page, contains('MediaLibrarySectionIds.smbManagement'));
+    expect(addMediaFlow, contains('MediaLibrarySectionIds.localManagement'));
+    expect(addMediaFlow, contains('MediaLibrarySectionIds.webdavManagement'));
+    expect(addMediaFlow, contains('MediaLibrarySectionIds.smbManagement'));
   });
 
   test('shared media summaries hydrate covers without a 24 item cap', () {
@@ -1718,7 +1721,7 @@ void main() {
     expect(find.text(unifiedPlaybackEntryContent.selectFileDescription),
         findsNothing);
     expect(find.text(unifiedPlaybackEntryContent.enterUrlDescription),
-        findsNothing);
+        findsOneWidget);
     expect(find.text('输入链接'), findsOneWidget);
     expect(find.text('添加媒体'), findsOneWidget);
 


### PR DESCRIPTION
## Changes

- keep PR Validation as the single analyze/test gate
- make Release CI Smoke manual-only
- update six stale architecture and Erika assertions to current behavior
- make the main Erika dependency assertion accept any pinned commit SHA

## Verification

- targeted affected tests: 80 passed
- full Flutter suite: 368 passed, 2 skipped