### PR TITLE
feat(erika): add ArtCNN C4F16 DS upscaler

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -34,7 +34,7 @@ jobs:
       FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
       FVP_DEPS_LATEST: 1
       ERIKA_PREBUILT: "1"
-      ERIKA_PREBUILT_TAG: v0.1.5
+      ERIKA_PREBUILT_TAG: v0.1.6
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -62,7 +62,7 @@ jobs:
       FVP_DEPS_URL: https://github.com/wang-bin/mdk-sdk/releases/latest/download/
       FVP_DEPS_LATEST: 1
       ERIKA_PREBUILT: "1"
-      ERIKA_PREBUILT_TAG: v0.1.5
+      ERIKA_PREBUILT_TAG: v0.1.6
     steps:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer

--- a/.github/workflows/build-ohos.yml
+++ b/.github/workflows/build-ohos.yml
@@ -67,7 +67,7 @@ env:
   RUSTUP_TOOLCHAIN: 1.93.0
   FVP_DEPS_LATEST: "0"
   ERIKA_PREBUILT: "1"
-  ERIKA_PREBUILT_TAG: v0.1.5
+  ERIKA_PREBUILT_TAG: v0.1.6
 
 jobs:
   build:
@@ -228,27 +228,26 @@ jobs:
           path = Path(sys.argv[1])
           source = path.read_text(encoding='utf-8')
           replacements = {
-              "    const metadataValue = args.get('metadata');":
+              "    const metadataValue: ESObject = args.get('metadata');":
                   "    const metadataValue: ESObject | undefined = args.get('metadata');",
-              "    const nativeArgs = new Map<string, ESObject>(args);":
-                  "    const nativeArgs: Map<string, ESObject> = new Map<string, ESObject>(args);",
-              "    const metadata = value as Map<string, ESObject>;":
-                  "    const metadata: Map<string, ESObject> = value as Map<string, ESObject>;",
-              "    const titleValue = metadata.get('title');":
+              "    const titleValue: ESObject = metadata.get('title');":
                   "    const titleValue: ESObject | undefined = metadata.get('title');",
-              "    const artist = metadata.get('artist');":
+              "    const artist: ESObject = metadata.get('artist');":
                   "    const artist: ESObject | undefined = metadata.get('artist');",
-              "    const album = metadata.get('album');":
+              "    const album: ESObject = metadata.get('album');":
                   "    const album: ESObject | undefined = metadata.get('album');",
-              "    const artwork = metadata.get('artwork');":
+              "    const artwork: ESObject = metadata.get('artwork');":
                   "    const artwork: ESObject | undefined = metadata.get('artwork');",
-              "    const args = extra ?? new Map<string, ESObject>();":
-                  "    const args: Map<string, ESObject> = extra ?? new Map<string, ESObject>();",
           }
           for old, new in replacements.items():
-              if source.count(old) != 1:
-                  raise SystemExit(f'Unexpected Erika v0.1.5 ArkTS source: {old}')
-              source = source.replace(old, new)
+              old_count = source.count(old)
+              new_count = source.count(new)
+              if old_count == 1 and new_count == 0:
+                  source = source.replace(old, new)
+              elif old_count == 0 and new_count == 1:
+                  continue
+              else:
+                  raise SystemExit(f'Unexpected Erika v0.1.6 ArkTS source: {old}')
           path.write_text(source, encoding='utf-8')
           PY
           python3 .github/workflows/scripts/generate-build-info-json.py assets/build_info.json

--- a/.github/workflows/build-tvos.yml
+++ b/.github/workflows/build-tvos.yml
@@ -32,7 +32,7 @@ concurrency:
 
 env:
   ERIKA_PREBUILT: "1"
-  ERIKA_PREBUILT_TAG: v0.1.5
+  ERIKA_PREBUILT_TAG: v0.1.6
 
 jobs:
   build:
@@ -183,9 +183,9 @@ jobs:
           if old_count == 1 and new_count == 0:
               path.write_text(source.replace(old, new), encoding='utf-8')
           elif old_count == 0 and new_count == 1:
-              print('Erika v0.1.5 tvOS podspec is already patched.')
+              print('Erika v0.1.6 tvOS podspec is already patched.')
           else:
-              raise SystemExit('Unexpected Erika v0.1.5 tvOS podspec layout')
+              raise SystemExit('Unexpected Erika v0.1.6 tvOS podspec layout')
           PY
 
           python3 - "$podspec" <<'PY'
