### PR TITLE
feat: optionally auto-match Jellyfin series by hash

### DIFF
--- a/lib/constants/settings_keys.dart
+++ b/lib/constants/settings_keys.dart
@@ -11,6 +11,9 @@ class SettingsKeys {
 
   static const String autoMatchDanmakuOnPlay = 'danmaku_auto_match_on_play';
 
+  static const String autoMatchJellyfinSeries =
+      'jellyfin_auto_match_series_by_hash';
+
   static const String danmakuAutoLoadStrategy = 'danmaku_auto_load_strategy';
 
   static const String fastPlaybackStartup = 'fast_playback_startup';

--- a/lib/pages/dashboard_home_page.dart
+++ b/lib/pages/dashboard_home_page.dart
@@ -16,6 +16,7 @@ import 'package:nipaplay/providers/watch_history_provider.dart';
 import 'package:nipaplay/providers/jellyfin_provider.dart';
 import 'package:nipaplay/providers/emby_provider.dart';
 import 'package:nipaplay/services/jellyfin_service.dart';
+import 'package:nipaplay/services/jellyfin_series_auto_match_service.dart';
 import 'package:nipaplay/services/emby_service.dart';
 import 'package:nipaplay/services/bangumi_service.dart';
 import 'package:nipaplay/utils/network_settings.dart';

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -22,6 +22,7 @@ class SettingsProvider with ChangeNotifier {
 
   // 播放时自动匹配弹幕
   bool _autoMatchDanmakuOnPlay = true; // 默认开启
+  bool _autoMatchJellyfinSeries = false;
   DanmakuAutoLoadStrategy _danmakuAutoLoadStrategy =
       DanmakuAutoLoadStrategy.remoteAndLocal;
   bool _fastPlaybackStartup = false;
@@ -48,6 +49,7 @@ class SettingsProvider with ChangeNotifier {
   bool get autoMatchDanmakuFirstSearchResultOnHashFail =>
       _autoMatchDanmakuFirstSearchResultOnHashFail;
   bool get autoMatchDanmakuOnPlay => _autoMatchDanmakuOnPlay;
+  bool get autoMatchJellyfinSeries => _autoMatchJellyfinSeries;
   DanmakuAutoLoadStrategy get danmakuAutoLoadStrategy =>
       _danmakuAutoLoadStrategy;
   bool get fastPlaybackStartup => _fastPlaybackStartup;
@@ -96,6 +98,8 @@ class SettingsProvider with ChangeNotifier {
     final savedAutoMatchDanmakuOnPlay =
         _prefs.getBool(SettingsKeys.autoMatchDanmakuOnPlay);
     _autoMatchDanmakuOnPlay = savedAutoMatchDanmakuOnPlay ?? true;
+    _autoMatchJellyfinSeries =
+        _prefs.getBool(SettingsKeys.autoMatchJellyfinSeries) ?? false;
     _danmakuAutoLoadStrategy = danmakuAutoLoadStrategyFromPrefs(
       _prefs.getString(SettingsKeys.danmakuAutoLoadStrategy),
       legacyAutoMatchOnPlay: _autoMatchDanmakuOnPlay,
@@ -216,6 +220,12 @@ class SettingsProvider with ChangeNotifier {
       SettingsKeys.danmakuAutoLoadStrategy,
       _danmakuAutoLoadStrategy.prefsValue,
     );
+    notifyListeners();
+  }
+
+  Future<void> setAutoMatchJellyfinSeries(bool enable) async {
+    _autoMatchJellyfinSeries = enable;
+    await _prefs.setBool(SettingsKeys.autoMatchJellyfinSeries, enable);
     notifyListeners();
   }
 

--- a/lib/services/jellyfin_dandanplay_matcher.dart
+++ b/lib/services/jellyfin_dandanplay_matcher.dart
@@ -732,6 +732,15 @@ class JellyfinDandanplayMatcher {
     }
   }
 
+  /// Runs only DandanPlay's hash-and-filename match endpoint.
+  ///
+  /// Unlike the interactive matcher, this never falls back to selecting the
+  /// first title-search result and is therefore safe for background matching.
+  Future<Map<String, dynamic>> matchVideoInfoExactly(
+      Map<String, dynamic> videoInfo) {
+    return _matchWithDandanPlayAPI(videoInfo);
+  }
+
   Map<String, dynamic> _normalizeMatchApiResult(Map<String, dynamic> raw) {
     final matches = raw['matches'];
     final normalizedMatches = (matches is List)

--- a/lib/services/jellyfin_episode_mapping_service.dart
+++ b/lib/services/jellyfin_episode_mapping_service.dart
@@ -96,8 +96,14 @@ class JellyfinEpisodeMappingService {
     // 检查是否已存在映射
     final existing = await _database!.query(
       'jellyfin_dandanplay_mapping',
-      where: 'jellyfin_series_id = ? AND jellyfin_season_id = ? AND dandanplay_anime_id = ?',
-      whereArgs: [jellyfinSeriesId, jellyfinSeasonId, dandanplayAnimeId],
+      where:
+          'jellyfin_series_id = ? AND (jellyfin_season_id = ? OR (jellyfin_season_id IS NULL AND ? IS NULL)) AND dandanplay_anime_id = ?',
+      whereArgs: [
+        jellyfinSeriesId,
+        jellyfinSeasonId,
+        jellyfinSeasonId,
+        dandanplayAnimeId,
+      ],
     );
 
     if (existing.isNotEmpty) {
@@ -114,6 +120,9 @@ class JellyfinEpisodeMappingService {
         whereArgs: [mappingId],
       );
       debugPrint('[映射服务] 更新现有动画映射: ID=$mappingId');
+      _animeMappingCache.removeWhere(
+        (key, _) => key.startsWith('${jellyfinSeriesId}_'),
+      );
       return mappingId;
     } else {
       // 创建新映射
@@ -128,6 +137,9 @@ class JellyfinEpisodeMappingService {
         },
       );
       debugPrint('[映射服务] 创建新动画映射: ID=$mappingId');
+      _animeMappingCache.removeWhere(
+        (key, _) => key.startsWith('${jellyfinSeriesId}_'),
+      );
       return mappingId;
     }
   }

--- a/lib/services/jellyfin_series_auto_match_service.dart
+++ b/lib/services/jellyfin_series_auto_match_service.dart
@@ -1,0 +1,297 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
+import 'package:nipaplay/models/jellyfin_model.dart';
+import 'package:nipaplay/services/jellyfin_dandanplay_matcher.dart';
+import 'package:nipaplay/services/jellyfin_episode_mapping_service.dart';
+import 'package:nipaplay/services/jellyfin_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+typedef JellyfinAutoMatchEnabledLoader = Future<bool> Function();
+typedef JellyfinMappingLoader = Future<Map<String, dynamic>?> Function(
+  String seriesId,
+);
+typedef JellyfinSeasonLoader = Future<List<JellyfinSeasonInfo>> Function(
+  String seriesId,
+);
+typedef JellyfinEpisodeLoader = Future<List<JellyfinEpisodeInfo>> Function(
+  String seriesId,
+  String seasonId,
+);
+typedef JellyfinVideoInfoLoader = Future<Map<String, dynamic>> Function(
+  JellyfinEpisodeInfo episode,
+);
+typedef JellyfinExactMatcher = Future<Map<String, dynamic>> Function(
+  Map<String, dynamic> videoInfo,
+);
+typedef JellyfinSeriesMappingWriter = Future<int> Function(
+  JellyfinMediaItem series,
+  int animeId,
+  String animeTitle,
+);
+typedef JellyfinEpisodeMappingWriter = Future<void> Function(
+  JellyfinEpisodeInfo episode,
+  int episodeId,
+  int mappingId,
+);
+
+class JellyfinSeriesAutoMatchResult {
+  const JellyfinSeriesAutoMatchResult({
+    required this.animeId,
+    required this.animeTitle,
+    required this.episodeId,
+  });
+
+  final int animeId;
+  final String animeTitle;
+  final int? episodeId;
+}
+
+/// Optionally identifies an unmapped Jellyfin Series from one episode hash.
+///
+/// The service does not create watch-history entries. It only persists the
+/// Series and representative Episode mappings used by the existing mapping
+/// and playback layers.
+class JellyfinSeriesAutoMatchService {
+  JellyfinSeriesAutoMatchService({
+    JellyfinAutoMatchEnabledLoader? isEnabled,
+    JellyfinMappingLoader? loadMapping,
+    JellyfinSeasonLoader? loadSeasons,
+    JellyfinEpisodeLoader? loadEpisodes,
+    JellyfinVideoInfoLoader? loadVideoInfo,
+    JellyfinExactMatcher? matchExactly,
+    JellyfinSeriesMappingWriter? writeSeriesMapping,
+    JellyfinEpisodeMappingWriter? writeEpisodeMapping,
+    DateTime Function()? clock,
+  })  : _isEnabled = isEnabled ?? _defaultIsEnabled,
+        _loadMapping = loadMapping ?? _defaultLoadMapping,
+        _loadSeasons = loadSeasons ??
+            ((seriesId) => JellyfinService.instance.getSeriesSeasons(seriesId)),
+        _loadEpisodes = loadEpisodes ??
+            ((seriesId, seasonId) =>
+                JellyfinService.instance.getSeasonEpisodes(seriesId, seasonId)),
+        _loadVideoInfo = loadVideoInfo ??
+            JellyfinDandanplayMatcher.instance.calculateVideoHash,
+        _matchExactly = matchExactly ??
+            JellyfinDandanplayMatcher.instance.matchVideoInfoExactly,
+        _writeSeriesMapping = writeSeriesMapping ?? _defaultWriteSeriesMapping,
+        _writeEpisodeMapping =
+            writeEpisodeMapping ?? _defaultWriteEpisodeMapping,
+        _clock = clock ?? DateTime.now;
+
+  static final JellyfinSeriesAutoMatchService instance =
+      JellyfinSeriesAutoMatchService();
+
+  static const Duration _failureCooldown = Duration(minutes: 30);
+  static const int _maxConcurrentMatches = 2;
+
+  final JellyfinAutoMatchEnabledLoader _isEnabled;
+  final JellyfinMappingLoader _loadMapping;
+  final JellyfinSeasonLoader _loadSeasons;
+  final JellyfinEpisodeLoader _loadEpisodes;
+  final JellyfinVideoInfoLoader _loadVideoInfo;
+  final JellyfinExactMatcher _matchExactly;
+  final JellyfinSeriesMappingWriter _writeSeriesMapping;
+  final JellyfinEpisodeMappingWriter _writeEpisodeMapping;
+  final DateTime Function() _clock;
+
+  final Map<String, Future<JellyfinSeriesAutoMatchResult?>> _inFlight = {};
+  final Map<String, DateTime> _lastFailedAt = {};
+  int _activeMatches = 0;
+  final List<Completer<void>> _waiters = [];
+
+  Future<void> matchSeriesBatchIfEnabled(
+    Iterable<JellyfinMediaItem> seriesItems,
+  ) async {
+    await Future.wait(seriesItems.map(matchSeriesIfEnabled), eagerError: false);
+  }
+
+  Future<JellyfinSeriesAutoMatchResult?> matchSeriesIfEnabled(
+    JellyfinMediaItem series,
+  ) async {
+    try {
+      return await _matchSeriesIfEnabled(series);
+    } catch (error) {
+      debugPrint('[JellyfinAutoMatch] ${series.name} setup failed: $error');
+      return null;
+    }
+  }
+
+  Future<JellyfinSeriesAutoMatchResult?> _matchSeriesIfEnabled(
+    JellyfinMediaItem series,
+  ) async {
+    if (kIsWeb || series.type?.toLowerCase() != 'series') return null;
+    if (!await _isEnabled()) return null;
+
+    final existing = await _loadMapping(series.id);
+    final existingAnimeId = _positiveInt(existing?['dandanplay_anime_id']);
+    if (existingAnimeId != null) {
+      return JellyfinSeriesAutoMatchResult(
+        animeId: existingAnimeId,
+        animeTitle:
+            existing?['dandanplay_anime_title']?.toString() ?? series.name,
+        episodeId: null,
+      );
+    }
+
+    final lastFailure = _lastFailedAt[series.id];
+    if (lastFailure != null &&
+        _clock().difference(lastFailure) < _failureCooldown) {
+      return null;
+    }
+
+    final running = _inFlight[series.id];
+    if (running != null) return running;
+
+    final task = _withPermit(() => _matchSeries(series));
+    _inFlight[series.id] = task;
+    try {
+      final result = await task;
+      if (result == null) {
+        _lastFailedAt[series.id] = _clock();
+      } else {
+        _lastFailedAt.remove(series.id);
+      }
+      return result;
+    } finally {
+      _inFlight.remove(series.id);
+    }
+  }
+
+  Future<JellyfinSeriesAutoMatchResult?> _matchSeries(
+    JellyfinMediaItem series,
+  ) async {
+    try {
+      final episode = await _loadRepresentativeEpisode(series.id);
+      if (episode == null) return null;
+
+      final videoInfo = await _loadVideoInfo(episode);
+      if (!_hasUsableVideoInfo(videoInfo)) return null;
+
+      final matchResult = await _matchExactly(videoInfo);
+      final match = _firstMatch(matchResult);
+      final animeId = _positiveInt(match?['animeId']);
+      final episodeId = _positiveInt(match?['episodeId']);
+      if (animeId == null || episodeId == null) return null;
+
+      final animeTitle = match?['animeTitle']?.toString().trim();
+      final resolvedTitle =
+          animeTitle?.isNotEmpty == true ? animeTitle! : series.name;
+      final mappingId = await _writeSeriesMapping(
+        series,
+        animeId,
+        resolvedTitle,
+      );
+      if (mappingId <= 0) return null;
+
+      await _writeEpisodeMapping(episode, episodeId, mappingId);
+      debugPrint(
+        '[JellyfinAutoMatch] ${series.name} -> $resolvedTitle ($animeId)',
+      );
+      return JellyfinSeriesAutoMatchResult(
+        animeId: animeId,
+        animeTitle: resolvedTitle,
+        episodeId: episodeId,
+      );
+    } catch (error) {
+      debugPrint('[JellyfinAutoMatch] ${series.name} failed: $error');
+      return null;
+    }
+  }
+
+  Future<JellyfinEpisodeInfo?> _loadRepresentativeEpisode(
+    String seriesId,
+  ) async {
+    final seasons = await _loadSeasons(seriesId);
+    for (final season in seasons) {
+      final episodes = await _loadEpisodes(seriesId, season.id);
+      for (final episode in episodes) {
+        final index = episode.indexNumber;
+        if (index != null && index > 0) return episode;
+      }
+    }
+    return null;
+  }
+
+  Future<T> _withPermit<T>(Future<T> Function() action) async {
+    if (_activeMatches >= _maxConcurrentMatches) {
+      final waiter = Completer<void>();
+      _waiters.add(waiter);
+      await waiter.future;
+    }
+    _activeMatches++;
+    try {
+      return await action();
+    } finally {
+      _activeMatches--;
+      if (_waiters.isNotEmpty) {
+        _waiters.removeAt(0).complete();
+      }
+    }
+  }
+
+  static bool _hasUsableVideoInfo(Map<String, dynamic> videoInfo) {
+    final hash = videoInfo['hash']?.toString().trim() ?? '';
+    final fileName = videoInfo['fileName']?.toString().trim() ?? '';
+    final fileSize = _positiveInt(videoInfo['fileSize']);
+    return hash.isNotEmpty && fileName.isNotEmpty && fileSize != null;
+  }
+
+  static Map<String, dynamic>? _firstMatch(Map<String, dynamic> matchResult) {
+    if (matchResult['isMatched'] != true) return null;
+    final matches = matchResult['matches'];
+    if (matches is! List || matches.isEmpty || matches.first is! Map) {
+      return null;
+    }
+    return Map<String, dynamic>.from(matches.first as Map);
+  }
+
+  static int? _positiveInt(dynamic value) {
+    final parsed = switch (value) {
+      int value => value,
+      double value => value.toInt(),
+      String value => int.tryParse(value),
+      _ => null,
+    };
+    return parsed != null && parsed > 0 ? parsed : null;
+  }
+
+  static Future<bool> _defaultIsEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(SettingsKeys.autoMatchJellyfinSeries) ?? false;
+  }
+
+  static Future<Map<String, dynamic>?> _defaultLoadMapping(String seriesId) {
+    return JellyfinEpisodeMappingService.instance.getAnimeMapping(
+      jellyfinSeriesId: seriesId,
+    );
+  }
+
+  static Future<int> _defaultWriteSeriesMapping(
+    JellyfinMediaItem series,
+    int animeId,
+    String animeTitle,
+  ) {
+    return JellyfinEpisodeMappingService.instance.createOrUpdateAnimeMapping(
+      jellyfinSeriesId: series.id,
+      jellyfinSeriesName: series.name,
+      dandanplayAnimeId: animeId,
+      dandanplayAnimeTitle: animeTitle,
+    );
+  }
+
+  static Future<void> _defaultWriteEpisodeMapping(
+    JellyfinEpisodeInfo episode,
+    int episodeId,
+    int mappingId,
+  ) {
+    return JellyfinEpisodeMappingService.instance.recordEpisodeMapping(
+      jellyfinEpisodeId: episode.id,
+      jellyfinIndexNumber: episode.indexNumber!,
+      dandanplayEpisodeId: episodeId,
+      mappingId: mappingId,
+      confirmed: true,
+    );
+  }
+}

--- a/lib/themes/nipaplay/pages/settings/jellyfin_mapping_management_page.dart
+++ b/lib/themes/nipaplay/pages/settings/jellyfin_mapping_management_page.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/providers/settings_provider.dart';
 import 'package:nipaplay/services/jellyfin_episode_mapping_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dialog.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_snackbar.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/hover_scale_text_button.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_card.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/settings_item.dart';
+import 'package:provider/provider.dart';
 
 class JellyfinMappingManagementPage extends StatefulWidget {
   const JellyfinMappingManagementPage({super.key});
@@ -231,6 +233,18 @@ class _JellyfinMappingManagementPageState
               title: '映射管理',
             ),
           ),
+          Consumer<SettingsProvider>(
+            builder: (context, settings, child) {
+              return SettingsItem.toggle(
+                title: '自动识别 Jellyfin 动画',
+                subtitle: '新系列缺少映射时，读取一集的前 16 MB 并使用文件哈希匹配',
+                icon: Ionicons.scan_outline,
+                value: settings.autoMatchJellyfinSeries,
+                onChanged: settings.setAutoMatchJellyfinSeries,
+              );
+            },
+          ),
+          Divider(height: 1, color: _dividerColor),
           SettingsItem.button(
             title: '重新加载统计',
             subtitle: '刷新映射统计信息',

--- a/lib/themes/nipaplay/widgets/dashboard_home_page_data_loading.dart
+++ b/lib/themes/nipaplay/widgets/dashboard_home_page_data_loading.dart
@@ -778,6 +778,8 @@ extension DashboardHomePageDataLoading on _DashboardHomePageState {
                       .getLatestMediaItemsByLibrary(library.id, limit: 25);
                   if (libraryItems.isNotEmpty) {
                     _recentJellyfinItemsByLibrary[library.name] = libraryItems;
+                    unawaited(JellyfinSeriesAutoMatchService.instance
+                        .matchSeriesBatchIfEnabled(libraryItems));
                   }
                 } catch (_) {}
               }());

