### PR TITLE
docs: remove outdated nipaplay-reload-bin AUR warning

### DIFF
--- a/Documentation/installation.md
+++ b/Documentation/installation.md
@@ -27,8 +27,6 @@
   ebuild gentoo/media-video/nipaplay-bin/nipaplay-bin-<版本号>.ebuild merge
   ```
 
-> **⚠️ 安全警告**：Arch Linux AUR 中的 `nipaplay-reload-bin` 包已被恶意用户接管，**请勿通过 AUR 安装**。
-
 - 其他发行版：从 [Release 页面](https://github.com/AimesSoft/NipaPlay-Reload/releases) 下载对应构建包（AppImage / deb 等）并按常规方式安装/运行。
 
 ## Android

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ brew install --cask nipaplay-reload
 
 
 > **⚠️ 安全警告**
-> Arch Linux AUR 中的 `nipaplay-reload-bin` 和 `misuzu-music-bin` 包已被恶意用户接管，**请勿安装**。如需在 Arch Linux 上使用，请从 GitHub Releases 下载。
+> Arch Linux AUR 中的 `misuzu-music-bin` 包已被恶意用户接管，**请勿安装**。
 
 #### Gentoo Linux
 


### PR DESCRIPTION
## What changed

- Remove the outdated `nipaplay-reload-bin` compromise warning from the main README.
- Keep the separate `misuzu-music-bin` warning intact.
- Remove the duplicate outdated warning from the installation guide.

## Why

The maintainer has regained ownership of the `nipaplay-reload-bin` AUR package and will continue maintaining it, so the existing warning is no longer accurate.

## Impact

Documentation-only change; no runtime behavior is affected.

## Validation

- `git diff --check`
- Confirmed no remaining `nipaplay-reload-bin` security warnings in `README.md` or `Documentation/installation.md`