@@ -221,9 +221,9 @@ jobs:
           if old_count == 1 and new_count == 0:
               path.write_text(source.replace(old, new), encoding='utf-8')
           elif old_count == 0 and new_count == 1:
-              print('Erika v0.1.5 tvOS prebuilt slice-name patch is already applied.')
+              print('Erika v0.1.6 tvOS prebuilt slice-name patch is already applied.')
           else:
-              raise SystemExit('Unexpected Erika v0.1.5 tvOS prebuilt slice layout')
+              raise SystemExit('Unexpected Erika v0.1.6 tvOS prebuilt slice layout')
           PY
 
       - name: Build tvOS simulator application

--- a/lib/player_abstraction/erika_player_adapter.dart
+++ b/lib/player_abstraction/erika_player_adapter.dart
@@ -1457,6 +1457,8 @@ class ErikaPlayerAdapter
         return ErikaUpscalerMode.artCnnC4F16;
       case PlayerUpscalerMode.erikaArtCnnC4F32:
         return ErikaUpscalerMode.artCnnC4F32;
+      case PlayerUpscalerMode.erikaArtCnnC4F16Ds:
+        return ErikaUpscalerMode.artCnnC4F16Ds;
       case PlayerUpscalerMode.off:
         return ErikaUpscalerMode.off;
     }
@@ -1468,6 +1470,8 @@ class ErikaPlayerAdapter
         return PlayerUpscalerMode.erikaArtCnnC4F16;
       case ErikaUpscalerMode.artCnnC4F32:
         return PlayerUpscalerMode.erikaArtCnnC4F32;
+      case ErikaUpscalerMode.artCnnC4F16Ds:
+        return PlayerUpscalerMode.erikaArtCnnC4F16Ds;
       case ErikaUpscalerMode.off:
         return PlayerUpscalerMode.off;
     }

--- a/lib/player_abstraction/player_data_models.dart
+++ b/lib/player_abstraction/player_data_models.dart
@@ -9,6 +9,7 @@ enum PlayerUpscalerMode {
   off,
   erikaArtCnnC4F16,
   erikaArtCnnC4F32,
+  erikaArtCnnC4F16Ds,
 }
 
 enum PlayerUpscalerBackendStatus {

--- a/lib/player_abstraction/tool/erika_player_adapter_native.dart.txt
+++ b/lib/player_abstraction/tool/erika_player_adapter_native.dart.txt
@@ -1291,6 +1291,8 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
         return ErikaUpscalerMode.artCnnC4F16;
       case PlayerUpscalerMode.erikaArtCnnC4F32:
         return ErikaUpscalerMode.artCnnC4F32;
+      case PlayerUpscalerMode.erikaArtCnnC4F16Ds:
+        return ErikaUpscalerMode.artCnnC4F16Ds;
       case PlayerUpscalerMode.off:
         return ErikaUpscalerMode.off;
     }
@@ -1302,6 +1304,8 @@ class ErikaPlayerAdapter implements AbstractPlayer, AsyncDisposablePlayer {
         return PlayerUpscalerMode.erikaArtCnnC4F16;
       case ErikaUpscalerMode.artCnnC4F32:
         return PlayerUpscalerMode.erikaArtCnnC4F32;
+      case ErikaUpscalerMode.artCnnC4F16Ds:
+        return PlayerUpscalerMode.erikaArtCnnC4F16Ds;
       case ErikaUpscalerMode.off:
         return PlayerUpscalerMode.off;
     }

--- a/lib/settings/pages/player_settings_content.dart
+++ b/lib/settings/pages/player_settings_content.dart
@@ -230,6 +230,8 @@ class _PlayerSettingsContentState extends State<PlayerSettingsContent> {
         return 'ART-CNN C4F16';
       case PlayerUpscalerMode.erikaArtCnnC4F32:
         return 'ART-CNN C4F32';
+      case PlayerUpscalerMode.erikaArtCnnC4F16Ds:
+        return 'ART-CNN C4F16 DS';
     }
   }
 
@@ -241,6 +243,8 @@ class _PlayerSettingsContentState extends State<PlayerSettingsContent> {
         return '半精度 ART-CNN，速度优先，推荐日常播放';
       case PlayerUpscalerMode.erikaArtCnnC4F32:
         return '单精度 ART-CNN，画质优先，对 GPU 压力更高';
+      case PlayerUpscalerMode.erikaArtCnnC4F16Ds:
+        return '半精度去噪锐化 ART-CNN，适合压缩痕迹明显的动画视频';
     }
   }
 

