### PR TITLE
fix(release): complete Linux build deps (gstreamer on arm64, libevdev)

### DIFF
--- a/.github/actions/build-linux/action.yml
+++ b/.github/actions/build-linux/action.yml
@@ -30,8 +30,13 @@ runs:
         sudo apt-get update
         # Install core build dependencies
         sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev
-        # audioplayers_linux requires gstreamer-1.0 at build time
+        # audioplayers_linux requires gstreamer-1.0 at build time. On arm64,
+        # the runner's preinstalled LLVM libunwind-14-dev Breaks libunwind-dev
+        # (Ubuntu bug #1989124), so remove it before installing.
+        sudo apt-get remove -y libunwind-14-dev 2>/dev/null || true
         sudo apt-get install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+        # universal_gamepad (large-screen gamepad support) requires libevdev
+        sudo apt-get install -y libevdev-dev
         # tray_manager needs ayatana-appindicator (or legacy appindicator)
         if apt-cache show libayatana-appindicator3-dev >/dev/null 2>&1; then
           sudo apt-get install -y libayatana-appindicator3-dev


### PR DESCRIPTION
## 背景

上一轮修复（#862，已合并）给 Linux 构建补了 gstreamer，但 arm64 和 amd64 各自又挂了：

| 平台 | 失败点 | 原因 |
|---|---|---|
| arm64 | apt 安装 gstreamer | `libgstreamer1.0-dev` 依赖 `libunwind-dev`，与 runner 预装的 LLVM `libunwind-14-dev` 冲突（`Breaks`，Ubuntu bug #1989124）→ `held broken packages` |
| amd64 | CMake configure | `universal_gamepad`（#851 大屏手柄支持）需要 `libevdev` pkg-config，未安装 |

## 改动（`.github/actions/build-linux/action.yml`）

1. gstreamer 安装前先 `apt-get remove -y libunwind-14-dev`（amd64 上不存在时静默跳过）
2. 补装 `libevdev-dev`（universal_gamepad 的 CMake 依赖）

修复方式参考 fio CI 的 workaround（Ubuntu bug #1989124）。