### PR TITLE
fix(release): repair Linux and HarmonyOS release builds

### DIFF
--- a/.github/actions/build-linux/action.yml
+++ b/.github/actions/build-linux/action.yml
@@ -30,6 +30,8 @@ runs:
         sudo apt-get update
         # Install core build dependencies
         sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev
+        # audioplayers_linux requires gstreamer-1.0 at build time
+        sudo apt-get install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
         # tray_manager needs ayatana-appindicator (or legacy appindicator)
         if apt-cache show libayatana-appindicator3-dev >/dev/null 2>&1; then
           sudo apt-get install -y libayatana-appindicator3-dev

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -40,6 +40,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  audioplayers:
+    dependency: "direct main"
+    description:
+      name: audioplayers
+      sha256: "2ba4bb2944baacbdd5372ff8254a8e7feb8c10d7739545e392f5605a8f618745"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.8.1"
+  audioplayers_android:
+    dependency: transitive
+    description:
+      name: audioplayers_android
+      sha256: f5ff5b15620fbab8cb0849e9636c48e2b96c3f0f71723bbbe2ad3c761b205f05
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.0"
+  audioplayers_darwin:
+    dependency: transitive
+    description:
+      name: audioplayers_darwin
+      sha256: "1ca553add991384ecf421b9569da850f3ab2472ffb83f6970b0416365abc51be"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
+  audioplayers_linux:
+    dependency: transitive
+    description:
+      name: audioplayers_linux
+      sha256: "15178b726b7cdee5364d0463c8d445630c4e0fb7d26612b73c767e7d25de9417"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  audioplayers_platform_interface:
+    dependency: transitive
+    description:
+      name: audioplayers_platform_interface
+      sha256: "765f6f0e6dca55cb471c9483fc77700564b3484d19198aca4ebb5147c6c85acb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
+  audioplayers_web:
+    dependency: transitive
+    description:
+      name: audioplayers_web
+      sha256: ae1e0103c865a03e273f6d13d97b93f5595eac09915729cd5e37ef96e2857319
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.0"
+  audioplayers_windows:
+    dependency: transitive
+    description:
+      name: audioplayers_windows
+      sha256: a70ae82bba2dfcb6eb03dd4815d737a2d46d33ea5a96a03f535cfcaac490e413
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.1"
   battery_plus:
     dependency: "direct main"
     description:
@@ -298,8 +354,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/erika_flutter"
-      ref: "e1d598d032c69ec53c42fe38d49c1d48503f5a91"
-      resolved-ref: "e1d598d032c69ec53c42fe38d49c1d48503f5a91"
+      ref: e1d598d032c69ec53c42fe38d49c1d48503f5a91
+      resolved-ref: e1d598d032c69ec53c42fe38d49c1d48503f5a91
       url: "https://github.com/AimesSoft/Erika.git"
     source: git
     version: "0.1.6"
@@ -1879,6 +1935,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: d53e1ccf5516f25017e3c9d44c39034db352d20fa34fe200674270242c2c5111
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.14.1"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: b98656fa4461f8cc05c48a778b4d4883e60ec63e1778348f363f9bb9a477745d
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.14.0"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "1221c1b12f5278791042f2ec2841743784cf25c5a644e23d6680e5d718824f04"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.1"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: c879dd64b87c452aa84381b244d5469da57ba7e8cca6884c7b1e0d406372c12d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.26.0"
   win32:
     dependency: transitive
     description:
@@ -1920,5 +2008,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.12.0 <4.0.0"
   flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -173,7 +173,8 @@ dependencies:
   # FFI bridge because flutter_js has no OHOS implementation.
   flutter_js: ^0.8.0
   # Optional plugin danmaku renderer host (enabled only on Android/iOS).
-  webview_flutter: ^4.14.1
+  # 4.14+ requires Dart >=3.10 which the HarmonyOS fork (3.35.8, Dart 3.9.2) cannot resolve.
+  webview_flutter: ^4.13.1
   audioplayers: ^6.1.0
 
 dev_dependencies:


### PR DESCRIPTION
## 问题

今天触发的 release run（31864594937）有 4 个失败 job，其中 2 个与依赖升级相关：

| Job | 原因 |
|---|---|
| Linux arm64/amd64 | `audioplayers ^6.1.0`（a0cbb14a）引入的 audioplayers_linux 在 CMake 里 `pkg_check_modules(GSTREAMER REQUIRED)`，而 build-linux action 的 apt 清单从未安装 gstreamer dev 包 |
| HarmonyOS HAP | `webview_flutter ^4.14.1`（#857）要求 Dart ≥3.10，但 OpenHarmony 工具链 3.35.8-ohos-1.0.1 是 Dart 3.9.2，pub 解析直接失败 |
| iOS App Store signed IPA | Apple 账号证书达到上限 + 缺 provisioning profile（与依赖无关，需单独处理） |

## 改动

1. **`.github/actions/build-linux/action.yml`**：apt 安装清单补上 `libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev`
2. **`pubspec.yaml`**：`webview_flutter` 从 `^4.14.1` 降为 `^4.13.1`——主平台（Dart ≥3.10）仍会解析到 4.14.x，只有 OhOS（Dart 3.9.2）自动选择 4.13.1；所用 API（`WebViewController`）两个版本均支持
3. **`pubspec.lock`**：补全 audioplayers 系列解析条目（pub.dev 官方源重新解析）

## 验证

- `flutter analyze` webview 使用代码：无问题
- 本地 pub get 用官方源解析成功，无镜像源差异

## iOS 遗留问题（不在本 PR）

`Your account has reached the maximum number of certificates` + 找不到 `com.aimessoft.nipaplay` profile：需要去 developer.apple.com 吊销旧证书、重建 profile，并确认 CI secrets 中的 p12 仍然有效。