### PR TITLE
fix(release): configure Fastlane for existing builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -611,9 +611,9 @@ jobs:
         env:
           SUBMIT_FOR_REVIEW: ${{ inputs.submit_ios_for_review }}
         run: |
+          mkdir -p metadata
           fastlane deliver \
             --api_key_path "$APP_STORE_CONNECT_API_KEY_PATH" \
-            --ipa "$SIGNED_IPA" \
             --skip_binary_upload true \
             --build_number "$APP_BUILD_NUMBER" \
             --app_identifier "$APP_BUNDLE_ID" \
@@ -839,9 +839,9 @@ jobs:
         env:
           SUBMIT_FOR_REVIEW: ${{ inputs.submit_ios_for_review }}
         run: |
+          mkdir -p metadata
           fastlane deliver \
             --api_key_path "$APP_STORE_CONNECT_API_KEY_PATH" \
-            --ipa "$SIGNED_IPA" \
             --skip_binary_upload true \
             --build_number "$APP_BUILD_NUMBER" \
             --app_identifier "$APP_BUNDLE_ID" \

--- a/test/mainline_flutter_compatibility_test.dart
+++ b/test/mainline_flutter_compatibility_test.dart
@@ -277,7 +277,8 @@ void main() {
     final workflow = File('.github/workflows/main.yml').readAsStringSync();
 
     expect('--skip_binary_upload true'.allMatches(workflow).length, 2);
-    expect('--ipa "\$SIGNED_IPA"'.allMatches(workflow).length, 4);
+    expect('mkdir -p metadata'.allMatches(workflow).length, 2);
+    expect('--ipa "\$SIGNED_IPA"'.allMatches(workflow).length, 2);
   });
 
   test('application source does not require custom Platform APIs', () {


### PR DESCRIPTION
## Summary
- mark the existing-build metadata flow as configured for Fastlane
- preserve the explicit App Store build number without passing a conflicting IPA option
- keep binary uploads disabled

## Verification
- `flutter test --no-pub test/mainline_flutter_compatibility_test.dart`