### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <br>
 
-<img src="https://api.star-history.com/svg?repos=aimessoft/nipaplay-reload&type=Date&theme=moebooru" alt="Star History Chart" width="80%">
+<img src="https://star-history.dera.page/svg?repos=aimessoft/nipaplay-reload&type=Date&theme=moebooru" alt="Star History Chart" width="80%">
 </div>
 
 <div align="center">


### PR DESCRIPTION
The star history chart at the top of the README is currently broken and shows nothing, because the upstream service can no longer fetch GitHub stargazer data reliably. This change points the chart at a working alternative service that uses a different data source and requires no API token, so visitors can see the project's growth again. No other content in the README is affected.