### PR TITLE
fix: 修复 Dart 3.13 VM 回归导致的弹弹play 接口崩溃与观看历史迁移不幂等

### DIFF
--- a/lib/media_library/adaptive_media_collection_view.dart
+++ b/lib/media_library/adaptive_media_collection_view.dart
@@ -59,6 +59,7 @@ class _AdaptiveMediaCollectionViewState
   MediaCollectionSort _sort = MediaCollectionSort.recentlyAdded;
   bool _isSyncing = false;
   bool _isLoadingWebCollection = false;
+  bool _requestedHistoryLoad = false;
   List<WatchHistoryItem> _webCollectionItems = const <WatchHistoryItem>[];
 
   @override
@@ -87,7 +88,12 @@ class _AdaptiveMediaCollectionViewState
   material.Widget build(material.BuildContext context) {
     return Consumer<WatchHistoryProvider>(
       builder: (context, provider, _) {
-        if (!provider.isLoaded && !provider.isLoading) {
+        // 只请求一次：loadHistory 失败时 isLoaded 会一直是 false，
+        // 在 build 里反复补load会变成每帧一次的重试风暴。
+        if (!_requestedHistoryLoad &&
+            !provider.isLoaded &&
+            !provider.isLoading) {
+          _requestedHistoryLoad = true;
           material.WidgetsBinding.instance.addPostFrameCallback((_) {
             if (mounted && !provider.isLoaded) provider.loadHistory();
           });

--- a/lib/media_library/adaptive_media_library_page.dart
+++ b/lib/media_library/adaptive_media_library_page.dart
@@ -57,6 +57,7 @@ class _AdaptiveMediaLibraryPageState extends State<AdaptiveMediaLibraryPage> {
   TabChangeNotifier? _tabChangeNotifier;
   CupertinoPageActionsController? _pageActionsController;
   bool _connectionsInitialized = false;
+  bool _requestedHistoryLoad = false;
   int _selectionRevision = 0;
   late final MediaLibrarySectionOrderStore _sectionOrderStore;
 
@@ -276,7 +277,12 @@ class _AdaptiveMediaLibraryPageState extends State<AdaptiveMediaLibraryPage> {
         watchHistoryProvider,
         _,
       ) {
-        if (!watchHistoryProvider.isLoaded && !watchHistoryProvider.isLoading) {
+        // 只请求一次：加载失败时 isLoaded 会一直是 false，
+        // 在 build 里反复补load会变成每帧一次的重试风暴。
+        if (!_requestedHistoryLoad &&
+            !watchHistoryProvider.isLoaded &&
+            !watchHistoryProvider.isLoading) {
+          _requestedHistoryLoad = true;
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (mounted && !watchHistoryProvider.isLoaded) {
               watchHistoryProvider.loadHistory();

--- a/lib/models/watch_history_database.dart
+++ b/lib/models/watch_history_database.dart
@@ -146,10 +146,13 @@ class WatchHistoryDatabase {
       return;
     }
     if (oldVersion < 2) {
-      // 迁移必须幂等：早期构建在 user_version 还是 1 的时候就已经把
-      // media_key 写进了 CREATE TABLE，这类库再执行 ALTER 会抛
-      // "duplicate column name: media_key"，导致整个 onUpgrade 回滚、
-      // 观看历史永远加载不出来。
+      // 迁移必须幂等：sqflite 在没有 onDowngrade 的情况下，遇到磁盘上的
+      // user_version 高于代码里的版本时，只会把 user_version 改小、不动表
+      // 结构。所以只要先用 1.11.6 及以后的版本跑过，再用 1.11.5 或更早的
+      // 版本打开同一个库（两者 bundle id 相同、共用 watch_history.db），
+      // 库就会变成「user_version = 1 但 media_key 已存在」。
+      // 这种库再无条件执行 ALTER 会抛 "duplicate column name: media_key"，
+      // 整个 onUpgrade 回滚，库再也打不开、观看历史一直为空。
       if (!await _hasColumn(db, 'watch_history', 'media_key')) {
         await db.execute(
           'ALTER TABLE watch_history ADD COLUMN media_key TEXT',

--- a/lib/models/watch_history_database.dart
+++ b/lib/models/watch_history_database.dart
@@ -102,7 +102,7 @@ class WatchHistoryDatabase {
   }
 
   // 创建数据库表
-  Future<void> _createDB(Database db, int version) async {
+  static Future<void> _createDB(Database db, int version) async {
     await db.execute('''
     CREATE TABLE watch_history(
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -131,17 +131,45 @@ class WatchHistoryDatabase {
 
   // 数据库升级处理
   Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    await applyMigrations(db, oldVersion, newVersion);
+  }
+
+  /// 具体的升级步骤。抽成静态方法便于测试直接调用。
+  @visibleForTesting
+  static Future<void> applyMigrations(
+    Database db,
+    int oldVersion,
+    int newVersion,
+  ) async {
     if (oldVersion < 1) {
       await _createDB(db, newVersion);
       return;
     }
     if (oldVersion < 2) {
-      await db.execute('ALTER TABLE watch_history ADD COLUMN media_key TEXT');
+      // 迁移必须幂等：早期构建在 user_version 还是 1 的时候就已经把
+      // media_key 写进了 CREATE TABLE，这类库再执行 ALTER 会抛
+      // "duplicate column name: media_key"，导致整个 onUpgrade 回滚、
+      // 观看历史永远加载不出来。
+      if (!await _hasColumn(db, 'watch_history', 'media_key')) {
+        await db.execute(
+          'ALTER TABLE watch_history ADD COLUMN media_key TEXT',
+        );
+      }
       await db.execute(
         'CREATE INDEX IF NOT EXISTS idx_media_key ON watch_history(media_key)',
       );
     }
     // 未来版本可以在这里添加更多迁移代码
+  }
+
+  /// SQLite 没有 `ADD COLUMN IF NOT EXISTS`，迁移前先查一下列是否存在。
+  static Future<bool> _hasColumn(
+    DatabaseExecutor db,
+    String table,
+    String column,
+  ) async {
+    final rows = await db.rawQuery('PRAGMA table_info("$table")');
+    return rows.any((row) => row['name'] == column);
   }
 
   // 关闭数据库连接

--- a/lib/services/dandanplay_http_client.dart
+++ b/lib/services/dandanplay_http_client.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as transport;
 import 'package:nipaplay/services/dandanplay_service.dart';
+import 'package:nipaplay/utils/http_header_utils.dart';
 import 'package:nipaplay/utils/network_settings.dart';
 
 export 'package:http/http.dart'
@@ -64,51 +65,18 @@ class DandanplayHttpClient extends transport.BaseClient {
           return _inner.send(request);
         }
         if (authorization.isEmpty) throw DandanplayLoginRequired();
-        _overwriteHeaders(request.headers, authorization);
+        // 这里不能用 removeWhere/addAll 改写：http 的 headers 是自定义
+        // equals 的 LinkedHashMap，会踩到 dart-lang/sdk#64217。
+        addOrReplaceHeaders(request.headers, authorization);
       }
     } else {
       // Older callers may still supply the account header for custom servers.
       final token = authorization['Authorization'];
       if (token != null) {
-        _removeHeaderIfValueMatches(request.headers, 'authorization', token);
+        removeHeaderIfValueMatches(request.headers, 'authorization', token);
       }
     }
     return _inner.send(request);
-  }
-
-  /// Overwrites [values] into [headers] in place.
-  ///
-  /// `http`'s `BaseRequest.headers` is a case-insensitive `LinkedHashMap`, and
-  /// on the Dart VM `LinkedHashMap.removeWhere` leaves the table index pointing
-  /// at the entries it just deleted: unlike `remove`, it only marks the data
-  /// slots of the tombstone and never writes `_DELETED_PAIR` into `_index`.
-  /// Inserting a key whose probe reaches such a stale slot then compares against
-  /// the tombstone and throws
-  /// `type 'List<dynamic>' is not a subtype of type 'String' of 'key1'`.
-  /// Assigning the entries keeps the same "replace whatever the caller sent"
-  /// semantics without ever creating a tombstone, and the case-insensitive
-  /// equality still folds differently cased keys onto a single entry.
-  static void _overwriteHeaders(
-    Map<String, String> headers,
-    Map<String, String> values,
-  ) {
-    for (final entry in values.entries) {
-      headers[entry.key] = entry.value;
-    }
-  }
-
-  /// Removes the header named [name] (case-insensitively) when its value equals
-  /// [value]. Uses `remove`, which keeps the hash table consistent.
-  static void _removeHeaderIfValueMatches(
-    Map<String, String> headers,
-    String name,
-    String value,
-  ) {
-    for (final key in headers.keys.toList()) {
-      if (key.toLowerCase() == name && headers[key] == value) {
-        headers.remove(key);
-      }
-    }
   }
 
   @override

--- a/lib/services/dandanplay_http_client.dart
+++ b/lib/services/dandanplay_http_client.dart
@@ -64,19 +64,51 @@ class DandanplayHttpClient extends transport.BaseClient {
           return _inner.send(request);
         }
         if (authorization.isEmpty) throw DandanplayLoginRequired();
-        request.headers
-            .removeWhere((key, _) => key.toLowerCase() == 'authorization');
-        request.headers.addAll(authorization);
+        _overwriteHeaders(request.headers, authorization);
       }
     } else {
       // Older callers may still supply the account header for custom servers.
       final token = authorization['Authorization'];
       if (token != null) {
-        request.headers.removeWhere((key, value) =>
-            key.toLowerCase() == 'authorization' && value == token);
+        _removeHeaderIfValueMatches(request.headers, 'authorization', token);
       }
     }
     return _inner.send(request);
+  }
+
+  /// Overwrites [values] into [headers] in place.
+  ///
+  /// `http`'s `BaseRequest.headers` is a case-insensitive `LinkedHashMap`, and
+  /// on the Dart VM `LinkedHashMap.removeWhere` leaves the table index pointing
+  /// at the entries it just deleted: unlike `remove`, it only marks the data
+  /// slots of the tombstone and never writes `_DELETED_PAIR` into `_index`.
+  /// Inserting a key whose probe reaches such a stale slot then compares against
+  /// the tombstone and throws
+  /// `type 'List<dynamic>' is not a subtype of type 'String' of 'key1'`.
+  /// Assigning the entries keeps the same "replace whatever the caller sent"
+  /// semantics without ever creating a tombstone, and the case-insensitive
+  /// equality still folds differently cased keys onto a single entry.
+  static void _overwriteHeaders(
+    Map<String, String> headers,
+    Map<String, String> values,
+  ) {
+    for (final entry in values.entries) {
+      headers[entry.key] = entry.value;
+    }
+  }
+
+  /// Removes the header named [name] (case-insensitively) when its value equals
+  /// [value]. Uses `remove`, which keeps the hash table consistent.
+  static void _removeHeaderIfValueMatches(
+    Map<String, String> headers,
+    String name,
+    String value,
+  ) {
+    for (final key in headers.keys.toList()) {
+      if (key.toLowerCase() == name && headers[key] == value) {
+        headers.remove(key);
+      }
+    }
   }
 
   @override

--- a/lib/services/web_ui_proxy_api.dart
+++ b/lib/services/web_ui_proxy_api.dart
@@ -1,4 +1,5 @@
 import 'package:nipaplay/services/dandanplay_http_client.dart' as http;
+import 'package:nipaplay/utils/http_header_utils.dart';
 import 'package:shelf/shelf.dart';
 
 class WebUiProxyApi {
@@ -81,12 +82,17 @@ class WebUiProxyApi {
       }
       target[entry.key] = entry.value;
     }
-    target.removeWhere((key, _) => key.toLowerCase() == 'accept-encoding');
+    // 不要用 removeWhere：http 的 headers 是自定义 equals 的 LinkedHashMap，
+    // 删完再塞回同名 key 会踩到 dart-lang/sdk#64217。
+    removeHeader(target, 'accept-encoding');
     target['accept-encoding'] = 'identity';
   }
 
   void _stripHopByHop(Map<String, String> headers) {
-    headers.removeWhere((key, _) => _hopByHopHeaders.contains(key.toLowerCase()));
+    removeHeadersWhere(
+      headers,
+      (key, _) => _hopByHopHeaders.contains(key.toLowerCase()),
+    );
     headers.remove('content-length');
   }
 }

--- a/lib/utils/http_header_utils.dart
+++ b/lib/utils/http_header_utils.dart
@@ -1,0 +1,61 @@
+/// 改写 HTTP 头的小工具。
+///
+/// `package:http` 的 `BaseRequest.headers` 是带自定义 `equals`/`hashCode` 的
+/// 大小写不敏感 `LinkedHashMap`，改写它时不能用 `removeWhere`：
+/// Dart 3.13 的 VM 回归（dart-lang/sdk#64217）里，`LinkedHashMap.removeWhere`
+/// 只把 `_data` 槽位标记成已删除，没有同步 `_index`，残留的索引槽里存的是
+/// 删除哨兵（data 数组本身）。之后任何落到这个槽位的插入或查找，都会把哨兵
+/// 当成 key 交给 `equals`；对带自定义相等性的 map 来说那是一次带参数类型检查
+/// 的动态调用，于是抛
+/// `type 'List<dynamic>' is not a subtype of type 'String' of 'a'`。
+///
+/// `remove` 与下标赋值都会正常维护 `_index`，所以下面几个函数用它们实现，
+/// 语义和原来的 `addAll` / `removeWhere` 一致，但不会留下墓碑。
+library;
+
+/// 逐项写入 [values]，同名的键会被覆盖（等价于 `addAll`，但不留墓碑）。
+void addOrReplaceHeaders(
+  Map<String, String> headers,
+  Map<String, String> values,
+) {
+  for (final entry in values.entries) {
+    headers[entry.key] = entry.value;
+  }
+}
+
+/// 大小写不敏感地删除所有名为 [name] 的头。
+void removeHeader(Map<String, String> headers, String name) {
+  final target = name.toLowerCase();
+  for (final key in headers.keys.toList()) {
+    if (key.toLowerCase() == target) {
+      headers.remove(key);
+    }
+  }
+}
+
+/// 大小写不敏感地删除名为 [name]、且值等于 [value] 的头。
+void removeHeaderIfValueMatches(
+  Map<String, String> headers,
+  String name,
+  String value,
+) {
+  final target = name.toLowerCase();
+  for (final key in headers.keys.toList()) {
+    if (key.toLowerCase() == target && headers[key] == value) {
+      headers.remove(key);
+    }
+  }
+}
+
+/// 删除所有满足 [test] 的头，用来替代 `headers.removeWhere(test)`。
+void removeHeadersWhere(
+  Map<String, String> headers,
+  bool Function(String key, String value) test,
+) {
+  for (final key in headers.keys.toList()) {
+    final value = headers[key];
+    if (value != null && test(key, value)) {
+      headers.remove(key);
+    }
+  }
+}

--- a/test/dandanplay_http_client_test.dart
+++ b/test/dandanplay_http_client_test.dart
@@ -159,4 +159,60 @@ void main() {
     await expectLater(client.get(uri), throwsA(isA<DandanplayLoginRequired>()));
     client.close();
   });
+
+  test('replacing a caller-supplied Authorization header never throws',
+      () async {
+    // Regression: `removeWhere` + `addAll` on http's case-insensitive headers
+    // map left a stale index slot pointing at a deleted entry, so re-inserting
+    // the same key threw
+    // `type 'List<dynamic>' is not a subtype of type 'String'`.
+    final seen = <http.Request>[];
+    final client = DandanplayHttpClient(
+      authorization: () => {'Authorization': 'Bearer account-token'},
+      inner: MockClient((request) async {
+        seen.add(request);
+        return http.Response('{}', 200);
+      }),
+    );
+    for (final path in ['trending/all/hot/week', 'comment/123', 'favorite']) {
+      await client.get(
+        Uri.parse('$gateway/api/v2/$path'),
+        headers: {
+          'Accept': 'application/json',
+          'X-AppId': 'app-id',
+          'Authorization': 'Bearer stale-caller-token',
+        },
+      );
+    }
+    expect(seen.length, 3);
+    for (final request in seen) {
+      expect(request.headers['Authorization'], 'Bearer account-token');
+      expect(
+        request.headers.keys
+            .where((key) => key.toLowerCase() == 'authorization')
+            .length,
+        1,
+      );
+    }
+    client.close();
+  });
+
+  test('dropping a stale account header for a custom provider never throws',
+      () async {
+    final seen = <http.Request>[];
+    final client = DandanplayHttpClient(
+      authorization: () => {'Authorization': 'Bearer account-token'},
+      inner: MockClient((request) async {
+        seen.add(request);
+        return http.Response('{}', 200);
+      }),
+    );
+    await client.get(
+      Uri.parse('https://third-party.example/api/v2/comment/123'),
+      headers: {'Authorization': 'Bearer account-token', 'X-Other': 'kept'},
+    );
+    expect(seen.single.headers.containsKey('authorization'), isFalse);
+    expect(seen.single.headers['X-Other'], 'kept');
+    client.close();
+  });
 }

--- a/test/http_header_utils_test.dart
+++ b/test/http_header_utils_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:nipaplay/utils/http_header_utils.dart';
+
+/// 回归背景：Dart 3.13 的 VM 里 `LinkedHashMap.removeWhere` 只标记 `_data`、
+/// 不同步 `_index`，残留索引槽中的删除哨兵会被当作 key 交给 `equals`，抛
+/// `type 'List<dynamic>' is not a subtype of type 'String'`（dart-lang/sdk#64217）。
+/// `http` 的 `headers` 正是带自定义 equals 的大小写不敏感 map。
+void main() {
+  test('addOrReplaceHeaders 覆盖同名头且不破坏大小写不敏感的查找', () {
+    final request = http.Request('GET', Uri.parse('https://example.com'));
+    request.headers['Authorization'] = 'Bearer stale';
+    request.headers['Accept'] = 'application/json';
+
+    addOrReplaceHeaders(request.headers, {'authorization': 'Bearer fresh'});
+
+    expect(request.headers['Authorization'], 'Bearer fresh');
+    expect(
+      request.headers.keys.where((key) => key.toLowerCase() == 'authorization'),
+      hasLength(1),
+    );
+    expect(request.headers['Accept'], 'application/json');
+  });
+
+  test('removeHeader 之后仍可插入同名头（旧写法会抛 TypeError）', () {
+    final request = http.Request('GET', Uri.parse('https://example.com'));
+    request.headers['Accept-Encoding'] = 'gzip, deflate';
+
+    removeHeader(request.headers, 'accept-encoding');
+    request.headers['accept-encoding'] = 'identity';
+
+    expect(request.headers.containsKey('Accept-Encoding'), isTrue);
+    expect(request.headers['accept-encoding'], 'identity');
+  });
+
+  test('removeHeaderIfValueMatches 只删值匹配的头', () {
+    final request = http.Request('GET', Uri.parse('https://example.com'));
+    request.headers['Authorization'] = 'Bearer ours';
+    request.headers['X-Other'] = 'kept';
+
+    removeHeaderIfValueMatches(request.headers, 'authorization', 'Bearer other');
+    expect(request.headers.containsKey('Authorization'), isTrue);
+
+    removeHeaderIfValueMatches(request.headers, 'authorization', 'Bearer ours');
+    expect(request.headers.containsKey('Authorization'), isFalse);
+    expect(request.headers['X-Other'], 'kept');
+  });
+
+  test('removeHeadersWhere 删掉全部命中的头且不留下坏索引', () {
+    final request = http.Request('GET', Uri.parse('https://example.com'));
+    request.headers['Connection'] = 'keep-alive';
+    request.headers['Host'] = 'example.com';
+    request.headers['Accept'] = 'application/json';
+
+    removeHeadersWhere(
+      request.headers,
+      (key, _) => key.toLowerCase() == 'connection' || key.toLowerCase() == 'host',
+    );
+    request.headers['connection'] = 'close';
+
+    expect(request.headers.containsKey('Host'), isFalse);
+    expect(request.headers['connection'], 'close');
+    expect(request.headers['Accept'], 'application/json');
+  });
+}

--- a/test/watch_history_database_migration_test.dart
+++ b/test/watch_history_database_migration_test.dart
@@ -4,8 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nipaplay/models/watch_history_database.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
-/// 早期构建把 media_key 写进了 user_version = 1 的建表语句里，
-/// 于是出现了一批「版本号是 1、但列已经存在」的库。
+/// 旧版本（代码里的数据库版本号还是 1）打开过已经升级过的库时，sqflite
+/// 会把 user_version 改小却不动表结构，于是留下「版本号是 1、但列已经
+/// 存在」的库。这里手工还原这种状态。
 const String _v1SchemaWithMediaKey = '''
 CREATE TABLE watch_history(
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/test/watch_history_database_migration_test.dart
+++ b/test/watch_history_database_migration_test.dart
@@ -1,0 +1,152 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nipaplay/models/watch_history_database.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+/// 早期构建把 media_key 写进了 user_version = 1 的建表语句里，
+/// 于是出现了一批「版本号是 1、但列已经存在」的库。
+const String _v1SchemaWithMediaKey = '''
+CREATE TABLE watch_history(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  file_path TEXT UNIQUE NOT NULL,
+  media_key TEXT,
+  anime_name TEXT NOT NULL,
+  episode_title TEXT,
+  episode_id INTEGER,
+  anime_id INTEGER,
+  watch_progress REAL NOT NULL,
+  last_position INTEGER NOT NULL,
+  duration INTEGER NOT NULL,
+  last_watch_time TEXT NOT NULL,
+  thumbnail_path TEXT,
+  is_from_scan INTEGER NOT NULL
+)
+''';
+
+/// 标准的 v1 建表语句：没有 media_key，v2 迁移需要补上这一列。
+const String _v1SchemaWithoutMediaKey = '''
+CREATE TABLE watch_history(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  file_path TEXT UNIQUE NOT NULL,
+  anime_name TEXT NOT NULL,
+  episode_title TEXT,
+  episode_id INTEGER,
+  anime_id INTEGER,
+  watch_progress REAL NOT NULL,
+  last_position INTEGER NOT NULL,
+  duration INTEGER NOT NULL,
+  last_watch_time TEXT NOT NULL,
+  thumbnail_path TEXT,
+  is_from_scan INTEGER NOT NULL
+)
+''';
+
+void main() {
+  late Directory tempDir;
+  late String dbPath;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('nipaplay_history_migrate');
+    dbPath = '${tempDir.path}/watch_history.db';
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  /// 造一个 user_version = 1 的历史库，并塞一条记录。
+  Future<void> createV1Database({
+    required String schema,
+    required bool hasMediaKey,
+    String? path,
+  }) async {
+    final db = await openDatabase(
+      path ?? dbPath,
+      version: 1,
+      onCreate: (db, version) async {
+        await db.execute(schema);
+        await db.execute(
+          'CREATE INDEX idx_file_path ON watch_history(file_path)',
+        );
+      },
+    );
+    await db.insert('watch_history', {
+      'file_path': '/tmp/anime/EP01.mkv',
+      if (hasMediaKey) 'media_key': 'episode:1',
+      'anime_name': '测试番剧',
+      'watch_progress': 0.5,
+      'last_position': 120,
+      'duration': 1440,
+      'last_watch_time': '2026-09-10T00:00:00.000',
+      'is_from_scan': 0,
+    });
+    await db.close();
+  }
+
+  /// 用生产同款迁移逻辑从 v1 升到 v2。
+  Future<Database> upgradeToV2({String? path}) {
+    return openDatabase(
+      path ?? dbPath,
+      version: 2,
+      onUpgrade: WatchHistoryDatabase.applyMigrations,
+    );
+  }
+
+  Future<bool> hasColumn(Database db, String column) async {
+    final rows = await db.rawQuery('PRAGMA table_info("watch_history")');
+    return rows.any((row) => row['name'] == column);
+  }
+
+  Future<bool> hasMediaKeyIndex(Database db) async {
+    final indexes = await db.rawQuery(
+      "SELECT name FROM sqlite_master "
+      "WHERE type = 'index' AND name = 'idx_media_key'",
+    );
+    return indexes.isNotEmpty;
+  }
+
+  test('v1 库已含 media_key 时升级到 v2 不再抛 duplicate column', () async {
+    await createV1Database(
+      schema: _v1SchemaWithMediaKey,
+      hasMediaKey: true,
+    );
+
+    // 回归点：旧实现会无条件 ALTER，抛 "duplicate column name: media_key"，
+    // 整个 onUpgrade 失败 -> 数据库打不开 -> 观看历史永远加载不出来。
+    final db = await upgradeToV2();
+    addTearDown(db.close);
+
+    expect(await db.getVersion(), 2);
+    expect(await hasColumn(db, 'media_key'), isTrue);
+    expect(await hasMediaKeyIndex(db), isTrue);
+    final count = await db.rawQuery('SELECT COUNT(*) AS c FROM watch_history');
+    expect(count.first['c'], 1);
+  });
+
+  test('标准 v1 库升级到 v2 会补上 media_key 列并保留数据', () async {
+    await createV1Database(
+      schema: _v1SchemaWithoutMediaKey,
+      hasMediaKey: false,
+    );
+
+    final db = await upgradeToV2();
+    addTearDown(db.close);
+
+    expect(await db.getVersion(), 2);
+    expect(await hasColumn(db, 'media_key'), isTrue);
+    expect(await hasMediaKeyIndex(db), isTrue);
+
+    final rows = await db.query('watch_history');
+    expect(rows, hasLength(1));
+    expect(rows.single['anime_name'], '测试番剧');
+    expect(rows.single['media_key'], isNull);
+  });
+}

--- a/test/web_ui_proxy_api_test.dart
+++ b/test/web_ui_proxy_api_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:nipaplay/services/web_ui_proxy_api.dart';
+import 'package:shelf/shelf.dart';
+
+void main() {
+  test('转发带 Accept-Encoding 的请求不会抛错，且改写为 identity', () async {
+    // 回归：代理先 removeWhere 掉 accept-encoding 再写回同名头，
+    // 在 Dart 3.13 上会抛 type 'List<dynamic>' is not a subtype of type
+    // 'String'（dart-lang/sdk#64217），而浏览器请求基本都带这个头。
+    http.BaseRequest? forwarded;
+    final api = WebUiProxyApi(
+      client: MockClient((request) async {
+        forwarded = request;
+        return http.Response(
+          '{}',
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }),
+    );
+
+    final response = await api.handle(
+      Request(
+        'GET',
+        Uri.parse('http://localhost/api/proxy?url=https%3A%2F%2Fapi.example.com%2Fv2%2Fcomment%2F1'),
+        headers: {
+          'accept': 'application/json',
+          'accept-encoding': 'gzip, deflate, br',
+        },
+      ),
+    );
+
+    expect(response.statusCode, 200);
+    expect(forwarded, isNotNull);
+    expect(forwarded!.headers['accept-encoding'], 'identity');
+    expect(forwarded!.headers['accept'], 'application/json');
+    await response.readAsString();
+  });
+}


### PR DESCRIPTION
## Summary

- 修复 #898：`DandanplayHttpClient` 合并请求头时会抛 `type 'List<dynamic>' is not a subtype of type 'String'`，带 token（登录或残留 token）时弹幕、排行榜、播放历史、收藏、番剧详情一起失败。
- 这是 Dart 3.13 的 VM 回归 [dart-lang/sdk#64217](https://github.com/dart-lang/sdk/issues/64217)：`LinkedHashMap.removeWhere` 只标记 `_data`、不同步 `_index`，残留索引槽里的删除哨兵会被当成 key 交给 `equals`，而 `http` 的 `headers` 正好是带自定义 `equals` 的大小写不敏感 map。本仓库里同款写法有两处，都已改掉：`DandanplayHttpClient`、以及 WebUI 代理 `WebUiProxyApi._copyHeaders`（浏览器请求基本都带 `Accept-Encoding`，那条路径几乎必炸）。
- 修复观看历史无法加载：v2 迁移无条件 `ALTER TABLE watch_history ADD COLUMN media_key`，一旦库处于「`user_version = 1` 但 `media_key` 已存在」的状态就会抛 `duplicate column name: media_key`，整个 `onUpgrade` 回滚、`watch_history.db` 打不开（数据还在，只是读不出来）。
- 这种库是这么来的：sqflite 在没有 `onDowngrade` 的情况下，遇到磁盘上的 `user_version` 高于代码里的版本，只会把 `user_version` 改小、不动表结构。`media_key` 是 1.11.6 加进来的，所以先用 1.11.6 及以后的版本跑过、再用 1.11.5 或更早的版本打开同一个库（release 与 dev 构建 bundle id 相同，共用同一个 `watch_history.db`），就会留下「版本号 1 但列已存在」的库；之后再回到新版，库就永久打不开了。

## Related Issue

- Closes #898
- 上游回归：[dart-lang/sdk#64217](https://github.com/dart-lang/sdk/issues/64217)（open，area-vm / type-bug / P2）

## What Changed

- 新增 `lib/utils/http_header_utils.dart`：把「改写 http headers 不用 `removeWhere`」的写法集中起来（`addOrReplaceHeaders` / `removeHeader` / `removeHeaderIfValueMatches` / `removeHeadersWhere`）。
- `lib/services/dandanplay_http_client.dart`：改用上面的 helper，不再产生 `LinkedHashMap` 的墓碑索引槽。
- `lib/services/web_ui_proxy_api.dart`：`_copyHeaders` / `_stripHopByHop` 同样改用 helper（原先删掉 `accept-encoding` 再写回同名头，是同一个坑）。
- `lib/models/watch_history_database.dart`：迁移前用 `PRAGMA table_info` 判断列是否存在，已存在就跳过 `ALTER`，所以已经卡住的库升到这个版本能自动恢复；迁移逻辑抽成可测试的 `applyMigrations`。
- `lib/media_library/adaptive_media_collection_view.dart`、`adaptive_media_library_page.dart`：补加载 `loadHistory()` 加一次性标记，避免加载失败时每帧重试（原先会刷出数万行日志并吃满 CPU）。
- 测试：`test/dandanplay_http_client_test.dart` 新增 2 个回归用例；新增 `test/http_header_utils_test.dart`、`test/web_ui_proxy_api_test.dart`、`test/watch_history_database_migration_test.dart`（还原旧写法可稳定复现 `duplicate column`）。

## Verification

- `flutter test test/http_header_utils_test.dart test/web_ui_proxy_api_test.dart test/dandanplay_http_client_test.dart`：14 个用例全绿；把 `_copyHeaders` 还原成 `removeWhere` 写法后 `web_ui_proxy_api_test` 稳定失败，确认用例抓得住这个回归。
- `flutter test`：`dandanplay_http_client_test`、`dandanplay_login_notice_test`、`danmaku_matching_access_test`、`app_http_proxy_test`、`watch_history_database_migration_test` 全绿。
- `flutter analyze` 改动文件无告警。
- 真实用户库实测：`user_version` 1 → 2，173 条记录无丢失，`duplicate column name` 日志由 6 万余行降为 0。
