### PR TITLE
Fix: GTK4 Apps have double titlebar after installing nipaplay

### DIFF
--- a/assets/linux/DEBIAN/control.template
+++ b/assets/linux/DEBIAN/control.template
@@ -10,5 +10,5 @@ Description: A cross platform danmaku video player.
  支持多种视频格式和弹幕显示的跨平台视频播放器。
  需要系统安装 libmpv 以支持视频播放功能。
 Homepage: https://github.com/AimesSoft/NipaPlay-Reload
-Depends: libgtk-3-0, libmpv1 | libmpv2, libmimalloc2.0, ffmpeg, libass9, libsqlite3-0, libcanberra-gtk3-module, gtk3-nocsd, libgtk3-nocsd0, libkeybinder-3.0-0
+Depends: libgtk-3-0, libmpv1 | libmpv2, libmimalloc2.0, ffmpeg, libass9, libsqlite3-0, libcanberra-gtk3-module, libkeybinder-3.0-0
 Recommends: mpv


### PR DESCRIPTION
## Summary
安装 NipaPlay 之后，Firefox 等Gtk 应用出现双标题栏的问题
- 

## Related Issue

- Closes #

## What Changed
去除 gtk4-nocsd
- 
