### PR TITLE
fix(settings): 修复 iOS 播放器 UA 无法保存

### DIFF
--- a/lib/settings/pages/network_settings_content.dart
+++ b/lib/settings/pages/network_settings_content.dart
@@ -2,6 +2,8 @@ import 'package:flutter/cupertino.dart' as cupertino;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
+import 'package:nipaplay/app/app_display_surface.dart';
+import 'package:nipaplay/app/app_display_surface_scope.dart';
 import 'package:nipaplay/l10n/l10n.dart';
 import 'package:nipaplay/player_abstraction/player_factory.dart';
 import 'package:nipaplay/services/app_http_proxy.dart';
@@ -630,8 +632,29 @@ class _NetworkSettingsContentState extends State<NetworkSettingsContent> {
 
   Future<String?> _showUserAgentInputDialog() async {
     final colorScheme = Theme.of(context).colorScheme;
-    final controller = TextEditingController(
-      text: PlayerFactory.getCustomPlayerUA(),
+    var inputValue = PlayerFactory.getCustomPlayerUA();
+    final isPhone =
+        AppDisplaySurfaceScope.of(context) == AppDisplaySurface.phone;
+    final dialogNavigator = Navigator.of(
+      context,
+      rootNavigator: isPhone,
+    );
+    final inputField = TextFormField(
+      initialValue: inputValue,
+      onChanged: (value) => inputValue = value,
+      keyboardType: TextInputType.multiline,
+      minLines: 2,
+      maxLines: 4,
+      autocorrect: false,
+      enableSuggestions: false,
+      cursorColor: AppAccentColors.current,
+      decoration: InputDecoration(
+        hintText: 'Mozilla/5.0 ...',
+        hintStyle: TextStyle(
+          color: colorScheme.onSurface.withValues(alpha: 0.38),
+        ),
+      ),
+      style: TextStyle(color: colorScheme.onSurface),
     );
     final result = await BlurDialog.show<String>(
       context: context,
@@ -665,22 +688,12 @@ class _NetworkSettingsContentState extends State<NetworkSettingsContent> {
               '自訂 User-Agent',
               'Custom User-Agent',
             ),
-            child: TextField(
-              controller: controller,
-              keyboardType: TextInputType.multiline,
-              minLines: 2,
-              maxLines: 4,
-              autocorrect: false,
-              enableSuggestions: false,
-              cursorColor: AppAccentColors.current,
-              decoration: InputDecoration(
-                hintText: 'Mozilla/5.0 ...',
-                hintStyle: TextStyle(
-                  color: colorScheme.onSurface.withValues(alpha: 0.38),
-                ),
-              ),
-              style: TextStyle(color: colorScheme.onSurface),
-            ),
+            child: isPhone
+                ? Material(
+                    type: MaterialType.transparency,
+                    child: inputField,
+                  )
+                : inputField,
           ),
         ],
       ),
@@ -688,16 +701,15 @@ class _NetworkSettingsContentState extends State<NetworkSettingsContent> {
         HoverScaleTextButton(
           text: context.l10n.cancel,
           idleColor: colorScheme.onSurface.withValues(alpha: 0.7),
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed: dialogNavigator.pop,
         ),
         HoverScaleTextButton(
           text: _text(context, '保存', '儲存', 'Save'),
           idleColor: colorScheme.onSurface,
-          onPressed: () => Navigator.of(context).pop(controller.text.trim()),
+          onPressed: () => dialogNavigator.pop(inputValue.trim()),
         ),
       ],
     );
-    controller.dispose();
     return result;
   }
 

--- a/test/network_settings_player_user_agent_widget_test.dart
+++ b/test/network_settings_player_user_agent_widget_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/app/app_display_surface.dart';
+import 'package:nipaplay/app/app_display_surface_scope.dart';
+import 'package:nipaplay/constants/settings_keys.dart';
+import 'package:nipaplay/l10n/app_localizations.dart';
+import 'package:nipaplay/player_abstraction/player_factory.dart';
+import 'package:nipaplay/providers/appearance_settings_provider.dart';
+import 'package:nipaplay/providers/bottom_bar_provider.dart';
+import 'package:nipaplay/settings/adaptive_settings_scope.dart';
+import 'package:nipaplay/settings/pages/network_settings_content.dart';
+import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('phone player UA setting saves without dialog lifecycle errors',
+      (tester) async {
+    final nestedNavigatorKey = GlobalKey<NavigatorState>();
+    SharedPreferences.setMockInitialValues({});
+    await PlayerFactory.saveCustomPlayerUA('');
+    addTearDown(() async {
+      await PlayerFactory.saveCustomPlayerUA('');
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(
+            create: (_) => AppearanceSettingsProvider(),
+          ),
+          ChangeNotifierProvider(
+            create: (_) => BottomBarProvider(),
+          ),
+        ],
+        child: MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.iOS),
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: AppDisplaySurfaceScope(
+            surface: AppDisplaySurface.phone,
+            child: AdaptiveSettingsScope(
+              style: AdaptiveSettingsStyle.phone,
+              child: Navigator(
+                key: nestedNavigatorKey,
+                onGenerateRoute: (_) => MaterialPageRoute<void>(
+                  builder: (_) => const SizedBox(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    nestedNavigatorKey.currentState!.push(
+      MaterialPageRoute<void>(
+        builder: (_) => const NetworkSettingsContent(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Custom User-Agent'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CupertinoBottomSheet), findsOneWidget);
+    await tester.enterText(
+      find.byType(EditableText),
+      'VLC/3.0.20 LibVLC/3.0.20',
+    );
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(
+      PlayerFactory.getCustomPlayerUA(),
+      'VLC/3.0.20 LibVLC/3.0.20',
+    );
+    final preferences = await SharedPreferences.getInstance();
+    expect(
+      preferences.getString(SettingsKeys.customPlayerUA),
+      'VLC/3.0.20 LibVLC/3.0.20',
+    );
+    expect(nestedNavigatorKey.currentState!.canPop(), isTrue);
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pumpAndSettle();
+  });
+}


### PR DESCRIPTION
## Summary

- 修复 iOS 网络设置中的播放器 User-Agent 保存后不生效，以及关闭输入面板时控制器提前释放的问题
- 保留现有手机端底部面板和桌面弹窗，仅调整导航关闭目标与输入状态生命周期