### PR TITLE
fix(ci): disable Dart problem matcher in setup-flutter action and update FVM contract test

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -28,6 +28,8 @@ runs:
 
     - name: Setup Dart (for FVM)
       uses: dart-lang/setup-dart@v1
+      with:
+        problem-matcher: false
 
     - name: Cache FVM & Pub cache (Linux/macOS)
       if: runner.os != 'Windows'

--- a/test/mainline_flutter_compatibility_test.dart
+++ b/test/mainline_flutter_compatibility_test.dart
@@ -12,7 +12,10 @@ void main() {
     expect(pubspec, isNot(contains('path: packages/fvp-0.37.3')));
     expect(pubspec, isNot(contains('path: packages/fluent_ui-4.15.1')));
     expect(pubspec, contains('fvp: ^0.33.1'));
-    expect(File('.fvmrc').readAsStringSync(), contains('3.44.6'));
+    expect(
+      File('.github/actions/setup-flutter/action.yml').readAsStringSync(),
+      contains("default: '3.44.6'"),
+    );
     expect(File('pubspec_overrides.ohos.yaml').existsSync(), isTrue);
     expect(File('pubspec_overrides.linux.yaml').existsSync(), isTrue);
     expect(File('pubspec_overrides.tvos.yaml').existsSync(), isTrue);


### PR DESCRIPTION
## Summary

- Pass `problem-matcher: false` to `dart-lang/setup-dart@v1` inside `.github/actions/setup-flutter/action.yml`.
- Update `test/mainline_flutter_compatibility_test.dart` to assert the default Flutter version from `.github/actions/setup-flutter/action.yml` instead of the removed `.fvmrc`.

## Root Cause

1. Recent runner image updates (`ubuntu-24.04` image `20260831.293.1`) strictly check file existence for `::add-matcher::`. When `dart-lang/setup-dart` runs within the composite action `.github/actions/setup-flutter`, the runner attempts to resolve `dart-analyzer.json` relative to `.github/actions/setup-flutter/dart-analyzer.json`, which does not exist and causes a fatal step failure.
2. Commit `e7384199` deleted `.fvmrc`, leaving `test/mainline_flutter_compatibility_test.dart` expecting `.fvmrc`.

## Verification

- `flutter test test/mainline_flutter_compatibility_test.dart` passes.
- Full `flutter test --no-pub` test suite (572 tests) passes.