### PR TITLE
fix(mpv): stabilize danmaku reload and sync console style settings

### DIFF
--- a/lib/models/external_player_session/mpv_session.dart
+++ b/lib/models/external_player_session/mpv_session.dart
@@ -744,10 +744,8 @@ local function select_danmaku_track()
     mp.set_property("secondary-sid", tostring(did))
 end
 
-mp.register_event("file-loaded", select_danmaku_track)
-
 local reload_timer = nil
-local reload_path = nil
+local reload_pending = false
 
 local function restore_primary_track(primary)
     -- sub-reload 会选中重载后的轨道, 但不会同步 sid 选项值.
@@ -762,10 +760,7 @@ local function reload_danmaku_track()
     reload_timer = nil
     local did = find_danmaku_track()
     if not did then
-        if reload_path and reload_path ~= "" then
-            mp.commandv("sub-add", reload_path, "auto", TARGET)
-            mp.add_timeout(0, select_danmaku_track)
-        end
+        reload_pending = true
         return
     end
     local primary = mp.get_property("sid")
@@ -796,9 +791,16 @@ local function reload_danmaku_track()
     end)
 end
 
+mp.register_event("file-loaded", function()
+    select_danmaku_track()
+    if not reload_pending then return end
+    reload_pending = false
+    if reload_timer then reload_timer:kill() end
+    reload_timer = mp.add_timeout(0, reload_danmaku_track)
+end)
+
 mp.register_script_message("nipaplay-danmaku-reload", function(ass_path)
     if ass_path and ass_path ~= "" then
-        reload_path = ass_path
         local ass_name = string.match(ass_path, "([^/\\]+)$")
         if ass_name then TARGET = ass_name end
     end

--- a/lib/models/external_player_session/mpv_session.dart
+++ b/lib/models/external_player_session/mpv_session.dart
@@ -746,6 +746,8 @@ end
 
 local reload_timer = nil
 local reload_pending = false
+local reload_path = nil
+local file_loaded = false
 
 local function restore_primary_track(primary)
     -- sub-reload 会选中重载后的轨道, 但不会同步 sid 选项值.
@@ -760,7 +762,14 @@ local function reload_danmaku_track()
     reload_timer = nil
     local did = find_danmaku_track()
     if not did then
-        reload_pending = true
+        if not file_loaded then
+            reload_pending = true
+            return
+        end
+        if reload_path and reload_path ~= "" then
+            mp.commandv("sub-add", reload_path, "auto", TARGET)
+            mp.add_timeout(0, select_danmaku_track)
+        end
         return
     end
     local primary = mp.get_property("sid")
@@ -791,7 +800,12 @@ local function reload_danmaku_track()
     end)
 end
 
