### PR TITLE
fix(emby): 修复播放剧集后详情窗口未关闭

### DIFF
--- a/lib/pages/media_server_detail_page.dart
+++ b/lib/pages/media_server_detail_page.dart
@@ -48,6 +48,17 @@ import 'package:nipaplay/app/app_display_surface_scope.dart';
 import 'package:nipaplay/media_library/adaptive_media_library_primitives.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
 
+@visibleForTesting
+Future<void> startEmbyPlaybackAndCloseDetail({
+  required NavigatorState detailNavigator,
+  required Future<void> Function() startPlayback,
+}) async {
+  if (detailNavigator.mounted) {
+    detailNavigator.pop();
+  }
+  await startPlayback();
+}
+
 class MediaServerDetailPage extends StatefulWidget {
   final String mediaId;
   final MediaServerType serverType;
@@ -1850,6 +1861,7 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage>
     }
 
     if (!mounted) return;
+    final detailNavigator = Navigator.of(context);
     final videoPlayerState =
         Provider.of<VideoPlayerState>(context, listen: false);
     TabChangeNotifier? tabChangeNotifier;
@@ -1879,20 +1891,26 @@ class _MediaServerDetailPageState extends State<MediaServerDetailPage>
       return;
     }
 
-    await Future<void>.delayed(const Duration(milliseconds: 100));
-    await initializeEmbyPlayerAttempt(
-      initialize: () => videoPlayerState.initializePlayer(
-        historyItem.filePath,
-        historyItem: historyItem,
-        playbackSession: playbackSession,
-        embyTrackSelection: embyTrackSelection,
-      ),
-      readError: () => videoPlayerState.error,
-      hasVideo: () => videoPlayerState.hasVideo,
-      play: () async => videoPlayerState.play(),
+    await startEmbyPlaybackAndCloseDetail(
+      detailNavigator: detailNavigator,
+      startPlayback: () async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        await initializeEmbyPlayerAttempt(
+          initialize: () => videoPlayerState.initializePlayer(
+            historyItem.filePath,
+            historyItem: historyItem,
+            playbackSession: playbackSession,
+            embyTrackSelection: embyTrackSelection,
+          ),
+          readError: () => videoPlayerState.error,
+          hasVideo: () => videoPlayerState.hasVideo,
+          play: () async => videoPlayerState.play(),
+        );
+        if (mounted) {
+          onPlaybackStarted?.call();
+        }
+      },
     );
-    onPlaybackStarted?.call();
-    if (mounted) Navigator.of(context).pop();
   }
 
   Widget _buildEpisodesListForSelectedSeason() {

--- a/test/media_server_detail_playback_navigation_test.dart
+++ b/test/media_server_detail_playback_navigation_test.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/pages/media_server_detail_page.dart';
+
+void main() {
+  testWidgets('starting Emby playback closes the original detail route',
+      (tester) async {
+    final playback = Completer<void>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showDialog<void>(
+              context: context,
+              builder: (dialogContext) => AlertDialog(
+                content: const Text('episode-detail'),
+                actions: [
+                  TextButton(
+                    onPressed: () {
+                      unawaited(startEmbyPlaybackAndCloseDetail(
+                        detailNavigator: Navigator.of(dialogContext),
+                        startPlayback: () => playback.future,
+                      ));
+                    },
+                    child: const Text('play'),
+                  ),
+                ],
+              ),
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('play'));
+    await tester.pumpAndSettle();
+    expect(find.text('episode-detail'), findsNothing);
+
+    playback.complete();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('failed Emby playback still closes the detail route',
+      (tester) async {
+    Object? caughtError;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showDialog<void>(
+              context: context,
+              builder: (dialogContext) => AlertDialog(
+                content: const Text('episode-detail'),
+                actions: [
+                  TextButton(
+                    onPressed: () async {
+                      try {
+                        await startEmbyPlaybackAndCloseDetail(
+                          detailNavigator: Navigator.of(dialogContext),
+                          startPlayback: () async => throw StateError('failed'),
+                        );
+                      } on StateError catch (error) {
+                        caughtError = error;
+                      }
+                    },
+                    child: const Text('play'),
+                  ),
+                ],
+              ),
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('play'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('episode-detail'), findsNothing);
+    expect(caughtError, isA<StateError>());
+  });
+
+  test('media detail captures its navigator before switching pages', () {
+    final source =
+        File('lib/pages/media_server_detail_page.dart').readAsStringSync();
+    final methodStart = source.indexOf('Future<void> _startEpisodePlayback(');
+    final methodEnd = source.indexOf(
+      'Widget _buildEpisodesListForSelectedSeason()',
+      methodStart,
+    );
+    final methodSource = source.substring(methodStart, methodEnd);
+
+    final navigatorCapture =
+        methodSource.indexOf('final detailNavigator = Navigator.of(context);');
+    final pageChange = methodSource.indexOf(
+      'tabChangeNotifier?.changePage(AppPageIds.video);',
+    );
+    final helperCall =
+        methodSource.indexOf('startEmbyPlaybackAndCloseDetail(');
+
+    expect(navigatorCapture, greaterThanOrEqualTo(0));
+    expect(navigatorCapture, lessThan(pageChange));
+    expect(helperCall, greaterThan(pageChange));
+  });
+}


### PR DESCRIPTION
## Summary

- 修复 Emby 剧集进入播放后详情窗口仍停留的问题
- 恢复原有关闭时序：切换播放器页面后立即关闭详情窗口，再初始化播放器