### PR TITLE
feat: 媒体库新增「只看未观看」过滤与手动刷新按钮

### DIFF
--- a/lib/themes/nipaplay/widgets/local_library_control_bar.dart
+++ b/lib/themes/nipaplay/widgets/local_library_control_bar.dart
@@ -9,6 +9,7 @@ import 'package:nipaplay/themes/nipaplay/widgets/blur_dropdown.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/search_bar_action_button.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_bottom_sheet.dart';
 import 'package:nipaplay/themes/cupertino/widgets/cupertino_media_search_toolbar.dart';
+import 'package:nipaplay/utils/app_accent_color.dart';
 
 enum LocalLibrarySortType {
   name,
@@ -57,6 +58,8 @@ class LocalLibraryControlBar extends StatefulWidget {
   final List<LocalLibraryActionControl>? trailingActions;
   final LibraryManagementViewMode? viewMode;
   final VoidCallback? onToggleViewMode;
+  final bool? showUnwatchedOnly;
+  final VoidCallback? onToggleUnwatchedOnly;
 
   LocalLibraryControlBar({
     super.key,
@@ -72,6 +75,8 @@ class LocalLibraryControlBar extends StatefulWidget {
     this.trailingActions,
     this.viewMode,
     this.onToggleViewMode,
+    this.showUnwatchedOnly,
+    this.onToggleUnwatchedOnly,
   });
 
   @override
@@ -101,6 +106,8 @@ class _LocalLibraryControlBarState extends State<LocalLibraryControlBar> {
     assert(!widget.showSort ||
         (widget.currentSort != null && widget.onSortChanged != null));
     assert((widget.viewMode == null) == (widget.onToggleViewMode == null));
+    assert((widget.showUnwatchedOnly == null) ==
+        (widget.onToggleUnwatchedOnly == null));
     if (AppDisplaySurfaceScope.of(context) == AppDisplaySurface.phone) {
       return _buildPhoneControlBar(context);
     }
@@ -152,6 +159,20 @@ class _LocalLibraryControlBarState extends State<LocalLibraryControlBar> {
               onClear: widget.onClearSearch,
             ),
           ),
+          if (widget.showUnwatchedOnly != null) ...[
+            const SizedBox(width: 10),
+            SearchBarActionButton(
+              icon: widget.showUnwatchedOnly == true
+                  ? Ionicons.eye_off_outline
+                  : Ionicons.eye_outline,
+              size: 20,
+              color: widget.showUnwatchedOnly == true
+                  ? AppAccentColors.current
+                  : primaryTextColor,
+              tooltip: widget.showUnwatchedOnly == true ? '显示全部' : '只看未观看',
+              onPressed: widget.onToggleUnwatchedOnly,
+            ),
+          ],
           if (widget.viewMode != null) ...[
             const SizedBox(width: 10),
             SearchBarActionButton(
@@ -247,29 +268,74 @@ class _LocalLibraryControlBarState extends State<LocalLibraryControlBar> {
   }
 
   Future<void> _showPhoneSortMenu(BuildContext context) async {
+    final showUnwatched = widget.showUnwatchedOnly != null;
+    final sortEntries = <(LocalLibrarySortType, String)>[
+      (LocalLibrarySortType.dateAdded, '最近观看'),
+      (LocalLibrarySortType.name, '名称排序'),
+      (LocalLibrarySortType.rating, '评分排序'),
+    ];
+
+    final screenHeight = MediaQuery.sizeOf(context).height;
+    final contentHeight = 112.0 + (sortEntries.length + 1) * 52.0;
+    final effectiveHeightRatio =
+        (contentHeight / screenHeight).clamp(0.3, 0.82).toDouble();
+
     final selected =
-        await CupertinoBottomSheet.showSelection<LocalLibrarySortType>(
+        await CupertinoBottomSheet.show<LocalLibrarySortType>(
       context: context,
       title: '排序',
-      options: [
-        _phoneSortOption(LocalLibrarySortType.dateAdded, '最近观看'),
-        _phoneSortOption(LocalLibrarySortType.name, '名称排序'),
-        _phoneSortOption(LocalLibrarySortType.rating, '评分排序'),
-      ],
+      heightRatio: effectiveHeightRatio,
+      child: CupertinoBottomSheetContentLayout(
+        sliversBuilder: (sheetContext, topSpacing) => [
+          SliverPadding(
+            padding: EdgeInsets.fromLTRB(12, topSpacing + 4, 12, 24),
+            sliver: SliverToBoxAdapter(
+              child: cupertino.CupertinoListSection.insetGrouped(
+                margin: EdgeInsets.zero,
+                children: [
+                  if (showUnwatched)
+                    cupertino.CupertinoListTile(
+                      leading: Icon(
+                        cupertino.CupertinoIcons.eye,
+                        size: 20,
+                      ),
+                      title: const Text('只看未观看'),
+                      trailing: widget.showUnwatchedOnly == true
+                          ? Icon(
+                              cupertino.CupertinoIcons.check_mark,
+                              size: 18,
+                              color: cupertino.CupertinoTheme.of(sheetContext)
+                                  .primaryColor,
+                            )
+                          : null,
+                      onTap: () {
+                        Navigator.of(sheetContext).pop();
+                        widget.onToggleUnwatchedOnly?.call();
+                      },
+                    ),
+                  for (final entry in sortEntries)
+                    cupertino.CupertinoListTile(
+                      title: Text(entry.$2),
+                      trailing: widget.currentSort == entry.$1
+                          ? Icon(
+                              cupertino.CupertinoIcons.check_mark,
+                              size: 18,
+                              color: cupertino.CupertinoTheme.of(sheetContext)
+                                  .primaryColor,
+                            )
+                          : null,
+                      onTap: () => Navigator.of(sheetContext)
+                          .pop<LocalLibrarySortType>(entry.$1),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
     );
     if (selected != null) {
       widget.onSortChanged?.call(selected);
     }
-  }
-
-  CupertinoBottomSheetOption<LocalLibrarySortType> _phoneSortOption(
-    LocalLibrarySortType type,
-    String label,
-  ) {
-    return CupertinoBottomSheetOption(
-      label: label,
-      value: type,
-      selected: widget.currentSort == type,
-    );
   }
 }

--- a/lib/themes/nipaplay/widgets/network_media_library_view.dart
+++ b/lib/themes/nipaplay/widgets/network_media_library_view.dart
@@ -44,6 +44,7 @@ abstract class NetworkMediaItem {
   double? get userRating;
   bool get isFolder;
   String? get progress; // 新增
+  bool get isPlayed; // 服务器端记录的已观看状态
 }
 
 // 通用媒体库接口
@@ -82,6 +83,9 @@ class JellyfinMediaItemAdapter implements NetworkMediaItem {
     // Jellyfin 列表接口可能不返回具体的播放进度集数，如果需要更详细的可以后续扩展
     return null;
   }
+
+  @override
+  bool get isPlayed => _item.userData?.played == true;
 
   JellyfinMediaItem get originalItem => _item;
 }
@@ -127,6 +131,9 @@ class EmbyMediaItemAdapter implements NetworkMediaItem {
     if (_item.userData?.played == true) return '已看完';
     return null;
   }
+
+  @override
+  bool get isPlayed => _item.userData?.played == true;
 
   EmbyMediaItem get originalItem => _item;
 }
@@ -184,6 +191,7 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
   List<NetworkMediaItem> _searchResults = [];
   List<NetworkMediaItem> _filteredMediaItems = [];
   Timer? _searchDebounceTimer;
+  bool _showOnlyUnwatched = false;
 
   Widget _buildPlainActionButton({
     required IconData icon,
@@ -220,6 +228,11 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
             .toList();
       }
 
+      // 只看未观看过滤
+      if (_showOnlyUnwatched) {
+        source = source.where((item) => !item.isPlayed).toList();
+      }
+
       if (_showRemoteSortDropdown) {
         _filteredMediaItems = source;
         return;
@@ -238,6 +251,39 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
       }
       _filteredMediaItems = source;
     });
+  }
+
+  // 切换“只看未观看”过滤（排序弹层开关会调用）
+  void _toggleShowOnlyUnwatched() {
+    setState(() {
+      _showOnlyUnwatched = !_showOnlyUnwatched;
+    });
+    _applySortAndFilter();
+  }
+
+  // 手动刷新当前视图（媒体库列表 / 媒体库内容 / 文件夹）
+  Future<void> _manualRefresh() async {
+    if (!mounted) return;
+    if (_isShowingLibraryContent) {
+      if (_isFolderNavigation) {
+        final folderId = _currentFolderId ?? _selectedLibraryId;
+        if (folderId != null) {
+          setState(() {
+            _isLoadingLibraryContent = true;
+            _error = null;
+          });
+          await _loadFolderItems(folderId);
+        }
+      } else if (_selectedLibraryId != null) {
+        setState(() {
+          _isLoadingLibraryContent = true;
+          _error = null;
+        });
+        await _loadLibraryContent(_selectedLibraryId!);
+      }
+    } else {
+      await _loadData();
+    }
   }
 
   @override
@@ -550,11 +596,17 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
         if (showRemoteSort) ...[
           NipaplayLargeScreenActionButton(
             icon: Icons.sort_rounded,
-            label: '排序',
+            label: _showOnlyUnwatched ? '排序·未看' : '排序',
             onPressed: _showLargeScreenRemoteSortDialog,
           ),
           const SizedBox(width: 10),
         ],
+        NipaplayLargeScreenActionButton(
+          icon: Icons.refresh_rounded,
+          label: '刷新',
+          onPressed: _manualRefresh,
+        ),
+        const SizedBox(width: 10),
         NipaplayLargeScreenActionButton(
           icon: Ionicons.settings_outline,
           label: '服务器',
@@ -711,10 +763,13 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
 
   Widget _buildLargeScreenMediaGrid(List<NetworkMediaItem> items) {
     if (items.isEmpty) {
-      return const NipaplayLargeScreenEmptyState(
-        icon: Icons.search_off_rounded,
-        title: '没有匹配结果',
-        subtitle: '换个关键词再试试',
+      final filteredEmpty = !_isSearching && _showOnlyUnwatched;
+      return NipaplayLargeScreenEmptyState(
+        icon: filteredEmpty
+            ? Ionicons.eye_off_outline
+            : Icons.search_off_rounded,
+        title: filteredEmpty ? '没有未观看的条目' : '没有匹配结果',
+        subtitle: filteredEmpty ? '关闭“只看未观看”或刷新后再试' : '换个关键词再试试',
       );
     }
 
@@ -953,7 +1008,20 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
                   Expanded(
                     child: SingleChildScrollView(
                       child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
+                          _buildLargeScreenRemoteUnwatchedTile(context),
+                          const SizedBox(height: 8),
+                          const Padding(
+                            padding: EdgeInsets.only(left: 4, bottom: 8),
+                            child: Text(
+                              '排序方式',
+                              style: TextStyle(
+                                fontSize: 13,
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                          ),
                           for (var index = 0;
                               index < items.length;
                               index++) ...[
@@ -977,6 +1045,58 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
     if (selection != null) {
       _applyRemoteSortSelection(selection);
     }
+  }
+
+  Widget _buildLargeScreenRemoteUnwatchedTile(BuildContext dialogContext) {
+    return NipaplayLargeScreenFocusableAction(
+      isSelected: _showOnlyUnwatched,
+      onActivate: () {
+        _toggleShowOnlyUnwatched();
+        Navigator.of(dialogContext).pop();
+      },
+      borderRadius: BorderRadius.circular(8),
+      padding: const EdgeInsets.all(14),
+      child: Row(
+        children: [
+          Icon(
+            _showOnlyUnwatched
+                ? Ionicons.eye_off_outline
+                : Ionicons.eye_outline,
+            size: 18,
+            color: _showOnlyUnwatched ? _accentColor : null,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '只看未观看',
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '仅显示服务器上还没看完的条目',
+                  style: TextStyle(
+                    color: Colors.white.withValues(alpha: 0.62),
+                    fontSize: 12,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (_showOnlyUnwatched)
+            Icon(
+              Icons.check_rounded,
+              size: 18,
+              color: _accentColor,
+            ),
+        ],
+      ),
+    );
   }
 
   Widget _buildLargeScreenRemoteSortItem(
@@ -1206,39 +1326,70 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
               controller: _gridScrollController,
               child: _isFolderNavigation
                   ? _buildFolderListView()
-                  : GridView.builder(
-                      controller: _gridScrollController,
-                      gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-                        maxCrossAxisExtent: showSummary
-                            ? HorizontalAnimeCard.detailedGridMaxCrossAxisExtent
-                            : HorizontalAnimeCard.compactGridMaxCrossAxisExtent,
-                        mainAxisExtent: showSummary
-                            ? HorizontalAnimeCard.detailedCardHeight
-                            : HorizontalAnimeCard.compactCardHeight,
-                        crossAxisSpacing: 16,
-                        mainAxisSpacing: 16,
-                      ),
-                      padding: const EdgeInsets.all(16),
-                      cacheExtent: 800,
-                      clipBehavior: Clip.hardEdge,
-                      physics: const AlwaysScrollableScrollPhysics(
-                          parent: BouncingScrollPhysics()),
-                      addAutomaticKeepAlives: false,
-                      addRepaintBoundaries: true,
-                      itemCount: _isSearching
-                          ? _searchResults.length
-                          : _filteredMediaItems.length,
-                      itemBuilder: (context, index) {
-                        final item = _isSearching
-                            ? _searchResults[index]
-                            : _filteredMediaItems[index];
-                        return _buildMediaCard(item);
-                      },
-                    ),
+                  : (_isSearching ? _searchResults : _filteredMediaItems)
+                          .isEmpty
+                      ? _buildEmptyResultsPlaceholder()
+                      : GridView.builder(
+                          controller: _gridScrollController,
+                          gridDelegate:
+                              SliverGridDelegateWithMaxCrossAxisExtent(
+                            maxCrossAxisExtent: showSummary
+                                ? HorizontalAnimeCard.detailedGridMaxCrossAxisExtent
+                                : HorizontalAnimeCard.compactGridMaxCrossAxisExtent,
+                            mainAxisExtent: showSummary
+                                ? HorizontalAnimeCard.detailedCardHeight
+                                : HorizontalAnimeCard.compactCardHeight,
+                            crossAxisSpacing: 16,
+                            mainAxisSpacing: 16,
+                          ),
+                          padding: const EdgeInsets.all(16),
+                          cacheExtent: 800,
+                          clipBehavior: Clip.hardEdge,
+                          physics: const AlwaysScrollableScrollPhysics(
+                              parent: BouncingScrollPhysics()),
+                          addAutomaticKeepAlives: false,
+                          addRepaintBoundaries: true,
+                          itemCount: _isSearching
+                              ? _searchResults.length
+                              : _filteredMediaItems.length,
+                          itemBuilder: (context, index) {
+                            final item = _isSearching
+                                ? _searchResults[index]
+                                : _filteredMediaItems[index];
+                            return _buildMediaCard(item);
+                          },
+                        ),
             ),
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildEmptyResultsPlaceholder() {
+    final filteredEmpty = !_isSearching && _showOnlyUnwatched;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              filteredEmpty
+                  ? Ionicons.eye_off_outline
+                  : Icons.search_off_rounded,
+              color: Colors.grey,
+              size: 48,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              filteredEmpty ? '没有未观看的条目' : '没有匹配结果',
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Colors.grey, fontSize: 16),
+            ),
+          ],
+        ),
+      ),
     );
   }
 
@@ -1460,6 +1611,7 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
 
     final showLocalSort = !_showRemoteSortDropdown;
     final trailingActions = [
+      _buildRefreshAction(),
       _buildServerSettingsAction(),
       if (_showRemoteSortDropdown) _buildRemoteSortDropdown(),
     ];
@@ -1493,6 +1645,7 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
         _applySortAndFilter();
       },
       trailingActions: [
+        _buildRefreshAction(),
         _buildServerSettingsAction(),
       ],
     );
@@ -1992,10 +2145,19 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
 
   LocalLibraryActionControl _buildRemoteSortDropdown() {
     return LocalLibraryActionControl(
-      label: '排序',
+      label: _showOnlyUnwatched ? '排序（只看未观看）' : '排序',
       desktopIcon: Icons.sort_rounded,
       phoneIcon: cupertino.CupertinoIcons.arrow_up_arrow_down,
       onPressed: _showAdaptiveRemoteSortDialog,
+    );
+  }
+
+  LocalLibraryActionControl _buildRefreshAction() {
+    return LocalLibraryActionControl(
+      label: '刷新',
+      desktopIcon: Icons.refresh,
+      phoneIcon: cupertino.CupertinoIcons.refresh,
+      onPressed: _manualRefresh,
     );
   }
 
@@ -2011,14 +2173,70 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
       currentSortSettings['sortOrder']!,
     );
 
+    final screenHeight = MediaQuery.sizeOf(context).height;
+    final contentHeight = 112.0 + (items.length + 1) * 52.0;
+    final effectiveHeightRatio =
+        (contentHeight / screenHeight).clamp(0.3, 0.82).toDouble();
+
     final selection =
-        await CupertinoBottomSheet.showSelection<_RemoteSortSelection>(
+        await CupertinoBottomSheet.show<_RemoteSortSelection>(
       context: context,
       title: '排序',
-      options: [
-        for (final item in items)
-          CupertinoBottomSheetOption(label: item.title, value: item.value),
-      ],
+      heightRatio: effectiveHeightRatio,
+      child: CupertinoBottomSheetContentLayout(
+        sliversBuilder: (sheetContext, topSpacing) => [
+          SliverPadding(
+            padding: EdgeInsets.fromLTRB(12, topSpacing + 4, 12, 24),
+            sliver: SliverToBoxAdapter(
+              child: cupertino.CupertinoListSection.insetGrouped(
+                margin: EdgeInsets.zero,
+                children: [
+                  cupertino.CupertinoListTile(
+                    leading: Icon(
+                      _showOnlyUnwatched
+                          ? cupertino.CupertinoIcons.eye_slash
+                          : cupertino.CupertinoIcons.eye,
+                      size: 20,
+                    ),
+                    title: const Text('只看未观看'),
+                    trailing: _showOnlyUnwatched
+                        ? Icon(
+                            cupertino.CupertinoIcons.check_mark,
+                            size: 18,
+                            color: cupertino.CupertinoTheme.of(sheetContext)
+                                .primaryColor,
+                          )
+                        : null,
+                    onTap: () {
+                      _toggleShowOnlyUnwatched();
+                      Navigator.of(sheetContext).pop();
+                    },
+                  ),
+                  for (final item in items)
+                    cupertino.CupertinoListTile(
+                      title: Text(item.title),
+                      subtitle: item.description == null
+                          ? null
+                          : Text(item.description!),
+                      trailing: item.isSelected
+                          ? Icon(
+                              cupertino.CupertinoIcons.check_mark,
+                              size: 18,
+                              color: cupertino.CupertinoTheme.of(sheetContext)
+                                  .primaryColor,
+                            )
+                          : null,
+                      onTap: () =>
+                          Navigator.of(sheetContext).pop<_RemoteSortSelection>(
+                        item.value,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
     );
     if (selection != null) _applyRemoteSortSelection(selection);
   }

--- a/lib/themes/nipaplay/widgets/shared_remote_library_view.dart
+++ b/lib/themes/nipaplay/widgets/shared_remote_library_view.dart
@@ -11,6 +11,7 @@ import 'package:nipaplay/models/watch_history_model.dart';
 import 'package:nipaplay/providers/appearance_settings_provider.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/themed_anime_detail.dart';
 import 'package:nipaplay/providers/shared_remote_library_provider.dart';
+import 'package:nipaplay/providers/watch_history_provider.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/cached_network_image_widget.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/horizontal_anime_card.dart';
 import 'package:nipaplay/themes/nipaplay/widgets/blur_login_dialog.dart';
@@ -50,6 +51,7 @@ class _SharedRemoteLibraryViewState extends State<SharedRemoteLibraryView>
   final ScrollController _managementScrollController = ScrollController();
   final TextEditingController _searchController = TextEditingController();
   LocalLibrarySortType _currentSort = LocalLibrarySortType.dateAdded;
+  bool _showOnlyUnwatched = false;
   LibraryManagementViewMode _managementViewMode =
       LibraryManagementViewMode.icons;
   String? _managementLoadedHostId;
@@ -62,6 +64,25 @@ class _SharedRemoteLibraryViewState extends State<SharedRemoteLibraryView>
 
   @override
   bool get wantKeepAlive => true;
+
+  // 本地观看历史中已看过的番剧 ID（用于“只看未观看”过滤）
+  Set<int> _watchedAnimeIds() {
+    try {
+      final provider = Provider.of<WatchHistoryProvider>(context, listen: false);
+      if (provider.isLoaded) {
+        return provider.history
+            .where((item) => item.animeId != null)
+            .map((item) => item.animeId!)
+            .toSet();
+      }
+    } catch (_) {
+      // Provider 不可用时退回到静态缓存
+    }
+    return WatchHistoryManager.getAllCachedHistory()
+        .where((item) => item.animeId != null)
+        .map((item) => item.animeId!)
+        .toSet();
+  }
 
   @override
   void initState() {
@@ -107,6 +128,15 @@ class _SharedRemoteLibraryViewState extends State<SharedRemoteLibraryView>
             return folder.name.toLowerCase().contains(query) ||
                 folder.path.toLowerCase().contains(query);
           }).toList();
+        }
+
+        // 只看未观看过滤（基于本地观看历史，看过即视为已观看）
+        if (widget.mode == SharedRemoteViewMode.mediaLibrary &&
+            _showOnlyUnwatched) {
+          final watchedIds = _watchedAnimeIds();
+          animeSummaries = animeSummaries
+              .where((anime) => !watchedIds.contains(anime.animeId))
+              .toList();
         }
 
         // 排序逻辑
@@ -161,6 +191,14 @@ class _SharedRemoteLibraryViewState extends State<SharedRemoteLibraryView>
                 });
               },
               showSort: true,
+              showUnwatchedOnly: isManagement ? null : _showOnlyUnwatched,
+              onToggleUnwatchedOnly: isManagement
+                  ? null
+                  : () {
+                      setState(() {
+                        _showOnlyUnwatched = !_showOnlyUnwatched;
+                      });
+                    },
               viewMode: isManagement ? _managementViewMode : null,
               onToggleViewMode: isManagement
                   ? () {
@@ -428,8 +466,47 @@ class _SharedRemoteLibraryViewState extends State<SharedRemoteLibraryView>
             icon: Icons.star_rounded,
             type: LocalLibrarySortType.rating,
           ),
+          const SizedBox(width: 10),
+          _buildLargeScreenUnwatchedChip(),
         ],
       ],
+    );
+  }
+
+  Widget _buildLargeScreenUnwatchedChip() {
+    final selected = _showOnlyUnwatched;
+    return NipaplayLargeScreenFocusableAction(
+      onActivate: () {
+        setState(() {
+          _showOnlyUnwatched = !_showOnlyUnwatched;
+        });
+      },
+      borderRadius: BorderRadius.circular(8),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 11),
+      focusScale: 1.04,
+      style: NipaplayLargeScreenFocusableStyle(
+        idleBackgroundDark: selected
+            ? _accentColor.withValues(alpha: 0.26)
+            : Colors.white.withValues(alpha: 0.09),
+        idleBackgroundLight: selected
+            ? _accentColor.withValues(alpha: 0.18)
+            : Colors.white.withValues(alpha: 0.82),
+        focusStrokeColor: selected ? _accentColor : null,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            selected ? Ionicons.eye_off_outline : Ionicons.eye_outline,
+            size: 18,
+          ),
+          const SizedBox(width: 8),
+          const Text(
+            '只看未观看',
+            style: TextStyle(fontSize: 14, fontWeight: FontWeight.w800),
+          ),
+        ],
+      ),
     );
   }
 
@@ -565,10 +642,18 @@ class _SharedRemoteLibraryViewState extends State<SharedRemoteLibraryView>
     }
 
     if (animeSummaries.isEmpty) {
+      final filteredEmpty =
+          _showOnlyUnwatched && _searchController.text.trim().isEmpty;
       return NipaplayLargeScreenEmptyState(
-        icon: Ionicons.folder_open_outline,
-        title: provider.activeHost == null ? '请选择共享客户端' : '该客户端尚未扫描番剧',
-        subtitle: '切换客户端或进入库管理添加远程文件夹',
+        icon: filteredEmpty
+            ? Ionicons.eye_off_outline
+            : Ionicons.folder_open_outline,
+        title: filteredEmpty
+            ? '没有未观看的番剧'
+            : (provider.activeHost == null ? '请选择共享客户端' : '该客户端尚未扫描番剧'),
+        subtitle: filteredEmpty
+            ? '关闭“只看未观看”后可查看全部内容'
+            : '切换客户端或进入库管理添加远程文件夹',
       );
     }
 
@@ -1080,7 +1165,12 @@ class _SharedRemoteLibraryViewState extends State<SharedRemoteLibraryView>
     }
 
     if (animeSummaries.isEmpty) {
-      return _buildEmptyLibraryPlaceholder(context, provider.activeHost);
+      return _buildEmptyLibraryPlaceholder(
+        context,
+        provider.activeHost,
+        filteredEmpty:
+            _showOnlyUnwatched && _searchController.text.trim().isEmpty,
+      );
     }
 
     final showSummary =
@@ -1672,15 +1762,30 @@ class _SharedRemoteLibraryViewState extends State<SharedRemoteLibraryView>
   }
 
   Widget _buildEmptyLibraryPlaceholder(
-      BuildContext context, SharedRemoteHost? host) {
+    BuildContext context,
+    SharedRemoteHost? host, {
+    bool filteredEmpty = false,
+  }) {
+    final String message;
+    if (host == null) {
+      message = '请选择一个共享客户端';
+    } else if (filteredEmpty) {
+      message = '没有未观看的番剧';
+    } else {
+      message = '该客户端尚未扫描任何番剧';
+    }
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(Ionicons.folder_open_outline, color: Colors.white38, size: 48),
+          Icon(
+            filteredEmpty ? Ionicons.eye_off_outline : Ionicons.folder_open_outline,
+            color: Colors.white38,
+            size: 48,
+          ),
           SizedBox(height: 12),
           Text(
-            host == null ? '请选择一个共享客户端' : '该客户端尚未扫描任何番剧',
+            message,
             locale: const Locale('zh', 'CN'),
             textAlign: TextAlign.center,
             style: TextStyle(color: Colors.white60),


### PR DESCRIPTION
Closes #883

## 改了什么

为媒体库新增「只看未观看」过滤开关与手动刷新按钮,统一覆盖 Jellyfin / Emby / 共享库(SMB / WebDAV / 本地文件夹)三种媒体库类型。

### 功能实现

1. **Jellyfin / Emby 网络媒体库**(`network_media_library_view.dart`)
   - `NetworkMediaItem` 抽象接口新增 `isPlayed`,由 `UserData.Played`(Jellyfin / Emby 共用)实现
   - `_applySortAndFilter` 中在搜索过滤之后、排序之前加入 `!item.isPlayed` 过滤
   - 桌面排序 Dialog 与手机排序 BottomSheet 顶部均增加「只看未观看」开关行,点击立即生效并关闭弹层
   - 开启时桌面排序按钮 label 显示「排序·未看」提示状态
2. **共享库视图**(`shared_remote_library_view.dart`)
   - 基于本地观看历史(`WatchHistoryProvider.history`,按 `animeId` 匹配)判断已观看,看过即视为已观看;Provider 不可用时回退到 `WatchHistoryManager.getAllCachedHistory()`
   - 通过 `LocalLibraryControlBar` 新增的可选参数 `showUnwatchedOnly` / `onToggleUnwatchedOnly` 接入:桌面为眼睛图标按钮,手机为排序菜单顶部开关行
   - 大屏排序行追加独立 chip;所有新参数均可选,不影响其他 `LocalLibraryControlBar` 调用方
3. **手动刷新按钮**(`network_media_library_view.dart`)
   - 新增 `_manualRefresh()`,根据当前视图(媒体库列表 / 单库内容 / 文件夹导航)调用对应加载逻辑
   - 大屏顶栏(排序与服务器按钮之间)与小屏控制栏均加入刷新入口
4. **空状态**:过滤后列表为空时显示「没有未观看的条目」专用提示,与搜索无结果区分

## 为什么

媒体库动辄几百上千条内容,已看与未看混在一起,追番 / 补片时只能一页页翻或靠记忆。官方 Jellyfin Web 自带「Unplayed」筛选,本客户端缺少同等能力。选择在客户端过滤是因为当前远程库为全量拉取后客户端渲染(`getLatestMediaItems(limit: 99999)`),不会出现分页丢数据。备注:若未来改为服务端分页,需在 `/Items` 请求中加 `Filters=IsUnplayed`(Jellyfin / Emby API 均支持)。

## 怎么验证

- `flutter analyze`(Flutter 3.47.2)对 3 个改动文件检查:0 error / 0 warning,仅存在仓库原有的 info 级提示
- 新增的 `LocalLibraryControlBar` 参数均为可选(默认 null),`adaptive_media_collection_view`、`library_management_tab` 等现有调用方行为不变
- 已人工确认:开关在三种媒体库类型中均生效;刷新按钮按当前视图层级正确刷新;过滤为空时的空状态文案正确

## 截图

(桌面 / 手机 / 大屏 三种形态的开关入口见 commit 内代码;如需截图可后续补充)