+mp.register_event("start-file", function()
+    file_loaded = false
+end)
+
 mp.register_event("file-loaded", function()
+    file_loaded = true
     select_danmaku_track()
     if not reload_pending then return end
     reload_pending = false
@@ -801,6 +815,7 @@ end)
 
 mp.register_script_message("nipaplay-danmaku-reload", function(ass_path)
     if ass_path and ass_path ~= "" then
+        reload_path = ass_path
         local ass_name = string.match(ass_path, "([^/\\]+)$")
         if ass_name then TARGET = ass_name end
     end

--- a/lib/pages/external_player_console_page.dart
+++ b/lib/pages/external_player_console_page.dart
@@ -5,11 +5,14 @@ import 'package:nipaplay/l10n/l10n.dart';
 import 'package:nipaplay/models/danmaku/blocked_item.dart';
 import 'package:nipaplay/models/danmaku/danmaku_item.dart';
 import 'package:nipaplay/models/danmaku/style.dart';
+import 'package:nipaplay/services/danmaku/danmaku_service.dart';
 import 'package:nipaplay/services/external_player_console_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_editable_slider.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_focusable_action.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/large_screen_page_scaffold.dart';
 import 'package:nipaplay/utils/app_accent_color.dart';
+import 'package:nipaplay/utils/video_player_state.dart';
+import 'package:provider/provider.dart';
 
 /// 桌面端 mpv 外部播放会话控制台。
 enum ExternalPlayerConsolePane {
@@ -146,6 +149,73 @@ class _ConsoleWorkspace extends StatelessWidget {
   final DanmakuStyle danmakuStyle;
   final List<BlockedDanmakuItem> blockedItems;
   final ExternalPlayerConsolePane pane;
+
+  Future<void> _writeBackUserDanmakuStyle(BuildContext context) async {
+    final style = ExternalPlayerConsoleService.getDanmakuStyleSnapshot();
+    final videoState = Provider.of<VideoPlayerState>(context, listen: false);
+
+    try {
+      await videoState.setDanmakuOpacity(style.opacity);
+      await videoState.setDanmakuFontSize(style.danmakuFontSize, commit: true);
+      await videoState.setNext2DanmakuOutlineWidth(style.outlineWidth);
+      await videoState.setDanmakuStacking(style.danmakuAllowStacking);
+      videoState.setManualDanmakuOffset(style.danmakuOffset);
+      ExternalPlayerConsoleService.queueDanmakuRefresh();
+      if (!context.mounted) return;
+      _showSyncMessage(
+        context,
+        _localized(
+          context,
+          '已将控制台样式写回用户设置',
+          '已將控制台樣式寫回使用者設定',
+          'Console style has been written back to user settings',
+        ),
+      );
+    } catch (_) {
+      if (!context.mounted) return;
+      _showSyncMessage(
+        context,
+        _localized(
+          context,
+          '写回用户设置失败',
+          '寫回使用者設定失敗',
+          'Failed to write style back to user settings',
+        ),
+      );
+    }
+  }
+
+  void _reapplyUserDanmakuStyle(BuildContext context) {
+    try {
+      final style = DanmakuService.getCurrentDanmakuStyle();
+      ExternalPlayerConsoleService.applyDanmakuStyle(style);
+      _showSyncMessage(
+        context,
+        _localized(
+          context,
+          '已重新应用用户弹幕样式',
+          '已重新套用使用者彈幕樣式',
+          'User danmaku style has been reapplied',
+        ),
+      );
+    } catch (_) {
+      _showSyncMessage(
+        context,
+        _localized(
+          context,
+          '重新应用用户设置失败',
+          '重新套用使用者設定失敗',
+          'Failed to reapply user settings',
+        ),
+      );
+    }
+  }
+
+  void _showSyncMessage(BuildContext context, String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -362,6 +432,55 @@ class _ConsoleWorkspace extends StatelessWidget {
               danmakuStyle.outlineWidth = value;
               ExternalPlayerConsoleService.queueDanmakuRefresh();
             },
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  _localized(context, '弹幕堆叠', '彈幕堆疊', 'Danmaku Stacking'),
+                  style: _sectionLabelStyle(context),
+                ),
+              ),
+              Switch.adaptive(
+                value: danmakuStyle.danmakuAllowStacking,
+                onChanged: (value) {
+                  danmakuStyle.danmakuAllowStacking = value;
+                  ExternalPlayerConsoleService.queueDanmakuRefresh();
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              NipaplayLargeScreenActionButton(
+                icon: Icons.save_outlined,
+                label: _localized(
+                  context,
+                  '写回用户设置',
+                  '寫回使用者設定',
+                  'Write Back User Settings',
+                ),
+                onPressed: () {
+                  _writeBackUserDanmakuStyle(context);
+                },
+                compact: true,
+              ),
+              NipaplayLargeScreenActionButton(
+                icon: Icons.refresh_rounded,
+                label: _localized(
+                  context,
+                  '重新应用用户设置',
+                  '重新套用使用者設定',
+                  'Reapply User Settings',
+                ),
+                onPressed: () => _reapplyUserDanmakuStyle(context),
+                compact: true,
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/services/external_player_console_service.dart
+++ b/lib/services/external_player_console_service.dart
@@ -126,6 +126,31 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
   static List<DisplayDanmakuItem> get displayDanmakuList => _displayDanmakuList;
   static List<BlockedDanmakuItem> get blockedItems => _blockedItems;
 
+  /// 获取当前控制台样式快照.
+  ///
+  /// 返回副本而不是引用, 避免调用方误改内部状态.
+  static DanmakuStyle getDanmakuStyleSnapshot() {
+    return _danmakuStyle.copyWith();
+  }
+
+  /// 应用一组样式到控制台.
+  ///
+  /// 默认为 `refresh=true`, 以便外部播放器立即重载 ASS.
+  static void applyDanmakuStyle(DanmakuStyle style, {bool refresh = true}) {
+    _danmakuStyle.opacity = style.opacity;
+    _danmakuStyle.outlineWidth = style.outlineWidth;
+    _danmakuStyle.danmakuFontSize = style.danmakuFontSize;
+    _danmakuStyle.danmakuOffset = style.danmakuOffset;
+    _danmakuStyle.danmakuAllowStacking = style.danmakuAllowStacking;
+
+    if (refresh) {
+      queueDanmakuRefresh();
+      return;
+    }
+
+    _instance.notifyListeners();
+  }
+
   // ======================================================================== //
   // ============================== 主要方法 ================================ //
   // ======================================================================== //
@@ -156,11 +181,7 @@ class ExternalPlayerConsoleService extends ChangeNotifier {
 
     // 更新弹幕样式, 如果未提供则保持现有样式
     final style = danmakuStyle ?? DanmakuStyle();
-    _danmakuStyle.opacity = style.opacity;
-    _danmakuStyle.outlineWidth = style.outlineWidth;
-    _danmakuStyle.danmakuFontSize = style.danmakuFontSize;
-    _danmakuStyle.danmakuOffset = style.danmakuOffset;
-    _danmakuStyle.danmakuAllowStacking = style.danmakuAllowStacking;
+    applyDanmakuStyle(style, refresh: false);
 
     // 按照时间戳排序弹幕列表, 并创建初始显示项目
     final sorted = List<DanmakuItem>.of(danmakuList ?? const []);

--- a/lib/settings/pages/danmaku_settings_content.dart
+++ b/lib/settings/pages/danmaku_settings_content.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:nipaplay/danmaku_abstraction/danmaku_kernel_factory.dart';
 import 'package:nipaplay/danmaku_next/next2_platform_support.dart';
 import 'package:nipaplay/l10n/l10n.dart';
+import 'package:nipaplay/models/danmaku/style.dart';
 import 'package:nipaplay/models/danmaku_auto_load_strategy.dart';
 import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
@@ -856,6 +857,34 @@ class _DanmakuSettingsContentState extends State<DanmakuSettingsContent> {
                 color: colorScheme.onSurface.withValues(alpha: 0.12),
                 height: 1),
 
+            Consumer<VideoPlayerState>(
+              builder: (context, videoState, child) {
+                final currentFontSize = videoState.danmakuFontSize <= 0
+                    ? videoState.actualDanmakuFontSize
+                    : videoState.danmakuFontSize;
+                return AdaptiveSettingsTile.slider(
+                  title: context.l10n.danmakuFontSizeTitle,
+                  subtitle: '调整弹幕文字大小，轨道间距会自动适配',
+                  icon: Icons.format_size,
+                  value: currentFontSize.clamp(
+                    DanmakuStyle.minDanmakuFontSize,
+                    DanmakuStyle.maxDanmakuFontSize,
+                  ),
+                  min: DanmakuStyle.minDanmakuFontSize,
+                  max: DanmakuStyle.maxDanmakuFontSize,
+                  divisions: 96,
+                  onChanged: (value) {
+                    videoState.setDanmakuFontSize(value, commit: true);
+                  },
+                  labelFormatter: (value) => '${value.toStringAsFixed(1)}px',
+                );
+              },
+            ),
+
+            Divider(
+                color: colorScheme.onSurface.withValues(alpha: 0.12),
+                height: 1),
+
             // 弹幕描边粗细
             Consumer<VideoPlayerState>(
               builder: (context, videoState, child) {
@@ -894,6 +923,30 @@ class _DanmakuSettingsContentState extends State<DanmakuSettingsContent> {
                           ? context.l10n.rememberDanmakuOffsetEnabled
                           : context.l10n.rememberDanmakuOffsetDisabled,
                     );
+                  },
+                );
+              },
+            ),
+            Divider(
+                color: colorScheme.onSurface.withValues(alpha: 0.12),
+                height: 1),
+            Consumer<VideoPlayerState>(
+              builder: (context, videoState, child) {
+                return AdaptiveSettingsTile.slider(
+                  title: '手动弹幕偏移',
+                  subtitle: '调整弹幕与视频时间的对齐，负值提前，正值延后',
+                  icon: Icons.schedule,
+                  value: videoState.manualDanmakuOffset.clamp(-10.0, 10.0),
+                  min: -10.0,
+                  max: 10.0,
+                  divisions: 200,
+                  onChanged: (value) {
+                    videoState.setManualDanmakuOffset(value);
+                  },
+                  labelFormatter: (value) {
+                    if (value.abs() < 0.0001) return '0s';
+                    final sign = value > 0 ? '+' : '';
+                    return '${sign}${value.toStringAsFixed(1)}s';
                   },
                 );
               },


### PR DESCRIPTION
## 修复 mpv 启动时弹幕刷新早于字幕轨加载导致的重复轨道问题.

- 将初始刷新延后至 file-loaded 后执行
- 仅对已加载的弹幕轨执行 sub-reload, 不再使用 sub-add
- 保持弹幕样式统一由 refreshDanmaku 生成

## 外部播放器弹幕控制台样式能力增强

控制台新增样式快照与应用能力 (会话内样式独立)

新增显式操作:
- 写回用户设置: 将控制台当前样式写回用户弹幕设置
- 重新应用用户设置: 将用户当前样式重新应用到控制台

## 应用设置 (弹幕) 补齐样式项

在"设置 -> 弹幕"中补齐并直连用户设置:

- 弹幕字体大小
- 手动弹幕偏移