### PR TITLE
docs: add Arch Linux AUR download option

### DIFF
--- a/Documentation/installation.md
+++ b/Documentation/installation.md
@@ -21,6 +21,11 @@
 
 ## Linux
 
+- Arch Linux (AUR)：从 [`nipaplay-reload-bin`](https://aur.archlinux.org/packages/nipaplay-reload-bin) 包页面下载，或使用 AUR 助手安装：
+  ```bash
+  yay -S nipaplay-reload-bin
+  ```
+
 - Gentoo Linux (x86_64)：
   ```bash
   # 将版本号替换为当前最新版本

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ brew tap AimesSoft/nipaplay-reload
 brew install --cask nipaplay-reload
 ```
 
+#### Arch Linux (AUR)
+
+从 AUR 下载 [`nipaplay-reload-bin`](https://aur.archlinux.org/packages/nipaplay-reload-bin)，或使用 AUR 助手安装：
+
+```bash
+yay -S nipaplay-reload-bin
+```
 
 > **⚠️ 安全警告**
 > Arch Linux AUR 中的 `misuzu-music-bin` 包已被恶意用户接管，**请勿安装**。


### PR DESCRIPTION
## What changed

- Add an Arch Linux (AUR) section to the main README.
- Link directly to the `nipaplay-reload-bin` AUR package page.
- Include the `yay -S nipaplay-reload-bin` install command.
- Add the same download and install guidance to the detailed installation guide.

## Why

After restoring the package ownership warning, Arch Linux users still need a clear download and installation path.

## Impact

Arch Linux users can find and install the maintained AUR package directly from the project documentation. This is a documentation-only change.

## Validation

- `git diff --check`
- Verified both documentation files contain the AUR package link and install command