--- a/lib/themes/nipaplay/widgets/playback_info_menu.dart
+++ b/lib/themes/nipaplay/widgets/playback_info_menu.dart
@@ -641,6 +641,9 @@ class _PlaybackInfoMenuState extends State<PlaybackInfoMenu> {
       case 'erikaArtCnnC4F32':
       case 'artCnnC4F32':
         return 'ART-CNN C4F32';
+      case 'erikaArtCnnC4F16Ds':
+      case 'artCnnC4F16Ds':
+        return 'ART-CNN C4F16 DS';
       case 'off':
         return '关闭';
       default:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -298,11 +298,11 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: "9285a1fe556ffacb490481acfb1195005f1886d9"
-      resolved-ref: "9285a1fe556ffacb490481acfb1195005f1886d9"
+      ref: "0e85ef666de84cbddca02a4bba117eae750d629a"
+      resolved-ref: "0e85ef666de84cbddca02a4bba117eae750d629a"
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
-    version: "0.1.5"
+    version: "0.1.6"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -135,7 +135,7 @@ dependencies:
   erika_flutter:
     git:
       url: https://github.com/AimesSoft/Erika.git
-      ref: 9285a1fe556ffacb490481acfb1195005f1886d9
+      ref: 0e85ef666de84cbddca02a4bba117eae750d629a
       path: packages/erika_flutter
   qr_flutter: ^4.1.0  # 用于生成二维码
   mobile_scanner: ^7.2.0

--- a/pubspec_overrides.tvos.yaml
+++ b/pubspec_overrides.tvos.yaml
@@ -10,7 +10,7 @@ dependency_overrides:
   erika_flutter:
     git:
       url: https://github.com/AimesSoft/Erika.git
-      ref: v0.1.5
+      ref: v0.1.6
       path: packages/erika_flutter
   # Shared repository overrides. Keep these keys aligned with pubspec.yaml.
   liquid_glass_widgets:

--- a/test/mainline_flutter_compatibility_test.dart
+++ b/test/mainline_flutter_compatibility_test.dart
@@ -18,7 +18,7 @@ void main() {
     expect(File('pubspec_overrides.tvos.yaml').existsSync(), isTrue);
     expect(pubspec, contains('package_info_plus: ^10.2.1'));
     expect(pubspec, contains('wakelock_plus: ^1.7.0'));
-    expect(erikaRef, matches(RegExp(r'^[0-9a-f]{40}$')));
+    expect(erikaRef, '0e85ef666de84cbddca02a4bba117eae750d629a');
     expect(
       File('.flutter-version-linux').readAsStringSync().trim(),
       '3.47.0-0.3.pre',
@@ -83,7 +83,7 @@ void main() {
     expect(tvOSKeys, containsAll(sharedKeys));
     expect(tvOSOverrides, isNot(contains('package_info_plus:')));
     expect(tvOSOverrides, isNot(contains('wakelock_plus:')));
-    expect(tvOSErikaRef, 'v0.1.5');
+    expect(tvOSErikaRef, 'v0.1.6');
     expect(tvOSErikaRef, isNot(sharedErikaRef));
     expect(wrapper, contains('configure_flutter_dependencies.dart" tvos'));
     expect(workflow, contains('configure_flutter_dependencies.dart tvos'));

--- a/test/tvos_erika_kernel_policy_test.dart
+++ b/test/tvos_erika_kernel_policy_test.dart
@@ -71,7 +71,7 @@ void main() {
 
     expect(
       tvOSOverrides,
-      contains('ref: v0.1.5'),
+      contains('ref: v0.1.6'),
     );
     expect(monitor, contains('_instance._updatePlayerKernelType();'));
     expect(monitor, contains("_instance._activeDecoder = 'Erika（等待媒体）';"));


### PR DESCRIPTION
## Summary

- update `erika_flutter` to Erika `v0.1.6` and pin all prebuilt workflows to its release artifacts
- expose ArtCNN C4F16 DS in NipaPlay's Erika upscaler settings, native adapter mapping, and playback diagnostics
- update tvOS and OpenHarmony integration checks for the new Erika source layout

## Validation

- `flutter analyze --no-pub` on the changed Dart files
- `flutter test --no-pub test/mainline_flutter_compatibility_test.dart`
- verified the OpenHarmony ArkTS compatibility patch applies cleanly to the `v0.1.6` plugin source

## Note

`test/tvos_erika_kernel_policy_test.dart` still has one unrelated baseline failure: it expects a stale `showNextPlusPlusToggle` source variable that is no longer present on current `main`.