### PR TITLE
fix: 密码输入统一使用英文输入模式

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:nipaplay/services/remote_control_access_guard_service.dart';
+import 'package:nipaplay/services/password_input_mode_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -164,6 +165,7 @@ Alignment _resolveStartupWindowAlignment(
 
 void main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
+  PasswordInputModeService.instance.start();
   if (!kIsWeb && globals.supportsRustNativeBridge) {
     try {
       await ensureRustInitialized();

--- a/lib/media_library/adaptive_media_library_primitives.dart
+++ b/lib/media_library/adaptive_media_library_primitives.dart
@@ -738,6 +738,9 @@ class _AdaptiveMediaTextFieldState
     if (mounted) setState(() {});
   }
 
+  bool get _isPassword => widget.obscureText ||
+      widget.keyboardType == material.TextInputType.visiblePassword;
+
   void _handleChanged(String value) {
     if (mounted) setState(() {});
     widget.onChanged?.call(value);
@@ -768,7 +771,13 @@ class _AdaptiveMediaTextFieldState
         placeholder: placeholder,
         style: widget.style,
         cursorColor: widget.cursorColor,
-        keyboardType: widget.keyboardType,
+        keyboardType: _isPassword
+            ? material.TextInputType.visiblePassword
+            : widget.keyboardType,
+        autocorrect: !_isPassword,
+        enableSuggestions: !_isPassword,
+        smartDashesType: _isPassword ? services.SmartDashesType.disabled : null,
+        smartQuotesType: _isPassword ? services.SmartQuotesType.disabled : null,
         minLines: widget.minLines,
         maxLines: widget.maxLines,
         obscureText: widget.obscureText,
@@ -832,7 +841,13 @@ class _AdaptiveMediaTextFieldState
         focusNode: _focusNode,
         style: style,
         cursorColor: widget.cursorColor,
-        keyboardType: widget.keyboardType,
+        keyboardType: _isPassword
+            ? material.TextInputType.visiblePassword
+            : widget.keyboardType,
+        autocorrect: !_isPassword,
+        enableSuggestions: !_isPassword,
+        smartDashesType: _isPassword ? services.SmartDashesType.disabled : null,
+        smartQuotesType: _isPassword ? services.SmartQuotesType.disabled : null,
         minLines: widget.minLines,
         maxLines: widget.maxLines,
         obscureText: widget.obscureText,
@@ -887,7 +902,13 @@ class _AdaptiveMediaTextFieldState
             backgroundCursorColor:
                 theme.colorScheme.onSurface.withValues(alpha: 0.4),
             selectionColor: theme.colorScheme.primary.withValues(alpha: 0.25),
-            keyboardType: widget.keyboardType,
+            keyboardType: _isPassword
+                ? material.TextInputType.visiblePassword
+                : widget.keyboardType,
+            autocorrect: !_isPassword,
+            enableSuggestions: !_isPassword,
+            smartDashesType: _isPassword ? services.SmartDashesType.disabled : null,
+            smartQuotesType: _isPassword ? services.SmartQuotesType.disabled : null,
             minLines: widget.minLines,
             maxLines: widget.maxLines,
             obscureText: widget.obscureText,

--- a/lib/services/password_input_mode_service.dart
+++ b/lib/services/password_input_mode_service.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// Restricts only the active macOS password field's input context to Roman
+/// input sources. No password text is sent to native code or modified here.
+class PasswordInputModeService with WidgetsBindingObserver {
+  static final instance = PasswordInputModeService();
+  static const _channel = MethodChannel('nipaplay/password_input_mode');
+  bool _started = false;
+  bool _scheduled = false;
+  bool _resumed = true;
+
+  void start() {
+    if (_started || kIsWeb || defaultTargetPlatform != TargetPlatform.macOS) {
+      return;
+    }
+    _started = true;
+    FocusManager.instance.addListener(_scheduleUpdate);
+    WidgetsBinding.instance.addObserver(this);
+    _scheduleUpdate();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    _resumed = state == AppLifecycleState.resumed;
+    _scheduleUpdate();
+  }
+
+  void _scheduleUpdate() {
+    if (!_started || _scheduled) return;
+    _scheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _scheduled = false;
+      if (!_started) return;
+      final context = FocusManager.instance.primaryFocus?.context;
+      final widget = context?.widget;
+      final editable = widget is EditableText
+          ? widget
+          : context?.findAncestorWidgetOfExactType<EditableText>();
+      final isPassword = editable != null &&
+          (editable.obscureText ||
+              editable.keyboardType == TextInputType.visiblePassword);
+      unawaited(_setNativeMode(_resumed && isPassword));
+    });
+    WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
+  Future<void> _setNativeMode(bool enabled) async {
+    try {
+      await _channel.invokeMethod<void>('setPasswordMode', enabled);
+    } on MissingPluginException {
+      // Older runners and non-native widget tests can still edit passwords.
+    } on PlatformException catch (error) {
+      debugPrint('Password input mode unavailable: ${error.code}');
+    }
+  }
+
+  void dispose() {
+    if (!_started) return;
+    _started = false;
+    FocusManager.instance.removeListener(_scheduleUpdate);
+    WidgetsBinding.instance.removeObserver(this);
+    unawaited(_setNativeMode(false));
+  }
+}

--- a/lib/themes/cupertino/widgets/cupertino_remote_text_input_sheet.dart
+++ b/lib/themes/cupertino/widgets/cupertino_remote_text_input_sheet.dart
@@ -208,7 +208,11 @@ class _CupertinoRemoteTextInputContentState
           focusNode: _focusNodes[field.id],
           autofocus: index == 0,
           obscureText: field.obscureText,
-          keyboardType: _keyboardType(field.inputType),
+          keyboardType: field.obscureText
+              ? TextInputType.visiblePassword
+              : _keyboardType(field.inputType),
+          autocorrect: !field.obscureText,
+          enableSuggestions: !field.obscureText,
           textInputAction: isLast ? TextInputAction.done : TextInputAction.next,
           minLines: field.multiline ? 4 : 1,
           maxLines: field.multiline ? 8 : 1,

--- a/lib/themes/cupertino/widgets/cupertino_smb_connection_dialog.dart
+++ b/lib/themes/cupertino/widgets/cupertino_smb_connection_dialog.dart
@@ -188,7 +188,9 @@ class _CupertinoSmbConnectionSheetState
         CupertinoTextField(
           controller: controller,
           placeholder: placeholder,
-          keyboardType: keyboardType,
+          keyboardType: obscureText ? TextInputType.visiblePassword : keyboardType,
+          autocorrect: !obscureText,
+          enableSuggestions: !obscureText,
           inputFormatters: inputFormatters,
           obscureText: obscureText,
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),

--- a/lib/themes/cupertino/widgets/cupertino_webdav_connection_dialog.dart
+++ b/lib/themes/cupertino/widgets/cupertino_webdav_connection_dialog.dart
@@ -243,7 +243,9 @@ class _CupertinoWebDAVConnectionSheetState
         CupertinoTextField(
           controller: controller,
           placeholder: placeholder,
-          keyboardType: keyboardType,
+          keyboardType: obscureText ? TextInputType.visiblePassword : keyboardType,
+          autocorrect: !obscureText,
+          enableSuggestions: !obscureText,
           inputFormatters: inputFormatters,
           obscureText: obscureText,
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),

--- a/lib/themes/nipaplay/pages/settings/backup_restore_page.dart
+++ b/lib/themes/nipaplay/pages/settings/backup_restore_page.dart
@@ -892,6 +892,11 @@ class _SyncSettingsDialogState extends State<_SyncSettingsDialog> {
                             child: TextField(
                               controller: _passwordController,
                               obscureText: _obscurePassword,
+                              keyboardType: TextInputType.visiblePassword,
+                              autocorrect: false,
+                              enableSuggestions: false,
+                              smartDashesType: SmartDashesType.disabled,
+                              smartQuotesType: SmartQuotesType.disabled,
                               decoration: InputDecoration(
                                 labelText: '密码',
                                 prefixIcon: const Icon(Icons.lock_outline),

--- a/lib/themes/nipaplay/widgets/smb_connection_dialog.dart
+++ b/lib/themes/nipaplay/widgets/smb_connection_dialog.dart
@@ -268,7 +268,13 @@ class _SMBConnectionFormState extends State<_SMBConnectionForm> {
       child: TextFormField(
         controller: controller,
         validator: validator,
-        keyboardType: keyboardType,
+        keyboardType: fieldId == 'password'
+            ? TextInputType.visiblePassword
+            : keyboardType,
+        autocorrect: fieldId != 'password',
+        enableSuggestions: fieldId != 'password',
+        smartDashesType: fieldId == 'password' ? SmartDashesType.disabled : null,
+        smartQuotesType: fieldId == 'password' ? SmartQuotesType.disabled : null,
         obscureText: obscureText,
         cursorColor: _accentColor,
         style: TextStyle(color: _textColor),

--- a/lib/themes/nipaplay/widgets/webdav_connection_dialog.dart
+++ b/lib/themes/nipaplay/widgets/webdav_connection_dialog.dart
@@ -241,6 +241,11 @@ class _WebDAVFormState extends State<_WebDAVForm> {
                 child: TextFormField(
                   controller: _passwordController,
                   obscureText: !_passwordVisible,
+                  keyboardType: TextInputType.visiblePassword,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  smartDashesType: SmartDashesType.disabled,
+                  smartQuotesType: SmartQuotesType.disabled,
                   cursorColor: accentColor,
                   style: TextStyle(color: textColor),
                   decoration: buildDecoration(

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -4,6 +4,59 @@ import ObjectiveC.runtime
 import QuartzCore
 import media_kit_video
 
+/// Flutter's macOS text input plugin does not select a Roman input source for
+/// password keyboard types. Restrict its active context, never the whole app.
+class PasswordInputModePlugin: NSObject, FlutterPlugin {
+    private weak var restrictedContext: NSTextInputContext?
+    private var previousLocales: [String]?
+    private var previousInputSource: NSTextInputSourceIdentifier?
+
+    static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(
+            name: "nipaplay/password_input_mode", binaryMessenger: registrar.messenger)
+        let instance = PasswordInputModePlugin()
+        registrar.addMethodCallDelegate(instance, channel: channel)
+        NotificationCenter.default.addObserver(
+            instance, selector: #selector(instance.restoreInputContext),
+            name: NSApplication.didResignActiveNotification, object: nil)
+    }
+
+    func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard call.method == "setPasswordMode", let enabled = call.arguments as? Bool else {
+            result(FlutterMethodNotImplemented)
+            return
+        }
+        if enabled, NSApp.isActive, let context = NSTextInputContext.current {
+            if restrictedContext !== context {
+                restoreInputContext()
+                restrictedContext = context
+                previousLocales = context.allowedInputSourceLocales
+                previousInputSource = context.selectedKeyboardInputSource
+            }
+            context.allowedInputSourceLocales = [NSAllRomanInputSourcesLocaleIdentifier]
+        } else {
+            restoreInputContext()
+        }
+        result(nil)
+    }
+
+    @objc private func restoreInputContext() {
+        guard let context = restrictedContext else { return }
+        context.allowedInputSourceLocales = previousLocales
+        if let previousInputSource {
+            context.selectedKeyboardInputSource = previousInputSource
+        }
+        restrictedContext = nil
+        previousLocales = nil
+        previousInputSource = nil
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        restoreInputContext()
+    }
+}
+
 class SecurityBookmarkPlugin: NSObject, FlutterPlugin {
     static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "security_bookmark", binaryMessenger: registrar.messenger)
@@ -1521,6 +1574,7 @@ class MainFlutterWindow: NSWindow {
     
     // 注册自定义安全书签插件
     SecurityBookmarkPlugin.register(with: flutterViewController.registrar(forPlugin: "SecurityBookmarkPlugin"))
+    PasswordInputModePlugin.register(with: flutterViewController.registrar(forPlugin: "PasswordInputModePlugin"))
     SystemSharePlugin.register(with: flutterViewController.registrar(forPlugin: "SystemSharePlugin"))
     MacOSNativeVideoPlugin.register(with: flutterViewController.registrar(forPlugin: "MacOSNativeVideoPlugin"))
 

--- a/packages/adaptive_platform_ui/ios/Classes/iOS26AlertDialogView.swift
+++ b/packages/adaptive_platform_ui/ios/Classes/iOS26AlertDialogView.swift
@@ -379,7 +379,14 @@ class iOS26AlertDialogView: NSObject, FlutterPlatformView {
                 textField.isSecureTextEntry = textFieldObscureText
 
                 // Set keyboard type
-                if let keyboardType = textFieldKeyboardType {
+                if textFieldObscureText || textFieldKeyboardType == "visiblePassword" {
+                    textField.keyboardType = .asciiCapable
+                    textField.autocorrectionType = .no
+                    textField.autocapitalizationType = .none
+                    textField.spellCheckingType = .no
+                    textField.smartDashesType = .no
+                    textField.smartQuotesType = .no
+                } else if let keyboardType = textFieldKeyboardType {
                     switch keyboardType {
                     case "emailAddress":
                         textField.keyboardType = .emailAddress

--- a/packages/adaptive_platform_ui/lib/src/widgets/adaptive_alert_dialog.dart
+++ b/packages/adaptive_platform_ui/lib/src/widgets/adaptive_alert_dialog.dart
@@ -30,6 +30,9 @@ class AdaptiveAlertDialogInput {
 
   /// Maximum length of the text input
   final int? maxLength;
+
+  bool get isPassword =>
+      obscureText || keyboardType == TextInputType.visiblePassword;
 }
 
 /// An adaptive alert dialog that renders platform-specific styles
@@ -260,7 +263,17 @@ class AdaptiveAlertDialog {
                   CupertinoTextField(
                     controller: textController,
                     placeholder: input.placeholder,
-                    keyboardType: input.keyboardType,
+                    keyboardType: input.isPassword
+                        ? TextInputType.visiblePassword
+                        : input.keyboardType,
+                    autocorrect: !input.isPassword,
+                    enableSuggestions: !input.isPassword,
+                    smartDashesType: input.isPassword
+                        ? SmartDashesType.disabled
+                        : null,
+                    smartQuotesType: input.isPassword
+                        ? SmartQuotesType.disabled
+                        : null,
                     obscureText: input.obscureText,
                     maxLength: input.maxLength,
                     autofocus: true,
@@ -380,7 +393,17 @@ class AdaptiveAlertDialog {
                     hintText: input.placeholder,
                     border: const OutlineInputBorder(),
                   ),
-                  keyboardType: input.keyboardType,
+                  keyboardType: input.isPassword
+                      ? TextInputType.visiblePassword
+                      : input.keyboardType,
+                  autocorrect: !input.isPassword,
+                  enableSuggestions: !input.isPassword,
+                  smartDashesType: input.isPassword
+                      ? SmartDashesType.disabled
+                      : null,
+                  smartQuotesType: input.isPassword
+                      ? SmartQuotesType.disabled
+                      : null,
                   obscureText: input.obscureText,
                   maxLength: input.maxLength,
                   autofocus: true,

--- a/packages/adaptive_platform_ui/lib/src/widgets/adaptive_text_field.dart
+++ b/packages/adaptive_platform_ui/lib/src/widgets/adaptive_text_field.dart
@@ -119,6 +119,9 @@ class AdaptiveTextField extends StatelessWidget {
   /// The decoration to show around the text field (Material only).
   final InputDecoration? decoration;
 
+  bool get _isPassword =>
+      obscureText || keyboardType == TextInputType.visiblePassword;
+
   @override
   Widget build(BuildContext context) {
     if (PlatformInfo.prefersCupertinoControls) {
@@ -133,7 +136,7 @@ class AdaptiveTextField extends StatelessWidget {
       controller: controller,
       focusNode: focusNode,
       placeholder: placeholder,
-      keyboardType: keyboardType,
+      keyboardType: _isPassword ? TextInputType.visiblePassword : keyboardType,
       textInputAction: textInputAction,
       textCapitalization: textCapitalization,
       style: style,
@@ -142,7 +145,10 @@ class AdaptiveTextField extends StatelessWidget {
       minLines: minLines,
       maxLength: maxLength,
       obscureText: obscureText,
-      autocorrect: autocorrect,
+      autocorrect: !_isPassword && autocorrect,
+      enableSuggestions: !_isPassword,
+      smartDashesType: _isPassword ? SmartDashesType.disabled : null,
+      smartQuotesType: _isPassword ? SmartQuotesType.disabled : null,
       autofocus: autofocus,
       enabled: enabled,
       readOnly: readOnly,
@@ -191,7 +197,7 @@ class AdaptiveTextField extends StatelessWidget {
     return TextField(
       controller: controller,
       focusNode: focusNode,
-      keyboardType: keyboardType,
+      keyboardType: _isPassword ? TextInputType.visiblePassword : keyboardType,
       textInputAction: textInputAction,
       textCapitalization: textCapitalization,
       style: style,
@@ -200,7 +206,10 @@ class AdaptiveTextField extends StatelessWidget {
       minLines: minLines,
       maxLength: maxLength,
       obscureText: obscureText,
-      autocorrect: autocorrect,
+      autocorrect: !_isPassword && autocorrect,
+      enableSuggestions: !_isPassword,
+      smartDashesType: _isPassword ? SmartDashesType.disabled : null,
+      smartQuotesType: _isPassword ? SmartQuotesType.disabled : null,
       autofocus: autofocus,
       enabled: enabled,
       readOnly: readOnly,

--- a/packages/adaptive_platform_ui/lib/src/widgets/adaptive_text_form_field.dart
+++ b/packages/adaptive_platform_ui/lib/src/widgets/adaptive_text_form_field.dart
@@ -135,6 +135,9 @@ class AdaptiveTextFormField extends StatelessWidget {
   /// Used to enable/disable this form field auto validation and update its error text.
   final AutovalidateMode? autovalidateMode;
 
+  bool get _isPassword =>
+      obscureText || keyboardType == TextInputType.visiblePassword;
+
   @override
   Widget build(BuildContext context) {
     if (PlatformInfo.prefersCupertinoControls) {
@@ -158,7 +161,9 @@ class AdaptiveTextFormField extends StatelessWidget {
               controller: controller,
               focusNode: focusNode,
               placeholder: placeholder,
-              keyboardType: keyboardType,
+              keyboardType: _isPassword
+                  ? TextInputType.visiblePassword
+                  : keyboardType,
               textInputAction: textInputAction,
               textCapitalization: textCapitalization,
               style: style,
@@ -167,7 +172,10 @@ class AdaptiveTextFormField extends StatelessWidget {
               minLines: minLines,
               maxLength: maxLength,
               obscureText: obscureText,
-              autocorrect: autocorrect,
+              autocorrect: _isPassword ? false : autocorrect,
+              enableSuggestions: !_isPassword,
+              smartDashesType: _isPassword ? SmartDashesType.disabled : null,
+              smartQuotesType: _isPassword ? SmartQuotesType.disabled : null,
               autofocus: autofocus,
               enabled: enabled,
               readOnly: readOnly,
@@ -239,7 +247,7 @@ class AdaptiveTextFormField extends StatelessWidget {
       controller: controller,
       focusNode: focusNode,
       initialValue: initialValue,
-      keyboardType: keyboardType,
+      keyboardType: _isPassword ? TextInputType.visiblePassword : keyboardType,
       textInputAction: textInputAction,
       textCapitalization: textCapitalization,
       style: style,
@@ -248,7 +256,10 @@ class AdaptiveTextFormField extends StatelessWidget {
       minLines: minLines,
       maxLength: maxLength,
       obscureText: obscureText,
-      autocorrect: autocorrect,
+      autocorrect: _isPassword ? false : autocorrect,
+      enableSuggestions: !_isPassword,
+      smartDashesType: _isPassword ? SmartDashesType.disabled : null,
+      smartQuotesType: _isPassword ? SmartQuotesType.disabled : null,
       autofocus: autofocus,
       enabled: enabled,
       readOnly: readOnly,

--- a/packages/adaptive_platform_ui/lib/src/widgets/ios26/ios26_alert_dialog.dart
+++ b/packages/adaptive_platform_ui/lib/src/widgets/ios26/ios26_alert_dialog.dart
@@ -143,6 +143,7 @@ class _IOS26AlertDialogState extends State<IOS26AlertDialog> {
   }
 
   String _keyboardTypeToString(TextInputType type) {
+    if (type == TextInputType.visiblePassword) return 'visiblePassword';
     if (type == TextInputType.emailAddress) return 'emailAddress';
     if (type == TextInputType.number) return 'number';
     if (type == TextInputType.phone) return 'phone';
@@ -231,7 +232,17 @@ class _IOS26AlertDialogState extends State<IOS26AlertDialog> {
                 CupertinoTextField(
                   controller: _textController,
                   placeholder: input.placeholder,
-                  keyboardType: input.keyboardType,
+                  keyboardType: input.isPassword
+                      ? TextInputType.visiblePassword
+                      : input.keyboardType,
+                  autocorrect: !input.isPassword,
+                  enableSuggestions: !input.isPassword,
+                  smartDashesType: input.isPassword
+                      ? SmartDashesType.disabled
+                      : null,
+                  smartQuotesType: input.isPassword
+                      ? SmartQuotesType.disabled
+                      : null,
                   obscureText: input.obscureText,
                   maxLength: input.maxLength,
                   autofocus: true,

--- a/packages/liquid_glass_widgets/lib/widgets/input/glass_text_field.dart
+++ b/packages/liquid_glass_widgets/lib/widgets/input/glass_text_field.dart
@@ -647,7 +647,21 @@ class _GlassTextFieldState extends State<GlassTextField> {
             controller: widget.controller,
             focusNode: _focusNode,
             obscureText: widget.obscureText,
-            keyboardType: widget.keyboardType,
+            keyboardType: widget.obscureText
+                ? TextInputType.visiblePassword
+                : widget.keyboardType,
+            autocorrect: !widget.obscureText &&
+                widget.keyboardType != TextInputType.visiblePassword,
+            enableSuggestions: !widget.obscureText &&
+                widget.keyboardType != TextInputType.visiblePassword,
+            smartDashesType: widget.obscureText ||
+                    widget.keyboardType == TextInputType.visiblePassword
+                ? SmartDashesType.disabled
+                : null,
+            smartQuotesType: widget.obscureText ||
+                    widget.keyboardType == TextInputType.visiblePassword
+                ? SmartQuotesType.disabled
+                : null,
             textInputAction: widget.textInputAction,
             maxLines: widget.maxLines,
             minLines: widget.minLines,

--- a/test/password_input_mode_service_test.dart
+++ b/test/password_input_mode_service_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/services/password_input_mode_service.dart';
+
+void main() {
+  const channel = MethodChannel('nipaplay/password_input_mode');
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('macOS restricts only the focused password and restores on blur',
+      (tester) async {
+    final calls = <bool>[];
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(channel,
+        (call) async {
+      expect(call.method, 'setPasswordMode');
+      expect(call.arguments, isA<bool>());
+      calls.add(call.arguments as bool);
+      return null;
+    });
+    final service = PasswordInputModeService()..start();
+    final passwordFocus = FocusNode();
+    final normalFocus = FocusNode();
+    addTearDown(() {
+      service.dispose();
+      passwordFocus.dispose();
+      normalFocus.dispose();
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    });
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: Column(children: [
+      TextField(focusNode: passwordFocus, obscureText: true),
+      TextField(focusNode: normalFocus),
+    ]))));
+    await tester.pumpAndSettle();
+    passwordFocus.requestFocus();
+    await tester.pumpAndSettle();
+    expect(calls.last, isTrue);
+
+    service.didChangeAppLifecycleState(AppLifecycleState.inactive);
+    await tester.pumpAndSettle();
+    expect(calls.last, isFalse);
+    service.didChangeAppLifecycleState(AppLifecycleState.resumed);
+    await tester.pumpAndSettle();
+    expect(calls.last, isTrue);
+
+    normalFocus.requestFocus();
+    await tester.pumpAndSettle();
+    expect(calls.last, isFalse);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
+
+  testWidgets('a revealed password stays in password input mode',
+      (tester) async {
+    final calls = <bool>[];
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(channel,
+        (call) async {
+      calls.add(call.arguments as bool);
+      return null;
+    });
+    final service = PasswordInputModeService()..start();
+    addTearDown(() {
+      service.dispose();
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    });
+    await tester.pumpWidget(const MaterialApp(
+        home: Scaffold(
+            body: TextField(
+      autofocus: true,
+      obscureText: false,
+      keyboardType: TextInputType.visiblePassword,
+    ))));
+    await tester.pumpAndSettle();
+    expect(calls.last, isTrue);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
+}

--- a/test/password_text_fields_test.dart
+++ b/test/password_text_fields_test.dart
@@ -1,0 +1,132 @@
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:nipaplay/app/app_display_surface.dart';
+import 'package:nipaplay/app/app_display_surface_scope.dart';
+import 'package:nipaplay/media_library/adaptive_media_library_primitives.dart';
+
+void main() {
+  tearDown(PlatformInfo.clearPlatformOverride);
+
+  void expectPassword(WidgetTester tester) {
+    final editable = tester.widget<EditableText>(find.byType(EditableText));
+    expect(editable.keyboardType, TextInputType.visiblePassword);
+    expect(editable.autocorrect, isFalse);
+    expect(editable.enableSuggestions, isFalse);
+    expect(editable.smartDashesType, SmartDashesType.disabled);
+    expect(editable.smartQuotesType, SmartQuotesType.disabled);
+    const password = TextEditingValue(text: '  Abc中文🔑—“123  ');
+    var formatted = password;
+    for (final formatter in editable.inputFormatters ?? []) {
+      formatted = formatter.formatEditUpdate(TextEditingValue.empty, formatted);
+    }
+    expect(formatted, password);
+  }
+
+  for (final platform in [PlatformOverride.android, PlatformOverride.ios]) {
+    for (final revealed in [false, true]) {
+      for (final formField in [false, true]) {
+        testWidgets('$platform form=$formField revealed=$revealed password',
+            (tester) async {
+          PlatformInfo.setPlatformOverride(platform);
+          final controller = TextEditingController();
+          addTearDown(controller.dispose);
+          await tester.pumpWidget(MaterialApp(
+            home: Scaffold(
+              body: formField
+                  ? AdaptiveTextFormField(
+                      controller: controller,
+                      obscureText: !revealed,
+                      keyboardType:
+                          revealed ? TextInputType.visiblePassword : null,
+                    )
+                  : AdaptiveTextField(
+                      controller: controller,
+                      obscureText: !revealed,
+                      keyboardType:
+                          revealed ? TextInputType.visiblePassword : null,
+                    ),
+            ),
+          ));
+          expectPassword(tester);
+          const password = '  Abc中文🔑—“123  ';
+          await tester.enterText(find.byType(EditableText), password);
+          expect(controller.text, password);
+        });
+      }
+    }
+
+    testWidgets('$platform normal input keeps text keyboard and correction',
+        (tester) async {
+      PlatformInfo.setPlatformOverride(platform);
+      await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AdaptiveTextField())));
+      final editable = tester.widget<EditableText>(find.byType(EditableText));
+      expect(editable.keyboardType, TextInputType.text);
+      expect(editable.autocorrect, isTrue);
+      expect(editable.enableSuggestions, isTrue);
+    });
+
+    testWidgets('$platform password input alert uses password keyboard',
+        (tester) async {
+      PlatformInfo.setPlatformOverride(platform);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => TextButton(
+              onPressed: () => AdaptiveAlertDialog.inputShow(
+                context: context,
+                title: 'Password',
+                input: const AdaptiveAlertDialogInput(
+                  placeholder: 'Password',
+                  obscureText: true,
+                ),
+                actions: [AlertAction(title: 'Cancel', onPressed: () {})],
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      expectPassword(tester);
+    });
+  }
+
+  for (final surface in AppDisplaySurface.values) {
+    testWidgets('media password keyboard on $surface', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: AppDisplaySurfaceScope(
+            surface: surface,
+            child: AdaptiveMediaTextField(
+              controller: controller,
+              obscureText: true,
+            ),
+          ),
+        ),
+      ));
+      expectPassword(tester);
+    });
+  }
+
+  for (final revealed in [false, true]) {
+    testWidgets('glass password keyboard revealed=$revealed', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: GlassTextField(
+            obscureText: !revealed,
+            keyboardType: revealed ? TextInputType.visiblePassword : null,
+            useOwnLayer: true,
+            quality: GlassQuality.standard,
+          ),
+        ),
+      ));
+      expectPassword(tester);
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- 修复密码框沿用中文输入法、自动纠错和候选词的问题；与弹弹play网关鉴权 PR #890 独立，可单独合并。
- 输入模式调整不做字符过滤，不改变现有密码，粘贴 Unicode、符号和空格仍保持原文。

## Related Issue

- 用户反馈：密码输入应直接使用英文模式。

## What Changed

- 共用 AdaptiveTextField / AdaptiveTextFormField、AdaptiveMediaTextField 和 GlassTextField 统一使用密码键盘并关闭纠错、建议、智能标点。
- 覆盖账户、SMB、WebDAV、备份同步、远程输入以及原生 iOS 输入弹窗；显示密码时仍保留密码键盘类型。
- macOS 的 Flutter 引擎不会依据密码键盘类型限制输入法，因此新增统一焦点服务：仅在密码框聚焦时使用 AppKit 的 Roman 输入源限制，离开密码框或应用失活时恢复之前的输入源。原生通道只传布尔值，不接触密码内容。
- 增加焦点/生命周期、显示密码、普通输入不受影响、跨主题/显示表面及密码文本原样保留的回归测试。

## Validation

- 33 项 Flutter 测试通过（新增密码测试、现有自适应输入及玻璃弹窗回归）。
- 新服务、测试和补充组件静态分析通过；其余改动文件无错误，存在原有弃用/风格提示。
- `flutter build macos --debug --no-pub` 完整构建通过，包含原生输入模式插件。
- `git diff --check` 通过。
- 未进行 iOS/Android 真机输入法验证。密码键盘遵循各平台及第三方键盘实现，不强制删除密码字符。
- macOS 测试构建已启动，但 UI 自动化在进入输入框前反复返回 `noWindowsAvailable`，因此真实输入法切换/恢复仍需人工验收，不能用 widget 测试替代。
- 不包含构建产生的 Podfile.lock / GeneratedPluginRegistrant.swift 变动。

## Post-creation Review

- 已回看实际 PR 的 18 个文件：只包含密码输入修复及测试，无凭据、生成文件或弹弹play网关改动。
- 原生通道仅传递布尔值；关闭输入限制会恢复原输入源；显示密码分支保留密码键盘；未新增密码字符过滤。
- 与 #890 使用 `git merge-tree` 做合并预检，无冲突（没有执行合并）。
