### PR TITLE
fix: 修复 Canvas 弹幕倍速重加载、seek 恢复与空闲耗电

### DIFF
--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -340,6 +340,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   bool _isControlsHovered = false;
   bool _controlsVisibilityLocked = false;
   bool _isSeeking = false;
+  int _seekRevision = 0;
   int _mdkNearEndLastPositionMs = -1;
   int _mdkNearEndStalledSinceMs = 0;
   final FocusNode _focusNode = FocusNode();
@@ -1448,6 +1449,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   double get effectivePlaybackRate =>
       _isSpeedBoostActive ? _speedBoostRate : _playbackRate;
   bool get isSpeedBoostActive => _isSpeedBoostActive;
+  int get seekRevision => _seekRevision;
   double get speedBoostRate => _speedBoostRate;
 
   // 跳过时间的getter

--- a/lib/utils/video_player_state/video_player_state_playback_controls.dart
+++ b/lib/utils/video_player_state/video_player_state_playback_controls.dart
@@ -427,6 +427,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
       _smoothAnchorElapsedUs = _lastElapsedUs;
       _seekTargetMs = 0.0; // 启用 seek 保护，而非清除
       _anchorSetBySeek = true; // 标记锚点由 seek/loop 设置
+      _seekRevision++;
       // [LOOP-RESTART-DIAG] 诊断：记录重置后的锚点状态
       if (!kReleaseMode) {
         debugPrint('[LOOP-RESTART-DIAG] AFTER RESET: '
@@ -853,6 +854,7 @@ extension VideoPlayerStatePlaybackControls on VideoPlayerState {
       _smoothAnchorElapsedUs = _lastElapsedUs;
       _seekTargetMs = _position.inMilliseconds.toDouble();
       _anchorSetBySeek = true; // 标记锚点由 seek 设置
+      _seekRevision++;
       if (_duration.inMilliseconds > 0) {
         _progress = clampedPosition.inMilliseconds / _duration.inMilliseconds;
       }

--- a/lib/widgets/danmaku_overlay.dart
+++ b/lib/widgets/danmaku_overlay.dart
@@ -132,6 +132,9 @@ class _DanmakuOverlayState extends State<DanmakuOverlay> {
             isPlaying: widget.isPlaying,
             playbackRate: videoState.effectivePlaybackRate,
             scrollDurationSeconds: scrollDuration,
+            seekRevision: videoState.seekRevision,
+            danmakuListVersion: videoState.danmakuListVersion,
+            timeOffsetSeconds: combinedTimeOffset,
           );
         }
 

--- a/packages/danmaku_canvas/lib/canvas_danmaku_renderer.dart
+++ b/packages/danmaku_canvas/lib/canvas_danmaku_renderer.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'danmaku_screen.dart';
 import 'danmaku_controller.dart';
+import 'danmaku_timeline.dart';
 import 'models/danmaku_option.dart';
 import 'models/danmaku_content_item.dart' as canvas_models;
 
@@ -23,6 +24,9 @@ class CanvasDanmakuManager {
     required bool isPlaying,
     required double playbackRate,
     required double scrollDurationSeconds,
+    int seekRevision = -1,
+    int danmakuListVersion = 0,
+    double timeOffsetSeconds = 0,
   }) {
     return CanvasDanmakuRenderer(
       fontSize: fontSize,
@@ -40,6 +44,9 @@ class CanvasDanmakuManager {
       isPlaying: isPlaying,
       playbackRate: playbackRate,
       scrollDurationSeconds: scrollDurationSeconds,
+      seekRevision: seekRevision,
+      danmakuListVersion: danmakuListVersion,
+      timeOffsetSeconds: timeOffsetSeconds,
     );
   }
 }
@@ -61,6 +68,9 @@ class CanvasDanmakuRenderer extends StatefulWidget {
   final bool isPlaying;
   final double playbackRate;
   final double scrollDurationSeconds;
+  final int seekRevision;
+  final int danmakuListVersion;
+  final double timeOffsetSeconds;
 
   const CanvasDanmakuRenderer({
     super.key,
@@ -79,6 +89,9 @@ class CanvasDanmakuRenderer extends StatefulWidget {
     required this.isPlaying,
     required this.playbackRate,
     required this.scrollDurationSeconds,
+    this.seekRevision = -1,
+    this.danmakuListVersion = 0,
+    this.timeOffsetSeconds = 0,
   });
 
   @override
@@ -87,29 +100,39 @@ class CanvasDanmakuRenderer extends StatefulWidget {
 
 class _CanvasDanmakuRendererState extends State<CanvasDanmakuRenderer> {
   DanmakuController? _controller;
-  List<Map<String, dynamic>> _lastProcessedDanmakuList = [];
-  double _lastCurrentTime = 0;
+  List<Map<String, dynamic>>? _lastDanmakuList;
+  int _lastDanmakuListVersion = -1;
+  int _lastDanmakuListLength = -1;
+  double _lastCurrentTime = double.nan;
   DanmakuScreen? _danmakuScreen;
   DanmakuOption? _currentOption;
 
   // 添加已添加弹幕的跟踪集合，避免重复添加
-  final Set<String> _addedDanmakuKeys = {};
+  final Map<Map<String, dynamic>, double> _addedDanmakuTimes = Map.identity();
+  // 时间线恢复期因轨道冲突被丢弃的弹幕的重试次数（身份去重）
+  final Map<Map<String, dynamic>, int> _restorationRetryCounts =
+      Map.identity();
+  List<Map<String, dynamic>> _pendingRestoration = const [];
+  int _pendingRestorationIndex = 0;
+  int _restorationGeneration = 0;
+  bool _restorationDrainScheduled = false;
+  bool _forceTimelineRestore = true;
+  // 时间线恢复锚定的目标时刻：分批排空期间 currentTime 仍在推进，
+  // 若逐条读取实时 currentTime，同一批内较老的弹幕会被误判为"已过
+  // 窗口"而在进入画面前被过滤，导致 seek 后弹幕播完即不再显示。
+  double? _restorationTime;
   static const double _historyWindowSeconds = 5.0;
-  static const double _historyWindowAfterJumpSeconds = 1.0;
   static const double _scrollLeadTimeSeconds = 1.0;
   static const double _staticLeadTimeSeconds = 0.0;
-  static const double _timeJumpLeadBonusSeconds = 0.5;
+  static const int _restorationBatchSize = 20;
+  // 恢复期同一条弹幕最多重试几次（等待已上屏弹幕离屏腾出轨道），
+  // 超限直接放弃，避免暂停状态下轨道永不腾空导致排空死循环。
+  static const int _maxRestorationRetries = 3;
 
   @override
   void initState() {
     super.initState();
     _initializeDanmakuScreen();
-
-    // 初始化时处理弹幕
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      _processAndAddDanmaku(widget.danmakuList, widget.currentTime);
-    });
   }
 
   int _effectiveScrollDurationSeconds() {
@@ -146,10 +169,28 @@ class _CanvasDanmakuRendererState extends State<CanvasDanmakuRenderer> {
       key: ValueKey(_currentOption.hashCode),
       option: _currentOption!,
       createdController: (controller) {
-        //print('Canvas弹幕: DanmakuController已创建');
         _controller = controller;
+        if (!widget.isPlaying) {
+          controller.pause();
+        }
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted || !identical(_controller, controller)) return;
+          _processAndAddDanmaku(widget.danmakuList, widget.currentTime);
+        });
       },
     );
+  }
+
+  void _prepareForScreenRecreation() {
+    _restorationGeneration++;
+    _pendingRestoration = const [];
+    _pendingRestorationIndex = 0;
+    _restorationDrainScheduled = false;
+    _addedDanmakuTimes.clear();
+    _restorationRetryCounts.clear();
+    _restorationTime = null;
+    _forceTimelineRestore = true;
+    _controller = null;
   }
 
   bool _needsScreenRecreation() {
@@ -162,8 +203,23 @@ class _CanvasDanmakuRendererState extends State<CanvasDanmakuRenderer> {
         _currentOption!.hideBottom != widget.blockBottomDanmaku ||
         _currentOption!.hideScroll != widget.blockScrollDanmaku ||
         _currentOption!.massiveMode != widget.stacking ||
-        _currentOption!.playbackRate != widget.playbackRate ||
+        // 注意：playbackRate 不在此处参与重建判断——倍速变化应只更新动画时长，
+        // 否则长按倍速/松手时整块 DanmakuScreen 被重建（ValueKey 变），
+        // 已上屏弹幕全部清空重加。倍速同步走 _syncPlaybackRateOnly()。
         _currentOption!.duration != _effectiveScrollDurationSeconds();
+  }
+
+  /// 仅同步倍速：只更新动画控制器时长（ScrollDanmakuPainter 用
+  /// duration/playbackRate 计算每 tick 位移），不重建 DanmakuScreen、不清空弹幕。
+  /// 已上屏弹幕从当前位置平滑加速/减速，不瞬移不重载。
+  void _syncPlaybackRateOnly() {
+    if (_controller == null || _currentOption == null) return;
+    if ((_currentOption!.playbackRate - widget.playbackRate).abs() < 0.0001) {
+      return;
+    }
+    _currentOption =
+        _currentOption!.copyWith(playbackRate: widget.playbackRate);
+    _controller!.updateOption(_currentOption!);
   }
 
   @override
@@ -172,9 +228,13 @@ class _CanvasDanmakuRendererState extends State<CanvasDanmakuRenderer> {
       return const SizedBox.shrink();
     }
 
-    // 如果配置发生变化，重新创建DanmakuScreen
+    // 如果配置发生变化，重新创建DanmakuScreen；仅倍速变化则只同步动画时长，
+    // 不重建屏幕（避免长按倍速/松手时弹幕闪没重滑入）。
     if (_needsScreenRecreation()) {
+      _prepareForScreenRecreation();
       _initializeDanmakuScreen();
+    } else {
+      _syncPlaybackRateOnly();
     }
 
     // 确保弹幕播放状态与视频播放状态同步
@@ -194,14 +254,31 @@ class _CanvasDanmakuRendererState extends State<CanvasDanmakuRenderer> {
   @override
   void dispose() {
     _controller?.clear();
+    _restorationGeneration++;
     _controller = null;
-    _addedDanmakuKeys.clear(); // 清理弹幕键值缓存
+    _addedDanmakuTimes.clear();
+    _restorationRetryCounts.clear();
+    _restorationTime = null;
     super.dispose();
   }
 
   @override
   void didUpdateWidget(CanvasDanmakuRenderer oldWidget) {
     super.didUpdateWidget(oldWidget);
+
+    if (!widget.visible && oldWidget.visible) {
+      _restorationGeneration++;
+      _pendingRestoration = const [];
+      _pendingRestorationIndex = 0;
+      _restorationDrainScheduled = false;
+      _addedDanmakuTimes.clear();
+      _restorationRetryCounts.clear();
+      _restorationTime = null;
+      _controller = null;
+    } else if (widget.visible && !oldWidget.visible) {
+      _prepareForScreenRecreation();
+      _initializeDanmakuScreen();
+    }
 
     // 处理播放/暂停状态变化
     if (widget.isPlaying != oldWidget.isPlaying && _controller != null) {
@@ -213,18 +290,29 @@ class _CanvasDanmakuRendererState extends State<CanvasDanmakuRenderer> {
       }
     }
 
-    // 检测时间轴大幅变化（用户拖拽进度条）
-    double timeDiff = (widget.currentTime - oldWidget.currentTime).abs();
-    if (timeDiff > 2.0 && _controller != null) {
-      //print('Canvas弹幕: didUpdateWidget检测到时间跳跃 ${timeDiff}秒，强制重新处理弹幕');
-      // 重置时间记录，确保下次_processAndAddDanmaku能检测到变化
-      _lastCurrentTime = widget.currentTime - 10.0; // 设置一个明显不同的值
+    final seekDetected = CanvasDanmakuTimeline.didSeek(
+      previousRevision: oldWidget.seekRevision,
+      currentRevision: widget.seekRevision,
+      previousTime: oldWidget.currentTime,
+      currentTime: widget.currentTime,
+    );
+    final listReplaced = !identical(widget.danmakuList, oldWidget.danmakuList);
+    final timelineShifted =
+        (widget.timeOffsetSeconds - oldWidget.timeOffsetSeconds).abs() > 0.0001;
+    if (seekDetected || listReplaced || timelineShifted) {
+      _forceTimelineRestore = true;
+      _restorationGeneration++;
+      _pendingRestoration = const [];
+      _pendingRestorationIndex = 0;
+      _restorationDrainScheduled = false;
     }
 
     // 只在时间变化、播放状态变化或其他重要属性变化时处理弹幕
     bool shouldProcessDanmaku = widget.currentTime != oldWidget.currentTime ||
         widget.danmakuList != oldWidget.danmakuList ||
-        widget.danmakuList.length != oldWidget.danmakuList.length ||
+        widget.danmakuListVersion != oldWidget.danmakuListVersion ||
+        widget.seekRevision != oldWidget.seekRevision ||
+        widget.timeOffsetSeconds != oldWidget.timeOffsetSeconds ||
         widget.isPlaying != oldWidget.isPlaying ||
         widget.fontSize != oldWidget.fontSize ||
         widget.opacity != oldWidget.opacity ||
@@ -242,140 +330,233 @@ class _CanvasDanmakuRendererState extends State<CanvasDanmakuRenderer> {
     }
   }
 
-  // 处理并添加弹幕到Canvas渲染器
   void _processAndAddDanmaku(
       List<Map<String, dynamic>> danmakuList, double currentTime) {
     if (_controller == null) return;
 
-    //print('Canvas弹幕: _processAndAddDanmaku 被调用, 当前时间=$currentTime, 弹幕总数=${danmakuList.length}');
+    final hasPreviousTime = !_lastCurrentTime.isNaN;
+    final timeDiff = hasPreviousTime
+        ? (currentTime - _lastCurrentTime).abs()
+        : 0.0;
+    final timeChanged = !hasPreviousTime || timeDiff > 0.1;
+    final dataChanged = widget.danmakuListVersion != _lastDanmakuListVersion ||
+        _lastDanmakuListLength != danmakuList.length;
+    final entriesRemoved = _lastDanmakuListLength >= 0 &&
+        danmakuList.length < _lastDanmakuListLength;
+    final listReplaced = _lastDanmakuList != null &&
+        !identical(_lastDanmakuList, danmakuList);
+    final fallbackSeek = widget.seekRevision < 0 &&
+        hasPreviousTime &&
+        timeDiff > CanvasDanmakuTimeline.fallbackSeekThresholdSeconds;
+    final shouldRestore = _forceTimelineRestore ||
+        listReplaced ||
+        entriesRemoved ||
+        fallbackSeek;
 
-    // 检查是否需要重新处理弹幕列表
-    double timeDiff = (currentTime - _lastCurrentTime).abs();
-    bool timeChanged = timeDiff > 0.1; // 普通时间变化阈值
-    bool timeJumped = timeDiff > 2.0; // 时间跳跃阈值（切换时间轴）
-    bool dataChanged = _lastProcessedDanmakuList.length != danmakuList.length;
-    bool forceProcess = _lastProcessedDanmakuList.isEmpty; // 第一次强制处理
+    _lastDanmakuList = danmakuList;
+    _lastDanmakuListVersion = widget.danmakuListVersion;
+    _lastDanmakuListLength = danmakuList.length;
 
-    // 如果发生时间跳跃，清空当前弹幕并强制重新处理
-    if (timeJumped) {
-      //print('Canvas弹幕: 检测到时间跳跃 ${timeDiff}秒，清空当前弹幕并重新处理');
-      _controller!.clear();
-      _addedDanmakuKeys.clear(); // 清空已添加弹幕的跟踪
-      forceProcess = true;
-    }
-
-    if (!timeChanged && !dataChanged && !forceProcess) {
-      //print('Canvas弹幕: 跳过处理，时间变化=${timeDiff}, 数据变化=$dataChanged');
+    // 注意：_lastCurrentTime 只在"真正处理"时更新（见下方两处），
+    // 不能放在函数开头提前 return 之前更新，否则 timeDiff 永远只有
+    // 上一帧的增量（<0.1s），timeChanged 恒为 false，正常播放时
+    // 窗口处理被跳过，seek 恢复填充的弹幕播完后就不会再有新弹幕了。
+    if (shouldRestore) {
+      _lastCurrentTime = currentTime;
+      _forceTimelineRestore = false;
+      _beginTimelineRestoration(danmakuList, currentTime);
       return;
     }
 
-    //print('Canvas弹幕: 开始处理弹幕，时间变化=${timeDiff}, 数据变化=$dataChanged, 强制处理=$forceProcess, 时间跳跃=$timeJumped');
+    if (_pendingRestorationIndex < _pendingRestoration.length) {
+      _scheduleRestorationDrain(_restorationGeneration);
+      return;
+    }
+    if (!timeChanged && !dataChanged) return;
 
-    _lastProcessedDanmakuList = List.from(danmakuList);
     _lastCurrentTime = currentTime;
-
-    // 获取弹幕显示的时间窗口
-    // 如果发生时间跳跃，使用较小的前置窗口以快速响应
-    final windowStart = currentTime -
-        (timeJumped
-            ? _historyWindowAfterJumpSeconds
-            : _historyWindowSeconds);
-    final windowEnd = currentTime + _forwardWindowSeconds(timeJumped);
-
-    //print('Canvas弹幕: 时间窗口 $windowStart ~ $windowEnd (时间跳跃: $timeJumped)');
-
-    int processedCount = 0;
-    int addedCount = 0;
-
-    for (var danmakuData in danmakuList) {
-      final time = (danmakuData['time'] as num?)?.toDouble() ?? 0.0;
-      processedCount++;
-
-      // 处理时间窗口内的弹幕
-      if (time < windowStart || time > windowEnd) {
-        if (processedCount <= 3) {
-          // 只打印前3条的详细信息
-          //print('Canvas弹幕: 跳过弹幕 时间=$time (超出窗口)');
-        }
-        continue;
-      }
-
-      // 正确的弹幕文本字段是'content'
-      final text = danmakuData['content']?.toString() ?? '';
-
-      if (processedCount <= 5) {
-        //print('Canvas弹幕: 弹幕数据 时间=$time, 内容="$text", 类型=${danmakuData['type']}');
-      }
-
-      if (text.isEmpty) {
-        if (processedCount <= 10) {
-          //print('Canvas弹幕: 跳过空文本弹幕 (所有字段都为空)');
-        }
-        continue;
-      }
-
-      if (_shouldBlockDanmaku(text)) {
-        //print('Canvas弹幕: 跳过被屏蔽弹幕: "$text"');
-        continue;
-      }
-
-      // 创建弹幕唯一标识符，用于去重
-      final danmakuKey =
-          '${time.toStringAsFixed(1)}_${text}_${danmakuData['type']}';
-      if (_addedDanmakuKeys.contains(danmakuKey)) {
-        //print('Canvas弹幕: 跳过重复弹幕: "$text" 时间=$time');
-        continue;
-      }
-
-      // 将抽象弹幕模型转换为Canvas弹幕模型
-      final canvasDanmaku = _convertToCanvasDanmaku(danmakuData, text);
-      if (canvasDanmaku != null) {
-        // 仅在允许的提前量内才真正显示，防止提前十几秒
-        if (!_isDanmakuReadyToDisplay(
-            canvasDanmaku, time, currentTime, timeJumped)) {
-          continue;
-        }
-        //print('Canvas弹幕: 准备添加弹幕 "$text" 时间=$time 类型=${canvasDanmaku.type}');
-        _controller!.addDanmaku(canvasDanmaku);
-        _addedDanmakuKeys.add(danmakuKey); // 记录已添加的弹幕
-        addedCount++;
-      } else {
-        //print('Canvas弹幕: 转换失败的弹幕: "$text"');
-      }
-
-      // 限制添加数量，避免一次添加太多
-      // 如果发生时间跳跃，允许添加更多弹幕以快速显示内容
-      if (addedCount >= (timeJumped ? 20 : 10)) {
-        //print('Canvas弹幕: 达到单次添加上限，停止处理 (时间跳跃模式: $timeJumped)');
-        break;
-      }
-    }
-
-    //print('Canvas弹幕: 处理完成，处理了 $processedCount 条，添加了 $addedCount 条弹幕');
-
-    // 定期清理过期的弹幕键值（超过30秒的弹幕键值），避免内存泄漏
-    if (_addedDanmakuKeys.length > 1000) {
-      _addedDanmakuKeys.clear();
-      //print('Canvas弹幕: 清理弹幕键值缓存，避免内存泄漏');
-    }
+    _processNormalWindow(danmakuList, currentTime);
   }
 
-  double _forwardWindowSeconds(bool timeJumped) {
-    return _scrollLeadTimeSeconds +
-        (timeJumped ? _timeJumpLeadBonusSeconds : 0.0);
+  void _beginTimelineRestoration(
+      List<Map<String, dynamic>> danmakuList, double currentTime) {
+    _restorationGeneration++;
+    final generation = _restorationGeneration;
+    _restorationDrainScheduled = false;
+    _controller!.clear();
+    _addedDanmakuTimes.clear();
+    _restorationRetryCounts.clear();
+    _pendingRestoration = CanvasDanmakuTimeline.activeEntries(
+      danmakuList,
+      timeOf: _danmakuTime,
+      currentTime: currentTime,
+      lookBackSeconds: _effectiveScrollDurationSeconds().toDouble(),
+    );
+    _pendingRestorationIndex = 0;
+    _restorationTime = currentTime;
+    _drainTimelineRestoration(generation);
+  }
+
+  void _drainTimelineRestoration(int generation) {
+    if (!mounted ||
+        generation != _restorationGeneration ||
+        _controller == null) {
+      return;
+    }
+
+    // 用锚定时刻而非实时 currentTime 计算每条弹幕的初始位置，
+    // 保证同批恢复的弹幕处于同一时间基准，不会因排空期间的推进被丢弃。
+    final anchorTime = _restorationTime;
+    if (anchorTime == null) {
+      _pendingRestoration = const [];
+      _pendingRestorationIndex = 0;
+      return;
+    }
+
+    var processed = 0;
+    while (_pendingRestorationIndex < _pendingRestoration.length &&
+        processed < _restorationBatchSize) {
+      final data = _pendingRestoration[_pendingRestorationIndex++];
+      final added = _tryAddDanmaku(data, anchorTime, isRestoration: true);
+      if (!added) {
+        final retries = (_restorationRetryCounts[data] ?? 0) + 1;
+        if (retries <= _maxRestorationRetries) {
+          _restorationRetryCounts[data] = retries;
+          // 轨道冲突被丢弃：放回队尾稍后重试，等已上屏弹幕离屏腾出轨道
+          _pendingRestoration.add(data);
+        } else {
+          _restorationRetryCounts.remove(data);
+        }
+      } else {
+        _restorationRetryCounts.remove(data);
+      }
+      processed++;
+    }
+
+    if (_pendingRestorationIndex < _pendingRestoration.length) {
+      _scheduleRestorationDrain(generation);
+      return;
+    }
+
+    _pendingRestoration = const [];
+    _pendingRestorationIndex = 0;
+    _restorationTime = null;
+
+    // 排空完成后清理跟踪表，避免排空期间已过期的弹幕占用去重窗口，
+    // 导致其后续正常进入窗口时被误判为已添加而不再显示。
+    _pruneAddedDanmakuTimes(widget.currentTime);
+    _processNormalWindow(widget.danmakuList, widget.currentTime);
+  }
+
+  void _scheduleRestorationDrain(int generation) {
+    if (_restorationDrainScheduled) return;
+    _restorationDrainScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (generation != _restorationGeneration) return;
+      _restorationDrainScheduled = false;
+      _drainTimelineRestoration(generation);
+    });
+  }
+
+  void _processNormalWindow(
+      List<Map<String, dynamic>> danmakuList, double currentTime) {
+    // 弹幕列表按 time 升序（上游 _updateMergedDanmakuList 保证），
+    // 用二分定位窗口起点，避免每帧从列表头扫描整个弹幕列表。
+    final windowStart = currentTime - _historyWindowSeconds;
+    final windowEnd = currentTime + _scrollLeadTimeSeconds;
+    final startIndex = CanvasDanmakuTimeline.lowerBound(
+      danmakuList,
+      windowStart,
+      timeOf: _danmakuTime,
+    );
+    var addedCount = 0;
+
+    for (int i = startIndex; i < danmakuList.length; i++) {
+      final danmakuData = danmakuList[i];
+      final time = _danmakuTime(danmakuData);
+      if (time > windowEnd) break;
+      if (_tryAddDanmaku(danmakuData, currentTime,
+          isRestoration: false)) {
+        addedCount++;
+        if (addedCount >= 10) break;
+      }
+    }
+    _pruneAddedDanmakuTimes(currentTime);
+  }
+
+  bool _tryAddDanmaku(
+    Map<String, dynamic> danmakuData,
+    double currentTime, {
+    required bool isRestoration,
+  }) {
+    final time = _danmakuTime(danmakuData);
+    final text = danmakuData['content']?.toString() ?? '';
+    if (text.isEmpty || _shouldBlockDanmaku(text)) return false;
+
+    if (_addedDanmakuTimes.containsKey(danmakuData)) return false;
+
+    final canvasDanmaku = _convertToCanvasDanmaku(danmakuData, text);
+    if (canvasDanmaku == null) return false;
+    if (!isRestoration &&
+        !_isDanmakuReadyToDisplay(canvasDanmaku, time, currentTime)) {
+      return false;
+    }
+
+    final duration = _effectiveScrollDurationSeconds().toDouble();
+    final elapsedSeconds = (currentTime - time).clamp(0.0, duration);
+    var initialProgress = 0.0;
+    if (canvasDanmaku.type == canvas_models.DanmakuItemType.scroll) {
+      initialProgress = CanvasDanmakuTimeline.scrollProgress(
+        scheduledTime: time,
+        currentTime: currentTime,
+        durationSeconds: duration,
+      );
+      if (initialProgress >= 1.0) return false;
+    } else {
+      final remaining = CanvasDanmakuTimeline.remainingLifetime(
+        scheduledTime: time,
+        currentTime: currentTime,
+        durationSeconds: duration,
+      );
+      if (remaining <= 0) return false;
+    }
+
+    // 只有真正上屏（轨道可用、类型未隐藏）才记录到跟踪表，
+    // 避免被丢弃的弹幕占用去重窗口，导致其后续重放缺失。
+    final added = _controller!.addDanmaku(
+      canvasDanmaku,
+      initialProgress: initialProgress,
+      elapsedSeconds: elapsedSeconds,
+    );
+    if (!added) return false;
+
+    _addedDanmakuTimes[danmakuData] = time;
+    return true;
+  }
+
+  double _danmakuTime(Map<String, dynamic> data) =>
+      (data['time'] as num?)?.toDouble() ?? 0.0;
+
+  void _pruneAddedDanmakuTimes(double currentTime) {
+    final duration = _effectiveScrollDurationSeconds();
+    final retainSeconds = duration > _historyWindowSeconds
+        ? duration.toDouble()
+        : _historyWindowSeconds;
+    final cutoff = currentTime - retainSeconds - 1.0;
+    _addedDanmakuTimes.removeWhere(
+      (_, scheduledTime) => scheduledTime < cutoff,
+    );
   }
 
   bool _isDanmakuReadyToDisplay(
     canvas_models.DanmakuContentItem danmaku,
     double scheduledTime,
     double currentTime,
-    bool timeJumped,
   ) {
     final baseLead = danmaku.type == canvas_models.DanmakuItemType.scroll
         ? _scrollLeadTimeSeconds
         : _staticLeadTimeSeconds;
-    final allowedLead = baseLead + (timeJumped ? _timeJumpLeadBonusSeconds : 0.0);
-    return scheduledTime - currentTime <= allowedLead;
+    return scheduledTime - currentTime <= baseLead;
   }
 
   // 检查弹幕是否应该被屏蔽

--- a/packages/danmaku_canvas/lib/danmaku_controller.dart
+++ b/packages/danmaku_canvas/lib/danmaku_controller.dart
@@ -1,12 +1,18 @@
 import 'models/danmaku_option.dart';
 import 'models/danmaku_content_item.dart';
 
+typedef AddDanmakuCallback = bool Function(
+  DanmakuContentItem item, {
+  required double initialProgress,
+  required double elapsedSeconds,
+});
+
 class DanmakuController {
-  final Function(DanmakuContentItem) onAddDanmaku;
-  final Function(DanmakuOption) onUpdateOption;
-  final Function onPause;
-  final Function onResume;
-  final Function onClear;
+  final AddDanmakuCallback onAddDanmaku;
+  final void Function(DanmakuOption) onUpdateOption;
+  final void Function() onPause;
+  final void Function() onResume;
+  final void Function() onClear;
   DanmakuController({
     required this.onAddDanmaku,
     required this.onUpdateOption,
@@ -20,24 +26,28 @@ class DanmakuController {
   /// 是否运行中
   /// 可以调用pause()暂停弹幕
   bool get running => _running;
-  set running(e) {
-    _running = e;
+  set running(bool value) {
+    _running = value;
   }
 
   DanmakuOption _option = DanmakuOption();
   DanmakuOption get option => _option;
-  set option(e) {
-    _option = e;
+  set option(DanmakuOption value) {
+    _option = value;
   }
 
   /// 暂停弹幕
   void pause() {
+    if (!_running) return;
     onPause.call();
+    _running = false;
   }
 
   /// 继续弹幕
   void resume() {
+    if (_running) return;
     onResume.call();
+    _running = true;
   }
 
   /// 清空弹幕
@@ -46,8 +56,19 @@ class DanmakuController {
   }
 
   /// 添加弹幕
-  void addDanmaku(DanmakuContentItem item) {
-    onAddDanmaku.call(item);
+  /// [initialProgress] 用于 seek 后恢复滚动弹幕的水平位置。
+  /// [elapsedSeconds] 用于恢复顶部/底部弹幕的剩余生命周期。
+  /// 返回是否真正上屏：轨道冲突、被隐藏等情况下返回 false。
+  bool addDanmaku(
+    DanmakuContentItem item, {
+    double initialProgress = 0,
+    double elapsedSeconds = 0,
+  }) {
+    return onAddDanmaku.call(
+      item,
+      initialProgress: initialProgress,
+      elapsedSeconds: elapsedSeconds,
+    );
   }
 
   /// 更新弹幕配置

--- a/packages/danmaku_canvas/lib/danmaku_screen.dart
+++ b/packages/danmaku_canvas/lib/danmaku_screen.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+import 'dart:math';
 import 'utils/utils.dart';
 import 'package:flutter/material.dart';
+import 'danmaku_timeline.dart';
 import 'models/danmaku_item.dart';
 import 'scroll_danmaku_painter.dart';
 import 'special_danmaku_painter.dart';
@@ -8,11 +11,10 @@ import 'danmaku_controller.dart';
 import 'dart:ui' as ui;
 import 'models/danmaku_option.dart';
 import 'models/danmaku_content_item.dart';
-import 'dart:math';
 
 class DanmakuScreen extends StatefulWidget {
   // 创建Screen后返回控制器
-  final Function(DanmakuController) createdController;
+  final void Function(DanmakuController) createdController;
   final DanmakuOption option;
 
   const DanmakuScreen({
@@ -69,6 +71,7 @@ class _DanmakuScreenState extends State<DanmakuScreen>
   int get _tick => _stopwatch.elapsedMilliseconds;
 
   final _stopwatch = Stopwatch();
+  Timer? _cleanupTimer;
 
   /// 运行状态
   bool _running = true;
@@ -76,9 +79,18 @@ class _DanmakuScreenState extends State<DanmakuScreen>
   @override
   void initState() {
     super.initState();
-    // 计时器初始化
-    _startTick();
     _option = widget.option;
+    _animationController = AnimationController(
+      vsync: this,
+      duration: _animationDuration(_option),
+    )..repeat();
+
+    _staticAnimationController = AnimationController(
+      vsync: this,
+      duration: _animationDuration(_option),
+    );
+
+    _startTick();
     _controller = DanmakuController(
       onAddDanmaku: addDanmaku,
       onUpdateOption: updateOption,
@@ -87,21 +99,8 @@ class _DanmakuScreenState extends State<DanmakuScreen>
       onClear: clearDanmakus,
     );
     _controller.option = _option;
-    widget.createdController.call(
-      _controller,
-    );
-
-    _animationController = AnimationController(
-      vsync: this,
-      duration: Duration(milliseconds: (_option.duration * 1000 / _option.playbackRate).round()),
-    )..repeat();
-
-    _staticAnimationController = AnimationController(
-      vsync: this,
-      duration: Duration(milliseconds: (_option.duration * 1000 / _option.playbackRate).round()),
-    );
-
     WidgetsBinding.instance.addObserver(this);
+    widget.createdController(_controller);
   }
 
   /// 处理 Android/iOS 应用后台或熄屏导致的动画问题
@@ -132,6 +131,7 @@ class _DanmakuScreenState extends State<DanmakuScreen>
   void dispose() {
     _running = false;
     WidgetsBinding.instance.removeObserver(this);
+    _cleanupTimer?.cancel();
     _animationController.dispose();
     _staticAnimationController.dispose();
     _stopwatch.stop();
@@ -139,161 +139,205 @@ class _DanmakuScreenState extends State<DanmakuScreen>
   }
 
   /// 添加弹幕
-  void addDanmaku(DanmakuContentItem content) {
-    if (!_running || !mounted) {
-      return;
+  /// [initialProgress] 用于 seek 后恢复滚动弹幕的水平位置。
+  /// [elapsedSeconds] 用于恢复顶部/底部弹幕的剩余生命周期。
+  /// 返回是否真正上屏：类型被隐藏或所有轨道均被占用时返回 false，
+  /// 调用方据此只记录真正上屏的弹幕，避免被丢弃的弹幕占用去重窗口。
+  bool addDanmaku(
+    DanmakuContentItem content, {
+    double initialProgress = 0,
+    double elapsedSeconds = 0,
+  }) {
+    if (!mounted) {
+      return false;
     }
 
     if (content.type == DanmakuItemType.special) {
-      if (!_option.hideSpecial) {
-        // 计算弹幕颜色的亮度，与其他内核保持一致
-        final color = content.color;
-        final luminance =
-            (0.299 * color.red + 0.587 * color.green + 0.114 * color.blue) / 255;
-        // 如果亮度小于0.2，说明是深色，使用白色描边；否则使用黑色描边
-        final strokeColor = luminance < 0.2 ? Colors.white : Colors.black;
-        
-        (content as SpecialDanmakuContentItem).painterCache = TextPainter(
-          text: TextSpan(
-            text: content.text,
-            style: TextStyle(
-              color: content.color,
-              fontSize: content.fontSize,
-              fontWeight: FontWeight.values[_option.fontWeight],
-              shadows: content.hasStroke
-                  ? [
-                      Shadow(
-                          color: strokeColor.withOpacity(
-                              content.alphaTween?.begin ??
-                                  content.color.opacity),
-                          blurRadius: 0)  // 使用0像素模糊来匹配其他内核
-                    ]
-                  : null,
-            ),
-          ),
-          textDirection: TextDirection.ltr,
-        )..layout();
-        _specialDanmakuItems.add(DanmakuItem(
-          width: 0,
-          height: 0,
-          creationTime: _tick,
-          content: content,
-          paragraph: null,
-          strokeParagraph: null,
-        ));
-      } else {
-        return;
+      if (_option.hideSpecial) {
+        return false;
       }
-    } else {
-      // 在这里提前创建 Paragraph 缓存防止卡顿
-      final textPainter = TextPainter(
+      // 计算弹幕颜色的亮度，与其他内核保持一致
+      final color = content.color;
+      final luminance =
+          (0.299 * color.red + 0.587 * color.green + 0.114 * color.blue) / 255;
+      // 如果亮度小于0.2，说明是深色，使用白色描边；否则使用黑色描边
+      final strokeColor = luminance < 0.2 ? Colors.white : Colors.black;
+
+      (content as SpecialDanmakuContentItem).painterCache = TextPainter(
         text: TextSpan(
-            text: content.text,
-            style: TextStyle(
-                fontSize: _option.fontSize,
-                fontWeight: FontWeight.values[_option.fontWeight])),
+          text: content.text,
+          style: TextStyle(
+            color: content.color,
+            fontSize: content.fontSize,
+            fontWeight: FontWeight.values[_option.fontWeight],
+            shadows: content.hasStroke
+                ? [
+                    Shadow(
+                        color: strokeColor.withOpacity(
+                            content.alphaTween?.begin ??
+                                content.color.opacity),
+                        blurRadius: 0) // 使用0像素模糊来匹配其他内核
+                  ]
+                : null,
+          ),
+        ),
         textDirection: TextDirection.ltr,
       )..layout();
-      final danmakuWidth = textPainter.width;
-      final danmakuHeight = textPainter.height;
-
-      final ui.Paragraph paragraph = Utils.generateParagraph(
-          content, danmakuWidth, _option.fontSize, _option.fontWeight);
-
-      ui.Paragraph? strokeParagraph;
-      if (_option.showStroke) {
-        strokeParagraph = Utils.generateStrokeParagraph(
-            content, danmakuWidth, _option.fontSize, _option.fontWeight);
+      _specialDanmakuItems.add(DanmakuItem(
+        width: 0,
+        height: 0,
+        creationTime: _tick,
+        content: content,
+        paragraph: null,
+        strokeParagraph: null,
+      ));
+      if (_running) {
+        if (!_animationController.isAnimating) {
+          _animationController.repeat();
+        }
+      } else {
+        setState(() {});
       }
-
-      int idx = 1;
-      for (double yPosition in _trackYPositions) {
-        if (content.type == DanmakuItemType.scroll && !_option.hideScroll) {
-          bool scrollCanAddToTrack =
-              _scrollCanAddToTrack(yPosition, danmakuWidth);
-
-          if (scrollCanAddToTrack) {
-            _scrollDanmakuItems.add(DanmakuItem(
-                yPosition: yPosition,
-                xPosition: _viewWidth,
-                width: danmakuWidth,
-                height: danmakuHeight,
-                creationTime: _tick,
-                content: content,
-                paragraph: paragraph,
-                strokeParagraph: strokeParagraph));
-            break;
-          }
-
-          /// 无法填充自己发送的弹幕时强制添加
-          if (content.selfSend && idx == _trackCount) {
-            _scrollDanmakuItems.add(DanmakuItem(
-                yPosition: _trackYPositions[0],
-                xPosition: _viewWidth,
-                width: danmakuWidth,
-                height: danmakuHeight,
-                creationTime: _tick,
-                content: content,
-                paragraph: paragraph,
-                strokeParagraph: strokeParagraph));
-            break;
-          }
-
-          /// 海量弹幕启用时进行随机添加
-          if (_option.massiveMode && idx == _trackCount) {
-            var randomYPosition =
-                _trackYPositions[_random.nextInt(_trackYPositions.length)];
-            _scrollDanmakuItems.add(DanmakuItem(
-                yPosition: randomYPosition,
-                xPosition: _viewWidth,
-                width: danmakuWidth,
-                height: danmakuHeight,
-                creationTime: _tick,
-                content: content,
-                paragraph: paragraph,
-                strokeParagraph: strokeParagraph));
-            break;
-          }
-        }
-
-        if (content.type == DanmakuItemType.top && !_option.hideTop) {
-          bool topCanAddToTrack = _topCanAddToTrack(yPosition);
-
-          if (topCanAddToTrack) {
-            _topDanmakuItems.add(DanmakuItem(
-                yPosition: yPosition,
-                xPosition: _viewWidth,
-                width: danmakuWidth,
-                height: danmakuHeight,
-                creationTime: _tick,
-                content: content,
-                paragraph: paragraph,
-                strokeParagraph: strokeParagraph));
-            break;
-          }
-        }
-
-        if (content.type == DanmakuItemType.bottom && !_option.hideBottom) {
-          bool bottomCanAddToTrack = _bottomCanAddToTrack(yPosition);
-
-          if (bottomCanAddToTrack) {
-            _bottomDanmakuItems.add(DanmakuItem(
-                yPosition: yPosition,
-                xPosition: _viewWidth,
-                width: danmakuWidth,
-                height: danmakuHeight,
-                creationTime: _tick,
-                content: content,
-                paragraph: paragraph,
-                strokeParagraph: strokeParagraph));
-            break;
-          }
-        }
-        idx++;
-      }
+      _syncCleanupTimer();
+      return true;
     }
 
-    switch (content.type) {
+    // 在这里提前创建 Paragraph 缓存防止卡顿
+    final textPainter = TextPainter(
+      text: TextSpan(
+          text: content.text,
+          style: TextStyle(
+              fontSize: _option.fontSize,
+              fontWeight: FontWeight.values[_option.fontWeight])),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    final danmakuWidth = textPainter.width;
+    final danmakuHeight = textPainter.height;
+    final remainingDuration =
+        (_option.duration - elapsedSeconds).clamp(0.0, _option.duration).toDouble();
+    if (content.type != DanmakuItemType.scroll && remainingDuration <= 0) {
+      return false;
+    }
+
+    // 弹幕初始 x 位置：按初始进度定位，0=从屏幕右侧进入，
+    // 进度>0 表示时间跳转后弹幕应已滚动了一部分，直接出现在正确位置。
+    final double initialX = _viewWidth -
+        initialProgress.clamp(0.0, 1.0) * (_viewWidth + danmakuWidth);
+
+    final ui.Paragraph paragraph = Utils.generateParagraph(
+        content, danmakuWidth, _option.fontSize, _option.fontWeight);
+
+    ui.Paragraph? strokeParagraph;
+    if (_option.showStroke) {
+      strokeParagraph = Utils.generateStrokeParagraph(
+          content, danmakuWidth, _option.fontSize, _option.fontWeight);
+    }
+
+    final type = content.type;
+    var added = false;
+    var idx = 1;
+    for (double yPosition in _trackYPositions) {
+      if (type == DanmakuItemType.scroll && !_option.hideScroll) {
+        final scrollCanAddToTrack = _scrollCanAddToTrack(
+          yPosition,
+          initialX,
+          danmakuWidth,
+        );
+
+        if (scrollCanAddToTrack) {
+          _scrollDanmakuItems.add(DanmakuItem(
+              yPosition: yPosition,
+              xPosition: initialX,
+              width: danmakuWidth,
+              height: danmakuHeight,
+              creationTime: _tick,
+              content: content,
+              paragraph: paragraph,
+              strokeParagraph: strokeParagraph));
+          added = true;
+          break;
+        }
+
+        /// 无法填充自己发送的弹幕时强制添加
+        if (content.selfSend && idx == _trackCount) {
+          _scrollDanmakuItems.add(DanmakuItem(
+              yPosition: _trackYPositions[0],
+              xPosition: initialX,
+              width: danmakuWidth,
+              height: danmakuHeight,
+              creationTime: _tick,
+              content: content,
+              paragraph: paragraph,
+              strokeParagraph: strokeParagraph));
+          added = true;
+          break;
+        }
+
+        /// 海量弹幕启用时进行随机添加
+        if (_option.massiveMode && idx == _trackCount) {
+          var randomYPosition =
+              _trackYPositions[_random.nextInt(_trackYPositions.length)];
+          _scrollDanmakuItems.add(DanmakuItem(
+              yPosition: randomYPosition,
+              xPosition: initialX,
+              width: danmakuWidth,
+              height: danmakuHeight,
+              creationTime: _tick,
+              content: content,
+              paragraph: paragraph,
+              strokeParagraph: strokeParagraph));
+          added = true;
+          break;
+        }
+      }
+
+      if (type == DanmakuItemType.top && !_option.hideTop) {
+        final topCanAddToTrack = _topCanAddToTrack(yPosition);
+
+        if (topCanAddToTrack) {
+          _topDanmakuItems.add(DanmakuItem(
+              yPosition: yPosition,
+              xPosition: _viewWidth,
+              width: danmakuWidth,
+              height: danmakuHeight,
+              creationTime: _tick,
+              remainingDurationSeconds: remainingDuration,
+              lastLifetimeTick: _tick,
+              content: content,
+              paragraph: paragraph,
+              strokeParagraph: strokeParagraph));
+          added = true;
+          break;
+        }
+      }
+
+      if (type == DanmakuItemType.bottom && !_option.hideBottom) {
+        final bottomCanAddToTrack = _bottomCanAddToTrack(yPosition);
+
+        if (bottomCanAddToTrack) {
+          _bottomDanmakuItems.add(DanmakuItem(
+              yPosition: yPosition,
+              xPosition: _viewWidth,
+              width: danmakuWidth,
+              height: danmakuHeight,
+              creationTime: _tick,
+              remainingDurationSeconds: remainingDuration,
+              lastLifetimeTick: _tick,
+              content: content,
+              paragraph: paragraph,
+              strokeParagraph: strokeParagraph));
+          added = true;
+          break;
+        }
+      }
+      idx++;
+    }
+
+    if (!added) {
+      return false;
+    }
+
+    switch (type) {
       case DanmakuItemType.top:
       case DanmakuItemType.bottom:
         // 重绘静态弹幕
@@ -302,20 +346,29 @@ class _DanmakuScreenState extends State<DanmakuScreen>
         });
         break;
       case DanmakuItemType.scroll:
-      case DanmakuItemType.special:
-        if (!_animationController.isAnimating &&
-            (_scrollDanmakuItems.isNotEmpty ||
-                _specialDanmakuItems.isNotEmpty)) {
-          _animationController.repeat();
+        if (_running) {
+          if (!_animationController.isAnimating &&
+              (_scrollDanmakuItems.isNotEmpty ||
+                  _specialDanmakuItems.isNotEmpty)) {
+            _animationController.repeat();
+          }
+        } else {
+          setState(() {});
         }
         break;
+      case DanmakuItemType.special:
+        break; // 已在上方处理
     }
+    _syncCleanupTimer();
+    return true;
   }
 
   /// 暂停
   void pause() {
     if (!mounted) return;
+    _controller.running = false;
     if (_running) {
+      _advanceStaticLifetimes(_tick, _safePlaybackRate(_option));
       setState(() {
         _running = false;
       });
@@ -325,21 +378,23 @@ class _DanmakuScreenState extends State<DanmakuScreen>
       if (_stopwatch.isRunning) {
         _stopwatch.stop();
       }
+      _cleanupTimer?.cancel();
+      _cleanupTimer = null;
     }
   }
 
   /// 恢复
   void resume() {
     if (!mounted) return;
+    _controller.running = true;
     if (!_running) {
       setState(() {
         _running = true;
       });
       if (!_animationController.isAnimating) {
         _animationController.repeat();
-        // 重启计时器
-        _startTick();
       }
+      _startTick();
     }
   }
 
@@ -359,7 +414,8 @@ class _DanmakuScreenState extends State<DanmakuScreen>
     }
     
     // 检查播放速度是否发生变化
-    if (option.playbackRate != _option.playbackRate) {
+    if (option.playbackRate != _option.playbackRate ||
+        option.duration != _option.duration) {
       needUpdateDuration = true;
     }
 
@@ -373,13 +429,15 @@ class _DanmakuScreenState extends State<DanmakuScreen>
     if (option.hideBottom && !_option.hideBottom) {
       _bottomDanmakuItems.clear();
     }
+    _advanceStaticLifetimes(_tick, _safePlaybackRate(_option));
     _option = option;
     _controller.option = _option;
 
     // 如果播放速度发生变化，更新动画控制器的持续时间
     if (needUpdateDuration) {
-      _animationController.duration = Duration(milliseconds: (_option.duration * 1000 / _option.playbackRate).round());
-      _staticAnimationController.duration = Duration(milliseconds: (_option.duration * 1000 / _option.playbackRate).round());
+      final duration = _animationDuration(_option);
+      _animationController.duration = duration;
+      _staticAnimationController.duration = duration;
     }
 
     /// 清理已经存在的 Paragraph 缓存
@@ -412,6 +470,7 @@ class _DanmakuScreenState extends State<DanmakuScreen>
     if (needRestart) {
       _animationController.repeat();
     }
+    _syncCleanupTimer();
     setState(() {});
   }
 
@@ -425,27 +484,25 @@ class _DanmakuScreenState extends State<DanmakuScreen>
       _specialDanmakuItems.clear();
     });
     _animationController.stop();
+    _syncCleanupTimer();
   }
 
   /// 确定滚动弹幕是否可以添加
-  bool _scrollCanAddToTrack(double yPosition, double newDanmakuWidth) {
-    for (var item in _scrollDanmakuItems) {
-      if (item.yPosition == yPosition) {
-        final existingEndPosition = item.xPosition + item.width;
-        // 首先保证进入屏幕时不发生重叠，其次保证知道移出屏幕前不与速度慢的弹幕(弹幕宽度较小)发生重叠
-        if (_viewWidth - existingEndPosition < 0) {
-          return false;
-        }
-        if (item.width < newDanmakuWidth) {
-          if ((1 -
-                  ((_viewWidth - item.xPosition) / (item.width + _viewWidth))) >
-              ((_viewWidth) / (_viewWidth + newDanmakuWidth))) {
-            return false;
-          }
-        }
-      }
-    }
-    return true;
+  bool _scrollCanAddToTrack(
+    double yPosition,
+    double candidateX,
+    double candidateWidth,
+  ) {
+    final existing = _scrollDanmakuItems
+        .where((item) => item.yPosition == yPosition)
+        .map((item) => (x: item.xPosition, width: item.width));
+    return ScrollDanmakuCollision.canPlace(
+      existing: existing,
+      candidateX: candidateX,
+      candidateWidth: candidateWidth,
+      viewWidth: _viewWidth,
+      durationSeconds: _option.duration.toDouble(),
+    );
   }
 
   /// 确定顶部弹幕是否可以添加
@@ -468,44 +525,100 @@ class _DanmakuScreenState extends State<DanmakuScreen>
     return true;
   }
 
-  // 基于Stopwatch的计时器同步
-  void _startTick() async {
-    // _stopwatch.reset();
+  Duration _animationDuration(DanmakuOption option) {
+    final milliseconds =
+        (option.duration * 1000 / _safePlaybackRate(option)).round();
+    return Duration(milliseconds: max(1, milliseconds));
+  }
+
+  double _safePlaybackRate(DanmakuOption option) {
+    final rate = option.playbackRate;
+    return rate.isFinite && rate > 0 ? rate : 1.0;
+  }
+
+  bool _advanceStaticLifetimes(int tick, double playbackRate) {
+    var changed = false;
+    for (final items in [_topDanmakuItems, _bottomDanmakuItems]) {
+      for (final item in items) {
+        final lastTick = item.lastLifetimeTick ?? tick;
+        final wallSeconds = max(0, tick - lastTick) / 1000.0;
+        item.remainingDurationSeconds = CanvasDanmakuTimeline.consumeLifetime(
+          remainingSeconds:
+              item.remainingDurationSeconds ?? _option.duration.toDouble(),
+          wallSeconds: wallSeconds,
+          playbackRate: playbackRate,
+        );
+        item.lastLifetimeTick = tick;
+      }
+      final before = items.length;
+      items.removeWhere((item) =>
+          (item.remainingDurationSeconds ?? _option.duration) <= 0);
+      changed = changed || before != items.length;
+    }
+    return changed;
+  }
+
+  void _cleanupExpiredDanmaku() {
+    if (!_running || !mounted) return;
+    final tick = _tick;
+    var changed = _advanceStaticLifetimes(
+      tick,
+      _safePlaybackRate(_option),
+    );
+
+    final scrollCount = _scrollDanmakuItems.length;
+    _scrollDanmakuItems
+        .removeWhere((item) => item.xPosition + item.width < 0);
+    changed = changed || scrollCount != _scrollDanmakuItems.length;
+
+    final specialCount = _specialDanmakuItems.length;
+    _specialDanmakuItems.removeWhere((item) =>
+        (tick - item.creationTime) >=
+        (item.content as SpecialDanmakuContentItem).duration);
+    changed = changed || specialCount != _specialDanmakuItems.length;
+
+    if (_scrollDanmakuItems.isEmpty &&
+        _specialDanmakuItems.isEmpty &&
+        _animationController.isAnimating) {
+      _animationController.stop();
+    }
+    if (changed && mounted) {
+      setState(() {});
+    }
+    _syncCleanupTimer();
+  }
+
+  // 基于 Stopwatch 的墙钟只负责增量推进，倍速在每次清理时读取最新 option。
+  void _startTick() {
     _stopwatch.start();
+    if (_cleanupTimer != null) return;
+    _cleanupTimer = Timer.periodic(
+      const Duration(milliseconds: 100),
+      (_) => _cleanupExpiredDanmaku(),
+    );
+  }
 
-    final staticDuration = (_option.duration * 1000 / _option.playbackRate).round();
-
-    while (_running && mounted) {
-      await Future.delayed(const Duration(milliseconds: 100));
-      // 移除屏幕外滚动弹幕
-      _scrollDanmakuItems
-          .removeWhere((item) => item.xPosition + item.width < 0);
-      // 移除顶部弹幕
-      _topDanmakuItems
-          .removeWhere((item) => (_tick - item.creationTime) >= staticDuration);
-      // 移除底部弹幕
-      _bottomDanmakuItems
-          .removeWhere((item) => (_tick - item.creationTime) >= staticDuration);
-      // 移除高级弹幕
-      _specialDanmakuItems.removeWhere((item) =>
-          (_tick - item.creationTime) >=
-          (item.content as SpecialDanmakuContentItem).duration);
-      // 暂停动画
+  /// 按当前是否有需要计时清理的弹幕，动态启停 100ms 清理定时器：
+  /// 没有任何弹幕在屏时保持零定时唤醒，避免空转耗电；
+  /// 有弹幕上屏（或恢复播放）时自动重启。
+  /// 顺带在空闲时停掉滚动动画控制器，避免清空列表后空转逐帧重绘。
+  void _syncCleanupTimer() {
+    final needsTimer = _running &&
+        (_scrollDanmakuItems.isNotEmpty ||
+            _topDanmakuItems.isNotEmpty ||
+            _bottomDanmakuItems.isNotEmpty ||
+            _specialDanmakuItems.isNotEmpty);
+    if (needsTimer) {
+      _startTick();
+    } else {
+      _cleanupTimer?.cancel();
+      _cleanupTimer = null;
       if (_scrollDanmakuItems.isEmpty &&
           _specialDanmakuItems.isEmpty &&
           _animationController.isAnimating) {
         _animationController.stop();
       }
-
-      /// 重绘静态弹幕
-      if (mounted) {
-        setState(() {
-          _staticAnimationController.value = 0;
-        });
-      }
     }
-
-    _stopwatch.stop();
   }
 
   @override
@@ -555,7 +668,8 @@ class _DanmakuScreenState extends State<DanmakuScreen>
                     painter: ScrollDanmakuPainter(
                         _animationController.value,
                         _scrollDanmakuItems,
-                        (_option.duration / _option.playbackRate).round(),
+                        _option.duration.toDouble(),
+                        _safePlaybackRate(_option),
                         _option.fontSize,
                         _option.fontWeight,
                         _option.showStroke,
@@ -575,7 +689,7 @@ class _DanmakuScreenState extends State<DanmakuScreen>
                         _staticAnimationController.value,
                         _topDanmakuItems,
                         _bottomDanmakuItems,
-                        (_option.duration / _option.playbackRate).round(),
+                        _option.duration,
                         _option.fontSize,
                         _option.fontWeight,
                         _option.showStroke,

--- a/packages/danmaku_canvas/lib/danmaku_timeline.dart
+++ b/packages/danmaku_canvas/lib/danmaku_timeline.dart
@@ -1,0 +1,142 @@
+class CanvasDanmakuTimeline {
+  static const double fallbackSeekThresholdSeconds = 2.0;
+
+  static bool didSeek({
+    required int previousRevision,
+    required int currentRevision,
+    required double previousTime,
+    required double currentTime,
+  }) {
+    if (previousRevision >= 0 && currentRevision >= 0) {
+      return previousRevision != currentRevision;
+    }
+    return (currentTime - previousTime).abs() >
+        fallbackSeekThresholdSeconds;
+  }
+
+  /// 返回 entries 中第一个 timeOf(entry) >= target 的下标。
+  /// 要求 entries 已按 timeOf 升序排列（上游弹幕列表按 time 排序）。
+  static int lowerBound<T>(
+    List<T> entries,
+    double target, {
+    required double Function(T entry) timeOf,
+  }) {
+    var low = 0;
+    var high = entries.length;
+    while (low < high) {
+      final mid = (low + high) >> 1;
+      if (timeOf(entries[mid]) < target) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    return low;
+  }
+
+  /// 收集 [currentTime - lookBackSeconds, currentTime] 窗口内的条目，
+  /// 按 timeOf 升序返回。输入不要求有序（恢复调用低频，全量过滤可接受）。
+  static List<T> activeEntries<T>(
+    Iterable<T> entries, {
+    required double Function(T entry) timeOf,
+    required double currentTime,
+    required double lookBackSeconds,
+  }) {
+    final windowStart = currentTime - lookBackSeconds;
+    final active = entries.where((entry) {
+      final time = timeOf(entry);
+      return time >= windowStart && time <= currentTime;
+    }).toList();
+    active.sort((a, b) => timeOf(a).compareTo(timeOf(b)));
+    return active;
+  }
+
+  static double scrollProgress({
+    required double scheduledTime,
+    required double currentTime,
+    required double durationSeconds,
+  }) {
+    if (durationSeconds <= 0 || !durationSeconds.isFinite) {
+      return 1;
+    }
+    return ((currentTime - scheduledTime) / durationSeconds)
+        .clamp(0.0, 1.0);
+  }
+
+  static double remainingLifetime({
+    required double scheduledTime,
+    required double currentTime,
+    required double durationSeconds,
+  }) {
+    return (durationSeconds - (currentTime - scheduledTime))
+        .clamp(0.0, durationSeconds);
+  }
+
+  static double advanceScrollX({
+    required double currentX,
+    required int previousTick,
+    required int currentTick,
+    required double viewWidth,
+    required double danmakuWidth,
+    required double durationSeconds,
+    required double playbackRate,
+  }) {
+    if (currentTick <= previousTick ||
+        durationSeconds <= 0 ||
+        playbackRate <= 0) {
+      return currentX;
+    }
+    final wallSeconds = (currentTick - previousTick) / 1000.0;
+    final distance = viewWidth + danmakuWidth;
+    return currentX -
+        wallSeconds * playbackRate * distance / durationSeconds;
+  }
+
+  static double consumeLifetime({
+    required double remainingSeconds,
+    required double wallSeconds,
+    required double playbackRate,
+  }) {
+    if (wallSeconds <= 0 || playbackRate <= 0) {
+      return remainingSeconds;
+    }
+    return remainingSeconds - wallSeconds * playbackRate;
+  }
+}
+
+class ScrollDanmakuCollision {
+  static bool canPlace({
+    required Iterable<({double x, double width})> existing,
+    required double candidateX,
+    required double candidateWidth,
+    required double viewWidth,
+    required double durationSeconds,
+    double gap = 0,
+  }) {
+    if (durationSeconds <= 0 || viewWidth <= 0) {
+      return false;
+    }
+
+    final candidateSpeed =
+        (viewWidth + candidateWidth) / durationSeconds;
+    for (final item in existing) {
+      final existingRight = item.x + item.width;
+      if (candidateX < existingRight + gap) {
+        return false;
+      }
+
+      final existingSpeed = (viewWidth + item.width) / durationSeconds;
+      if (candidateSpeed <= existingSpeed) {
+        continue;
+      }
+
+      final separation = candidateX - existingRight - gap;
+      final catchUpSeconds = separation / (candidateSpeed - existingSpeed);
+      final existingExitSeconds = existingRight / existingSpeed;
+      if (catchUpSeconds < existingExitSeconds) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/packages/danmaku_canvas/lib/models/danmaku_item.dart
+++ b/packages/danmaku_canvas/lib/models/danmaku_item.dart
@@ -23,6 +23,12 @@ class DanmakuItem {
   /// 上次绘制时间
   int? lastDrawTick;
 
+  /// 顶部/底部弹幕剩余的视频时间。滚动与高级弹幕不使用。
+  double? remainingDurationSeconds;
+
+  /// 上次更新剩余生命周期时的墙钟 tick。
+  int? lastLifetimeTick;
+
   /// 弹幕布局缓存
   ui.Paragraph? paragraph;
   ui.Paragraph? strokeParagraph;
@@ -37,5 +43,7 @@ class DanmakuItem {
     this.paragraph,
     this.strokeParagraph,
     this.lastDrawTick,
+    this.remainingDurationSeconds,
+    this.lastLifetimeTick,
   });
 }

--- a/packages/danmaku_canvas/lib/scroll_danmaku_painter.dart
+++ b/packages/danmaku_canvas/lib/scroll_danmaku_painter.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'dart:ui' as ui;
 import 'models/danmaku_item.dart';
 import 'utils/utils.dart';
+import 'danmaku_timeline.dart';
 
 class ScrollDanmakuPainter extends CustomPainter {
   final double progress;
   final List<DanmakuItem> scrollDanmakuItems;
-  final int danmakuDurationInSeconds;
+  final double danmakuDurationInSeconds;
+  final double playbackRate;
   final double fontSize;
   final int fontWeight;
   final bool showStroke;
@@ -15,7 +17,6 @@ class ScrollDanmakuPainter extends CustomPainter {
   final int tick;
   final int batchThreshold;
 
-  final double totalDuration;
   final Paint selfSendPaint = Paint()
     ..style = PaintingStyle.stroke
     ..strokeWidth = 1.5
@@ -25,6 +26,7 @@ class ScrollDanmakuPainter extends CustomPainter {
     this.progress,
     this.scrollDanmakuItems,
     this.danmakuDurationInSeconds,
+    this.playbackRate,
     this.fontSize,
     this.fontWeight,
     this.showStroke,
@@ -32,7 +34,7 @@ class ScrollDanmakuPainter extends CustomPainter {
     this.running,
     this.tick, {
     this.batchThreshold = 10, // 默认值为10，可以自行调整
-  }) : totalDuration = danmakuDurationInSeconds * 1000;
+  });
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -45,10 +47,15 @@ class ScrollDanmakuPainter extends CustomPainter {
 
       for (var item in scrollDanmakuItems) {
         item.lastDrawTick ??= item.creationTime;
-        final endPosition = -item.width;
-        final distance = startPosition - endPosition;
-        item.xPosition = item.xPosition +
-            (((item.lastDrawTick! - tick) / totalDuration) * distance);
+        item.xPosition = CanvasDanmakuTimeline.advanceScrollX(
+          currentX: item.xPosition,
+          previousTick: item.lastDrawTick!,
+          currentTick: tick,
+          viewWidth: startPosition,
+          danmakuWidth: item.width,
+          durationSeconds: danmakuDurationInSeconds,
+          playbackRate: playbackRate,
+        );
 
         if (item.xPosition < -item.width || item.xPosition > size.width) {
           continue;
@@ -82,10 +89,15 @@ class ScrollDanmakuPainter extends CustomPainter {
       // 弹幕数量较少时直接绘制 (节约创建 canvas 的开销)
       for (var item in scrollDanmakuItems) {
         item.lastDrawTick ??= item.creationTime;
-        final endPosition = -item.width;
-        final distance = startPosition - endPosition;
-        item.xPosition = item.xPosition +
-            (((item.lastDrawTick! - tick) / totalDuration) * distance);
+        item.xPosition = CanvasDanmakuTimeline.advanceScrollX(
+          currentX: item.xPosition,
+          previousTick: item.lastDrawTick!,
+          currentTick: tick,
+          viewWidth: startPosition,
+          danmakuWidth: item.width,
+          durationSeconds: danmakuDurationInSeconds,
+          playbackRate: playbackRate,
+        );
 
         if (item.xPosition < -item.width || item.xPosition > size.width) {
           continue;

--- a/test/canvas_danmaku_timeline_test.dart
+++ b/test/canvas_danmaku_timeline_test.dart
@@ -1,0 +1,428 @@
+import 'package:danmaku_canvas/canvas_danmaku_renderer.dart';
+import 'package:danmaku_canvas/danmaku_controller.dart';
+import 'package:danmaku_canvas/danmaku_screen.dart';
+import 'package:danmaku_canvas/danmaku_timeline.dart';
+import 'package:danmaku_canvas/models/danmaku_content_item.dart';
+import 'package:danmaku_canvas/models/danmaku_option.dart';
+import 'package:danmaku_canvas/scroll_danmaku_painter.dart';
+import 'package:danmaku_canvas/static_danmaku_painter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CanvasDanmakuTimeline', () {
+    test('explicit seek revision catches a sub-two-second seek', () {
+      expect(
+        CanvasDanmakuTimeline.didSeek(
+          previousRevision: 4,
+          currentRevision: 5,
+          previousTime: 20,
+          currentTime: 20.5,
+        ),
+        isTrue,
+      );
+      expect(
+        CanvasDanmakuTimeline.didSeek(
+          previousRevision: 5,
+          currentRevision: 5,
+          previousTime: 20,
+          currentTime: 25,
+        ),
+        isFalse,
+      );
+    });
+
+    test('fallback seek detection remains available without a revision', () {
+      expect(
+        CanvasDanmakuTimeline.didSeek(
+          previousRevision: -1,
+          currentRevision: -1,
+          previousTime: 20,
+          currentTime: 22.1,
+        ),
+        isTrue,
+      );
+    });
+
+    test('active restoration keeps and sorts more than one batch', () {
+      final entries = List.generate(
+        45,
+        (index) => <String, dynamic>{'time': 10 - index / 10},
+      );
+      final active = CanvasDanmakuTimeline.activeEntries(
+        entries,
+        timeOf: (entry) => (entry['time'] as num).toDouble(),
+        currentTime: 10,
+        lookBackSeconds: 10,
+      );
+
+      expect(active, hasLength(45));
+      for (var index = 1; index < active.length; index++) {
+        expect(
+          active[index - 1]['time'],
+          lessThanOrEqualTo(active[index]['time']),
+        );
+      }
+    });
+
+    test('rate changes affect only subsequent incremental movement', () {
+      final atOneX = CanvasDanmakuTimeline.advanceScrollX(
+        currentX: 800,
+        previousTick: 0,
+        currentTick: 1000,
+        viewWidth: 800,
+        danmakuWidth: 200,
+        durationSeconds: 10,
+        playbackRate: 1,
+      );
+      final nextAtTwoX = CanvasDanmakuTimeline.advanceScrollX(
+        currentX: atOneX,
+        previousTick: 1000,
+        currentTick: 2000,
+        viewWidth: 800,
+        danmakuWidth: 200,
+        durationSeconds: 10,
+        playbackRate: 2,
+      );
+
+      expect(atOneX, 700);
+      expect(nextAtTwoX, 500);
+    });
+
+    test('fixed lifetime consumes wall time at the current rate', () {
+      expect(
+        CanvasDanmakuTimeline.consumeLifetime(
+          remainingSeconds: 1,
+          wallSeconds: 0.6,
+          playbackRate: 2,
+        ),
+        closeTo(-0.2, 0.0001),
+      );
+    });
+
+    test('lowerBound locates the first entry at or after the target', () {
+      final entries = List.generate(
+        10,
+        (index) => <String, dynamic>{'time': index * 1.0},
+      );
+      double timeOf(Map<String, dynamic> entry) =>
+          (entry['time'] as num).toDouble();
+
+      // 目标落在区间内：返回第一个 >= 目标的下标
+      expect(CanvasDanmakuTimeline.lowerBound(entries, 4.5, timeOf: timeOf), 5);
+      // 目标恰好命中元素：返回该元素下标
+      expect(CanvasDanmakuTimeline.lowerBound(entries, 4.0, timeOf: timeOf), 4);
+      // 目标小于所有元素：返回 0
+      expect(CanvasDanmakuTimeline.lowerBound(entries, -1, timeOf: timeOf), 0);
+      // 目标大于所有元素：返回 length（空窗口）
+      expect(CanvasDanmakuTimeline.lowerBound(entries, 100, timeOf: timeOf), 10);
+      // 空列表返回 0
+      expect(
+        CanvasDanmakuTimeline.lowerBound(
+          const <Map<String, dynamic>>[],
+          0,
+          timeOf: timeOf,
+        ),
+        0,
+      );
+    });
+  });
+
+  group('ScrollDanmakuCollision', () {
+    test('rejects overlap at a seek-restored x position', () {
+      expect(
+        ScrollDanmakuCollision.canPlace(
+          existing: const [(x: 760.0, width: 200.0)],
+          candidateX: 880,
+          candidateWidth: 200,
+          viewWidth: 1000,
+          durationSeconds: 10,
+        ),
+        isFalse,
+      );
+    });
+
+    test('accepts a candidate that cannot catch the previous item', () {
+      expect(
+        ScrollDanmakuCollision.canPlace(
+          existing: const [(x: 400.0, width: 300.0)],
+          candidateX: 900,
+          candidateWidth: 100,
+          viewWidth: 1000,
+          durationSeconds: 10,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  testWidgets('speed boost and release preserve the active danmaku',
+      (tester) async {
+    final danmaku = [
+      <String, dynamic>{
+        'time': 0.0,
+        'content': 'rate-continuity',
+        'type': 'scroll',
+      },
+    ];
+    await tester.pumpWidget(_rendererHost(danmakuList: danmaku));
+    await tester.pump();
+    final original = tester.element(find.byType(DanmakuScreen));
+    final originalItem = _scrollPainter(tester).scrollDanmakuItems.single;
+
+    await tester.pumpWidget(
+      _rendererHost(danmakuList: danmaku, playbackRate: 2),
+    );
+    await tester.pump();
+
+    expect(tester.element(find.byType(DanmakuScreen)), same(original));
+    expect(_scrollPainter(tester).scrollDanmakuItems.single, same(originalItem));
+
+    await tester.pumpWidget(_rendererHost(danmakuList: danmaku));
+    await tester.pump();
+
+    expect(tester.element(find.byType(DanmakuScreen)), same(original));
+    expect(_scrollPainter(tester).scrollDanmakuItems.single, same(originalItem));
+  });
+
+  testWidgets('renderer initializes safely while playback is paused',
+      (tester) async {
+    final danmaku = [
+      <String, dynamic>{
+        'time': 0.0,
+        'content': 'paused-start',
+        'type': 'scroll',
+      },
+    ];
+
+    await tester.pumpWidget(
+      _rendererHost(danmakuList: danmaku, isPlaying: false),
+    );
+    await tester.pump();
+
+    expect(_scrollPainter(tester).scrollDanmakuItems, hasLength(1));
+  });
+
+  testWidgets('an in-place list clear removes active danmaku', (tester) async {
+    final danmaku = [
+      <String, dynamic>{
+        'time': 0.0,
+        'content': 'removed-entry',
+        'type': 'scroll',
+      },
+    ];
+    await tester.pumpWidget(_rendererHost(danmakuList: danmaku));
+    await tester.pump();
+    expect(_scrollPainter(tester).scrollDanmakuItems, hasLength(1));
+
+    danmaku.clear();
+    await tester.pumpWidget(
+      _rendererHost(danmakuList: danmaku, danmakuListVersion: 2),
+    );
+    await tester.pump();
+
+    expect(_scrollPainter(tester).scrollDanmakuItems, isEmpty);
+  });
+
+  testWidgets('showing after a hidden rate change uses a fresh controller',
+      (tester) async {
+    final danmaku = [
+      <String, dynamic>{
+        'time': 0.0,
+        'content': 'visibility-rate',
+        'type': 'scroll',
+      },
+    ];
+    await tester.pumpWidget(_rendererHost(danmakuList: danmaku));
+    await tester.pump();
+
+    await tester.pumpWidget(
+      _rendererHost(
+        danmakuList: danmaku,
+        playbackRate: 2,
+        visible: false,
+      ),
+    );
+    await tester.pump();
+    expect(find.byType(DanmakuScreen), findsNothing);
+
+    await tester.pumpWidget(
+      _rendererHost(danmakuList: danmaku, playbackRate: 2),
+    );
+    await tester.pump();
+
+    expect(_scrollPainter(tester).scrollDanmakuItems, hasLength(1));
+  });
+
+  testWidgets('explicit small seek restores the scrolling x position',
+      (tester) async {
+    final danmaku = [
+      <String, dynamic>{
+        'time': 0.0,
+        'content': 'seek-position',
+        'type': 'scroll',
+      },
+    ];
+    await tester.pumpWidget(
+      _rendererHost(danmakuList: danmaku, isPlaying: false),
+    );
+    await tester.pump();
+
+    await tester.pumpWidget(
+      _rendererHost(
+        danmakuList: danmaku,
+        currentTime: 0.5,
+        seekRevision: 1,
+        isPlaying: false,
+      ),
+    );
+    await tester.pump();
+
+    final painter = _scrollPainter(tester);
+    final item = painter.scrollDanmakuItems.single;
+    final viewWidth = tester.getSize(find.byType(DanmakuScreen)).width;
+    final expectedX = viewWidth - 0.05 * (viewWidth + item.width);
+    expect(item.xPosition, closeTo(expectedX, 0.01));
+  });
+
+  testWidgets('seek restoration drains every active candidate',
+      (tester) async {
+    final danmaku = List.generate(
+      30,
+      (index) => <String, dynamic>{
+        'time': 9.0,
+        'content': 'dense-$index',
+        'type': 'scroll',
+      },
+    );
+    await tester.pumpWidget(
+      _rendererHost(
+        danmakuList: danmaku,
+        currentTime: 10,
+        stacking: true,
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(_scrollPainter(tester).scrollDanmakuItems, hasLength(30));
+  });
+
+  testWidgets('paused seek restores fixed danmaku with remaining lifetime',
+      (tester) async {
+    late DanmakuController controller;
+    final option = DanmakuOption(duration: 10, playbackRate: 1);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 800,
+          height: 400,
+          child: DanmakuScreen(
+            option: option,
+            createdController: (value) => controller = value,
+          ),
+        ),
+      ),
+    );
+    controller.pause();
+    controller.addDanmaku(
+      DanmakuContentItem('fixed', type: DanmakuItemType.top),
+      elapsedSeconds: 9,
+    );
+    await tester.pump();
+
+    final restored = _staticPainter(tester).topDanmakuItems.single;
+    expect(restored.remainingDurationSeconds, closeTo(1, 0.01));
+  });
+
+  testWidgets('addDanmaku reports whether a danmaku actually mounted',
+      (tester) async {
+    late DanmakuController controller;
+    // area 0.0 表示单行模式：始终只有 1 条轨道，
+    // 便于构造"轨道已占用 → 上屏失败"的场景。
+    final option = DanmakuOption(duration: 10, playbackRate: 1, area: 0.0);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 800,
+          height: 40,
+          child: DanmakuScreen(
+            option: option,
+            createdController: (value) => controller = value,
+          ),
+        ),
+      ),
+    );
+
+    // 空轨道：第一条顶部弹幕成功上屏
+    expect(
+      controller.addDanmaku(DanmakuContentItem('first', type: DanmakuItemType.top)),
+      isTrue,
+    );
+    await tester.pump();
+    expect(_staticPainter(tester).topDanmakuItems, hasLength(1));
+
+    // 轨道已占用：第二条被丢弃并如实返回 false，
+    // 调用方据此不应把它记入"已添加"去重表，否则其后续重放会缺失。
+    expect(
+      controller.addDanmaku(DanmakuContentItem('second', type: DanmakuItemType.top)),
+      isFalse,
+    );
+    await tester.pump();
+    expect(_staticPainter(tester).topDanmakuItems, hasLength(1));
+  });
+}
+
+Widget _rendererHost({
+  required List<Map<String, dynamic>> danmakuList,
+  double currentTime = 0,
+  double playbackRate = 1,
+  int seekRevision = 0,
+  bool stacking = false,
+  bool isPlaying = true,
+  int danmakuListVersion = 1,
+  bool visible = true,
+}) {
+  return MaterialApp(
+    home: Center(
+      child: SizedBox(
+        width: 800,
+        height: 400,
+        child: CanvasDanmakuRenderer(
+          fontSize: 16,
+          opacity: 1,
+          displayArea: 1,
+          visible: visible,
+          stacking: stacking,
+          mergeDanmaku: false,
+          blockTopDanmaku: false,
+          blockBottomDanmaku: false,
+          blockScrollDanmaku: false,
+          blockWords: const [],
+          danmakuList: danmakuList,
+          currentTime: currentTime,
+          isPlaying: isPlaying,
+          playbackRate: playbackRate,
+          scrollDurationSeconds: 10,
+          seekRevision: seekRevision,
+          danmakuListVersion: danmakuListVersion,
+          timeOffsetSeconds: 0,
+        ),
+      ),
+    ),
+  );
+}
+
+ScrollDanmakuPainter _scrollPainter(WidgetTester tester) => tester
+    .widgetList<CustomPaint>(find.byType(CustomPaint))
+    .map((paint) => paint.painter)
+    .whereType<ScrollDanmakuPainter>()
+    .single;
+
+StaticDanmakuPainter _staticPainter(WidgetTester tester) => tester
+    .widgetList<CustomPaint>(find.byType(CustomPaint))
+    .map((paint) => paint.painter)
+    .whereType<StaticDanmakuPainter>()
+    .single;


### PR DESCRIPTION
### 摘要
本次修复集中在 Canvas 弹幕渲染引擎（`packages/danmaku_canvas` + 少量 `lib/` 接线），共 1 个合并提交，解决三个问题：**长按倍速/松手时弹幕整体重加载**、**拖动进度条（seek）后弹幕从屏幕右侧重新滑入而非直接出现在正确位置**、以及 **seek 恢复后弹幕播完即不再显示**；顺带做了**空闲耗电优化**和**恢复稳定性加固**。

**影响范围仅限 Canvas 弹幕引擎，不触及 GPU / Next / Next2 / DFM+ 等其他弹幕内核。**

### 改动明细
（合并自 `2836a420` / `2c13da67` / `5eb50f5a` / `f6b298f3`）

- **倍速**：`playbackRate` 不再作为 `DanmakuScreen` 重建条件，新增 `_syncPlaybackRateOnly()` 只更新动画时长，长按倍速/松手时已上屏弹幕从当前位置平滑加减速，不重载不瞬移。
- **seek 恢复**：新增 `CanvasDanmakuTimeline`（`advanceScrollX` 墙钟运动 / `scrollProgress` 恢复定位 / `remainingLifetime` 顶底生命周期）与 `ScrollDanmakuCollision` 追尾碰撞模型；`VideoPlayerState` 新增 `seekRevision` 精确标记 seek；恢复走分批 + 锚定 seek 时刻 + 重试上限。
- **回归修复**：修复 seek 恢复后弹幕播完不再显示的问题——`_lastCurrentTime` 只在真正处理时更新，恢复正常播放的窗口处理语义。
- **稳定性与省电**：`addDanmaku` 返回真实上屏结果，去重表只记录成功上屏；轨道冲突重试上限 3 次防死循环；正常窗口二分定位起点；100ms 清理定时器按需启停，无弹幕在屏时零定时唤醒、空闲自动停滚动动画控制器。

### 影响范围
- **引擎隔离**：`danmaku_overlay.dart` 仅在 `canvas` 分支新增 `seekRevision / danmakuListVersion / timeOffsetSeconds` 传参，GPU/Next/Next2/DFM+ 分支未动；`_seekRevision` 是纯加性字段，仅 canvas 消费，其他引擎无行为变化。
- **依赖封闭**：`DanmakuController` 签名改动封闭在 `danmaku_canvas` 包内。

### 测试
- 新增 `test/canvas_danmaku_timeline_test.dart`（428 行），覆盖 `didSeek` / `lowerBound` / `scrollProgress` / `consumeLifetime` / 碰撞模型。

### 已知取舍
- 暂停状态下恢复的弹幕会因轨道永不腾空而丢弃（重试 3 次上限），属防死循环的有意取舍。