--- a/lib/themes/nipaplay/widgets/network_media_library_view.dart
+++ b/lib/themes/nipaplay/widgets/network_media_library_view.dart
@@ -11,6 +11,7 @@ import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'package:nipaplay/providers/jellyfin_provider.dart';
 import 'package:nipaplay/providers/emby_provider.dart';
 import 'package:nipaplay/services/jellyfin_service.dart';
+import 'package:nipaplay/services/jellyfin_series_auto_match_service.dart';
 import 'package:nipaplay/services/emby_service.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/horizontal_anime_card.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
@@ -1925,8 +1926,10 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
   List<NetworkMediaItem> _convertToNetworkMediaItems(List<dynamic> items) {
     switch (widget.serverType) {
       case NetworkMediaServerType.jellyfin:
-        return items
-            .cast<JellyfinMediaItem>()
+        final jellyfinItems = items.cast<JellyfinMediaItem>().toList();
+        unawaited(JellyfinSeriesAutoMatchService.instance
+            .matchSeriesBatchIfEnabled(jellyfinItems));
+        return jellyfinItems
             .map((item) => JellyfinMediaItemAdapter(item))
             .toList();
       case NetworkMediaServerType.emby:

--- a/test/jellyfin_series_auto_match_service_test.dart
+++ b/test/jellyfin_series_auto_match_service_test.dart
@@ -1,0 +1,203 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/models/jellyfin_model.dart';
+import 'package:nipaplay/services/jellyfin_series_auto_match_service.dart';
+
+JellyfinMediaItem series({String id = 'series-1'}) => JellyfinMediaItem(
+      id: id,
+      name: 'Server title',
+      dateAdded: DateTime(2026),
+      type: 'Series',
+      isFolder: true,
+    );
+
+JellyfinSeasonInfo season() => JellyfinSeasonInfo(
+      id: 'season-1',
+      name: 'Season 1',
+      seriesId: 'series-1',
+      indexNumber: 1,
+    );
+
+JellyfinEpisodeInfo episode() => JellyfinEpisodeInfo(
+      id: 'episode-1',
+      name: 'Episode 1',
+      seriesId: 'series-1',
+      seriesName: 'Server title',
+      seasonId: 'season-1',
+      indexNumber: 1,
+      dateAdded: DateTime(2026),
+    );
+
+JellyfinSeriesAutoMatchService service({
+  required Future<bool> Function() isEnabled,
+  Future<Map<String, dynamic>?> Function(String)? loadMapping,
+  Future<Map<String, dynamic>> Function(JellyfinEpisodeInfo)? loadVideoInfo,
+  Future<Map<String, dynamic>> Function(Map<String, dynamic>)? matchExactly,
+  Future<int> Function(JellyfinMediaItem, int, String)? writeSeriesMapping,
+  Future<void> Function(JellyfinEpisodeInfo, int, int)? writeEpisodeMapping,
+}) {
+  return JellyfinSeriesAutoMatchService(
+    isEnabled: isEnabled,
+    loadMapping: loadMapping ?? (_) async => null,
+    loadSeasons: (_) async => [season()],
+    loadEpisodes: (_, __) async => [episode()],
+    loadVideoInfo: loadVideoInfo ??
+        (_) async => {
+              'hash': 'hash',
+              'fileName': 'Episode 1.mkv',
+              'fileSize': 1024,
+            },
+    matchExactly: matchExactly ??
+        (_) async => {
+              'isMatched': true,
+              'matches': [
+                {
+                  'animeId': 123,
+                  'animeTitle': 'Canonical title',
+                  'episodeId': 1230001,
+                },
+              ],
+            },
+    writeSeriesMapping: writeSeriesMapping ?? (_, __, ___) async => 7,
+    writeEpisodeMapping: writeEpisodeMapping ?? (_, __, ___) async {},
+  );
+}
+
+void main() {
+  test('disabled setting leaves an unmapped Series untouched', () async {
+    var loadedVideoInfo = false;
+    final matcher = service(
+      isEnabled: () async => false,
+      loadVideoInfo: (_) async {
+        loadedVideoInfo = true;
+        return {};
+      },
+    );
+
+    final result = await matcher.matchSeriesIfEnabled(series());
+
+    expect(result, isNull);
+    expect(loadedVideoInfo, isFalse);
+  });
+
+  test('existing Series mapping avoids reading media data', () async {
+    var loadedVideoInfo = false;
+    final matcher = service(
+      isEnabled: () async => true,
+      loadMapping: (_) async => {
+        'dandanplay_anime_id': 456,
+        'dandanplay_anime_title': 'Mapped title',
+      },
+      loadVideoInfo: (_) async {
+        loadedVideoInfo = true;
+        return {};
+      },
+    );
+
+    final result = await matcher.matchSeriesIfEnabled(series());
+
+    expect(result?.animeId, 456);
+    expect(result?.animeTitle, 'Mapped title');
+    expect(loadedVideoInfo, isFalse);
+  });
+
+  test(
+    'exact match creates Series and representative Episode mappings',
+    () async {
+      final writes = <String>[];
+      final matcher = service(
+        isEnabled: () async => true,
+        writeSeriesMapping: (item, animeId, animeTitle) async {
+          writes.add('series:${item.id}:$animeId:$animeTitle');
+          return 9;
+        },
+        writeEpisodeMapping: (item, episodeId, mappingId) async {
+          writes.add('episode:${item.id}:$episodeId:$mappingId');
+        },
+      );
+
+      final result = await matcher.matchSeriesIfEnabled(series());
+
+      expect(result?.animeId, 123);
+      expect(result?.episodeId, 1230001);
+      expect(writes, [
+        'series:series-1:123:Canonical title',
+        'episode:episode-1:1230001:9',
+      ]);
+    },
+  );
+
+  test('concurrent requests for one Series share a single hash task', () async {
+    final gate = Completer<void>();
+    var hashCalls = 0;
+    final matcher = service(
+      isEnabled: () async => true,
+      loadVideoInfo: (_) async {
+        hashCalls++;
+        await gate.future;
+        return {'hash': 'hash', 'fileName': 'Episode 1.mkv', 'fileSize': 1024};
+      },
+    );
+
+    final first = matcher.matchSeriesIfEnabled(series());
+    final second = matcher.matchSeriesIfEnabled(series());
+    await Future<void>.delayed(Duration.zero);
+    gate.complete();
+
+    final results = await Future.wait([first, second]);
+    expect(hashCalls, 1);
+    expect(results.map((result) => result?.animeId), [123, 123]);
+  });
+
+  test('batch matching hashes at most two Series concurrently', () async {
+    final gate = Completer<void>();
+    var active = 0;
+    var maxActive = 0;
+    var hashCalls = 0;
+    final matcher = service(
+      isEnabled: () async => true,
+      loadVideoInfo: (_) async {
+        hashCalls++;
+        active++;
+        if (active > maxActive) maxActive = active;
+        await gate.future;
+        active--;
+        return {'hash': 'hash', 'fileName': 'Episode 1.mkv', 'fileSize': 1024};
+      },
+    );
+
+    final batch = matcher.matchSeriesBatchIfEnabled([
+      series(id: 'series-1'),
+      series(id: 'series-2'),
+      series(id: 'series-3'),
+    ]);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(hashCalls, 2);
+    expect(maxActive, 2);
+    gate.complete();
+    await batch;
+    expect(hashCalls, 3);
+  });
+
+  test('invalid exact match is not persisted', () async {
+    var writeCalled = false;
+    final matcher = service(
+      isEnabled: () async => true,
+      matchExactly: (_) async => {
+        'isMatched': false,
+        'matches': <Map<String, dynamic>>[],
+      },
+      writeSeriesMapping: (_, __, ___) async {
+        writeCalled = true;
+        return 1;
+      },
+    );
+
+    final result = await matcher.matchSeriesIfEnabled(series());
+
+    expect(result, isNull);
+    expect(writeCalled, isFalse);
+  });
+}


### PR DESCRIPTION
## What changed

- adds a disabled-by-default `自动识别 Jellyfin 动画` toggle to Jellyfin mapping settings
- discovers unmapped Jellyfin Series from the home feed and network media library
- hashes one representative episode through the existing 16 MiB Jellyfin hash path
- calls only DandanPlay's exact `hashAndFileName` match endpoint
- persists the existing Series and representative Episode mapping records without creating watch history
- coalesces duplicate Series requests, limits hashing to two concurrent tasks, and cools down failures for 30 minutes
- makes nullable season-level mapping upserts idempotent and invalidates stale mapping cache entries

## Why this is opt-in

Some users want Jellyfin to remain the only source of media identity. Others use NipaPlay's local-library matcher and want the same identity mapping for newly discovered Jellyfin anime. The setting therefore defaults to off and does not alter existing Jellyfin behavior until explicitly enabled.

The background path accepts only the existing exact match API result. It never silently selects the first title-search result, so ambiguous remakes and similarly named seasons remain on the existing interactive path.

## Resource and behavior impact

- mapped Series do not read media data again
- a new unmapped Series reads the first 16 MiB of one numbered episode
- at most two Series are hashed concurrently
- no media files are moved or modified
- no local watch-history entry is created

## Validation

- `flutter test test/jellyfin_series_auto_match_service_test.dart`
- 39 focused Jellyfin/media-server tests passed
- targeted analyzer: no issues in `jellyfin_series_auto_match_service.dart`
- isolated integration smoke test against Jellyfin 10.11.11: 5/5 Series and representative Episode mappings created from an empty NipaPlay database; `watch_history` remained empty

This is opened as a draft so the maintainers can evaluate whether the discovery triggers and setting placement fit the project's preferred UX.
