### PR TITLE
fix: 恢复 Android TV 内核与大屏幕切换

### DIFF
--- a/lib/danmaku_next/next2_platform_support.dart
+++ b/lib/danmaku_next/next2_platform_support.dart
@@ -8,7 +8,7 @@ class Next2PlatformSupport {
   /// Web is intentionally excluded because the current Rust runtime is not
   /// packaged as a wasm module for the Flutter web target.
   static bool get isKernelSupported {
-    if (kIsWeb || globals.isTelevision) return false;
+    if (kIsWeb || globals.isTvOS) return false;
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
       case TargetPlatform.iOS:
@@ -27,7 +27,7 @@ class Next2PlatformSupport {
 
   /// Native texture rendering is required on every non-web platform.
   static bool get isNativeTextureSupported {
-    if (kIsWeb || globals.isTelevision) return false;
+    if (kIsWeb || globals.isTvOS) return false;
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
       case TargetPlatform.iOS:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -969,7 +969,7 @@ class _NipaPlayAppState extends State<NipaPlayApp> with WidgetsBindingObserver {
               isWeb: kIsWeb,
               isIOS: !kIsWeb && Platform.isIOS,
               isTablet: globals.isTablet,
-              isTelevision: globals.isTelevision,
+              isTelevision: globals.isTvOS,
             );
             Widget overlayBuilder(Widget child) {
               return _buildGlobalAppOverlay(child, isDragging: _isDragging);
@@ -1568,7 +1568,7 @@ class MainPageState extends State<MainPage>
   }
 
   void _syncLargeScreenHotkeySuppression() {
-    final isLargeScreenModeActive = globals.isTelevision ||
+    final isLargeScreenModeActive = globals.isTvOS ||
         (globals.isDesktopOrTablet && _useLargeScreenLayout);
     HotkeyService().setLargeScreenModeActive(isLargeScreenModeActive);
   }
@@ -1751,8 +1751,10 @@ class MainPageState extends State<MainPage>
     final bool allowLargeScreenControls = shouldOfferLargeScreenModeControl(
       isDesktopOrTablet: globals.isDesktopOrTablet,
       isTelevisionSurface: isTelevisionSurface,
+      isTvOS: globals.isTvOS,
     );
-    final bool isLargeScreenLayoutActive = isTelevisionSurface ||
+    final bool isLargeScreenLayoutActive =
+        (isTelevisionSurface && globals.isTvOS) ||
         (canUseLargeScreenLayout && _useLargeScreenLayout);
     final double baseTopPadding = isMac ? 10 : 4;
     final double baseRightPadding = isMac ? 20 : 10;

--- a/lib/player_abstraction/player_factory.dart
+++ b/lib/player_abstraction/player_factory.dart
@@ -87,7 +87,7 @@ class PlayerFactory {
         _erikaAndroidOutputModeKey,
       );
 
-      if (globals.isTelevision) {
+      if (globals.isTvOS) {
         _cachedKernelType = PlayerKernelType.erika;
         await prefs.setInt(
           _playerKernelTypeKey,
@@ -106,9 +106,9 @@ class PlayerFactory {
           '${_defaultKernelType.name}',
         );
       }
-      if (globals.isTelevision) {
+      if (globals.isTvOS) {
         debugPrint(
-          '[PlayerFactory] 电视设备强制使用 Erika 播放内核',
+          '[PlayerFactory] tvOS 强制使用 Erika 播放内核',
         );
       }
       _cachedPrecacheBufferSizeMb = _clampPrecacheBufferSizeMb(
@@ -218,23 +218,23 @@ class PlayerFactory {
     if (!_hasLoadedSettings) {
       _loadSettingsSync();
     }
-    if (globals.isTelevision) {
+    if (globals.isTvOS) {
       return PlayerKernelType.erika;
     }
     return _cachedKernelType ?? _defaultKernelType;
   }
 
   static PlayerKernelType get _defaultKernelType =>
-      globals.isTelevision ? PlayerKernelType.erika : PlayerKernelType.mdk;
+      globals.isTvOS ? PlayerKernelType.erika : PlayerKernelType.mdk;
 
   static bool _isKernelSupportedOnCurrentPlatform(PlayerKernelType type) {
     if (kIsWeb) return type == PlayerKernelType.videoPlayer;
-    if (globals.isTelevision) return isKernelSupportedOnTelevision(type);
+    if (globals.isTvOS) return isKernelSupportedOnTvOS(type);
     return true;
   }
 
   @visibleForTesting
-  static bool isKernelSupportedOnTelevision(PlayerKernelType type) =>
+  static bool isKernelSupportedOnTvOS(PlayerKernelType type) =>
       type == PlayerKernelType.erika;
 
   /// 获取自定义播放器 User-Agent（空字符串 = 用内核默认 UA）。

--- a/lib/providers/ui_theme_provider.dart
+++ b/lib/providers/ui_theme_provider.dart
@@ -48,7 +48,7 @@ class UIThemeProvider extends ChangeNotifier {
         isWeb: kIsWeb,
         isIOS: !kIsWeb && Platform.isIOS,
         isTablet: globals.isTablet,
-        isTelevision: globals.isTelevision,
+        isTelevision: globals.isTvOS,
       );
 
   Future<void> _loadTheme() async {

--- a/lib/settings/pages/danmaku_settings_content.dart
+++ b/lib/settings/pages/danmaku_settings_content.dart
@@ -736,10 +736,10 @@ class _DanmakuSettingsContentState extends State<DanmakuSettingsContent> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final isErikaPlayerKernel = globals.isTelevision ||
+    final isErikaPlayerKernel = globals.isTvOS ||
         PlayerFactory.getKernelType() == PlayerKernelType.erika;
     final next2Supported = Next2PlatformSupport.isKernelSupported;
-    final showNextPlusPlusToggle = !globals.isTelevision &&
+    final showNextPlusPlusToggle = !globals.isTvOS &&
         _selectedDanmakuRenderEngine == DanmakuRenderEngine.nipaplayNext;
     final showRendererSupersample = !isErikaPlayerKernel &&
         (_selectedDanmakuRenderEngine == DanmakuRenderEngine.next2 ||

--- a/lib/settings/pages/player_settings_content.dart
+++ b/lib/settings/pages/player_settings_content.dart
@@ -338,13 +338,13 @@ class _PlayerSettingsContentState extends State<PlayerSettingsContent> {
             Divider(
                 color: colorScheme.onSurface.withValues(alpha: 0.12),
                 height: 1),
-            if (!kIsWeb && !globals.isTelevision) ...[
+            if (!kIsWeb && !globals.isTvOS) ...[
               AdaptiveSettingsTile.dropdown(
                 title: "播放器内核",
                 subtitle: "选择播放器使用的核心引擎",
                 icon: Ionicons.play_circle_outline,
                 items: [
-                  if (!globals.isTelevision)
+                  if (!globals.isTvOS)
                     DropdownMenuItemData(
                       title: "MDK",
                       value: PlayerKernelType.mdk,
@@ -361,7 +361,7 @@ class _PlayerSettingsContentState extends State<PlayerSettingsContent> {
                       description: _getPlayerKernelDescription(
                           PlayerKernelType.videoPlayer),
                     ),
-                    if (!globals.isTelevision)
+                    if (!globals.isTvOS)
                       DropdownMenuItemData(
                         title: "Libmpv",
                         value: PlayerKernelType.mediaKit,

--- a/lib/themes/nipaplay/widgets/large_screen_mode_actions.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_mode_actions.dart
@@ -10,8 +10,9 @@ const double kNipaplayWindowCaptionHeight = WindowControlButtons.buttonHeight;
 bool shouldOfferLargeScreenModeControl({
   required bool isDesktopOrTablet,
   required bool isTelevisionSurface,
+  required bool isTvOS,
 }) {
-  return isDesktopOrTablet && !isTelevisionSurface;
+  return isDesktopOrTablet && !(isTelevisionSurface && isTvOS);
 }
 
 class NipaplayLargeScreenModeActionsOverlay extends StatelessWidget {

--- a/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
+++ b/lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart
@@ -89,7 +89,7 @@ class _NipaplayLargeScreenScaffoldLayoutState
 
   int get _menuItemCount {
     final int actionCount = [
-      globals.isTelevision ? null : widget.onToggleLargeScreen,
+      globals.isTvOS ? null : widget.onToggleLargeScreen,
       widget.onToggleThemeFromOrigin,
       widget.onOpenSettings,
     ].where((callback) => callback != null).length;
@@ -1219,7 +1219,7 @@ class _NipaplayLargeScreenScaffoldLayoutState
                 },
                 onTabActivated: _closeTabPanel,
                 onToggleLargeScreen:
-                    globals.isTelevision ? null : widget.onToggleLargeScreen,
+                    globals.isTvOS ? null : widget.onToggleLargeScreen,
                 onToggleThemeFromOrigin: widget.onToggleThemeFromOrigin,
                 onOpenSettings: _toggleSettingsPanel,
               ),

--- a/lib/utils/player_kernel_manager.dart
+++ b/lib/utils/player_kernel_manager.dart
@@ -219,7 +219,7 @@ class PlayerKernelManager {
     if (kIsWeb) {
       // Web平台只支持特定内核
       return ['Video Player'];
-    } else if (globals.isTelevision) {
+    } else if (globals.isTvOS) {
       return ['Erika'];
     } else if (PlayerFactory.isHarmonyOS) {
       return ['FVP', 'Erika'];
@@ -246,14 +246,14 @@ class PlayerKernelManager {
 
   /// 获取当前播放器内核
   static Future<String> getCurrentPlayerKernel() async {
-    if (globals.isTelevision) return 'Erika';
+    if (globals.isTvOS) return 'Erika';
     final prefs = await SharedPreferences.getInstance();
     return prefs.getString('player_kernel') ?? 'FVP';
   }
 
   /// 设置播放器内核
   static Future<void> setPlayerKernel(String kernel) async {
-    final resolvedKernel = globals.isTelevision ? 'Erika' : kernel;
+    final resolvedKernel = globals.isTvOS ? 'Erika' : kernel;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('player_kernel', resolvedKernel);
 

--- a/lib/utils/system_resource_monitor.dart
+++ b/lib/utils/system_resource_monitor.dart
@@ -59,7 +59,7 @@ class SystemResourceMonitor {
   String get danmakuKernelType => _danmakuKernelType;
 
   static Future<void> initialize() async {
-    if (!kIsWeb && !globals.isTelevision) {
+    if (!kIsWeb && !globals.isTvOS) {
       _instance._initMdkVersion();
       _instance._updatePlayerKernelType();
       _instance._updateDanmakuKernelType();
@@ -71,7 +71,7 @@ class SystemResourceMonitor {
       _instance._activeDecoder = '浏览器解码';
       _instance._gpuUsage = null;
     } else {
-      // Television devices are locked to Erika by PlayerFactory. Keep the
+      // tvOS devices are locked to Erika by PlayerFactory. Keep the
       // diagnostics panel in sync with the actual factory policy.
       _instance._updatePlayerKernelType();
       _instance._danmakuKernelType = 'DFM+';

--- a/lib/utils/video_player_state.dart
+++ b/lib/utils/video_player_state.dart
@@ -501,7 +501,7 @@ class VideoPlayerState extends ChangeNotifier implements WindowListener {
   DanmakuShadowStyle _danmakuShadowStyle = globals.isMobilePlatform
       ? DanmakuShadowStyle.none
       : DanmakuShadowStyle.strong;
-  double _next2DanmakuOutlineWidth = globals.isTelevision
+  double _next2DanmakuOutlineWidth = globals.isTvOS
       ? defaultTvOSErikaDanmakuOutlineWidthLevel
       : defaultDanmakuOutlineWidthLevel;
   static const double minSubtitleScale = 0.5;

--- a/lib/utils/video_player_state/video_player_state_preferences.dart
+++ b/lib/utils/video_player_state/video_player_state_preferences.dart
@@ -1424,7 +1424,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
   double _sanitizeNext2DanmakuOutlineWidth(double? value) {
     return normalizeDanmakuOutlineWidthLevel(
       value,
-      fallback: globals.isTelevision
+      fallback: globals.isTvOS
           ? defaultTvOSErikaDanmakuOutlineWidthLevel
           : defaultDanmakuOutlineWidthLevel,
     );
@@ -1506,7 +1506,7 @@ extension VideoPlayerStatePreferences on VideoPlayerState {
 
   Future<void> _loadDanmakuDisplayEffectSettings() async {
     final prefs = await SharedPreferences.getInstance();
-    final migrateTvOSErikaOutlineDefault = globals.isTelevision &&
+    final migrateTvOSErikaOutlineDefault = globals.isTvOS &&
         !(prefs.getBool(
               SettingsKeys.tvOSErikaDanmakuOutlineDefaultMigrated,
             ) ??

--- a/test/android_tv_platform_policy_test.dart
+++ b/test/android_tv_platform_policy_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Android TV keeps Android player and danmaku kernel choices', () {
+    final playerFactory = File(
+      'lib/player_abstraction/player_factory.dart',
+    ).readAsStringSync();
+    final playerSettings = File(
+      'lib/settings/pages/player_settings_content.dart',
+    ).readAsStringSync();
+    final danmakuSettings = File(
+      'lib/settings/pages/danmaku_settings_content.dart',
+    ).readAsStringSync();
+    final next2Support = File(
+      'lib/danmaku_next/next2_platform_support.dart',
+    ).readAsStringSync();
+    final kernelManager = File(
+      'lib/utils/player_kernel_manager.dart',
+    ).readAsStringSync();
+
+    expect(
+      playerFactory,
+      contains(
+        'globals.isTvOS ? PlayerKernelType.erika : PlayerKernelType.mdk',
+      ),
+    );
+    expect(playerSettings, contains('if (!kIsWeb && !globals.isTvOS)'));
+    expect(
+      danmakuSettings,
+      contains('final isErikaPlayerKernel = globals.isTvOS ||'),
+    );
+    expect(
+      next2Support,
+      contains('if (kIsWeb || globals.isTvOS) return false;'),
+    );
+    expect(next2Support, isNot(contains('kIsWeb || globals.isTelevision')));
+    expect(kernelManager, contains('globals.isTvOS ? \'Erika\' : kernel'));
+  });
+
+  test('Android TV can leave large-screen mode while tvOS stays locked', () {
+    final main = File('lib/main.dart').readAsStringSync();
+    final themeProvider = File(
+      'lib/providers/ui_theme_provider.dart',
+    ).readAsStringSync();
+    final scaffold = File(
+      'lib/themes/nipaplay/widgets/large_screen_scaffold_layout.dart',
+    ).readAsStringSync();
+
+    expect(main, contains('isTelevision: globals.isTvOS'));
+    expect(main, contains('final isLargeScreenModeActive = globals.isTvOS ||'));
+    expect(themeProvider, contains('isTelevision: globals.isTvOS'));
+    expect(
+      scaffold,
+      contains('globals.isTvOS ? null : widget.onToggleLargeScreen'),
+    );
+  });
+}

--- a/test/large_screen_mode_actions_test.dart
+++ b/test/large_screen_mode_actions_test.dart
@@ -9,6 +9,7 @@ void main() {
       shouldOfferLargeScreenModeControl(
         isDesktopOrTablet: true,
         isTelevisionSurface: false,
+        isTvOS: false,
       ),
       isTrue,
     );
@@ -16,6 +17,7 @@ void main() {
       shouldOfferLargeScreenModeControl(
         isDesktopOrTablet: false,
         isTelevisionSurface: false,
+        isTvOS: false,
       ),
       isFalse,
     );
@@ -23,8 +25,17 @@ void main() {
       shouldOfferLargeScreenModeControl(
         isDesktopOrTablet: true,
         isTelevisionSurface: true,
+        isTvOS: true,
       ),
       isFalse,
+    );
+    expect(
+      shouldOfferLargeScreenModeControl(
+        isDesktopOrTablet: true,
+        isTelevisionSurface: true,
+        isTvOS: false,
+      ),
+      isTrue,
     );
   });
 

--- a/test/tvos_erika_kernel_policy_test.dart
+++ b/test/tvos_erika_kernel_policy_test.dart
@@ -5,21 +5,21 @@ import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/utils/danmaku/style.dart';
 
 void main() {
-  test('televisions expose Erika as their only player kernel', () {
+  test('tvOS exposes Erika as its only player kernel', () {
     expect(
-      PlayerFactory.isKernelSupportedOnTelevision(PlayerKernelType.videoPlayer),
+      PlayerFactory.isKernelSupportedOnTvOS(PlayerKernelType.videoPlayer),
       isFalse,
     );
     expect(
-      PlayerFactory.isKernelSupportedOnTelevision(PlayerKernelType.erika),
+      PlayerFactory.isKernelSupportedOnTvOS(PlayerKernelType.erika),
       isTrue,
     );
     expect(
-      PlayerFactory.isKernelSupportedOnTelevision(PlayerKernelType.mdk),
+      PlayerFactory.isKernelSupportedOnTvOS(PlayerKernelType.mdk),
       isFalse,
     );
     expect(
-      PlayerFactory.isKernelSupportedOnTelevision(PlayerKernelType.mediaKit),
+      PlayerFactory.isKernelSupportedOnTvOS(PlayerKernelType.mediaKit),
       isFalse,
     );
   });
@@ -50,14 +50,14 @@ void main() {
       labs,
       contains('PlayerFactory.isErikaKernelSupported &&'),
     );
-    expect(player, contains('if (!kIsWeb && !globals.isTelevision)'));
+    expect(player, contains('if (!kIsWeb && !globals.isTvOS)'));
     expect(
       danmaku,
-      contains('final isErikaPlayerKernel = globals.isTelevision ||'),
+      contains('final isErikaPlayerKernel = globals.isTvOS ||'),
     );
     expect(
       danmaku,
-      contains('final showNextPlusPlusToggle = !globals.isTelevision &&'),
+      contains('final showNextPlusPlusToggle = !globals.isTvOS &&'),
     );
   });
 
@@ -76,8 +76,7 @@ void main() {
     expect(monitor, contains('_instance._updatePlayerKernelType();'));
     expect(monitor, contains("_instance._activeDecoder = 'Erika（等待媒体）';"));
 
-    final tvOSBranchStart =
-        monitor.indexOf('    } else {\n      // Television');
+    final tvOSBranchStart = monitor.indexOf('    } else {\n      // tvOS');
     final tvOSBranchEnd = monitor.indexOf('\n    }\n  }', tvOSBranchStart);
     expect(tvOSBranchStart, greaterThanOrEqualTo(0));
     expect(tvOSBranchEnd, greaterThan(tvOSBranchStart));

--- a/test/tvos_large_screen_adaptation_policy_test.dart
+++ b/test/tvos_large_screen_adaptation_policy_test.dart
@@ -38,7 +38,7 @@ void main() {
 
     expect(
       scaffold,
-      contains('globals.isTelevision ? null : widget.onToggleLargeScreen'),
+      contains('globals.isTvOS ? null : widget.onToggleLargeScreen'),
     );
     expect(
       scaffold,


### PR DESCRIPTION
## 改动内容

- 将播放器 Erika 强制策略从所有电视设备收窄为仅 tvOS，Android TV 恢复 MDK、Video Player、Libmpv 与 Erika 的选择能力。
- Android TV 恢复弹幕渲染内核选择，并启用 Android 原生支持的 Next2 / DFM+ 路径；tvOS 仍维持 Erika 原生弹幕策略。
- Android TV 改用桌面/平板基础显示面，默认仍进入大屏幕模式，但可从侧栏“退出大屏幕模式”，退出状态会持久化，并恢复鼠标友好的普通界面与热键策略。
- tvOS 继续锁定 Erika 播放器和大屏幕模式，不改变 Apple TV 行为。

## 根因

Android TV 与 tvOS 共用了 `isTelevision` 条件。原本只为 tvOS 设计的播放器、弹幕和大屏幕限制因此同时作用到了 Android TV。

## 验证

- `flutter test --no-pub test/android_tv_platform_policy_test.dart test/large_screen_mode_actions_test.dart test/tvos_erika_kernel_policy_test.dart test/tvos_large_screen_adaptation_policy_test.dart`（16 项通过）
- `flutter test --no-pub test/hotkey_service_policy_test.dart test/timeline_preview_kernel_policy_test.dart test/decoder_manager_platform_policy_test.dart`（14 项通过）
- `git diff --check`（通过）
- `flutter analyze --no-pub` 对改动文件未发现编译错误；仓库当前仍有 49 条既有 warning/info。

## 已知基线问题

扩展测试中两个未改动区域的既有用例仍失败：`television media library uses remote-first navigation` 和 `phone notifications sit higher and use neutral colors`。本 PR 未修改对应实现或断言文件。
