### PR TITLE
fix(release): submit existing App Store build non-interactively

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -613,6 +613,7 @@ jobs:
         run: |
           fastlane deliver \
             --api_key_path "$APP_STORE_CONNECT_API_KEY_PATH" \
+            --ipa "$SIGNED_IPA" \
             --skip_binary_upload true \
             --build_number "$APP_BUILD_NUMBER" \
             --app_identifier "$APP_BUNDLE_ID" \
@@ -840,6 +841,7 @@ jobs:
         run: |
           fastlane deliver \
             --api_key_path "$APP_STORE_CONNECT_API_KEY_PATH" \
+            --ipa "$SIGNED_IPA" \
             --skip_binary_upload true \
             --build_number "$APP_BUILD_NUMBER" \
             --app_identifier "$APP_BUNDLE_ID" \

--- a/test/mainline_flutter_compatibility_test.dart
+++ b/test/mainline_flutter_compatibility_test.dart
@@ -273,6 +273,13 @@ void main() {
     }
   });
 
+  test('App Store existing-build publishing remains non-interactive', () {
+    final workflow = File('.github/workflows/main.yml').readAsStringSync();
+
+    expect('--skip_binary_upload true'.allMatches(workflow).length, 2);
+    expect('--ipa "\$SIGNED_IPA"'.allMatches(workflow).length, 4);
+  });
+
   test('application source does not require custom Platform APIs', () {
     final incompatibleFiles = Directory('lib')
         .listSync(recursive: true)


### PR DESCRIPTION
## Summary
- pass the downloaded IPA to Fastlane when reusing an existing App Store build
- keep binary upload disabled while preventing Fastlane from entering interactive setup
- add a workflow regression test

## Verification
- `flutter test --no-pub test/mainline_flutter_compatibility_test.dart`