### PR TITLE
feat: 「只看未观看」开关状态持久化

### DIFF
--- a/lib/themes/nipaplay/widgets/network_media_library_view.dart
+++ b/lib/themes/nipaplay/widgets/network_media_library_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart' as cupertino;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nipaplay/models/jellyfin_model.dart';
 import 'package:nipaplay/models/emby_model.dart';
 import 'package:nipaplay/models/watch_history_model.dart';
@@ -171,6 +172,10 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
     with AutomaticKeepAliveClientMixin {
   static Color get _accentColor => AppAccentColors.current;
 
+  // “只看未观看”状态的持久化 Key（按服务器类型区分）
+  String get _unwatchedFilterPrefsKey =>
+      'network_media_unwatched_only_${widget.serverType.name}';
+
   List<NetworkMediaItem> _mediaItems = [];
   String? _error;
   Timer? _refreshTimer;
@@ -259,6 +264,7 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
       _showOnlyUnwatched = !_showOnlyUnwatched;
     });
     _applySortAndFilter();
+    _persistUnwatchedFilterState();
   }
 
   // 手动刷新当前视图（媒体库列表 / 媒体库内容 / 文件夹）
@@ -296,9 +302,35 @@ class _NetworkMediaLibraryViewState extends State<NetworkMediaLibraryView>
       if (mounted) {
         final provider = _provider;
         provider.addListener(_onProviderChanged);
+        _restoreUnwatchedFilterState();
         _loadData(); // Initial load based on current provider state
       }
     });
+  }
+
+  // 从本地存储恢复“只看未观看”开关状态（重开应用后保持上一次的状态）
+  Future<void> _restoreUnwatchedFilterState() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final saved = prefs.getBool(_unwatchedFilterPrefsKey);
+      if (saved == null || !mounted) return;
+      setState(() {
+        _showOnlyUnwatched = saved;
+      });
+      _applySortAndFilter();
+    } catch (e) {
+      debugPrint('[$_serverName] 恢复未观看过滤状态失败: $e');
+    }
+  }
+
+  // 将“只看未观看”开关状态写入本地存储
+  Future<void> _persistUnwatchedFilterState() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_unwatchedFilterPrefsKey, _showOnlyUnwatched);
+    } catch (e) {
+      debugPrint('[$_serverName] 保存未观看过滤状态失败: $e');
+    }
   }
 
   @override

--- a/lib/themes/nipaplay/widgets/shared_remote_library_view.dart
+++ b/lib/themes/nipaplay/widgets/shared_remote_library_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:kmbal_ionicons/kmbal_ionicons.dart';
 import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:nipaplay/models/shared_remote_library.dart';
 import 'package:nipaplay/models/watch_history_model.dart';
@@ -47,6 +48,35 @@ class SharedRemoteLibraryView extends StatefulWidget {
 class _SharedRemoteLibraryViewState extends State<SharedRemoteLibraryView>
     with AutomaticKeepAliveClientMixin {
   static Color get _accentColor => AppAccentColors.current;
+
+  // “只看未观看”状态的持久化 Key
+  static const String _unwatchedFilterPrefsKey =
+      'shared_library_unwatched_only';
+
+  // 从本地存储恢复“只看未观看”开关状态（重开应用后保持上一次的状态）
+  Future<void> _restoreUnwatchedFilterState() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final saved = prefs.getBool(_unwatchedFilterPrefsKey);
+      if (saved == null || !mounted) return;
+      setState(() {
+        _showOnlyUnwatched = saved;
+      });
+    } catch (e) {
+      debugPrint('[共享媒体库] 恢复未观看过滤状态失败: $e');
+    }
+  }
+
+  // 将“只看未观看”开关状态写入本地存储
+  Future<void> _persistUnwatchedFilterState() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_unwatchedFilterPrefsKey, _showOnlyUnwatched);
+    } catch (e) {
+      debugPrint('[共享媒体库] 保存未观看过滤状态失败: $e');
+    }
+  }
+
   final ScrollController _gridScrollController = ScrollController();
   final ScrollController _managementScrollController = ScrollController();
   final TextEditingController _searchController = TextEditingController();
@@ -95,6 +125,12 @@ class _SharedRemoteLibraryViewState extends State<SharedRemoteLibraryView>
         }
       });
     }
+    // 恢复“只看未观看”开关状态
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _restoreUnwatchedFilterState();
+      }
+    });
   }
 
   @override
@@ -198,6 +234,7 @@ class _SharedRemoteLibraryViewState extends State<SharedRemoteLibraryView>
                       setState(() {
                         _showOnlyUnwatched = !_showOnlyUnwatched;
                       });
+                      _persistUnwatchedFilterState();
                     },
               viewMode: isManagement ? _managementViewMode : null,
               onToggleViewMode: isManagement
@@ -480,6 +517,7 @@ class _SharedRemoteLibraryViewState extends State<SharedRemoteLibraryView>
         setState(() {
           _showOnlyUnwatched = !_showOnlyUnwatched;
         });
+        _persistUnwatchedFilterState();
       },
       borderRadius: BorderRadius.circular(8),
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 11),


### PR DESCRIPTION
## 改了什么

为 #888 引入的「只看未观看」开关增加状态持久化:重开应用后自动恢复上一次关闭时的状态,无需每次手动重新勾选。

- **网络媒体库(Jellyfin / Emby)**:按服务器类型分别记录(`network_media_unwatched_only_jellyfin` / `network_media_unwatched_only_emby`),两个标签页互不干扰
- **共享库(SMB / WebDAV / 本地文件夹)**:统一记录(`shared_library_unwatched_only`),手机排序菜单开关与桌面大屏 chip 两条入口均会写入
- 复用项目现有的 `SharedPreferences` 机制,存储方式与 `AppearanceSettingsProvider` 一致
- 读写均带 try/catch,存储失败只打日志,不影响功能使用

## 为什么

「只看未观看」是追番 / 补片场景下的常用过滤,但目前每次重开应用都会重置为关闭,用户需要反复手动开启。

## 怎么验证

- `flutter analyze`(Flutter 3.47.2)对 2 个改动文件检查:0 error / 0 warning,info 提示与仓库既有状态一致
- 新增代码不改变任何现有调用方接口,`LocalLibraryControlBar` 无接口变化
- 已人工确认:切换开关后冷启动应用,Jellyfin / Emby / 共享库三种形态下开关状态均能正确恢复并立即生效于列表过滤
